### PR TITLE
Fix performance issues

### DIFF
--- a/prisma/migrations/20260203145120_add_utterance_indices/migration.sql
+++ b/prisma/migrations/20260203145120_add_utterance_indices/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "Utterance_discussionSubjectId_idx" ON "Utterance"("discussionSubjectId");
+
+-- CreateIndex
+CREATE INDEX "Utterance_discussionStatus_idx" ON "Utterance"("discussionStatus");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -303,8 +303,11 @@ model Utterance {
   words Word[]
   highlightedUtterances HighlightedUtterance[]
   podcastPartAudioUtterances PodcastPartAudioUtterance[]
-  @@index([speakerSegmentId, startTimestamp])
   utteranceEdits UtteranceEdit[]
+
+  @@index([speakerSegmentId, startTimestamp])
+  @@index([discussionSubjectId])
+  @@index([discussionStatus])
 }
 
 enum DiscussionStatus {

--- a/src/components/meetings/CouncilMeetingDataContext.tsx
+++ b/src/components/meetings/CouncilMeetingDataContext.tsx
@@ -48,6 +48,7 @@ export function CouncilMeetingDataProvider({ children, data }: {
     const [highlights, setHighlights] = useState(data.highlights);
     const speakerTagsMap = useMemo(() => new Map(speakerTags.map(tag => [tag.id, tag])), [speakerTags]);
     const speakerSegmentsMap = useMemo(() => new Map(transcript.map(segment => [segment.id, segment])), [transcript]);
+    const highlightsMap = useMemo(() => new Map(highlights.map(h => [h.id, h])), [highlights]);
 
     // Helper function to recalculate segment timestamps based on utterances
     const recalculateSegmentTimestamps = useCallback((utterances: Array<{ startTimestamp: number; endTimestamp: number }>) => {
@@ -93,8 +94,8 @@ export function CouncilMeetingDataProvider({ children, data }: {
     }, []);
 
     const getHighlight = useCallback((highlightId: string) => {
-        return highlights.find(h => h.id === highlightId);
-    }, [highlights]);
+        return highlightsMap.get(highlightId);
+    }, [highlightsMap]);
 
     const contextValue = useMemo(() => ({
         ...data,

--- a/src/components/meetings/EditingContext.tsx
+++ b/src/components/meetings/EditingContext.tsx
@@ -22,7 +22,7 @@ export function EditingProvider({ children }: { children: ReactNode }) {
     const [lastClickedUtteranceId, setLastClickedUtteranceId] = useState<string | null>(null);
     const [isProcessing, setIsProcessing] = useState(false);
     
-    const { transcript, extractSpeakerSegment } = useCouncilMeetingData();
+    const { transcript, extractSpeakerSegment, getSpeakerSegmentById } = useCouncilMeetingData();
     const { toast } = useToast();
     const t = useTranslations('editing.toasts');
 
@@ -100,7 +100,7 @@ export function EditingProvider({ children }: { children: ReactNode }) {
             const endUtteranceId = allUtterances[indices[indices.length - 1]].id;
 
             // Validate extraction leaves utterances before and after (A-B-A pattern)
-            const originalSegment = transcript.find(s => s.id === targetSegmentId);
+            const originalSegment = getSpeakerSegmentById(targetSegmentId);
             if (originalSegment) {
                 const totalUtterances = originalSegment.utterances.length;
                 const segmentStartIndex = originalSegment.utterances.findIndex(u => u.id === startUtteranceId);

--- a/src/components/meetings/HighlightContext.tsx
+++ b/src/components/meetings/HighlightContext.tsx
@@ -80,7 +80,7 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
   const [lastClickedAction, setLastClickedAction] = useState<'add' | 'remove' | null>(null);
   
   // Get transcript and speaker data from CouncilMeetingDataContext
-  const { transcript, getSpeakerTag, getPerson, meeting, addHighlight, updateHighlight } = useCouncilMeetingData();
+  const { transcript, getSpeakerTag, getPerson, getSpeakerSegmentById, meeting, addHighlight, updateHighlight } = useCouncilMeetingData();
   const { currentTime, seekTo, isPlaying, setIsPlaying, seekToAndPlay } = useVideo();
   const router = useRouter();
   const pathname = usePathname();
@@ -111,7 +111,7 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
       highlight.highlightedUtterances.forEach(hu => {
         const utterance = utteranceMap.get(hu.utteranceId);
         if (utterance) {
-          const segment = transcript.find(s => s.id === utterance.speakerSegmentId);
+          const segment = getSpeakerSegmentById(utterance.speakerSegmentId);
           const speakerTag = segment ? getSpeakerTag(segment.speakerTagId) : null;
           const person = speakerTag?.personId ? getPerson(speakerTag.personId) : undefined;
           const speakerName = person ? person.name_short : speakerTag?.label || 'Unknown';

--- a/src/components/meetings/Subjects.tsx
+++ b/src/components/meetings/Subjects.tsx
@@ -17,7 +17,7 @@ import { formatTimestamp } from "@/lib/utils";
 type AllocationOption = 'onlyMention' | 'skip' | 1 | 2 | 3 | 5;
 
 export default function Subjects() {
-    const { subjects, getSpeakerTag, getPerson, getParty, transcript } = useCouncilMeetingData();
+    const { subjects, getSpeakerTag, getPerson, getParty, getSpeakerSegmentById } = useCouncilMeetingData();
     const [expandedSubjects, setExpandedSubjects] = useState<string[]>([]);
     const { seekTo } = useVideo();
     const { options } = useTranscriptOptions();
@@ -49,7 +49,7 @@ export default function Subjects() {
     };
 
     const handleSpeakerClick = (speakerSegmentId: string) => {
-        const segment = transcript.find(s => s.id === speakerSegmentId);
+        const segment = getSpeakerSegmentById(speakerSegmentId);
         if (segment) {
             seekTo(segment.startTimestamp);
         }
@@ -119,14 +119,14 @@ export default function Subjects() {
                                 <ul className="space-y-2">
                                     {subject.speakerSegments
                                         .sort((a, b) => {
-                                            const aTimestamp = transcript.find(s => s.id === a.speakerSegment.id)?.startTimestamp || 0;
-                                            const bTimestamp = transcript.find(s => s.id === b.speakerSegment.id)?.startTimestamp || 0;
+                                            const aTimestamp = getSpeakerSegmentById(a.speakerSegment.id)?.startTimestamp || 0;
+                                            const bTimestamp = getSpeakerSegmentById(b.speakerSegment.id)?.startTimestamp || 0;
                                             return aTimestamp - bTimestamp;
                                         })
                                         .map(segment => {
                                             const speakerTag = getSpeakerTag(segment.speakerSegment.speakerTagId);
                                             const person = speakerTag?.personId ? getPerson(speakerTag.personId) : null;
-                                            const segmentTimestamp = transcript.find(s => s.id === segment.speakerSegment.id)?.startTimestamp;
+                                            const segmentTimestamp = getSpeakerSegmentById(segment.speakerSegment.id)?.startTimestamp;
                                             return (
                                                 <li key={segment.id} className="text-sm">
                                                     <div onClick={() => handleSpeakerClick(segment.speakerSegment.id)} className="cursor-pointer flex items-center">

--- a/src/components/meetings/subject/VotingSection.tsx
+++ b/src/components/meetings/subject/VotingSection.tsx
@@ -3,7 +3,6 @@ import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import { useCouncilMeetingData } from '../CouncilMeetingDataContext';
 import { UtteranceMiniTranscript } from './UtteranceMiniTranscript';
-import type { Utterance } from '@prisma/client';
 
 interface VotingUtterance {
     id: string;
@@ -39,7 +38,7 @@ interface VotingSectionProps {
 export function VotingSection({ subjectId }: VotingSectionProps) {
     const [votingUtterances, setVotingUtterances] = useState<VotingUtterance[] | null>(null);
     const [loading, setLoading] = useState(true);
-    const { transcript, meeting } = useCouncilMeetingData();
+    const { meeting, getSpeakerSegmentById } = useCouncilMeetingData();
     const t = useTranslations('Subject');
 
     useEffect(() => {
@@ -95,8 +94,7 @@ export function VotingSection({ subjectId }: VotingSectionProps) {
             </p>
             <div className="space-y-3">
                 {Array.from(utterancesBySegment.entries()).map(([segmentId, segmentVotingUtterances]) => {
-                    // Find the speaker segment in transcript
-                    const transcriptSegment = transcript.find(seg => seg.id === segmentId);
+                    const transcriptSegment = getSpeakerSegmentById(segmentId);
                     if (!transcriptSegment) return null;
 
                     const targetUtteranceIds = segmentVotingUtterances.map(u => u.id);

--- a/src/lib/getMeetingData.ts
+++ b/src/lib/getMeetingData.ts
@@ -44,9 +44,14 @@ export const getMeetingData = async (cityId: string, meetingId: string): Promise
         statistics: await getStatisticsFor({ subjectId: subject.id }, ["person", "party"])
     })));
 
-    const speakerTags: SpeakerTag[] = Array.from(new Set(transcript.map((segment) => segment.speakerTag.id)))
-        .map(id => transcript.find(s => s.speakerTag.id === id)?.speakerTag)
-        .filter((tag): tag is NonNullable<typeof tag> => tag !== undefined);
+    // Extract unique speaker tags in O(n) using Map
+    const speakerTagsMap = new Map<string, SpeakerTag>();
+    for (const segment of transcript) {
+        if (!speakerTagsMap.has(segment.speakerTag.id)) {
+            speakerTagsMap.set(segment.speakerTag.id, segment.speakerTag);
+        }
+    }
+    const speakerTags = Array.from(speakerTagsMap.values());
 
     return { 
         meeting, 


### PR DESCRIPTION
  - Add missing database indexes on Utterance.discussionSubjectId and discussionStatus                                    
  - Skip loading topicLabels relation when statistics don't group by topic                                                
  - Replace array.find() with Map lookups across meeting page components                                         

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily performance-focused query/include changes and in-memory lookup refactors; main risk is subtle data-shape differences when `topicLabels` are intentionally not loaded.
> 
> **Overview**
> Improves meeting-page performance by **adding DB indexes** for `Utterance.discussionSubjectId` and `Utterance.discussionStatus`, and wiring them into Prisma via new `@@index` entries.
> 
> Reduces CPU/DB work in hot paths: `getStatisticsFor` now conditionally loads `topicLabels` only when grouping by topic, `getMeetingData` dedupes `speakerTags` in O(n), and several meeting UI contexts/components replace repeated `array.find()` scans with memoized `Map` lookups (e.g., `getSpeakerSegmentById`, `getHighlight`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc5c13c8e6b18b4b2ba34ee240bc31110c7a677d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->