### PR TITLE
Rename discord notifications to admin alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ OpenCouncil is developed by [Schema Labs](https://schemalabs.gr), a non-profit o
 - 🌐 **Open Data**: All data available through a public API
 - 🔐 **Role-Based Access**: Granular permissions for different user types
 - 🤖 **AI Chat Assistant**: Ask questions about council meetings
-- 💬 **Discord Integration**: Real-time notifications for system events
+- 💬 **Discord Integration**: Real-time admin alerts for system events
 - 🌍 **Multilingual Support**: (Coming Soon) Support for multicultural cities
 
 ## Technical Architecture

--- a/docs/admin-alerts.md
+++ b/docs/admin-alerts.md
@@ -1,14 +1,14 @@
-# Discord Notifications Setup
+# Discord Admin Alerts Setup
 
-OpenCouncil sends real-time notifications to Discord for key events:
+OpenCouncil sends real-time admin alerts to Discord for key events:
 
 - 🆕 **New meeting added** - With link to view meeting
 - ▶️ **Task started/completed/failed** - With links to admin panel
 - ✨ **User onboarded** - Via notification preferences, petition, magic link, or admin invite
 - 📝 **New petition** - When submitted for a municipality
-- 🔔 **Notification signup** - When users sign up
+- 🔔 **Citizen notification signup** - When users sign up for citizen notifications
 
-*No PII (emails, phone numbers, names) is transmitted.*
+*No PII (emails, phone numbers, names) is transmitted in these admin alerts.*
 
 ## Quick Setup
 
@@ -16,7 +16,7 @@ OpenCouncil sends real-time notifications to Discord for key events:
 
 1. Open your Discord server → Right-click channel → **Edit Channel**
 2. Go to **Integrations** → **Webhooks** → **New Webhook**
-3. Name it (e.g., "OpenCouncil Bot")
+3. Name it (e.g., "OpenCouncil Admin Alerts")
 4. **Copy Webhook URL**
 
 The URL looks like: `https://discord.com/api/webhooks/123.../AbCd...`
@@ -33,11 +33,11 @@ DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHO
 
 ### 3. Test It
 
-Create a meeting or start a task - you should see notifications in Discord
+Create a meeting or start a task - you should see admin alerts in Discord
 
-## Notification Examples
+## Admin Alert Examples
 
-All notifications include timestamps, color coding (green/red/blue), and clickable links.
+All admin alerts include timestamps, color coding (green/red/blue), and clickable links.
 
 **New Meeting:**
 ```
@@ -65,13 +65,13 @@ Municipality: Athens | Source: Notification Preferences
 
 ## Troubleshooting
 
-**Notifications not appearing?**
+**Admin alerts not appearing?**
 1. Verify webhook URL in `.env` file
 2. Check webhook exists in Discord (Channel Settings > Integrations > Webhooks)
 3. Check application logs for errors
-4. Test manually: `curl -X POST "YOUR_WEBHOOK_URL" -H "Content-Type: application/json" -d '{"content": "Test"}'`
+4. Test manually: `curl -X POST "YOUR_WEBHOOK_URL" -H "Content-Type: application/json" -d '{"content": "Admin Alert Test"}'`
 
-**Rate limits:** 30 requests/minute per webhook. OpenCouncil stays well within this.
+**Rate limits:** 30 requests/minute per webhook. OpenCouncil admin alerts stay well within this.
 
 ## Security Notes
 
@@ -83,4 +83,4 @@ Municipality: Athens | Source: Notification Preferences
 
 To disable: Remove `DISCORD_WEBHOOK_URL` from `.env`
 
-To customize: Edit `/src/lib/discord.ts` - all notification functions are non-blocking.
+To customize: Edit `/src/lib/discord.ts` - all admin alert functions are non-blocking.

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -7,7 +7,7 @@ import { NextResponse } from "next/server"
 import { createHash } from "crypto"
 import { env } from "@/env.mjs"
 import { createUser, getUsers, updateUser } from "@/lib/db/users"
-import { notifyUserOnboarded } from "@/lib/discord"
+import { sendUserOnboardedAdminAlert } from "@/lib/discord"
 
 async function generateSignInLink(email: string) {
     // Create a token that expires in 24 hours
@@ -74,8 +74,8 @@ export async function POST(request: Request) {
         // Send invitation email
         await sendInviteEmail(email, name)
 
-        // Send Discord notification for admin invite
-        notifyUserOnboarded({
+        // Send Discord admin alert for admin invite
+        sendUserOnboardedAdminAlert({
             cityName: isSuperAdmin ? 'Super Admin' : 'Admin User',
             onboardingSource: 'admin_invite',
         });

--- a/src/app/api/cities/[cityId]/meetings/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/route.ts
@@ -3,7 +3,7 @@ import { revalidatePath, revalidateTag } from 'next/cache';
 import { z } from 'zod';
 import { createCouncilMeeting, getCouncilMeetingsForCity } from '@/lib/db/meetings';
 import { withUserAuthorizedToEdit } from '@/lib/auth';
-import { notifyMeetingCreated } from '@/lib/discord';
+import { sendMeetingCreatedAdminAlert } from '@/lib/discord';
 import prisma from '@/lib/db/prisma';
 
 const meetingSchema = z.object({
@@ -65,14 +65,14 @@ export async function POST(
         revalidateTag(`city:${cityId}:meetings`);
         revalidatePath(`/${cityId}`, "layout");
 
-        // Send Discord notification
+        // Send Discord admin alert
         const city = await prisma.city.findUnique({
             where: { id: cityId },
             select: { name_en: true }
         });
 
         if (city) {
-            notifyMeetingCreated({
+            sendMeetingCreatedAdminAlert({
                 cityName: city.name_en,
                 meetingName: name_en,
                 meetingDate: date,

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
 import { updateUserProfile } from "@/lib/db/users";
-import { notifyUserOnboarded } from "@/lib/discord";
+import { sendUserOnboardedAdminAlert } from "@/lib/discord";
 
 export async function POST(request: Request) {
     try {
@@ -20,10 +20,10 @@ export async function POST(request: Request) {
 
         const updatedUser = await updateUserProfile(user.id, updateData);
 
-        // Send Discord notification if user just completed onboarding
+        // Send Discord admin alert if user just completed onboarding
         if (isCompletingOnboarding) {
-            console.log('Sending Discord notification for user onboarding');
-            notifyUserOnboarded({
+            console.log('Sending Discord admin alert for user onboarding');
+            sendUserOnboardedAdminAlert({
                 cityName: 'General', // No specific city for magic link signups
                 onboardingSource: 'magic_link',
             });

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -40,7 +40,7 @@ export const env = createEnv({
     ELASTICSEARCH_URL: z.string().url(),
     ELASTICSEARCH_API_KEY: z.string().min(1),
 
-    // Discord Notifications
+    // Discord Admin Alerts
     DISCORD_WEBHOOK_URL: z.string().url().optional(),
 
     // Development

--- a/src/lib/db/notifications.ts
+++ b/src/lib/db/notifications.ts
@@ -5,7 +5,7 @@ import { auth, signIn } from "@/auth";
 import { getCitiesWithGeometry } from "./cities";
 import prisma from "@/lib/db/prisma";
 import { Result, createSuccess, createError } from "@/lib/result";
-import { notifyPetitionReceived, notifyUserOnboarded, notifyNotificationSignup } from "@/lib/discord";
+import { sendPetitionReceivedAdminAlert, sendUserOnboardedAdminAlert, sendNotificationSignupAdminAlert } from "@/lib/discord";
 
 // Type definitions for user preferences data
 export type PetitionWithRelations = Petition & {
@@ -425,16 +425,16 @@ export async function saveNotificationPreferences(data: OnboardingData & {
                 }
             });
 
-            // Send Discord notification for new notification signup
-            notifyNotificationSignup({
+            // Send Discord admin alert for new citizen notification signup
+            sendNotificationSignupAdminAlert({
                 cityName: result.city.name_en,
                 locationCount: validLocationIds.length,
                 topicCount: validTopicIds.length,
             });
 
-            // Send Discord notification for user onboarding (if we just created the user)
+            // Send Discord admin alert for user onboarding (if we just created the user)
             if (isNewlyCreatedUser) {
-                notifyUserOnboarded({
+                sendUserOnboardedAdminAlert({
                     cityName: result.city.name_en,
                     onboardingSource: 'notification_preferences',
                 });
@@ -554,16 +554,16 @@ export async function savePetition(data: OnboardingData & {
                 }
             });
 
-            // Send Discord notification for new petition
-            notifyPetitionReceived({
+            // Send Discord admin alert for new petition
+            sendPetitionReceivedAdminAlert({
                 cityName: result.city.name_en,
                 isResident: isResident,
                 isCitizen: isCitizen,
             });
 
-            // Send Discord notification for user onboarding (if we just created the user)
+            // Send Discord admin alert for user onboarding (if we just created the user)
             if (isNewlyCreatedUser) {
-                notifyUserOnboarded({
+                sendUserOnboardedAdminAlert({
                     cityName: result.city.name_en,
                     onboardingSource: 'petition',
                 });

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -1,7 +1,7 @@
 /**
- * Discord Webhook Integration
+ * Discord Admin Alerts Integration
  * 
- * This module provides utilities to send notifications to a Discord channel
+ * This module provides utilities to send admin alerts to a Discord channel
  * via webhook for important system events.
  */
 
@@ -33,7 +33,7 @@ interface DiscordWebhookPayload {
 async function sendDiscordMessage(payload: DiscordWebhookPayload): Promise<void> {
     // Skip if webhook URL is not configured
     if (!env.DISCORD_WEBHOOK_URL) {
-        console.log('Discord webhook URL not configured, skipping notification');
+        console.log('Discord webhook URL not configured, skipping admin alert');
         return;
     }
 
@@ -47,17 +47,17 @@ async function sendDiscordMessage(payload: DiscordWebhookPayload): Promise<void>
         });
 
         if (!response.ok) {
-            console.error('Failed to send Discord notification:', response.statusText);
+            console.error('Failed to send Discord admin alert:', response.statusText);
         }
     } catch (error) {
-        console.error('Error sending Discord notification:', error);
+        console.error('Error sending Discord admin alert:', error);
     }
 }
 
 /**
- * Notify when a new council meeting is added
+ * Send admin alert when a new council meeting is added
  */
-export async function notifyMeetingCreated(data: {
+export async function sendMeetingCreatedAdminAlert(data: {
     cityName: string;
     meetingName: string;
     meetingDate: Date;
@@ -110,9 +110,9 @@ export async function notifyMeetingCreated(data: {
 }
 
 /**
- * Notify when a task starts
+ * Send admin alert when a task starts
  */
-export async function notifyTaskStarted(data: {
+export async function sendTaskStartedAdminAlert(data: {
     taskType: string;
     cityName: string;
     meetingName: string;
@@ -160,9 +160,9 @@ export async function notifyTaskStarted(data: {
 }
 
 /**
- * Notify when a task completes successfully
+ * Send admin alert when a task completes successfully
  */
-export async function notifyTaskCompleted(data: {
+export async function sendTaskCompletedAdminAlert(data: {
     taskType: string;
     cityName: string;
     meetingName: string;
@@ -210,9 +210,9 @@ export async function notifyTaskCompleted(data: {
 }
 
 /**
- * Notify when a task fails
+ * Send admin alert when a task fails
  */
-export async function notifyTaskFailed(data: {
+export async function sendTaskFailedAdminAlert(data: {
     taskType: string;
     cityName: string;
     meetingName: string;
@@ -266,9 +266,9 @@ export async function notifyTaskFailed(data: {
 }
 
 /**
- * Notify when a user completes onboarding
+ * Send admin alert when a user completes onboarding
  */
-export async function notifyUserOnboarded(data: {
+export async function sendUserOnboardedAdminAlert(data: {
     cityName: string;
     onboardingSource: 'notification_preferences' | 'petition' | 'admin_invite' | 'magic_link';
 }): Promise<void> {
@@ -305,9 +305,9 @@ export async function notifyUserOnboarded(data: {
 }
 
 /**
- * Notify when a petition is received
+ * Send admin alert when a petition is received
  */
-export async function notifyPetitionReceived(data: {
+export async function sendPetitionReceivedAdminAlert(data: {
     cityName: string;
     isResident: boolean;
     isCitizen: boolean;
@@ -343,9 +343,9 @@ export async function notifyPetitionReceived(data: {
 }
 
 /**
- * Notify when someone signs up for notifications
+ * Send admin alert when someone signs up for notifications
  */
-export async function notifyNotificationSignup(data: {
+export async function sendNotificationSignupAdminAlert(data: {
     cityName: string;
     locationCount: number;
     topicCount: number;


### PR DESCRIPTION
In preparation for citizen notifications, renames discord admin messages to `Admin Alerts` (previously `Notifications`) in code, comments and documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames Discord notifications to admin alerts, adds presigned S3 upload flow with utilities, and introduces reusable UI badges (official support, role display) with related refactors.
> 
> - **Backend/API**:
>   - Rename Discord "notifications" to "admin alerts" across code (`src/lib/discord.ts`) and update all call sites (`tasks`, profile, admin users, notifications, meetings APIs).
>   - Add `POST /api/upload/presigned-url` for direct client uploads; simplify `POST /api/upload` to use shared S3 utils.
>   - Refactor party/person/city image uploads to use `uploadFile` from `src/lib/s3`.
> - **Storage**:
>   - Introduce `src/lib/s3.ts` (shared S3 client, upload helpers, presigned URL generation, file existence checks).
>   - Add `@aws-sdk/s3-request-presigner` dependency.
>   - Add `types/upload.ts` and filename `UploadConfig` scheme; wire via `LinkOrDrop` and meeting form.
> - **UI**:
>   - New `OfficialSupportBadge` component and replace hardcoded badges in `CityCard` and `CityHeader`; adjust OG badge styling.
>   - New `RoleDisplay` component; integrate into `Person`, `PersonBadge`, and `PersonCard` for consistent role rendering.
>   - Enhance `LinkOrDrop` with presigned uploads, progress, errors, and optional naming config.
>   - Minor tweaks: meeting "today/upcoming" badge logic; greeting text correction.
> - **Docs**:
>   - Rename and clarify Discord docs to "Admin Alerts" with updated examples; README wording updated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9ef52d5cb03f778e5dc092f3077636b218483b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->