### PR TITLE
Make mobile transcript view tolerable

### DIFF
--- a/src/components/meetings/transcript/SpeakerSegment.tsx
+++ b/src/components/meetings/transcript/SpeakerSegment.tsx
@@ -8,7 +8,7 @@ import UtteranceC from "./Utterance";
 import { useTranscriptOptions } from "../options/OptionsContext";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
-import { Plus, Trash2, Bot, FileJson, MessageSquarePlus, ChevronDown, ChevronUp, Copy } from "lucide-react";
+import { Plus, Trash2, FileJson, MessageSquarePlus, ChevronDown, ChevronUp, Copy } from "lucide-react";
 import { getPartyFromRoles, buildUnknownSpeakerLabel, UNKNOWN_SPEAKER_LABEL, formatTimestamp } from "@/lib/utils";
 import { AIGeneratedBadge } from '@/components/AIGeneratedBadge';
 import SpeakerSegmentMetadataDialog from "./SpeakerSegmentMetadataDialog";
@@ -442,10 +442,7 @@ const SpeakerSegment = React.memo(({ segment, renderMock, isFirstSegment }: {
                                                             Διαδικαστικό
                                                         </span>
                                                     )}
-                                                    <div className='flex items-center gap-1 whitespace-nowrap'>
-                                                        <Bot className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
-                                                        <span>Σύνοψη</span>
-                                                    </div>
+                                                        <AIGeneratedBadge className="text-[10px] sm:text-xs whitespace-nowrap" />
                                                 </div>
                                             </div>
                                         </div>

--- a/src/components/meetings/transcript/SpeakerSegment.tsx
+++ b/src/components/meetings/transcript/SpeakerSegment.tsx
@@ -8,7 +8,7 @@ import UtteranceC from "./Utterance";
 import { useTranscriptOptions } from "../options/OptionsContext";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
-import { Plus, Trash2, FileJson, MessageSquarePlus, Copy } from "lucide-react";
+import { Plus, Trash2, Bot, FileJson, MessageSquarePlus, ChevronDown, ChevronUp, Copy } from "lucide-react";
 import { getPartyFromRoles, buildUnknownSpeakerLabel, UNKNOWN_SPEAKER_LABEL, formatTimestamp } from "@/lib/utils";
 import { AIGeneratedBadge } from '@/components/AIGeneratedBadge';
 import SpeakerSegmentMetadataDialog from "./SpeakerSegmentMetadataDialog";
@@ -106,16 +106,16 @@ const EmptySegmentState = ({ segmentId }: { segmentId: string }) => {
     };
 
     return (
-        <div className="px-4 py-8 flex flex-col items-center gap-3 border-2 border-dashed border-muted rounded-md my-2">
-            <MessageSquarePlus className="h-8 w-8 text-muted-foreground" />
-            <p className="text-sm text-muted-foreground">{t('noUtterances')}</p>
-            <Button 
-                onClick={handleAddUtterance} 
-                size="sm" 
+        <div className="px-2 sm:px-4 py-4 sm:py-8 flex flex-col items-center gap-2 sm:gap-3 border-2 border-dashed border-muted rounded-md my-2">
+            <MessageSquarePlus className="h-6 w-6 sm:h-8 sm:w-8 text-muted-foreground" />
+            <p className="text-xs sm:text-sm text-muted-foreground">{t('noUtterances')}</p>
+            <Button
+                onClick={handleAddUtterance}
+                size="sm"
                 variant="outline"
                 disabled={isLoading}
             >
-                <Plus className="h-4 w-4 mr-2" />
+                <Plus className="h-3 w-3 sm:h-4 sm:w-4 mr-1 sm:mr-2" />
                 {isLoading ? t('adding') : t('addUtterance')}
             </Button>
         </div>
@@ -167,10 +167,10 @@ const AddUtteranceButton = ({ segmentId }: { segmentId: string }) => {
     );
 };
 
-const SpeakerSegment = React.memo(({ segment, renderMock, isFirstSegment }: { 
-    segment: TranscriptType[number], 
+const SpeakerSegment = React.memo(({ segment, renderMock, isFirstSegment }: {
+    segment: TranscriptType[number],
     renderMock: boolean,
-    isFirstSegment?: boolean 
+    isFirstSegment?: boolean
 }) => {
     const { getPerson, getSpeakerTag, getSpeakerSegmentCount, people, speakerTags, updateSpeakerTagPerson, updateSpeakerTagLabel, deleteEmptySegment } = useCouncilMeetingData();
     const { currentTime } = useVideo();
@@ -180,6 +180,7 @@ const SpeakerSegment = React.memo(({ segment, renderMock, isFirstSegment }: {
     const tCopy = useTranslations('transcript.copySegment');
     const isSuperAdmin = session?.user?.isSuperAdmin;
     const [metadataDialogOpen, setMetadataDialogOpen] = useState(false);
+    const [isCollapsed, setIsCollapsed] = useState(false);
 
     // Calculate the next unknown speaker label
     const nextUnknownLabel = useMemo(() => {
@@ -250,7 +251,7 @@ const SpeakerSegment = React.memo(({ segment, renderMock, isFirstSegment }: {
                 <AddSegmentBeforeButton segmentId={segment.id} isFirstSegment={true} />
             )}
             
-            <div className='my-6 flex flex-col items-start w-full rounded-r-lg hover:bg-accent/5 transition-colors' style={{ borderLeft: `4px solid ${memoizedData.borderColor}` }}>
+            <div className='my-2 sm:my-6 flex flex-col items-start w-full rounded-r-lg hover:bg-accent/5 transition-colors border-l-[3px] sm:border-l-4' style={{ borderLeftColor: memoizedData.borderColor }}>
                 <div className='w-full'>
                     <div 
                         className='sticky flex flex-row items-center justify-between w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 z-30 transition-all duration-200'
@@ -294,110 +295,153 @@ const SpeakerSegment = React.memo(({ segment, renderMock, isFirstSegment }: {
                                 )}
                             </div>
                         ) : (
-                            <div className='flex flex-col w-full space-y-2 py-2'>
-                                <div className='flex items-center justify-between w-full px-4'>
-                                    <div className='flex-grow overflow-hidden'>
-                                        {memoizedData.speakerTag && (
-                                            <PersonBadge
-                                                person={memoizedData.person}
-                                                speakerTag={memoizedData.speakerTag}
-                                                segmentCount={memoizedData.segmentCount}
-                                                editable={options.editable}
-                                                onPersonChange={handlePersonChange}
-                                                onLabelChange={handleLabelChange}
-                                                nextUnknownLabel={nextUnknownLabel}
-                                                availablePeople={people.map(p => ({
-                                                    ...p,
-                                                    party: getPartyFromRoles(p.roles)
-                                                }))}
-                                            />
-                                        )}
-                                    </div>
-                                    <div className='flex items-center gap-3 ml-4'>
-                                        {options.editable && isEmpty && !renderMock && (
-                                            <Tooltip>
-                                                <TooltipTrigger asChild>
-                                                    <Button
-                                                        variant="ghost"
-                                                        size="icon"
-                                                        className="h-7 w-7 text-destructive hover:text-destructive hover:bg-destructive/10"
-                                                        onClick={() => deleteEmptySegment(segment.id)}
-                                                    >
-                                                        <Trash2 className="h-4 w-4" />
-                                                    </Button>
-                                                </TooltipTrigger>
-                                                <TooltipContent>
-                                                    <p>Delete empty segment</p>
-                                                </TooltipContent>
-                                            </Tooltip>
-                                        )}
-                                        {isSuperAdmin && !renderMock && (
-                                            <Tooltip>
-                                                <TooltipTrigger asChild>
-                                                    <Button
-                                                        variant="ghost"
-                                                        size="icon"
-                                                        className="h-7 w-7 text-muted-foreground hover:text-primary hover:bg-primary/10"
-                                                        onClick={() => setMetadataDialogOpen(true)}
-                                                    >
-                                                        <FileJson className="h-4 w-4" />
-                                                    </Button>
-                                                </TooltipTrigger>
-                                                <TooltipContent>
-                                                    <p>View segment metadata</p>
-                                                </TooltipContent>
-                                            </Tooltip>
-                                        )}
-                                        {!renderMock && (
-                                            <Tooltip>
-                                                <TooltipTrigger asChild>
-                                                    <Button
-                                                        variant="ghost"
-                                                        size="icon"
-                                                        className="h-7 w-7 text-muted-foreground hover:text-primary hover:bg-primary/10"
-                                                        onClick={handleCopySegment}
-                                                    >
-                                                        <Copy className="h-4 w-4" />
-                                                    </Button>
-                                                </TooltipTrigger>
-                                                <TooltipContent>
-                                                    <p>{tCopy('button')}</p>
-                                                </TooltipContent>
-                                            </Tooltip>
-                                        )}
-                                        <div className='flex items-center gap-2 text-xs text-muted-foreground'>
-                                            <span className='font-medium'>{formatTimestamp(segment.startTimestamp)}</span>
-                                        </div>
-                                    </div>
-                                </div>
-                                {summary && (
-                                    <div className='px-4 space-y-2'>
-                                        <div className='text-sm'>
-                                            {summary.text}
-                                        </div>
-                                        <div className='flex items-center justify-between'>
-                                            {segment.topicLabels.length > 0 && (
-                                                <div className='flex flex-wrap gap-2'>
-                                                    {segment.topicLabels.map(tl =>
-                                                        <TopicBadge topic={tl.topic} key={tl.topic.id} />
-                                                    )}
-                                                </div>
+                            <div className='flex flex-col w-full'>
+                                {/* Collapsed header (mobile only, shown when collapsed) */}
+                                {isCollapsed && (
+                                    <button
+                                        onClick={() => setIsCollapsed(false)}
+                                        className='sticky flex md:hidden items-center justify-between w-full px-2.5 py-1.5 hover:bg-accent/20 transition-colors bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 z-30 border-b border-border/40'
+                                        style={{ top: 'var(--banner-offset, 0px)' }}
+                                    >
+                                        <div className='flex items-center gap-2.5 min-w-0 flex-1'>
+                                            {memoizedData.party && (
+                                                <div
+                                                    className="w-2 h-2 rounded-full shrink-0"
+                                                    style={{ backgroundColor: memoizedData.party.colorHex }}
+                                                />
                                             )}
-                                            <div className='flex items-center gap-2 text-xs text-muted-foreground ml-auto'>
-                                                {summary?.type === 'procedural' && (
-                                                    <span className="bg-muted/50 px-1.5 py-0.5 rounded text-[10px] font-medium">
-                                                        Διαδικαστικό
-                                                    </span>
-                                                )}
-                                                <AIGeneratedBadge />
+                                            <span className='text-sm font-medium truncate'>
+                                                {memoizedData.person ? memoizedData.person.name : memoizedData.speakerTag?.label}
+                                            </span>
+                                        </div>
+                                        <div className='flex items-center gap-1.5 shrink-0'>
+                                            <span className='text-[10px] text-muted-foreground font-medium'>
+                                                {formatTimestamp(segment.startTimestamp)}
+                                            </span>
+                                            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                                        </div>
+                                    </button>
+                                )}
+
+                                {/* Full header (always on desktop, conditional on mobile) */}
+                                <div className={`${isCollapsed ? 'hidden md:flex' : 'flex'} flex-col w-full space-y-2 py-2`}>
+                                    <div className='flex items-center justify-between w-full px-2.5 sm:px-4 gap-2'>
+                                        <div className='flex-grow overflow-hidden min-w-0'>
+                                            {memoizedData.speakerTag && (
+                                                <PersonBadge
+                                                    person={memoizedData.person}
+                                                    speakerTag={memoizedData.speakerTag}
+                                                    segmentCount={memoizedData.segmentCount}
+                                                    editable={options.editable}
+                                                    onPersonChange={handlePersonChange}
+                                                    onLabelChange={handleLabelChange}
+                                                    nextUnknownLabel={nextUnknownLabel}
+                                                    availablePeople={people.map(p => ({
+                                                        ...p,
+                                                        party: getPartyFromRoles(p.roles)
+                                                    }))}
+                                                    size="sm"
+                                                />
+                                            )}
+                                        </div>
+                                        <div className='flex items-center gap-1.5 sm:gap-3 shrink-0'>
+                                            {/* Manual collapse button (mobile only) */}
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                className="h-7 w-7 md:hidden"
+                                                onClick={() => setIsCollapsed(true)}
+                                            >
+                                                <ChevronUp className="h-4 w-4" />
+                                            </Button>
+                                            {options.editable && isEmpty && !renderMock && (
+                                                <Tooltip>
+                                                    <TooltipTrigger asChild>
+                                                        <Button
+                                                            variant="ghost"
+                                                            size="icon"
+                                                            className="h-7 w-7 text-destructive hover:text-destructive hover:bg-destructive/10"
+                                                            onClick={() => deleteEmptySegment(segment.id)}
+                                                        >
+                                                            <Trash2 className="h-4 w-4" />
+                                                        </Button>
+                                                    </TooltipTrigger>
+                                                    <TooltipContent>
+                                                        <p>Delete empty segment</p>
+                                                    </TooltipContent>
+                                                </Tooltip>
+                                            )}
+                                            {isSuperAdmin && !renderMock && (
+                                                <Tooltip>
+                                                    <TooltipTrigger asChild>
+                                                        <Button
+                                                            variant="ghost"
+                                                            size="icon"
+                                                            className="h-7 w-7 text-muted-foreground hover:text-primary hover:bg-primary/10"
+                                                            onClick={() => setMetadataDialogOpen(true)}
+                                                        >
+                                                            <FileJson className="h-4 w-4" />
+                                                        </Button>
+                                                    </TooltipTrigger>
+                                                    <TooltipContent>
+                                                        <p>View segment metadata</p>
+                                                    </TooltipContent>
+                                                </Tooltip>
+                                            )}
+                                            {!renderMock && (
+                                                <Tooltip>
+                                                    <TooltipTrigger asChild>
+                                                        <Button
+                                                            variant="ghost"
+                                                            size="icon"
+                                                            className="h-7 w-7 text-muted-foreground hover:text-primary hover:bg-primary/10"
+                                                            onClick={handleCopySegment}
+                                                        >
+                                                            <Copy className="h-4 w-4" />
+                                                        </Button>
+                                                    </TooltipTrigger>
+                                                    <TooltipContent>
+                                                        <p>{tCopy('button')}</p>
+                                                    </TooltipContent>
+                                                </Tooltip>
+                                            )}
+                                            <div className='flex items-center gap-2 text-[10px] sm:text-xs text-muted-foreground'>
+                                                <span className='font-medium whitespace-nowrap'>{formatTimestamp(segment.startTimestamp)}</span>
                                             </div>
                                         </div>
                                     </div>
-                                )}
+                                    {summary && (
+                                        <div className='px-2.5 sm:px-4 space-y-2'>
+                                            <div className='text-xs sm:text-sm'>
+                                                {summary.text}
+                                            </div>
+                                            <div className='flex flex-col gap-2'>
+                                                {segment.topicLabels.length > 0 && (
+                                                    <div className='flex flex-wrap gap-1.5'>
+                                                        {segment.topicLabels.map(tl =>
+                                                            <TopicBadge topic={tl.topic} key={tl.topic.id} />
+                                                        )}
+                                                    </div>
+                                                )}
+                                                <div className='flex items-center gap-2 text-[10px] sm:text-xs text-muted-foreground'>
+                                                    {summary?.type === 'procedural' && (
+                                                        <span className="bg-muted/50 px-1.5 py-0.5 rounded text-[9px] sm:text-[10px] font-medium whitespace-nowrap">
+                                                            Διαδικαστικό
+                                                        </span>
+                                                    )}
+                                                    <div className='flex items-center gap-1 whitespace-nowrap'>
+                                                        <Bot className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
+                                                        <span>Σύνοψη</span>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
                             </div>
                         )}
                     </div>
-                    <div className='font-mono px-4 py-3 text-justify w-full leading-relaxed group'>
+                    <div className='font-mono px-2.5 sm:px-4 py-1.5 sm:py-3 text-left sm:text-justify w-full leading-relaxed group text-sm sm:text-base'>
                         {utterances.length === 0 && options.editable && !renderMock ? (
                             <EmptySegmentState segmentId={segment.id} />
                         ) : renderMock ? (

--- a/src/components/meetings/transcript/SpeakerSegment.tsx
+++ b/src/components/meetings/transcript/SpeakerSegment.tsx
@@ -303,17 +303,12 @@ const SpeakerSegment = React.memo(({ segment, renderMock, isFirstSegment }: {
                                         className='sticky flex md:hidden items-center justify-between w-full px-2.5 py-1.5 hover:bg-accent/20 transition-colors bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 z-30 border-b border-border/40'
                                         style={{ top: 'var(--banner-offset, 0px)' }}
                                     >
-                                        <div className='flex items-center gap-2.5 min-w-0 flex-1'>
-                                            {memoizedData.party && (
-                                                <div
-                                                    className="w-2 h-2 rounded-full shrink-0"
-                                                    style={{ backgroundColor: memoizedData.party.colorHex }}
-                                                />
-                                            )}
-                                            <span className='text-sm font-medium truncate'>
-                                                {memoizedData.person ? memoizedData.person.name : memoizedData.speakerTag?.label}
-                                            </span>
-                                        </div>
+                                        <PersonBadge
+                                            person={memoizedData.person}
+                                            speakerTag={memoizedData.speakerTag}
+                                            variant="inline"
+                                            className="flex-1 min-w-0"
+                                        />
                                         <div className='flex items-center gap-1.5 shrink-0'>
                                             <span className='text-[10px] text-muted-foreground font-medium'>
                                                 {formatTimestamp(segment.startTimestamp)}

--- a/src/components/meetings/transcript/Topic.tsx
+++ b/src/components/meetings/transcript/Topic.tsx
@@ -5,16 +5,16 @@ import { Topic } from "@prisma/client";
 export default function TopicBadge({ topic, count, className, size = "default" }: { topic: Topic, count?: number, className?: string, size?: "default" | "compact" }) {
     const sizeClasses = size === "compact"
         ? "mt-0 py-0.5 px-1.5 gap-1.5"
-        : "mt-2 py-1 px-2 gap-2";
-    const textSize = size === "compact" ? "text-xs" : "text-sm";
-    const dotSize = size === "compact" ? "w-1.5 h-1.5" : "w-2 h-2";
+        : "mt-1 sm:mt-2 py-0.5 sm:py-1 px-1.5 sm:px-2 gap-1 sm:gap-2";
+    const textSize = size === "compact" ? "text-xs" : "text-[10px] sm:text-sm";
+    const dotSize = size === "compact" ? "w-1.5 h-1.5" : "w-1.5 h-1.5 sm:w-2 sm:h-2";
 
     return (
         <div className={cn("inline-flex items-center rounded-full", sizeClasses, className)} style={{ backgroundColor: topic.colorHex + '20' }}>
-            <div className={cn("rounded-full", dotSize)} style={{ backgroundColor: topic.colorHex }} />
-            <span className={textSize} style={{ color: topic.colorHex }}>{topic.name}</span>
+            <div className={cn("rounded-full shrink-0", dotSize)} style={{ backgroundColor: topic.colorHex }} />
+            <span className={cn("truncate", textSize)} style={{ color: topic.colorHex }}>{topic.name}</span>
             {count !== undefined && (
-                <span className="text-xs" style={{ color: topic.colorHex }}>({count})</span>
+                <span className="text-[9px] sm:text-xs shrink-0" style={{ color: topic.colorHex }}>({count})</span>
             )}
         </div>
     );

--- a/src/components/meetings/transcript/Transcript.tsx
+++ b/src/components/meetings/transcript/Transcript.tsx
@@ -174,7 +174,7 @@ export default function Transcript() {
     }
 
     return (
-        <div className="container" ref={containerRef} style={isUnverified ? { '--banner-offset': bannerHeight } as React.CSSProperties : undefined}>
+        <div className="container px-2 sm:px-4 md:px-6" ref={containerRef} style={isUnverified ? { '--banner-offset': bannerHeight } as React.CSSProperties : undefined}>
             {isUnverified && (
                 <UnverifiedTranscriptBanner 
                     isScrolled={isScrolled}

--- a/src/components/persons/PersonBadge.tsx
+++ b/src/components/persons/PersonBadge.tsx
@@ -14,6 +14,13 @@ import { Button } from "../ui/button";
 import { PersonWithRelations } from '@/lib/db/people';
 import { RoleDisplay } from './RoleDisplay';
 
+// Helper function to switch name order (reverses word order for display)
+const switchOrder = (name: string | undefined) => {
+    if (!name) return null;
+    const parts = name.split(' ');
+    return parts.length > 1 ? parts.reverse().join(' ') : name;
+};
+
 interface PersonDisplayProps {
     person?: PersonWithRelations;
     speakerTag?: SpeakerTag;
@@ -40,12 +47,6 @@ function PersonDisplay({ person, speakerTag, segmentCount, short = false, prefer
     };
 
     const imageSize = imageSizes[size];
-
-    const switchOrder = (name: string | undefined) => {
-        if (!name) return null;
-        const parts = name.split(' ');
-        return parts.length > 1 ? parts.reverse().join(' ') : name;
-    };
 
     const nameTextSize = size === 'lg' || size === 'xl' ? 'text-lg' : 'text-base';
     const roleTextSize = size === 'sm' ? 'text-xs' : 'text-sm';
@@ -123,6 +124,7 @@ interface PersonBadgeProps extends PersonDisplayProps {
     onLabelChange?: (label: string) => void;
     availablePeople?: PersonWithRelations[];
     nextUnknownLabel?: string;
+    variant?: 'default' | 'inline';
 }
 
 function PersonBadge({
@@ -140,6 +142,7 @@ function PersonBadge({
     nextUnknownLabel,
     preferFullName = false,
     size = 'md',
+    variant = 'default',
 }: PersonBadgeProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
@@ -166,6 +169,28 @@ function PersonBadge({
             router.push(`/${person.cityId}/people/${person.id}`);
         }
     };
+
+    // Inline variant - minimal display with just party dot and name
+    if (variant === 'inline') {
+        const party = person ? getPartyFromRoles(person.roles) : null;
+        return (
+            <div className={cn("flex items-center gap-2.5 min-w-0", className)}>
+                {party && (
+                    <div
+                        className="w-2 h-2 rounded-full shrink-0"
+                        style={{ backgroundColor: party.colorHex }}
+                    />
+                )}
+                <span className="text-sm font-medium truncate">
+                    {person ? (
+                        preferFullName ? person.name : switchOrder(person.name)
+                    ) : (
+                        speakerTag?.label
+                    )}
+                </span>
+            </div>
+        );
+    }
 
     const badge = (
         <div

--- a/src/components/persons/PersonBadge.tsx
+++ b/src/components/persons/PersonBadge.tsx
@@ -51,14 +51,14 @@ function PersonDisplay({ person, speakerTag, segmentCount, short = false, prefer
     const roleTextSize = size === 'sm' ? 'text-xs' : 'text-sm';
 
     return (
-        <div className="flex items-center gap-3 w-full">
+        <div className="flex items-center gap-3 w-full min-w-0">
             <div
                 className={cn(
                     "relative shrink-0",
-                    size === 'sm' && "w-10 h-10",
-                    size === 'md' && "w-12 h-12",
-                    size === 'lg' && "w-16 h-16",
-                    size === 'xl' && "w-24 h-24",
+                    size === 'sm' && "w-8 h-8 sm:w-10 sm:h-10",
+                    size === 'md' && "w-10 h-10 sm:w-12 sm:h-12",
+                    size === 'lg' && "w-12 h-12 sm:w-16 sm:h-16",
+                    size === 'xl' && "w-16 h-16 sm:w-24 sm:h-24",
                     !editable && "cursor-pointer"
                 )}
                 onClick={onClick}
@@ -86,28 +86,28 @@ function PersonDisplay({ person, speakerTag, segmentCount, short = false, prefer
             </div>
             {!short && (
                 <div className="flex flex-col justify-center min-w-0 flex-1">
-                    <div className={cn("font-medium text-foreground break-words", nameTextSize)}>
+                    <div className={cn("font-medium text-foreground truncate sm:whitespace-normal sm:break-words", nameTextSize, size === 'sm' && "text-sm sm:text-base")}>
                         {person ? (
                             preferFullName ? person.name : switchOrder(person.name)
                         ) : (
                             speakerTag?.label
                         )}
                         {editable && segmentCount !== undefined && (
-                            <span className="ml-2 text-muted-foreground font-normal">
+                            <span className="hidden sm:inline ml-2 text-muted-foreground font-normal">
                                 ({segmentCount} {segmentCount === 1 ? 'segment' : 'segments'})
                             </span>
                         )}
                     </div>
 
                     {/* Display roles using RoleDisplay component */}
-                    <div className="mt-1.5">
+                    <div className="mt-0.5 sm:mt-1.5">
                         <RoleDisplay
                             roles={activeRoles}
                             size={size === 'sm' ? 'sm' : 'md'}
-                            layout="inline"
-                            showIcons={true}
+                            layout="compact"
+                            showIcons={false}
                             borderless={true}
-                            className={roleTextSize}
+                            className={cn(roleTextSize, "text-[10px] sm:text-xs")}
                         />
                     </div>
                 </div>
@@ -170,7 +170,7 @@ function PersonBadge({
     const badge = (
         <div
             className={cn(
-                "relative flex items-center gap-2 rounded-lg p-2",
+                "relative flex items-center gap-2 rounded-lg p-1.5 sm:p-2 min-w-0",
                 withBorder && "border",
                 isSelected && "bg-accent",
                 editable && "cursor-pointer hover:bg-accent/50",
@@ -199,13 +199,13 @@ function PersonBadge({
                 <Button
                     variant="ghost"
                     size="icon"
-                    className="shrink-0 h-8 w-8 ml-auto"
+                    className="shrink-0 h-6 w-6 sm:h-8 sm:w-8 ml-auto"
                     onClick={(e) => {
                         e.stopPropagation();
                         setIsOpen(true);
                     }}
                 >
-                    <Edit2 className="h-4 w-4" />
+                    <Edit2 className="h-3 w-3 sm:h-4 sm:w-4" />
                 </Button>
             )}
         </div>

--- a/src/components/persons/RoleDisplay.tsx
+++ b/src/components/persons/RoleDisplay.tsx
@@ -99,48 +99,44 @@ export function RoleDisplay({
         const primaryRole = roles.find(r => r.isHead) || roles[0];
 
         return (
-            <div className={cn("flex items-center", sizeClasses[size], className)}>
+            <div className={cn("flex items-center min-w-0", sizeClasses[size], className)}>
                 {primaryRole.partyId && primaryRole.party ? (
                     <Link
                         href={`/${primaryRole.city?.id || primaryRole.party.cityId}/parties/${primaryRole.party.id}`}
-                        className="no-underline hover:no-underline unstyled"
+                        className="no-underline hover:no-underline unstyled min-w-0"
                     >
                         <Badge
                             variant="secondary"
                             className={cn(
-                                "flex items-center gap-1.5 text-muted-foreground hover:bg-accent cursor-pointer font-normal",
+                                "flex items-center gap-1 sm:gap-1.5 text-muted-foreground hover:bg-accent cursor-pointer font-normal px-1.5 sm:px-2.5 py-0.5 sm:py-1 max-w-full",
                                 borderless && "border-0 bg-muted/50 hover:bg-muted"
                             )}
                         >
-                            <div className="flex items-center gap-1.5 w-6 flex-shrink-0">
+                            <div className="flex items-center gap-0.5 sm:gap-1 shrink-0">
                                 <div
-                                    className="w-2 h-2 rounded-full flex-shrink-0"
+                                    className="w-1.5 h-1.5 sm:w-2 sm:h-2 rounded-full shrink-0"
                                     style={{ backgroundColor: primaryRole.party.colorHex }}
                                 />
-                                <div className="w-3 h-3 flex items-center justify-center">
-                                    {showIcons && primaryRole.isHead && (
-                                        <Star className="w-3 h-3 text-[#fc550a]" />
-                                    )}
-                                </div>
+                                {showIcons && primaryRole.isHead && (
+                                    <Star className="w-2 h-2 sm:w-3 sm:h-3 text-[#fc550a]" />
+                                )}
                             </div>
                             <span className={cn(
-                                "truncate",
+                                "truncate min-w-0",
                                 borderless && "text-sm"
                             )}>
                                 {primaryRole.party.name_short}
-                                {primaryRole.isHead && ' (Επικ.)'}
+                                {primaryRole.isHead && <span className="hidden sm:inline"> (Επικ.)</span>}
                             </span>
                         </Badge>
                     </Link>
                 ) : (
-                    <div className="flex items-center gap-1.5">
-                        <div className="w-3 h-3 flex items-center justify-center flex-shrink-0">
-                            {showIcons && primaryRole.isHead && (
-                                <Star className="w-3 h-3 text-[#fc550a]" />
-                            )}
-                        </div>
+                    <div className="flex items-center gap-1 sm:gap-1.5 min-w-0">
+                        {showIcons && primaryRole.isHead && (
+                            <Star className="w-2 h-2 sm:w-3 sm:h-3 text-[#fc550a] shrink-0" />
+                        )}
                         <span className={cn(
-                            "text-muted-foreground truncate",
+                            "text-muted-foreground truncate min-w-0",
                             borderless && "text-sm"
                         )}>
                             {getRoleText(primaryRole)}


### PR DESCRIPTION
We should get back to mobile friendliness in general -- but currently /<cityId>/<meetingId>/transcript is intolerable on mobile. This PR makes it usable at least:

- Add collapsible speaker segment headers on mobile (manual expand/collapse)
- Reduce horizontal padding and margins throughout (px-2 vs px-4)
- Use compact role display layout showing only primary role
- Reduce font sizes and component sizes for mobile screens
- Make topic badges smaller with tighter spacing
- Stack summary metadata vertically on mobile instead of horizontally
- Reduce speaker segment vertical spacing (my-2 vs my-6)
- Smaller profile images and icons on mobile
- Collapsed headers stick to top for easy access

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only responsiveness changes; main risk is minor layout/regression issues on different breakpoints rather than data or security impact.
> 
> **Overview**
> Makes the meeting transcript view usable on mobile by **collapsing speaker segment headers by default on small screens** with a sticky, tap-to-expand header and manual expand/collapse controls.
> 
> Tightens mobile layout throughout the transcript (reduced paddings/margins, smaller fonts/icons/avatars, left-aligned body text) and adjusts metadata presentation (topics/AI/procedural badges stacked and truncated). Also adds an `inline` variant to `PersonBadge` and updates `RoleDisplay`/`TopicBadge` styling to better fit narrow viewports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10161be75f1f17181de56a83128aabaf9d08f72c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->