### PR TITLE
Remove stale initdb copy from db Dockerfile

### DIFF
--- a/db/Dockerfile.db
+++ b/db/Dockerfile.db
@@ -2,6 +2,3 @@ ARG POSTGIS_IMAGE=postgis/postgis:16-3.5
 
 # Use the PostGIS image as the base
 FROM ${POSTGIS_IMAGE}
-
-# Copy initialization scripts
-COPY ./docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/

--- a/db/docker-entrypoint-initdb.d/README.md
+++ b/db/docker-entrypoint-initdb.d/README.md
@@ -1,2 +1,0 @@
-This directory holds optional SQL or shell scripts that PostgreSQL runs at container startup.
-Currently empty; kept to satisfy Docker build context and allow future init scripts.


### PR DESCRIPTION
## Summary
- remove the COPY of docker-entrypoint-initdb.d that referenced a deleted entrypoint directory
- drop the placeholder initdb folder since it is no longer needed

## Problem
The db Dockerfile still tried to copy ./docker-entrypoint-initdb.d into the image even though we previously removed our custom entrypoint directory. Builds failed with:
```
failed to compute cache key: failed to calculate checksum ... "/docker-entrypoint-initdb.d": not found
```

## Fix
Delete the stale COPY step and remove the now-unused directory. The image now builds using the upstream PostGIS defaults.

## Testing
- docker build ./db -f db/Dockerfile.db --build-arg POSTGIS_IMAGE=imresamu/postgis:16-3.5
- ./run.sh (uses POSTGIS_IMAGE auto-detection)