### PR TITLE
Fix: Resolve Select dropdown recursion error and missing hover highlight

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -74,7 +74,7 @@ SelectScrollDownButton.displayName =
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", onCloseAutoFocus, onEscapeKeyDown, onPointerDownOutside, ...props }, ref) => {
+>(({ className, children, position = "popper", onCloseAutoFocus, onEscapeKeyDown, onPointerDownOutside, onFocus, ...props }, ref) => {
   const handleCloseAutoFocus = React.useCallback((event: Event) => {
     // Prevent default focus restoration to avoid conflicts with parent focus scopes (Sheet/Dialog)
     // This is critical to prevent "too much recursion" errors
@@ -94,6 +94,12 @@ const SelectContent = React.forwardRef<
     onPointerDownOutside?.(event);
   }, [onPointerDownOutside]);
 
+  const handleFocus = React.useCallback((event: React.FocusEvent<HTMLDivElement>) => {
+    // Stop propagation to prevent focus events from reaching parent focus scopes
+    event.stopPropagation();
+    onFocus?.(event);
+  }, [onFocus]);
+
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
@@ -108,6 +114,7 @@ const SelectContent = React.forwardRef<
         onCloseAutoFocus={handleCloseAutoFocus}
         onEscapeKeyDown={handleEscapeKeyDown}
         onPointerDownOutside={handlePointerDownOutside}
+        onFocus={handleFocus}
         {...props}
       >
         <SelectScrollUpButton />


### PR DESCRIPTION
## Problem

The Select dropdown in `AddMeetingForm` was experiencing two critical issues:

1. **Recursion Error**: Opening the dropdown and hovering over options triggered repeated `Uncaught InternalError: too much recursion` errors in the console, causing browser performance degradation and potential crashes in development.

2. **Missing Hover Highlight**: After closing and reopening the dropdown, the blue background highlight on hover was no longer visible, making it difficult to see which option was being hovered.

### Related Issue
Solves #82 

## Root Causes

### Recursion Error
The recursion was caused by spreading `{...field}` props from React Hook Form onto the `SelectTrigger` component. This conflicted with Radix UI's internal event handlers, creating an infinite loop when hovering over dropdown items.

**Before:**
```tsx
<SelectTrigger {...field}>
```

The `field` object contains props like `onChange`, `onBlur`, `ref`, etc., which conflicted with Radix UI Select's internal state management.

### Missing Hover Highlight
The `SelectItem` component was missing the `data-[highlighted]` attribute styles. Radix UI Select uses this data attribute to indicate when an item is highlighted (via hover or keyboard navigation), but the component only had `focus:` styles which only work for keyboard navigation.

## Changes

### 1. Fixed Recursion Error (`AddMeetingForm.tsx`)
- Removed `{...field}` spread from `SelectTrigger`
- Used `value` and `onValueChange` props directly on the `Select` component
- Simplified value handling to use `field.value || "none"` instead of complex string conversion

**After:**
```tsx
<Select 
    onValueChange={(value) => {
        field.onChange(value === "none" ? undefined : value);
    }} 
    value={field.value || "none"}
>
    <FormControl>
        <SelectTrigger>
            <SelectValue placeholder={t('selectAdministrativeBody')} />
        </SelectTrigger>
    </FormControl>
    {/* ... */}
</Select>
```

### 2. Fixed Hover Highlight (`select.tsx`)
- Added `data-[highlighted]:bg-accent` and `data-[highlighted]:text-accent-foreground` styles to `SelectItem`
- Also added `hover:bg-accent` and `hover:text-accent-foreground` as a fallback for better browser compatibility

## Testing

- No console errors when opening dropdown and hovering over options
- Blue hover highlight appears consistently on dropdown items
- Hover highlight works after closing and reopening the dropdown

---

Let me know if the issue is resolved.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves focus recursion and missing hover highlight in the Radix Select component.
> 
> - Wraps `SelectContent` handlers to `preventDefault` on `onCloseAutoFocus` and `stopPropagation` on focus to avoid recursion with parent focus scopes (e.g., Sheet/Dialog); preserves default `Escape` and pointer-outside behavior
> - Adds `data-[highlighted]` and `hover` styles to `SelectItem` to ensure visible option highlighting
> - Introduces `PointerDownOutsideEvent` type and routes children through `Viewport` consistently
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba244afac5bbac66fe2d5f354a22acf2c5d2b3f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->