### PR TITLE
Change transcript highlight color

### DIFF
--- a/src/components/meetings/transcript/Utterance.tsx
+++ b/src/components/meetings/transcript/Utterance.tsx
@@ -77,7 +77,7 @@ const UtteranceC: React.FC<{
     const className = cn(
         "cursor-pointer hover:bg-accent utterance transcript-text",
         {
-            "bg-accent": isActive,
+            "bg-yellow-200": isActive,
             "font-bold underline": isHighlighted,
             "text-blue-500 font-bold underline": isTaskModified,
             "text-green-500 font-bold underline": isUserModified,


### PR DESCRIPTION
### Description
This PR improves the visual feedback during transcription playback by changing the active segment highlight color from grey to Yellow. It also addresses accessibility/readability issues where user-edited text (displayed in green) became difficult to read against the active background.

### Related issue
Issue #99 

### Changes
1. Component Updates: `src/components/meetings/transcript/Utterance.tsx`
    - Changed the active background color class from `bg-accent (grey)` to `bg-yellow-200` to make the current playback position more distinct.

### Showcase
- Active segment (Yellow highlight):

<p align="center">

<img src="https://imgur.com/EmLj1MT.png"/>

</p>

---
Let me know your thoughts on this PR.