### PR TITLE
Add copy segment functionality

### DIFF
--- a/messages/el/transcript.json
+++ b/messages/el/transcript.json
@@ -61,5 +61,10 @@
         "pause": "Παύση",
         "seekTo": "Μετάβαση",
         "transcript": "Απομαγνητοφώνηση"
+    },
+    "copySegment": {
+        "button": "Αντιγραφή τμήματος",
+        "segmentCopied": "Το τμήμα αντιγράφηκε",
+        "copySourceAttribution": "Αντιγράφηκε από το OpenCouncil · opencouncil.gr"
     }
 }

--- a/messages/en/transcript.json
+++ b/messages/en/transcript.json
@@ -61,5 +61,10 @@
     "pause": "Pause",
     "seekTo": "Seek to",
     "transcript": "Transcript"
+  },
+  "copySegment": {
+    "button": "Copy segment",
+    "segmentCopied": "Segment copied",
+    "copySourceAttribution": "Copied from OpenCouncil · opencouncil.gr"
   }
 }

--- a/src/components/meetings/transcript/SpeakerSegment.tsx
+++ b/src/components/meetings/transcript/SpeakerSegment.tsx
@@ -8,12 +8,13 @@ import UtteranceC from "./Utterance";
 import { useTranscriptOptions } from "../options/OptionsContext";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
-import { Plus, Trash2, FileJson, MessageSquarePlus } from "lucide-react";
+import { Plus, Trash2, FileJson, MessageSquarePlus, Copy } from "lucide-react";
 import { getPartyFromRoles, buildUnknownSpeakerLabel, UNKNOWN_SPEAKER_LABEL, formatTimestamp } from "@/lib/utils";
 import { AIGeneratedBadge } from '@/components/AIGeneratedBadge';
 import SpeakerSegmentMetadataDialog from "./SpeakerSegmentMetadataDialog";
 import { useSession } from 'next-auth/react';
 import { useTranslations } from 'next-intl';
+import { useToast } from '@/hooks/use-toast';
 
 const AddSegmentButton = ({ segmentId }: { segmentId: string }) => {
     const { createEmptySegmentAfter } = useCouncilMeetingData();
@@ -175,6 +176,8 @@ const SpeakerSegment = React.memo(({ segment, renderMock, isFirstSegment }: {
     const { currentTime } = useVideo();
     const { options } = useTranscriptOptions();
     const { data: session } = useSession();
+    const { toast } = useToast();
+    const tCopy = useTranslations('transcript.copySegment');
     const isSuperAdmin = session?.user?.isSuperAdmin;
     const [metadataDialogOpen, setMetadataDialogOpen] = useState(false);
 
@@ -229,6 +232,15 @@ const SpeakerSegment = React.memo(({ segment, renderMock, isFirstSegment }: {
         if (memoizedData.speakerTag) {
             updateSpeakerTagLabel(memoizedData.speakerTag.id, label);
         }
+    };
+
+    const handleCopySegment = () => {
+        const mainText = segment.utterances.map(u => u.text).join(' ');
+        const attribution = tCopy('copySourceAttribution');
+        const text = mainText ? `${mainText}\n\n${attribution}` : attribution;
+        navigator.clipboard.writeText(text).then(() => {
+            toast({ description: tCopy('segmentCopied') });
+        }).catch(console.error);
     };
 
     return (
@@ -333,6 +345,23 @@ const SpeakerSegment = React.memo(({ segment, renderMock, isFirstSegment }: {
                                                 </TooltipTrigger>
                                                 <TooltipContent>
                                                     <p>View segment metadata</p>
+                                                </TooltipContent>
+                                            </Tooltip>
+                                        )}
+                                        {!renderMock && (
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="h-7 w-7 text-muted-foreground hover:text-primary hover:bg-primary/10"
+                                                        onClick={handleCopySegment}
+                                                    >
+                                                        <Copy className="h-4 w-4" />
+                                                    </Button>
+                                                </TooltipTrigger>
+                                                <TooltipContent>
+                                                    <p>{tCopy('button')}</p>
                                                 </TooltipContent>
                                             </Tooltip>
                                         )}


### PR DESCRIPTION
- Introduced a new feature to copy segments of utterances to the clipboard.
- Added corresponding translations for the copy segment button and success message in both English and Greek.
- Enhanced the SpeakerSegment component with a new button for copying segment text, improving user experience. fixes #151

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that uses the browser clipboard API and adds i18n strings; main risk is clipboard availability/permissions or minor UX issues.
> 
> **Overview**
> Adds a **Copy segment** action to `SpeakerSegment` that concatenates the segment’s utterance text, appends an OpenCouncil attribution line, copies it to the clipboard, and shows a localized success toast.
> 
> Introduces new `transcript.copySegment` translations in `messages/en/transcript.json` and `messages/el/transcript.json` for the button label, success message, and attribution text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a322f3a3558abb32bd11abfb0d2291192fade00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->