### PR TITLE
fix(onboarding): return predictable error objects from server actions

### DIFF
--- a/src/contexts/OnboardingContext.tsx
+++ b/src/contexts/OnboardingContext.tsx
@@ -156,7 +156,7 @@ export function OnboardingProvider({
             const topicIds = selectedTopics.map(topic => topic.id);
 
             // Submit notification preferences
-            await saveNotificationPreferences({
+            const result = await saveNotificationPreferences({
                 cityId: city.id,
                 locationIds,
                 topicIds,
@@ -165,15 +165,19 @@ export function OnboardingProvider({
                 name: session?.user?.name || name
             });
 
-            // Move to completion stage
-            setStage(OnboardingStage.NOTIFICATION_COMPLETE);
+            if (result.error) {
+                if (result.error === "email_exists") {
+                    setEmailExistsError(session?.user?.email || email);
+                } else {
+                    setError('genericError');
+                }
+            } else {
+                // Move to completion stage
+                setStage(OnboardingStage.NOTIFICATION_COMPLETE);
+            }
         } catch (error: any) {
             console.error('Error saving notification preferences:', error);
-            if (error.message === "email_exists" || error.message?.includes("email_exists")) {
-                setEmailExistsError(session?.user?.email || email);
-            } else {
-                setError('genericError');
-            }
+            setError('genericError');
         } finally {
             setUpdating(false);
         }
@@ -187,7 +191,7 @@ export function OnboardingProvider({
 
         try {
             // Submit petition data
-            await savePetition({
+            const result = await savePetition({
                 cityId: city.id,
                 isResident: petitionData.isResident,
                 isCitizen: petitionData.isCitizen,
@@ -196,15 +200,19 @@ export function OnboardingProvider({
                 name: petitionData.name
             });
 
-            // Move to completion stage
-            setStage(OnboardingStage.PETITION_COMPLETE);
+            if (result.error) {
+                if (result.error === "email_exists") {
+                    setEmailExistsError(session?.user?.email || email);
+                } else {
+                    setError('genericError');
+                }
+            } else {
+                // Move to completion stage
+                setStage(OnboardingStage.PETITION_COMPLETE);
+            }
         } catch (error: any) {
             console.error('Error saving petition:', error);
-            if (error.message === "email_exists" || error.message?.includes("email_exists")) {
-                setEmailExistsError(session?.user?.email || email);
-            } else {
-                setError('genericError');
-            }
+            setError('genericError');
         } finally {
             setUpdating(false);
         }

--- a/src/lib/db/notifications.ts
+++ b/src/lib/db/notifications.ts
@@ -35,6 +35,11 @@ export type UserPreference = {
     topics?: Topic[];
 };
 
+export type SaveResult<T> = {
+    data?: T;
+    error?: string;
+};
+
 /**
  * Get server session wrapper
  */
@@ -235,7 +240,7 @@ export async function saveNotificationPreferences(data: {
     phone?: string;
     email?: string; // For non-authenticated users
     name?: string;
-}): Promise<NotificationPreference> {
+}): Promise<SaveResult<NotificationPreference>> {
     const { cityId, locationIds, topicIds, phone, email, name } = data;
     const session = await getServerSession();
 
@@ -277,8 +282,8 @@ export async function saveNotificationPreferences(data: {
             });
 
             if (user) {
-                // Email exists but user is not authenticated - throw error instead of continuing
-                throw new Error("email_exists");
+                // Email exists but user is not authenticated - return error
+                return { error: "email_exists" };
             } else {
                 // Create new user
                 const newUser = await prisma.user.create({
@@ -383,7 +388,7 @@ export async function saveNotificationPreferences(data: {
             }
 
             // Finally, fetch the updated preferences with the new relationships
-            return await prisma.notificationPreference.findUnique({
+            const result = await prisma.notificationPreference.findUnique({
                 where: { id: updatedPreference.id },
                 include: {
                     city: true,
@@ -391,9 +396,10 @@ export async function saveNotificationPreferences(data: {
                     interests: true
                 }
             }) as NotificationPreference;
+            return { data: result };
         } else {
             // Create new preferences with existing relationships
-            return await prisma.notificationPreference.create({
+            const result = await prisma.notificationPreference.create({
                 data: {
                     userId,
                     cityId,
@@ -411,10 +417,11 @@ export async function saveNotificationPreferences(data: {
                     interests: true
                 }
             });
+            return { data: result };
         }
     } catch (error) {
         console.error('Error saving notification preferences:', error);
-        throw error;
+        return { error: 'An unexpected error occurred.' };
     }
 }
 
@@ -428,7 +435,7 @@ export async function savePetition(data: {
     phone?: string;
     email?: string; // For non-authenticated users
     name?: string; // We'll store this in user if needed, but not in petition
-}): Promise<Petition> {
+}): Promise<SaveResult<Petition>> {
     const { cityId, isResident, isCitizen, phone, email, name } = data;
     const session = await getServerSession();
 
@@ -463,8 +470,8 @@ export async function savePetition(data: {
             });
 
             if (user) {
-                // Email exists but user is not authenticated - throw error instead of continuing
-                throw new Error("email_exists");
+                // Email exists but user is not authenticated - return error
+                return { error: "email_exists" };
             } else {
                 // Create new user
                 const newUser = await prisma.user.create({
@@ -498,7 +505,7 @@ export async function savePetition(data: {
 
         if (existingPetition) {
             // Update existing petition
-            return await prisma.petition.update({
+            const result = await prisma.petition.update({
                 where: { id: existingPetition.id },
                 data: {
                     is_resident: isResident,
@@ -508,9 +515,10 @@ export async function savePetition(data: {
                     city: true
                 }
             });
+            return { data: result };
         } else {
             // Create new petition
-            return await prisma.petition.create({
+            const result = await prisma.petition.create({
                 data: {
                     userId,
                     cityId,
@@ -521,9 +529,10 @@ export async function savePetition(data: {
                     city: true
                 }
             });
+            return { data: result };
         }
     } catch (error) {
         console.error('Error saving petition:', error);
-        throw error;
+        return { error: 'An unexpected error occurred.' };
     }
 } 


### PR DESCRIPTION
fixes #49 

Refactors server actions in the onboarding flow to return a `{ data, error }` object instead of throwing exceptions. This prevents Next.js from sanitizing thrown errors in production, which previously caused specific error details (like 'email_exists') to be lost on the client.

The client-side context now inspects the returned object to handle success and error states, ensuring a consistent and predictable user experience.