### PR TITLE
Add env directory on gitignore

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-        # required: false  # Makes this dependency optional
+        required: false  # Makes this dependency optional
     profiles: ["prod"]
 
   app-dev:
@@ -37,7 +37,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
-        # required: false  # Makes this dependency optional
+        required: false  # Makes this dependency optional
     profiles: ["dev"]
 
   # Local database service

--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,7 @@ LAST_CONFIG_FILE=".last_docker_config"
 
 # Function to safely clean Docker resources specific to our app
 function clean_resources() {
-    local project_name=$(docker-compose ps --format json 2>/dev/null | jq -r '.[0].Project' 2>/dev/null)
+    local project_name=$(docker compose ps --format json 2>/dev/null | jq -r '.[0].Project' 2>/dev/null)
     
     if [ -z "$project_name" ]; then
         # If no project is running, use the directory name as fallback
@@ -185,4 +185,4 @@ if [ "$MODE" = "dev" ]; then
   COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.dev.yml"
 fi
 
-docker-compose --env-file $ENV_FILE $COMPOSE_FILES $PROFILES up $DETACHED $EXTRA_OPTIONS
+docker compose --env-file $ENV_FILE $COMPOSE_FILES $PROFILES up $DETACHED $EXTRA_OPTIONS


### PR DESCRIPTION
### Summary
Addition on gitignore.

### Changes
1. Added `env/` directory on `.gitignore`. 

### Future suggestions
1. Add instructions to `README`. Someone has to make sure `distutils-standards` is installed and it should also be recommended to build the project on a Python virtual environment.
2. Add Docker compose v2 (`apt-get install docker-compose-v2`) on requirements. Docker compose v1 complains about `require: false` option on `docker-compose.yml`.

---
Let me know your thoughts on this PR.