### PR TITLE
feat(meetings): implement meeting status tracking and UI enhancements

### DIFF
--- a/docs/task-architecture.md
+++ b/docs/task-architecture.md
@@ -61,6 +61,7 @@ graph TD;
 -   **Role:** Initiates tasks and handles updates.
 -   **Key Files:**
     -   `src/lib/tasks/tasks.ts`: Contains the core logic for starting tasks (`startTask`) and handling updates (`handleTaskUpdate`).
+    -   `src/lib/tasks/types.ts`: Centralized task configuration and type definitions with automatic derivation of pipeline tasks and stages.
     -   `src/app/api/cities/[cityId]/meetings/[meetingId]/taskStatuses/[taskStatusId]/route.ts`: The API endpoint that receives all callback requests from the task server.
     -   `src/lib/apiTypes.ts`: Defines the TypeScript interfaces for task requests and results.
     -   Task-specific handlers (e.g., `src/lib/tasks/transcribe.ts`): Contain the logic for processing the results of a specific task type.
@@ -125,7 +126,11 @@ This capability significantly speeds up development and debugging, as you can it
 
 To add a new task type to the system, follow these steps:
 
-1.  **Define Types:**
+1.  **Add to Task Configuration:**
+    -   In `src/lib/tasks/types.ts`, add your new task to the `TASK_CONFIG` object with appropriate `requiredForPipeline` setting.
+    -   The system will automatically derive the task type and include it in the appropriate categories.
+
+2.  **Define Types:**
     -   In `src/lib/apiTypes.ts`, create new interfaces for the task's request and result data. For example:
 
     ```typescript
@@ -138,7 +143,7 @@ To add a new task type to the system, follow these steps:
     }
     ```
 
-2.  **Create a Result Handler:**
+3.  **Create a Result Handler:**
     -   Create a new file in `src/lib/tasks/` for the new task (e.g., `myNewTask.ts`).
     -   In this file, create a handler function to process the task's result. This function will be called when the task completes successfully.
 
@@ -150,7 +155,7 @@ To add a new task type to the system, follow these steps:
     };
     ```
 
-3.  **Update the Callback Handler:**
+4.  **Update the Callback Handler:**
     -   In `src/app/api/cities/[cityId]/meetings/[meetingId]/taskStatuses/[taskStatusId]/route.ts`, add a new `else if` block to the `handleUpdateRequest` function to handle the new task type.
 
     ```typescript
