### PR TITLE
fix: support both role patterns in validation

### DIFF
--- a/docs/roles.prd.md
+++ b/docs/roles.prd.md
@@ -4,10 +4,10 @@ This document describes the Role model in OpenCouncil and how it relates to Peop
 
 ## Current Schema
 
-The Role model connects a Person to:
-- A City (e.g. as Mayor)
-- A Party (e.g. as Party Member) 
-- An Administrative Body (e.g. as Committee Chair)
+The Role model connects a Person to one of three entity types:
+- **City** (city-level roles like "Mayor")
+- **Party** (party membership)
+- **Administrative Body** (committee/community membership)
 
 Key characteristics:
 - Each Person can have multiple roles
@@ -15,7 +15,66 @@ Key characteristics:
 - Roles have both Greek and English names (name, name_en)
 - Roles can be marked as "head" positions (isHead)
 - Roles can have start and end dates
-- All roles are tied to a specific City
+
+## Role Data Model - Flexible Patterns
+
+The system supports two valid patterns for storing roles. Both patterns are valid and can coexist in the same database.
+
+### Pattern A: Explicit City Scope (Recommended)
+
+In this pattern, **all roles include `cityId`** to specify the city context. The role type is determined by which additional field is set:
+
+- **City-level role**: Only `cityId` is set
+  - Example: `{cityId: "athens", partyId: null, administrativeBodyId: null}` → Mayor of Athens
+
+- **Party role**: `cityId` + `partyId` are set
+  - Example: `{cityId: "athens", partyId: "partyA", administrativeBodyId: null}` → Member of Party A in Athens
+
+- **Administrative Body role**: `cityId` + `administrativeBodyId` are set
+  - Example: `{cityId: "athens", partyId: null, administrativeBodyId: "community5"}` → Member of 5th Municipal Community
+
+**Advantages**:
+- Simpler queries (no need to join through Party/AdministrativeBody to get city)
+- Consistent data pattern
+- Explicit city context for all roles
+
+### Pattern B: Implicit City Scope
+
+In this pattern, only city-level roles have `cityId` set. Party and administrative body roles derive the city from the entity:
+
+- **City-level role**: Only `cityId` is set
+  - Example: `{cityId: "athens", partyId: null, administrativeBodyId: null}` → Mayor of Athens
+
+- **Party role**: Only `partyId` is set (city derived from `Party.cityId`)
+  - Example: `{cityId: null, partyId: "partyA", administrativeBodyId: null}` → Member of Party A
+
+- **Administrative Body role**: Only `administrativeBodyId` is set (city derived from `AdministrativeBody.cityId`)
+  - Example: `{cityId: null, partyId: null, administrativeBodyId: "community5"}` → Member of 5th Municipal Community
+
+**Advantages**:
+- More normalized (no redundant cityId)
+- Clear semantic distinction (cityId = city-level role)
+
+### Validation Rules (Both Patterns)
+
+1. A role **cannot** have both `partyId` and `administrativeBodyId` set
+2. If `cityId` is set, it must match the person's current city context
+3. City-level roles (no party/admin body) **must** have `cityId`
+4. Party and administrative body entities must belong to the current city
+5. The unique constraint `@@unique([personId, cityId, partyId, administrativeBodyId])` ensures:
+   - One city-level role per person per city
+   - One party role per person per (city, party) pair
+   - One admin body role per person per (city, admin body) pair
+
+### Recommendation
+
+**Use Pattern A (Explicit City Scope)** for new code:
+- Provides consistency
+- Simplifies queries
+- Makes the city context explicit
+- The import script (`scripts/insert_athens_communities.ts`) uses this pattern
+
+Pattern B is supported for backward compatibility.
 
 ## Migration from Legacy Schema
 

--- a/src/lib/utils/roles.ts
+++ b/src/lib/utils/roles.ts
@@ -258,10 +258,15 @@ export function getNonPartyRoles(roles: (Role & { party?: Party | null })[], dat
 export function getSingleCityRole(roles: (Role & { cityId?: string | null })[], date?: Date, administrativeBodyId?: string): Role | null {
   const checkDate = date || new Date();
   const filteredRoles = getNonPartyRoles(roles, checkDate, administrativeBodyId);
-  // If administrativeBodyId was provided, getNonPartyRoles already filtered for it
-  // If not provided, we want city-level roles (no admin body)
-  // In both cases, just return the first filtered role (no need to filter by cityId)
-  return filteredRoles.length > 0 ? filteredRoles[0] : null;
+
+  if (administrativeBodyId) {
+    // If looking for a specific admin body role, return the first match
+    return filteredRoles.length > 0 ? filteredRoles[0] : null;
+  }
+
+  // Otherwise, we want city-level roles (no admin body)
+  const cityLevelRoles = filteredRoles.filter(role => !role.administrativeBodyId);
+  return cityLevelRoles.length > 0 ? cityLevelRoles[0] : null;
 }
 
 /**


### PR DESCRIPTION
fixes not being able to edit municipal community members due to role validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request-time validation for creating/updating people and changes role selection behavior used in downstream outputs; mistakes could reject valid edits or label roles incorrectly.
> 
> **Overview**
> Fixes person create/update role validation to support *both* role storage patterns (explicit `cityId` on all roles vs implicit `cityId` only for city-level roles), unblocking edits for municipal community members.
> 
> Role validation logic is centralized into a new `validateRoles` helper and reused by both `POST /cities/[cityId]/people` and `PUT /cities/[cityId]/people/[personId]`. `getSingleCityRole` is adjusted to correctly return an administrative-body role when a body id is provided, otherwise returning a true city-level (non-party, non-admin-body) role.
> 
> Documentation (`docs/roles.prd.md`) is expanded to describe the two supported patterns and the shared validation rules, recommending explicit city scope for new code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f123ed88c220d212f629906a1e691547640be0d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->