### PR TITLE
Notification messages with dynamic meeting and task details

### DIFF
--- a/docs/discord-notifications.md
+++ b/docs/discord-notifications.md
@@ -41,14 +41,16 @@ All notifications include timestamps, color coding (green/red/blue), and clickab
 
 **New Meeting:**
 ```
-🆕 New Meeting Added
+🆕 athens: jan15_2025
+Scheduled for Monday, January 15, 2025, 14:30
 Municipality: Athens | Meeting: City Council - January 2025
 Date: January 15, 2025 | [View Meeting](https://...)
 ```
 
 **Task Updates:**
 ```
-▶️ Task Started | ✅ Task Completed | ❌ Task Failed
+▶️|✅|❌ transcribe - athens
+Processing|Completed|Failed: jan15_2025
 Task Type: transcribe | Municipality: Athens
 Meeting: City Council - January 2025
 [Open Admin Panel](https://...)

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -68,8 +68,15 @@ export async function notifyMeetingCreated(data: {
 
     await sendDiscordMessage({
         embeds: [{
-            title: '🆕 New Meeting Added',
-            description: `A new council meeting has been added to the system.`,
+            title: `🆕 ${data.cityId}: ${data.meetingId}`,
+            description: `Scheduled for ${data.meetingDate.toLocaleDateString('el-GR', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+                weekday: 'long',
+                hour: '2-digit',
+                minute: '2-digit'
+            })}`,
             color: 0x00ff00, // Green
             fields: [
                 {
@@ -117,8 +124,8 @@ export async function notifyTaskStarted(data: {
 
     await sendDiscordMessage({
         embeds: [{
-            title: '▶️ Task Started',
-            description: `A new task has been initiated.`,
+            title: `▶️ ${data.taskType} - ${data.cityId}`,
+            description: `Processing: ${data.meetingId}`,
             color: 0x0099ff, // Blue
             fields: [
                 {
@@ -167,8 +174,8 @@ export async function notifyTaskCompleted(data: {
 
     await sendDiscordMessage({
         embeds: [{
-            title: '✅ Task Completed',
-            description: `A task has completed successfully.`,
+            title: `✅ ${data.taskType} - ${data.cityId}`,
+            description: `Completed: ${data.meetingId}`,
             color: 0x00ff00, // Green
             fields: [
                 {
@@ -218,8 +225,8 @@ export async function notifyTaskFailed(data: {
 
     await sendDiscordMessage({
         embeds: [{
-            title: '❌ Task Failed',
-            description: `A task has failed.`,
+            title: `❌ ${data.taskType} - ${data.cityId}`,
+            description: `Failed: ${data.meetingId}`,
             color: 0xff0000, // Red
             fields: [
                 {


### PR DESCRIPTION
This commit/PR
- Update meeting notification to include specific city and meeting date
- Modify task notifications to reflect task type and current status
- Improve message formatting for better clarity and user engagement

Previous 
<img width="1079" height="276" alt="Screenshot from 2025-10-10 15-31-19" src="https://github.com/user-attachments/assets/5fc15485-130d-4b06-b826-9ffa3ef124b5" />

Now
<img width="1030" height="230" alt="image" src="https://github.com/user-attachments/assets/df508d30-90e1-47eb-8699-742fef18c737" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Discord embeds now show cityId/meetingId, task type, and status with localized scheduling; docs updated to match.
> 
> - **Discord notifications (`src/lib/discord.ts`)**:
>   - **Meeting Created**: Update `title` to `🆕 ${cityId}: ${meetingId}` and `description` to localized schedule via `toLocaleDateString('el-GR', ...)` with weekday and time.
>   - **Task Started/Completed/Failed**: Update `title` to `▶️|✅|❌ ${taskType} - ${cityId}` and `description` to `Processing|Completed|Failed: ${meetingId}`.
> - **Docs (`docs/discord-notifications.md`)**:
>   - Refresh examples to reflect new dynamic titles and status lines for meetings and tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc231bb89345ec6e3d7d16901de030e827d50758. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->