### PR TITLE
improve reviews dashboard

### DIFF
--- a/src/app/[locale]/(other)/admin/reviews/page.tsx
+++ b/src/app/[locale]/(other)/admin/reviews/page.tsx
@@ -1,25 +1,33 @@
-import { getMeetingsNeedingReview, getReviewers } from '@/lib/db/reviews';
+import { getMeetingsNeedingReview, getReviewers, getReviewMetrics } from '@/lib/db/reviews';
 import { ReviewsTable } from '@/components/admin/reviews/ReviewsTable';
 import { ReviewFilters } from '@/components/admin/reviews/ReviewFilters';
+import { ReviewVolumeChart } from '@/components/admin/reviews/ReviewVolumeChart';
+import { Last30DaysFilter } from '@/components/admin/reviews/Last30DaysFilter';
+import { formatDistanceToNow } from 'date-fns';
+import { formatDurationMs } from '@/lib/formatters/time';
+import { Card, CardContent } from '@/components/ui/card';
 
 interface PageProps {
   searchParams: { 
     show?: 'needsAttention' | 'all' | 'completed';
     reviewerId?: string;
+    last30Days?: string;
   };
 }
 
 export default async function ReviewsPage({ searchParams }: PageProps) {
-  const { show = 'needsAttention', reviewerId } = searchParams;
+  const { show = 'needsAttention', reviewerId, last30Days } = searchParams;
+  const last30DaysBool = last30Days !== 'false';
   
-  const [reviews, reviewers] = await Promise.all([
-    getMeetingsNeedingReview({ show, reviewerId }),
-    getReviewers()
+  const [reviews, reviewers, metrics] = await Promise.all([
+    getMeetingsNeedingReview({ show, reviewerId, last30Days: last30DaysBool }),
+    getReviewers(),
+    getReviewMetrics(last30DaysBool)
   ]);
   
   return (
     <div className="container mx-auto py-8 px-4">
-      <div className="mb-8">
+      <div className="mb-6">
         <div className="flex items-baseline gap-3">
           <h1 className="text-3xl font-bold">Transcript Reviews</h1>
           <span className="text-lg text-muted-foreground">
@@ -29,6 +37,44 @@ export default async function ReviewsPage({ searchParams }: PageProps) {
         <p className="text-muted-foreground mt-2">
           Track and manage human review progress on meeting transcripts
         </p>
+      </div>
+
+      {/* Review Volume Chart - Not affected by 30-day filter */}
+      <div className="mb-6">
+        <ReviewVolumeChart />
+      </div>
+
+      {/* 30-Day Filter - Prominent at top */}
+      <Last30DaysFilter last30Days={last30DaysBool} />
+
+      {/* Metrics Display */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+        <Card>
+          <CardContent className="pt-6">
+            <div className="text-2xl font-bold">{formatDurationMs(metrics.needsCorrections)}</div>
+            <div className="text-sm text-muted-foreground mt-1">
+              Meeting time needs corrections
+            </div>
+            {metrics.oldestNeedsCorrections && (
+              <div className="text-xs text-muted-foreground mt-2">
+                Oldest: {formatDistanceToNow(metrics.oldestNeedsCorrections, { addSuffix: true })}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="text-2xl font-bold">{metrics.needsUpload}</div>
+            <div className="text-sm text-muted-foreground mt-1">
+              Meetings need upload
+            </div>
+            {metrics.oldestNeedsUpload && (
+              <div className="text-xs text-muted-foreground mt-2">
+                Oldest: {formatDistanceToNow(metrics.oldestNeedsUpload, { addSuffix: true })}
+              </div>
+            )}
+          </CardContent>
+        </Card>
       </div>
       
       <div className="flex flex-col md:flex-row gap-4 mb-6">

--- a/src/app/[locale]/(other)/admin/reviews/page.tsx
+++ b/src/app/[locale]/(other)/admin/reviews/page.tsx
@@ -1,4 +1,5 @@
-import { getMeetingsNeedingReview, getReviewers, getReviewMetrics } from '@/lib/db/reviews';
+import { getMeetingsNeedingReview, getReviewers, type ReviewListItem } from '@/lib/db/reviews';
+import { getMeetingUploadMetrics } from '@/lib/db/meetings';
 import { ReviewsTable } from '@/components/admin/reviews/ReviewsTable';
 import { ReviewFilters } from '@/components/admin/reviews/ReviewFilters';
 import { ReviewVolumeChart } from '@/components/admin/reviews/ReviewVolumeChart';
@@ -8,23 +9,63 @@ import { formatDurationMs } from '@/lib/formatters/time';
 import { Card, CardContent } from '@/components/ui/card';
 
 interface PageProps {
-  searchParams: { 
+  searchParams: {
     show?: 'needsAttention' | 'all' | 'completed';
     reviewerId?: string;
     last30Days?: string;
   };
 }
 
+function filterReviewsByShow(reviews: ReviewListItem[], show: 'needsAttention' | 'all' | 'completed'): ReviewListItem[] {
+  switch (show) {
+    case 'needsAttention':
+      return reviews.filter(r => r.status !== 'completed');
+    case 'completed':
+      return reviews.filter(r => r.status === 'completed');
+    case 'all':
+    default:
+      return reviews;
+  }
+}
+
+function calculateReviewMetrics(reviews: ReviewListItem[]) {
+  const needsReviewMeetings = reviews.filter(m => m.status !== 'completed');
+
+  const needsReviewDuration = needsReviewMeetings.reduce(
+    (sum, meeting) => sum + meeting.meetingDurationMs,
+    0
+  );
+
+  const oldestNeedsReview = needsReviewMeetings.length > 0
+    ? needsReviewMeetings.reduce((oldest, meeting) =>
+      meeting.meetingDate < oldest ? meeting.meetingDate : oldest,
+      needsReviewMeetings[0].meetingDate
+    )
+    : null;
+
+  return {
+    needsReview: needsReviewDuration,
+    oldestNeedsReview,
+  };
+}
+
 export default async function ReviewsPage({ searchParams }: PageProps) {
   const { show = 'needsAttention', reviewerId, last30Days } = searchParams;
   const last30DaysBool = last30Days !== 'false';
-  
-  const [reviews, reviewers, metrics] = await Promise.all([
-    getMeetingsNeedingReview({ show, reviewerId, last30Days: last30DaysBool }),
+
+  // Fetch all meetings once (with reviewerId filter if specified), then filter client-side
+  const [allReviews, reviewers, uploadMetrics] = await Promise.all([
+    getMeetingsNeedingReview({ show: 'all', reviewerId, last30Days: last30DaysBool }),
     getReviewers(),
-    getReviewMetrics(last30DaysBool)
+    getMeetingUploadMetrics(last30DaysBool)
   ]);
-  
+
+  // Filter for table display
+  const reviews = filterReviewsByShow(allReviews, show);
+
+  // Calculate metrics from all reviews (not filtered by show, but respects reviewerId)
+  const reviewMetrics = calculateReviewMetrics(allReviews);
+
   return (
     <div className="container mx-auto py-8 px-4">
       <div className="mb-6">
@@ -48,43 +89,56 @@ export default async function ReviewsPage({ searchParams }: PageProps) {
       <Last30DaysFilter last30Days={last30DaysBool} />
 
       {/* Metrics Display */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
         <Card>
           <CardContent className="pt-6">
-            <div className="text-2xl font-bold">{formatDurationMs(metrics.needsCorrections)}</div>
+            <div className="text-2xl font-bold">{formatDurationMs(reviewMetrics.needsReview)}</div>
             <div className="text-sm text-muted-foreground mt-1">
-              Meeting time needs corrections
+              Meeting time needs review
             </div>
-            {metrics.oldestNeedsCorrections && (
+            {reviewMetrics.oldestNeedsReview && (
               <div className="text-xs text-muted-foreground mt-2">
-                Oldest: {formatDistanceToNow(metrics.oldestNeedsCorrections, { addSuffix: true })}
+                Oldest: {formatDistanceToNow(reviewMetrics.oldestNeedsReview, { addSuffix: true })}
               </div>
             )}
           </CardContent>
         </Card>
         <Card>
           <CardContent className="pt-6">
-            <div className="text-2xl font-bold">{metrics.needsUpload}</div>
+            <div className="text-2xl font-bold">{uploadMetrics.needsUpload}</div>
             <div className="text-sm text-muted-foreground mt-1">
               Meetings need upload
             </div>
-            {metrics.oldestNeedsUpload && (
+            {uploadMetrics.oldestNeedsUpload && (
               <div className="text-xs text-muted-foreground mt-2">
-                Oldest: {formatDistanceToNow(metrics.oldestNeedsUpload, { addSuffix: true })}
+                Oldest: {formatDistanceToNow(uploadMetrics.oldestNeedsUpload, { addSuffix: true })}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <div className="text-2xl font-bold">{uploadMetrics.scheduledFuture}</div>
+            <div className="text-sm text-muted-foreground mt-1">
+              Meetings scheduled
+            </div>
+            {uploadMetrics.earliestScheduledFuture && (
+              <div className="text-xs text-muted-foreground mt-2">
+                Earliest: {formatDistanceToNow(uploadMetrics.earliestScheduledFuture, { addSuffix: true })}
               </div>
             )}
           </CardContent>
         </Card>
       </div>
-      
+
       <div className="flex flex-col md:flex-row gap-4 mb-6">
-        <ReviewFilters 
+        <ReviewFilters
           show={show}
           reviewerId={reviewerId}
           reviewers={reviewers}
         />
       </div>
-      
+
       <ReviewsTable reviews={reviews} />
     </div>
   );

--- a/src/app/api/admin/reviews/volume-chart/route.ts
+++ b/src/app/api/admin/reviews/volume-chart/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/db/prisma';
+import { withUserAuthorizedToEdit } from '@/lib/auth';
+import { calculateMeetingDurationMs } from '@/lib/db/utils/meetingDuration';
+import { startOfWeek, subWeeks, format } from 'date-fns';
+
+interface WeekData {
+  week: string;
+  corrected: number;
+  uncorrected: number;
+}
+
+export async function GET() {
+  // Check authentication - admin routes require authorization
+  await withUserAuthorizedToEdit({});
+  
+  try {
+    const now = new Date();
+    const currentWeekStart = startOfWeek(now, { weekStartsOn: 1 }); // Monday
+    const twelveWeeksAgo = subWeeks(currentWeekStart, 11); // 12 weeks including current week
+
+    // Get all meetings from the past 12 weeks with their task statuses and duration
+    const meetings = await prisma.councilMeeting.findMany({
+      where: {
+        dateTime: {
+          gte: twelveWeeksAgo
+        }
+      },
+      include: {
+        taskStatuses: {
+          where: {
+            type: { in: ['transcribe', 'fixTranscript', 'humanReview'] },
+            status: 'succeeded'
+          }
+        },
+        speakerSegments: {
+          include: {
+            utterances: {
+              select: {
+                startTimestamp: true,
+                endTimestamp: true
+              }
+            }
+          }
+        }
+      }
+    });
+
+    // Calculate meeting duration and categorize
+    const meetingsByWeek = new Map<string, { corrected: number; uncorrected: number }>();
+
+    // Initialize all 12 weeks with zero values
+    for (let i = 0; i < 12; i++) {
+      const weekStart = subWeeks(currentWeekStart, 11 - i);
+      const weekKey = format(weekStart, 'yyyy-MM-dd');
+      meetingsByWeek.set(weekKey, { corrected: 0, uncorrected: 0 });
+    }
+
+    for (const meeting of meetings) {
+      // Calculate meeting duration from utterances using shared utility
+      const meetingDurationMs = calculateMeetingDurationMs(meeting);
+
+      if (meetingDurationMs === 0) {
+        continue; // Skip meetings without duration
+      }
+
+      // Determine week
+      const meetingWeekStart = startOfWeek(meeting.dateTime, { weekStartsOn: 1 });
+      const weekKey = format(meetingWeekStart, 'yyyy-MM-dd');
+
+      // Skip if outside our 12-week range
+      if (!meetingsByWeek.has(weekKey)) {
+        continue;
+      }
+
+      // Check task statuses
+      const hasFixTranscript = meeting.taskStatuses.some(
+        t => t.type === 'fixTranscript' && t.status === 'succeeded'
+      );
+      const hasHumanReview = meeting.taskStatuses.some(
+        t => t.type === 'humanReview' && t.status === 'succeeded'
+      );
+
+      // Categorize: corrected = has humanReview, uncorrected = has fixTranscript but no humanReview
+      if (hasHumanReview) {
+        const weekData = meetingsByWeek.get(weekKey)!;
+        weekData.corrected += meetingDurationMs;
+      } else if (hasFixTranscript) {
+        const weekData = meetingsByWeek.get(weekKey)!;
+        weekData.uncorrected += meetingDurationMs;
+      }
+    }
+
+    // Convert to array format
+    const result: WeekData[] = Array.from(meetingsByWeek.entries())
+      .map(([week, data]) => ({
+        week,
+        corrected: data.corrected,
+        uncorrected: data.uncorrected
+      }))
+      .sort((a, b) => a.week.localeCompare(b.week));
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('Error fetching volume chart data:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch volume chart data' },
+      { status: 500 }
+    );
+  }
+}
+

--- a/src/components/admin/reviews/Last30DaysFilter.tsx
+++ b/src/components/admin/reviews/Last30DaysFilter.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Loader2 } from "lucide-react";
+import { useUrlParams } from "@/hooks/useUrlParams";
+
+interface Last30DaysFilterProps {
+  last30Days: boolean;
+}
+
+export function Last30DaysFilter({ last30Days }: Last30DaysFilterProps) {
+  const { updateParam, isPending } = useUrlParams();
+
+  const handleChange = (checked: boolean) => {
+    updateParam('last30Days', checked ? 'true' : 'false');
+  };
+
+  return (
+    <div className="mb-6 p-4 bg-muted/50 rounded-lg border">
+      <div className="flex items-center space-x-3">
+        <Checkbox
+          id="last30Days-top"
+          checked={last30Days}
+          onCheckedChange={handleChange}
+          disabled={isPending}
+          className="h-5 w-5"
+        />
+        <Label
+          htmlFor="last30Days-top"
+          className="text-base font-semibold cursor-pointer select-none"
+        >
+          Show only last 30 days
+        </Label>
+        {isPending && (
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        )}
+      </div>
+      <p className="text-sm text-muted-foreground mt-2 ml-8">
+        This filter affects all metrics and the meeting list below
+      </p>
+    </div>
+  );
+}
+

--- a/src/components/admin/reviews/ReviewFilters.tsx
+++ b/src/components/admin/reviews/ReviewFilters.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { Label } from "@/components/ui/label";
-import { useTransition } from "react";
 import { Loader2 } from "lucide-react";
+import { useUrlParams } from "@/hooks/useUrlParams";
 
 interface ReviewFiltersProps {
   show: 'needsAttention' | 'all' | 'completed';
@@ -13,32 +12,24 @@ interface ReviewFiltersProps {
 }
 
 export function ReviewFilters({ show, reviewerId, reviewers }: ReviewFiltersProps) {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const [isPending, startTransition] = useTransition();
-
-  const updateFilter = (key: string, value: string) => {
-    const params = new URLSearchParams(searchParams);
-    
-    if (value === 'all-reviewers' || value === 'needsAttention') {
-      // Remove the filter if it's the default value
-      params.delete(key);
-    } else {
-      params.set(key, value);
-    }
-
-    startTransition(() => {
-      router.push(`${pathname}?${params.toString()}`);
-    });
-  };
+  const { updateParam, isPending } = useUrlParams();
 
   const handleShowChange = (value: string) => {
-    updateFilter('show', value);
+    // Remove the filter if it's the default value
+    if (value === 'needsAttention') {
+      updateParam('show', null);
+    } else {
+      updateParam('show', value);
+    }
   };
 
   const handleReviewerChange = (value: string) => {
-    updateFilter('reviewerId', value);
+    // Remove the filter if it's the default value
+    if (value === 'all-reviewers') {
+      updateParam('reviewerId', null);
+    } else {
+      updateParam('reviewerId', value);
+    }
   };
 
   return (
@@ -77,6 +68,7 @@ export function ReviewFilters({ show, reviewerId, reviewers }: ReviewFiltersProp
           </SelectContent>
         </Select>
       </div>
+
 
       {isPending && (
         <div className="flex items-end pb-2">

--- a/src/components/admin/reviews/ReviewVolumeChart.tsx
+++ b/src/components/admin/reviews/ReviewVolumeChart.tsx
@@ -11,17 +11,17 @@ import { formatDurationMs } from "@/lib/formatters/time";
 
 interface WeekData {
   week: string;
-  corrected: number;
-  uncorrected: number;
+  reviewed: number;
+  needsReview: number;
 }
 
 const chartConfig: ChartConfig = {
-  corrected: {
-    label: "Corrected",
+  reviewed: {
+    label: "Reviewed",
     color: "hsl(var(--chart-2))",
   },
-  uncorrected: {
-    label: "Uncorrected",
+  needsReview: {
+    label: "Needs Review",
     color: "hsl(var(--chart-1))",
   },
 };
@@ -34,15 +34,16 @@ export function ReviewVolumeChart() {
   const [hasLoaded, setHasLoaded] = useState(false);
 
   // Custom tooltip formatter - memoized to avoid recreating on each render
-  const formatTooltipValue = useCallback((value: number) => {
-    return formatDurationMs(value);
+  const formatTooltipValue = useCallback((value: number | string) => {
+    const numValue = typeof value === 'number' ? value : Number(value);
+    return formatDurationMs(numValue);
   }, []);
 
   useEffect(() => {
     // Only fetch data when expanded and not already loaded
     if (isOpen && !hasLoaded) {
       const abortController = new AbortController();
-      
+
       const fetchData = async () => {
         try {
           setIsLoading(true);
@@ -54,7 +55,7 @@ export function ReviewVolumeChart() {
             throw new Error("Failed to fetch chart data");
           }
           const result = await response.json();
-          
+
           // Check if request was aborted
           if (!abortController.signal.aborted) {
             setData(result);
@@ -102,12 +103,11 @@ export function ReviewVolumeChart() {
             <div className="flex items-center justify-between">
               <div>
                 <CardTitle>Review Volume (12 Weeks)</CardTitle>
-                <CardDescription>Meeting time corrected vs uncorrected</CardDescription>
+                <CardDescription>Meeting time reviewed vs needs review</CardDescription>
               </div>
               <ChevronDown
-                className={`h-5 w-5 text-muted-foreground transition-transform ${
-                  isOpen ? "rotate-180" : ""
-                }`}
+                className={`h-5 w-5 text-muted-foreground transition-transform ${isOpen ? "rotate-180" : ""
+                  }`}
               />
             </div>
           </CardHeader>
@@ -146,23 +146,23 @@ export function ReviewVolumeChart() {
                     <ChartTooltip
                       content={
                         <ChartTooltipContent
-                          formatter={(value: number) => formatTooltipValue(value)}
+                          formatter={(value) => formatTooltipValue(value as number | string)}
                           labelFormatter={(label) => `Week of ${label}`}
                         />
                       }
                     />
                     <Legend />
                     <Bar
-                      dataKey="corrected"
+                      dataKey="reviewed"
                       stackId="a"
-                      fill="var(--color-corrected)"
-                      name="Corrected"
+                      fill="var(--color-reviewed)"
+                      name="Reviewed"
                     />
                     <Bar
-                      dataKey="uncorrected"
+                      dataKey="needsReview"
                       stackId="a"
-                      fill="var(--color-uncorrected)"
-                      name="Uncorrected"
+                      fill="var(--color-needsReview)"
+                      name="Needs Review"
                     />
                   </BarChart>
                 </ResponsiveContainer>

--- a/src/components/admin/reviews/ReviewVolumeChart.tsx
+++ b/src/components/admin/reviews/ReviewVolumeChart.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useEffect, useState, useCallback, useMemo } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartContainer, ChartConfig, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, ResponsiveContainer, Legend } from "recharts";
+import { format, parseISO } from "date-fns";
+import { Loader2, ChevronDown } from "lucide-react";
+import { formatDurationMs } from "@/lib/formatters/time";
+
+interface WeekData {
+  week: string;
+  corrected: number;
+  uncorrected: number;
+}
+
+const chartConfig: ChartConfig = {
+  corrected: {
+    label: "Corrected",
+    color: "hsl(var(--chart-2))",
+  },
+  uncorrected: {
+    label: "Uncorrected",
+    color: "hsl(var(--chart-1))",
+  },
+};
+
+export function ReviewVolumeChart() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [data, setData] = useState<WeekData[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasLoaded, setHasLoaded] = useState(false);
+
+  // Custom tooltip formatter - memoized to avoid recreating on each render
+  const formatTooltipValue = useCallback((value: number) => {
+    return formatDurationMs(value);
+  }, []);
+
+  useEffect(() => {
+    // Only fetch data when expanded and not already loaded
+    if (isOpen && !hasLoaded) {
+      const abortController = new AbortController();
+      
+      const fetchData = async () => {
+        try {
+          setIsLoading(true);
+          setError(null);
+          const response = await fetch("/api/admin/reviews/volume-chart", {
+            signal: abortController.signal
+          });
+          if (!response.ok) {
+            throw new Error("Failed to fetch chart data");
+          }
+          const result = await response.json();
+          
+          // Check if request was aborted
+          if (!abortController.signal.aborted) {
+            setData(result);
+            setHasLoaded(true);
+          }
+        } catch (err) {
+          // Don't set error if request was aborted
+          if (err instanceof Error && err.name === 'AbortError') {
+            return;
+          }
+          console.error("Error fetching volume chart data:", err);
+          if (!abortController.signal.aborted) {
+            setError(err instanceof Error ? err.message : "Failed to load chart data");
+          }
+        } finally {
+          if (!abortController.signal.aborted) {
+            setIsLoading(false);
+          }
+        }
+      };
+
+      fetchData();
+
+      // Cleanup: abort fetch if component unmounts or dependencies change
+      return () => {
+        abortController.abort();
+      };
+    }
+  }, [isOpen, hasLoaded]);
+
+  // Format week labels for display - memoized to avoid recalculation
+  const chartData = useMemo(() => {
+    if (!hasLoaded) return [];
+    return data.map((item) => ({
+      ...item,
+      weekLabel: format(parseISO(item.week), "MMM d"),
+    }));
+  }, [data, hasLoaded]);
+
+  return (
+    <Card>
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsibleTrigger asChild>
+          <CardHeader className="cursor-pointer hover:bg-muted/50 transition-colors">
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle>Review Volume (12 Weeks)</CardTitle>
+                <CardDescription>Meeting time corrected vs uncorrected</CardDescription>
+              </div>
+              <ChevronDown
+                className={`h-5 w-5 text-muted-foreground transition-transform ${
+                  isOpen ? "rotate-180" : ""
+                }`}
+              />
+            </div>
+          </CardHeader>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <CardContent>
+            {isLoading && (
+              <div className="flex items-center justify-center h-[400px]">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+              </div>
+            )}
+            {error && !isLoading && (
+              <div className="flex items-center justify-center h-[400px] text-muted-foreground">
+                <p>Error loading chart: {error}</p>
+              </div>
+            )}
+            {!isLoading && !error && hasLoaded && (
+              <ChartContainer config={chartConfig}>
+                <ResponsiveContainer width="100%" height={400}>
+                  <BarChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="weekLabel"
+                      tick={{ fill: "hsl(var(--muted-foreground))" }}
+                      angle={-45}
+                      textAnchor="end"
+                      height={80}
+                    />
+                    <YAxis
+                      tick={{ fill: "hsl(var(--muted-foreground))" }}
+                      tickFormatter={(value) => {
+                        const hours = Math.floor(value / (1000 * 60 * 60));
+                        return `${hours}h`;
+                      }}
+                    />
+                    <ChartTooltip
+                      content={
+                        <ChartTooltipContent
+                          formatter={(value: number) => formatTooltipValue(value)}
+                          labelFormatter={(label) => `Week of ${label}`}
+                        />
+                      }
+                    />
+                    <Legend />
+                    <Bar
+                      dataKey="corrected"
+                      stackId="a"
+                      fill="var(--color-corrected)"
+                      name="Corrected"
+                    />
+                    <Bar
+                      dataKey="uncorrected"
+                      stackId="a"
+                      fill="var(--color-uncorrected)"
+                      name="Uncorrected"
+                    />
+                  </BarChart>
+                </ResponsiveContainer>
+              </ChartContainer>
+            )}
+          </CardContent>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  );
+}
+

--- a/src/components/admin/reviews/ReviewsTable.tsx
+++ b/src/components/admin/reviews/ReviewsTable.tsx
@@ -78,7 +78,7 @@ export function ReviewsTable({ reviews }: ReviewsTableProps) {
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>City</TableHead>
+            <TableHead>Admin Body</TableHead>
             <TableHead>Meeting</TableHead>
             <TableHead>Status</TableHead>
             <TableHead>
@@ -109,7 +109,12 @@ export function ReviewsTable({ reviews }: ReviewsTableProps) {
           {reviews.map((review) => {
             return (
             <TableRow key={`${review.cityId}-${review.meetingId}`}>
-              <TableCell className="font-medium">{review.cityName}</TableCell>
+              <TableCell className="font-medium">
+                <div>
+                  <div>{review.administrativeBodyName ?? "Χωρίς διοικητικό όργανο"}</div>
+                  <div className="text-xs text-muted-foreground">{review.cityName}</div>
+                </div>
+              </TableCell>
               
               <TableCell>
                 <div>

--- a/src/components/admin/sidebar.tsx
+++ b/src/components/admin/sidebar.tsx
@@ -1,4 +1,4 @@
-import { LayoutDashboard, Users, FileText, Settings, Files, Rocket, UserRound, List, RefreshCw, Search, Bell, QrCode } from "lucide-react";
+import { LayoutDashboard, Users, FileText, Settings, Files, Rocket, UserRound, List, RefreshCw, Search, Bell, QrCode, ClipboardCheck } from "lucide-react";
 import Link from "next/link";
 import {
     Sidebar,
@@ -33,6 +33,11 @@ const menuItems = [
         title: "Meetings",
         icon: FileText,
         url: "/admin/meetings",
+    },
+    {
+        title: "Reviews",
+        icon: ClipboardCheck,
+        url: "/admin/reviews",
     },
     {
         title: "Notifications",

--- a/src/hooks/useUrlParams.ts
+++ b/src/hooks/useUrlParams.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
+
+/**
+ * Custom hook for updating URL search parameters
+ * Provides a consistent way to update URL params with loading state
+ */
+export function useUrlParams() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const updateParam = (key: string, value: string | null) => {
+    const params = new URLSearchParams(searchParams);
+    
+    if (value === null) {
+      params.delete(key);
+    } else {
+      params.set(key, value);
+    }
+
+    startTransition(() => {
+      router.push(`${pathname}?${params.toString()}`);
+    });
+  };
+
+  return {
+    updateParam,
+    isPending,
+    searchParams
+  };
+}
+

--- a/src/lib/db/reviews.ts
+++ b/src/lib/db/reviews.ts
@@ -1,7 +1,6 @@
 'use server'
 import { Prisma } from '@prisma/client';
 import prisma from './prisma';
-import { calculateMeetingDurationMs } from './utils/meetingDuration';
 import { buildDateFilter } from './reviews/dateFilters';
 
 // ============================================================================

--- a/src/lib/db/reviews/dateFilters.ts
+++ b/src/lib/db/reviews/dateFilters.ts
@@ -1,0 +1,25 @@
+import { Prisma } from '@prisma/client';
+
+/**
+ * Build date filter for last 30 days or all past meetings
+ */
+export function buildDateFilter(last30Days: boolean): Prisma.CouncilMeetingWhereInput {
+  const now = new Date();
+  
+  if (last30Days) {
+    const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    return {
+      dateTime: {
+        gte: thirtyDaysAgo,
+        lte: now
+      }
+    };
+  }
+  
+  return {
+    dateTime: {
+      lte: now
+    }
+  };
+}
+

--- a/src/lib/db/utils/meetingDuration.ts
+++ b/src/lib/db/utils/meetingDuration.ts
@@ -1,0 +1,33 @@
+/**
+ * Calculate meeting duration from utterances
+ * Returns duration in milliseconds
+ */
+export function calculateMeetingDurationMs(meeting: {
+    speakerSegments: Array<{
+        utterances: Array<{
+            startTimestamp: number;
+            endTimestamp: number;
+        }>;
+    }>;
+}): number {
+    if (meeting.speakerSegments.length === 0) {
+        return 0;
+    }
+
+    const allTimestamps: number[] = [];
+    meeting.speakerSegments.forEach(segment => {
+        segment.utterances.forEach(utterance => {
+            allTimestamps.push(utterance.startTimestamp);
+            allTimestamps.push(utterance.endTimestamp);
+        });
+    });
+
+    if (allTimestamps.length === 0) {
+        return 0;
+    }
+
+    const minTimestamp = Math.min(...allTimestamps);
+    const maxTimestamp = Math.max(...allTimestamps);
+    return (maxTimestamp - minTimestamp) * 1000; // Convert to ms
+}
+


### PR DESCRIPTION
Solves #160 -- and adds /admin/reviews to the sidebar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a more informative reviews dashboard with historical trends, time-window filtering, and operational metrics.
> 
> - New `ReviewVolumeChart` component with `/api/admin/reviews/volume-chart` endpoint (12-week reviewed vs needsReview durations computed via `calculateMeetingDurationMs`)
> - New `Last30DaysFilter` (URL-param driven via `useUrlParams`) affecting list and metrics
> - `reviews/page.tsx` now fetches all (`show: 'all'`) with optional `reviewerId`/`last30Days`, filters client-side, and shows metric cards (review time needing review, meetings needing upload, scheduled meetings)
> - `getMeetingUploadMetrics` in `lib/db/meetings.ts` + shared `buildDateFilter` for date scoping
> - Review queries updated to use `transcribe` status, support `last30Days`, and include `administrativeBodyName`; safety checks added
> - `ReviewsTable` shows `Admin Body` with city subtitle; sidebar adds `Reviews` link under admin navigation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c13a0fdc27ef0bb12a81d224ebf703009d0c41a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->