### PR TITLE
feat: make consultations tab editable in CityForm

### DIFF
--- a/messages/el.json
+++ b/messages/el.json
@@ -85,6 +85,8 @@
         "statusListed": "Καταχωρημένη",
         "supportsNotifications": "Υποστήριξη Ειδοποιήσεων",
         "supportsNotificationsDescription": "Ενεργοποίηση εγγραφής και διαχείρισης ειδοποιήσεων για τους πολίτες.",
+        "consultationsEnabled": "Ενεργοποίηση Διαβουλεύσεων",
+        "consultationsEnabledDescription": "Ενεργοποίηση της καρτέλας δημόσιων διαβουλεύσεων για αυτήν την πόλη",
         "administrativeBodies": "Διοικητικά Όργανα",
         "municipality": "Δήμος",
         "region": "Περιφέρεια",

--- a/messages/en.json
+++ b/messages/en.json
@@ -81,6 +81,11 @@
         "highlightCreationAdminsOnly": "Admins Only",
         "highlightCreationEveryone": "Everyone",
         "highlightCreationPermissionDescription": "Control who can create highlights for this city",
+        "supportsNotifications": "Enable Notifications",
+        "supportsNotificationsDescription": "Enable email and SMS notifications for meetings in this city",
+        "consultationsEnabled": "Enable Consultations",
+        "consultationsEnabledDescription": "Enable the public consultations tab for this city",
+        "administrativeBodies": "Administrative Bodies",
         "CityMessageForm": {
             "sectionTitle": "City Message",
             "toggle": "Toggle city message",

--- a/src/app/api/cities/[cityId]/route.ts
+++ b/src/app/api/cities/[cityId]/route.ts
@@ -36,6 +36,7 @@ export async function PUT(request: Request, { params }: { params: { cityId: stri
     const logoImage = formData.get('logoImage') as File | null
     const authorityType = (formData.get('authorityType') as 'municipality' | 'region') || 'municipality'
     const supportsNotifications = formData.get('supportsNotifications') === 'true'
+    const consultationsEnabled = formData.get('consultationsEnabled') === 'true'
     const peopleOrdering = formData.get('peopleOrdering') as 'default' | 'partyRank' | null
     const highlightCreationPermission = formData.get('highlightCreationPermission') as 'ADMINS_ONLY' | 'EVERYONE' | null
 
@@ -89,6 +90,7 @@ export async function PUT(request: Request, { params }: { params: { cityId: stri
             authorityType: 'municipality' | 'region'
             officialSupport?: boolean
             supportsNotifications?: boolean
+            consultationsEnabled?: boolean
             status?: 'pending' | 'unlisted' | 'listed'
             highlightCreationPermission?: 'ADMINS_ONLY' | 'EVERYONE'
         } = {
@@ -100,6 +102,7 @@ export async function PUT(request: Request, { params }: { params: { cityId: stri
             ...(logoImageUrl && { logoImage: logoImageUrl }),
             authorityType,
             supportsNotifications,
+            consultationsEnabled,
             ...(peopleOrdering && { peopleOrdering }),
             ...(highlightCreationPermission && { highlightCreationPermission })
         }

--- a/src/app/api/cities/route.ts
+++ b/src/app/api/cities/route.ts
@@ -59,6 +59,7 @@ export async function POST(request: Request) {
     const officialSupport = formData.get('officialSupport') === 'true'
     const status = (formData.get('status') as 'pending' | 'unlisted' | 'listed') || 'pending'
     const supportsNotifications = formData.get('supportsNotifications') === 'true'
+    const consultationsEnabled = formData.get('consultationsEnabled') === 'true'
     const highlightCreationPermission = (formData.get('highlightCreationPermission') as 'ADMINS_ONLY' | 'EVERYONE') || 'ADMINS_ONLY'
 
     if (!id || !name || !name_en || !name_municipality || !name_municipality_en || !timezone || !logoImage) {
@@ -85,7 +86,7 @@ export async function POST(request: Request) {
             authorityType,
             wikipediaId: null,
             supportsNotifications,
-            consultationsEnabled: false,
+            consultationsEnabled,
             peopleOrdering: 'default',
             highlightCreationPermission
         })

--- a/src/components/cities/CityForm.tsx
+++ b/src/components/cities/CityForm.tsx
@@ -57,6 +57,7 @@ const formSchema = z.object({
     officialSupport: z.boolean().default(false),
     status: z.enum(['pending', 'unlisted', 'listed']).default('pending'),
     supportsNotifications: z.boolean(),
+    consultationsEnabled: z.boolean(),
     peopleOrdering: z.enum(['default', 'partyRank']).optional(),
     highlightCreationPermission: z.enum(['ADMINS_ONLY', 'EVERYONE']).default('ADMINS_ONLY')
 })
@@ -131,6 +132,7 @@ export default function CityForm({ city, cityMessage, onSuccess }: CityFormProps
             officialSupport: city?.officialSupport || false,
             status: city?.status || 'pending',
             supportsNotifications: city?.supportsNotifications || false,
+            consultationsEnabled: city?.consultationsEnabled || false,
             peopleOrdering: city?.peopleOrdering || "default",
             highlightCreationPermission: city?.highlightCreationPermission || 'ADMINS_ONLY'
         },
@@ -162,6 +164,7 @@ export default function CityForm({ city, cityMessage, onSuccess }: CityFormProps
         formData.append('officialSupport', values.officialSupport.toString())
         formData.append('status', values.status)
         formData.append('supportsNotifications', values.supportsNotifications.toString())
+        formData.append('consultationsEnabled', values.consultationsEnabled.toString())
         formData.append('highlightCreationPermission', values.highlightCreationPermission)
         if (values.peopleOrdering) {
             formData.append('peopleOrdering', values.peopleOrdering)
@@ -424,6 +427,28 @@ export default function CityForm({ city, cityMessage, onSuccess }: CityFormProps
                                         </FormLabel>
                                         <FormDescription>
                                             {t('supportsNotificationsDescription')}
+                                        </FormDescription>
+                                    </div>
+                                    <FormControl>
+                                        <Switch
+                                            checked={field.value}
+                                            onCheckedChange={field.onChange}
+                                        />
+                                    </FormControl>
+                                </FormItem>
+                            )}
+                        />
+                        <FormField
+                            control={form.control}
+                            name="consultationsEnabled"
+                            render={({ field }) => (
+                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                                    <div className="space-y-0.5">
+                                        <FormLabel className="text-base">
+                                            {t('consultationsEnabled')}
+                                        </FormLabel>
+                                        <FormDescription>
+                                            {t('consultationsEnabledDescription')}
                                         </FormDescription>
                                     </div>
                                     <FormControl>


### PR DESCRIPTION
made with paidaki

- Add consultationsEnabled switch to CityForm Details section
- Update form schema to include consultationsEnabled field
- Save consultationsEnabled in both POST and PUT API routes
- Add translations for consultationsEnabled in en.json and el.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a city-level toggle for public consultations visibility.
> 
> - Adds `consultationsEnabled` switch to `CityForm` (schema, defaults, form submission)
> - Updates `POST /api/cities` and `PUT /api/cities/[cityId]` to accept and persist `consultationsEnabled`
> - Updates translations in `en.json` and `el.json` for the new setting (and related admin labels)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22c34087dfc035c21ca02743ec447127945f8223. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->