@@ -165,14 +170,14 @@ To add a new task type to the system, follow these steps:
     // ...
     ```
 
-4.  **Update the `processTaskResponse` function:**
+5.  **Update the `processTaskResponse` function:**
     - In `src/lib/tasks/tasks.ts`, update `processTaskResponse` to include your new task. This is used for reprocessing tasks.
 
-5.  **Implement the Backend Task:**
+6.  **Implement the Backend Task:**
     -   On the `opencouncil-tasks` server, create a new endpoint (e.g., `/my-new-task`) that accepts the `MyNewTaskRequest` payload.
     -   Implement the task logic, ensuring that it sends status updates to the `callbackUrl`.
 
-6.  **Update the Frontend:**
+7.  **Update the Frontend:**
     -   In the frontend, create a new UI element that calls the `startTask` function with the new task type and request body.
     
 That's it! By following these steps, you can easily extend the platform with new asynchronous task capabilities. 

--- a/messages/el.json
+++ b/messages/el.json
@@ -484,5 +484,16 @@
         },
         "submitting": "Υποβολή...",
         "continue": "Υποβολή"
+    },
+    "MeetingStatus": {
+        "scheduled": "Προγραμματισμένη",
+        "ready": "Ολοκληρωμένη",
+        "notReady": "Μη Ολοκληρωμένη",
+        "requiredForCompletion": "Απαιτείται για ολοκλήρωση",
+        "processAgenda": "Ημερήσια Διάταξη Επεξεργασμένη",
+        "transcribe": "Απομαγνητοφωνημένη",
+        "fixTranscript": "Αυτόματη Διόρθωση",
+        "humanReview": "Αξιολογημένη από άνθρωπο",
+        "summarize": "Summarized"
     }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -335,5 +335,16 @@
         "noSegmentsFound": "No statements found",
         "loading": "Loading...",
         "loadMore": "Load more"
+    },
+    "MeetingStatus": {
+        "scheduled": "Scheduled",
+        "ready": "Ready",
+        "notReady": "Not Ready",
+        "requiredForCompletion": "Required for completion",
+        "processAgenda": "Agenda processed",
+        "transcribe": "Transcribed",
+        "fixTranscript": "Automatic correction",
+        "humanReview": "Human reviewed",
+        "summarize": "Summarized"
     }
 }

--- a/src/app/[locale]/(other)/admin/tasks/page.tsx
+++ b/src/app/[locale]/(other)/admin/tasks/page.tsx
@@ -1,7 +1,8 @@
 import { getHighestVersionsForTasks, getTaskVersionsGroupedByCity } from "@/lib/tasks/tasks";
 import TaskVersionsTable from "@/components/admin/tasks/TaskVersionsTable";
+import { MeetingTaskType } from "@/lib/tasks/types";
 
-const MEETING_TASKS = ['transcribe', 'processAgenda', 'summarize'];
+const MEETING_TASKS: MeetingTaskType[] = ['transcribe', 'processAgenda', 'summarize'];
 
 export default async function TasksPage() {
     // Fetch the highest versions for each task type

--- a/src/app/api/cities/[cityId]/meetings/[meetingId]/status/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/[meetingId]/status/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getMeetingStatusCached } from '@/lib/cache';
+import { getCouncilMeeting } from '@/lib/db/meetings';
+
+export async function GET(
+    request: Request,
+    { params }: { params: { cityId: string; meetingId: string } }
+) {
+    // Check if meeting exists and if user is authorized to view it (handles unreleased meetings)
+    const meeting = await getCouncilMeeting(params.cityId, params.meetingId);
+    
+    if (!meeting) {
+        return NextResponse.json({ error: 'Meeting not found' }, { status: 404 });
+    }
+
+    const meetingStatus = await getMeetingStatusCached(params.cityId, params.meetingId);
+    return NextResponse.json(meetingStatus);
+}
+
+

--- a/src/components/admin/meetings/Meetings.tsx
+++ b/src/components/admin/meetings/Meetings.tsx
@@ -2,6 +2,7 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useState, useMemo, useEffect } from "react";
 import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
@@ -165,6 +166,21 @@ export default function Meetings({ meetings, currentCityName, selectedCityId }: 
                                     <TableHead className="w-12"></TableHead>
                                     <TableHead>Meeting</TableHead>
                                     <TableHead>Status</TableHead>
+                                    <TableHead className="w-16 text-center">
+                                        <TooltipProvider>
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <span className="cursor-help">👨‍💻</span>
+                                                </TooltipTrigger>
+                                                <TooltipContent>
+                                                    <p className="max-w-xs">
+                                                        Human Review Status - Shows whether the meeting transcript has been manually reviewed and corrected by a human. 
+                                                        Green checkmark indicates human review is complete.
+                                                    </p>
+                                                </TooltipContent>
+                                            </Tooltip>
+                                        </TooltipProvider>
+                                    </TableHead>
                                     <TableHead>Subjects</TableHead>
                                 </TableRow>
                             </TableHeader>

--- a/src/components/admin/tasks/TaskVersionsTable.tsx
+++ b/src/components/admin/tasks/TaskVersionsTable.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
+import { MeetingTaskType } from '@/lib/tasks/types';
 import {
     Table,
     TableBody,
@@ -37,7 +38,7 @@ interface City {
 interface TaskVersionsTableProps {
     highestVersions: Record<string, TaskVersion>;
     citiesData: Record<string, City>;
-    taskTypes: string[];
+    taskTypes: MeetingTaskType[];
 }
 
 export default function TaskVersionsTable({

--- a/src/components/meetings/MeetingStatusBadge.tsx
+++ b/src/components/meetings/MeetingStatusBadge.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { CheckCircle2, ListChecks } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { MeetingStage } from "@/lib/meetingStatus";
+
+interface MeetingStatusBadgeProps {
+    stage: MeetingStage;
+}
+
+export function MeetingStatusBadge({ stage }: MeetingStatusBadgeProps) {
+    const ready = stage === 'ready';
+    const t = useTranslations('MeetingStatus');
+
+    return (
+        <Badge variant={ready ? "default" : "secondary"} className="text-xs whitespace-nowrap">
+            <span className="inline-flex items-center gap-1">
+                {ready ? <CheckCircle2 className="h-3 w-3" /> : <ListChecks className="h-3 w-3" />}
+                {t(stage)}
+            </span>
+        </Badge>
+    );
+}
+
+

--- a/src/components/meetings/MeetingTimeline.tsx
+++ b/src/components/meetings/MeetingTimeline.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { MeetingStatus, getTasks } from "@/lib/meetingStatus";
+import { CheckCircle, Clock, XCircle } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+interface MeetingTimelineProps {
+    meetingStatus: MeetingStatus;
+}
+
+export function MeetingTimeline({ meetingStatus }: MeetingTimelineProps) {
+    const t = useTranslations('MeetingStatus');
+    
+    // Derive tasks from centralized definitions
+    const tasks = getTasks(meetingStatus.tasks, (key) => t(key));
+
+    return (
+        <div className="space-y-2 min-w-[200px]">
+            <div className="text-sm font-medium mb-3">Processing Timeline</div>
+            {tasks.map((task, index) => (
+                <div key={task.key} className="flex items-center gap-2">
+                    <div className="flex-shrink-0">
+                        {task.completed ? (
+                            <CheckCircle className="h-4 w-4 text-green-600" />
+                        ) : (
+                            <Clock className="h-4 w-4 text-muted-foreground" />
+                        )}
+                    </div>
+                    <div className="flex-1">
+                        <div className={`text-sm ${task.completed ? 'text-foreground' : 'text-muted-foreground'}`}>
+                            {task.label}
+                        </div>
+                        {task.required && !task.completed && (
+                            <div className="text-xs text-muted-foreground">
+                                {t('requiredForCompletion')}
+                            </div>
+                        )}
+                    </div>
+                </div>
+            ))}
+            <div className="pt-2 border-t">
+                <div className="flex items-center gap-2">
+                    <div className="flex-shrink-0">
+                        {meetingStatus.ready ? (
+                            <CheckCircle className="h-4 w-4 text-green-600" />
+                        ) : (
+                            <XCircle className="h-4 w-4 text-muted-foreground" />
+                        )}
+                    </div>
+                    <div className="text-sm font-medium">
+                        {meetingStatus.ready ? t('ready') : t('notReady')}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/meetings/admin/Admin.tsx
+++ b/src/components/meetings/admin/Admin.tsx
@@ -1,6 +1,6 @@
 "use client"
-import React, { useEffect } from 'react';
-import { CouncilMeeting, TaskStatus } from '@prisma/client';
+import React from 'react';
+import { TaskStatus } from '@prisma/client';
 import { useToast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -18,11 +18,12 @@ import { useCouncilMeetingData } from '../CouncilMeetingDataContext';
 import { requestProcessAgenda } from '@/lib/tasks/processAgenda';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import AddMeetingForm from '@/components/meetings/AddMeetingForm';
-import { Pencil, Loader2, ChevronDown, ChevronUp, Bell } from 'lucide-react';
+import { Pencil, Bell } from 'lucide-react';
 import { LinkOrDrop } from '@/components/ui/link-or-drop';
 import { requestSyncElasticsearch } from '@/lib/tasks/syncElasticsearch';
 import { MeetingExportButtons } from '../MeetingExportButtons';
 import { CreateNotificationModal } from './CreateNotificationModal';
+import { markHumanReviewComplete } from '@/lib/tasks/humanReview';
 
 export default function AdminActions({
 }: {
@@ -136,6 +137,23 @@ export default function AdminActions({
         } catch (error) {
             toast({
                 title: "Error requesting transcript fix",
+                description: `${error}`,
+                variant: 'destructive'
+            });
+        }
+    };
+
+    const handleMarkReviewComplete = async () => {
+        try {
+            await markHumanReviewComplete(meeting.cityId, meeting.id);
+            toast({
+                title: "Human review marked complete",
+                description: "The meeting has been marked as human reviewed.",
+            });
+            fetchTaskStatuses();
+        } catch (error) {
+            toast({
+                title: "Error marking review complete",
                 description: `${error}`,
                 variant: 'destructive'
             });
@@ -407,6 +425,9 @@ export default function AdminActions({
                 </Popover>
                 <Button onClick={handleFixTranscript}>
                     Fix Transcript
+                </Button>
+                <Button variant="outline" onClick={handleMarkReviewComplete}>
+                    Mark Human Review Complete
                 </Button>
                 <Button onClick={handleSyncElasticsearch} disabled={isSyncingElasticsearch}>
                     {isSyncingElasticsearch ? 'Syncing...' : 'Sync Elasticsearch'}

--- a/src/components/meetings/admin/TaskStatus.tsx
+++ b/src/components/meetings/admin/TaskStatus.tsx
@@ -9,6 +9,7 @@ import { Progress } from "@/components/ui/progress";
 import TimeAgo from "react-timeago";
 import { motion, AnimatePresence } from "framer-motion";
 import { processTaskResponse } from "@/lib/tasks/tasks";
+import { MeetingTaskType } from "@/lib/tasks/types";
 
 const staleTimeMs = 10 * 60 * 1000; // 10 minutes
 interface TaskStatusComponentProps {
@@ -132,7 +133,7 @@ export function TaskStatusComponent({ task, onDelete }: TaskStatusComponentProps
                                             className="h-5 w-5 p-0"
                                             onClick={(e) => {
                                                 e.stopPropagation();
-                                                processTaskResponse(task.type, task.id);
+                                                processTaskResponse(task.type as MeetingTaskType, task.id);
                                             }}
                                         >
                                             <RefreshCw className="h-3 w-3" />
@@ -162,7 +163,7 @@ export function TaskStatusComponent({ task, onDelete }: TaskStatusComponentProps
                                         className="h-5 w-5 p-0"
                                         onClick={(e) => {
                                             e.stopPropagation();
-                                            processTaskResponse(task.type, task.id);
+                                            processTaskResponse(task.type as MeetingTaskType, task.id);
                                         }}
                                     >
                                         <RefreshCw className="h-3 w-3" />

--- a/src/lib/cache/queries.ts
+++ b/src/lib/cache/queries.ts
@@ -7,6 +7,7 @@ import { getPartiesForCity } from "@/lib/db/parties";
 import { getPeopleForCity } from "@/lib/db/people";
 import { getAdministrativeBodiesForCity } from "@/lib/db/administrativeBodies";
 import { getMeetingData, MeetingData } from "@/lib/getMeetingData";
+import { getMeetingStatus } from "@/lib/meetingStatus";
 import { createCache } from "./index";
 import { fetchLatestSubstackPost } from "@/lib/db/landing";
 
@@ -64,6 +65,17 @@ export async function getCouncilMeetingsForCityCached(cityId: string, { limit }:
     () => getCouncilMeetingsForCity(cityId, { includeUnreleased, limit }),
     ['city', cityId, 'meetings', includeUnreleased ? 'withUnreleased' : 'onlyReleased', limit ? `limit:${limit}` : 'all'],
     { tags: ['city', `city:${cityId}`, `city:${cityId}:meetings`] }
+  )();
+}
+
+/**
+ * Cached derived status per meeting
+ */
+export async function getMeetingStatusCached(cityId: string, meetingId: string) {
+    return createCache(
+        () => getMeetingStatus(cityId, meetingId),
+    ['city', cityId, 'meetings', 'derived', meetingId],
+    { tags: ['city', `city:${cityId}`, `city:${cityId}:meetings`, `city:${cityId}:meeting:${meetingId}:derived`] }
   )();
 }
 

--- a/src/lib/meetingStatus.ts
+++ b/src/lib/meetingStatus.ts
@@ -1,0 +1,64 @@
+import { getMeetingTaskStatus, MeetingTaskStatus } from "./db/tasks";
+import { TASK_CONFIG, CORE_PROCESSING_TASKS, Task } from "./tasks/types";
+
+// Derive meeting stages from core processing tasks
+export const MEETING_STAGES = [
+    'scheduled',
+    ...CORE_PROCESSING_TASKS,
+    'ready',
+  ] as const;
+
+export type MeetingStage = typeof MEETING_STAGES[number];
+
+export type MeetingStatus = {
+    tasks: MeetingTaskStatus;
+    ready: boolean;
+    computedAt: Date;
+    stage: MeetingStage;
+};
+
+/**
+ * Derive the current meeting stage from completed tasks
+ * Note: humanReview is not considered in stage derivation - it's shown separately in UI
+ */
+function deriveMeetingStageFromTasks(tasks: MeetingTaskStatus): MeetingStage {
+    // Check tasks in reverse order to find the latest completed stage
+    for (let i = CORE_PROCESSING_TASKS.length - 1; i >= 0; i--) {
+        const taskKey = CORE_PROCESSING_TASKS[i];
+        if (tasks[taskKey]) {
+            return taskKey as MeetingStage;
+        }
+    }
+    return 'scheduled';
+}
+
+/**
+ * Get tasks configuration from centralized definitions
+ * Maps task keys to their display labels and determines which are required
+ */
+export function getTasks(tasks: MeetingTaskStatus, getLabel: (key: string) => string): Task[] {
+    return CORE_PROCESSING_TASKS.map(taskKey => ({
+        key: taskKey,
+        label: getLabel(taskKey),
+        completed: tasks[taskKey],
+        required: TASK_CONFIG[taskKey].requiredForPipeline,
+    }));
+}
+
+/**
+ * Get the complete meeting status including tasks, stage, and readiness
+ */
+export async function getMeetingStatus(cityId: string, meetingId: string): Promise<MeetingStatus> {
+    const tasks = await getMeetingTaskStatus(cityId, meetingId);
+    // A meeting is ready if all required tasks are completed
+    const ready = CORE_PROCESSING_TASKS.every(taskKey => 
+        !TASK_CONFIG[taskKey].requiredForPipeline || tasks[taskKey]
+    );
+    
+    return {
+        tasks,
+        ready,
+        computedAt: new Date(),
+        stage: deriveMeetingStageFromTasks(tasks),
+    };
+}

--- a/src/lib/tasks/humanReview.ts
+++ b/src/lib/tasks/humanReview.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import prisma from '@/lib/db/prisma';
+import { withUserAuthorizedToEdit } from '@/lib/auth';
+import { revalidateTag } from 'next/cache';
+
+/**
+ * Mark human review as complete for a meeting
+ * This creates a virtual task that represents human review completion
+ */
+export async function markHumanReviewComplete(cityId: string, meetingId: string) {
+    await withUserAuthorizedToEdit({ councilMeetingId: meetingId, cityId });
+    
+    // If one already exists, return it
+    const existing = await prisma.taskStatus.findFirst({
+        where: { 
+            cityId, 
+            councilMeetingId: meetingId, 
+            type: 'humanReview', 
+            status: 'succeeded' 
+        },
+        orderBy: [{ version: 'desc' }, { createdAt: 'desc' }]
+    });
+    
+    if (existing) {
+        return existing;
+    }
+    
+    const created = await prisma.taskStatus.create({
+        data: {
+            type: 'humanReview',
+            status: 'succeeded',
+            requestBody: JSON.stringify({ triggeredBy: 'user' }),
+            councilMeeting: { connect: { cityId_id: { cityId, id: meetingId } } }
+        }
+    });
+    
+    // Revalidate tags that list meetings for the city
+    try {
+        revalidateTag(`city:${cityId}:meetings`);
+    } catch (error) {
+        // Log cache revalidation errors but don't fail the operation
+        // Cache revalidation is not critical for the core functionality
+        console.error(`Failed to revalidate cache for city ${cityId}:`, error);
+    }
+    
+    return created;
+}

--- a/src/lib/tasks/types.ts
+++ b/src/lib/tasks/types.ts
@@ -1,0 +1,49 @@
+// Centralized task configuration and types
+export const TASK_CONFIG = {
+  processAgenda: {
+    requiredForPipeline: false,
+  },
+  transcribe: {
+    requiredForPipeline: true,
+  },
+  fixTranscript: {
+    requiredForPipeline: true,
+  },
+  humanReview: {
+    requiredForPipeline: true,
+  },
+  summarize: {
+    requiredForPipeline: true,
+  },
+  syncElasticsearch: {
+    requiredForPipeline: false,
+  },
+  generatePodcastSpec: {
+    requiredForPipeline: false,
+  },
+  generateHighlight: {
+    requiredForPipeline: false,
+  },
+  splitMediaFile: {
+    requiredForPipeline: false,
+  },
+  generateVoiceprint: {
+    requiredForPipeline: false,
+  },
+} as const;
+
+// Derive MeetingTaskType from the configuration
+export type MeetingTaskType = keyof typeof TASK_CONFIG;
+
+// Derive core processing tasks from configuration
+export const CORE_PROCESSING_TASKS = Object.entries(TASK_CONFIG)
+  .filter(([_, config]) => config.requiredForPipeline)
+  .map(([key]) => key as MeetingTaskType);
+
+// Task type for UI components
+export type Task = {
+  key: MeetingTaskType;
+  label: string;
+  completed: boolean;
+  required: boolean;
+};


### PR DESCRIPTION
This PR derives the current stage of a meeting based on completed tasks.
To support this logic, a `humanReviewed` virtual task has been added to better track human-in-the-loop progress. Fixes #57.

Current behavior: Meeting status is only visible in `/admin/meetings`

<img width="1216" height="471" alt="Screenshot from 2025-09-19 16-01-53" src="https://github.com/user-attachments/assets/d41d0106-1df4-44ee-8cf9-ffbab94c6f15" />

Next steps (not currently included in this PR)
1. Display a simplified status view on the main meeting page to keep users informed.
2. Add a dedicated admin view (maybe in `/admin`) for meetings that need attention (for admins and human reviewers).
3. Provide a way to create tasks in development, making it easier to test transitions between stages.
4. Consider updating `copy_db.sh` to include (at least partial) task records, so meeting status is accurate when syncing production data to staging/remote development environments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce centralized meeting task config with derived status/stage, a cached status API, and admin UI (badge/timeline, human review completion) to surface processing progress.
> 
> - **Meetings – Status tracking**:
>   - Centralized task config (`src/lib/tasks/types.ts`) deriving core pipeline tasks and types.
>   - New status engine (`src/lib/meetingStatus.ts`) computes per-meeting task completion, stage, and readiness.
>   - Cached status fetcher (`getMeetingStatusCached`) and API route `GET /api/cities/[cityId]/meetings/[meetingId]/status`.
>   - Server action to mark human review complete (`markHumanReviewComplete`) creating a virtual `humanReview` task.
> - **Admin UI**:
>   - Enhanced meeting list row to fetch/display status: stage badge (`MeetingStatusBadge`), processing timeline (`MeetingTimeline`), and human review indicator.
>   - Added tooltip column for human review; export row updated; task reprocessing buttons now typed; task versions admin uses `MeetingTaskType`.
> - **Tasks & cache**:
>   - `startTask`, `processTaskResponse`, version helpers typed with `MeetingTaskType`; selective cache revalidation on task completion.
>   - DB helpers: `getMeetingTaskStatus` for per-meeting completion map.
> - **Docs & i18n**:
>   - Expanded guides (`docs/guides/meeting-lifecycle.md`, `docs/task-architecture.md`) to include stages and config flow.
>   - New translations for meeting status in `messages/en.json` and `messages/el.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ceda770a47d648959ead0d468bce9022f58fbc62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->