### PR TITLE
perf: batch statistics queries and cache meeting sub-queries

### DIFF
--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
@@ -11,7 +11,7 @@ import { formatDate } from 'date-fns';
 import { el, enUS } from 'date-fns/locale';
 import EditButton from '@/components/meetings/EditButton';
 import ShareDropdown from '@/components/meetings/ShareDropdown';
-import { getMeetingDataCached } from '@/lib/cache';
+import { getMeetingDataCached } from '@/lib/getMeetingData';
 import { NavigationEvents } from '@/components/meetings/NavigationEvents';
 
 import { HighlightModeBar } from '@/components/meetings/HighlightModeBar';

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import Subject from "@/components/meetings/subject/subject";
-import { getMeetingDataCached, getSubjectFromMeetingCached } from "@/lib/cache";
+import { getMeetingDataCached, getSubjectFromMeetingCached } from "@/lib/getMeetingData";
 import { notFound } from "next/navigation";
 
 export async function generateMetadata({

--- a/src/app/api/cities/[cityId]/meetings/[meetingId]/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/[meetingId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { revalidatePath, revalidateTag } from 'next/cache';
-import { getMeetingData } from '@/lib/getMeetingData';
+import { getMeetingDataCore } from '@/lib/getMeetingData';
 import { editCouncilMeeting } from '@/lib/db/meetings';
 import { z } from 'zod';
 import { withUserAuthorizedToEdit } from '@/lib/auth';
@@ -34,7 +34,7 @@ export async function GET(
     { params }: { params: { cityId: string; meetingId: string } }
 ) {
     try {
-        const data = await getMeetingData(params.cityId, params.meetingId);
+        const data = await getMeetingDataCore(params.cityId, params.meetingId);
         return NextResponse.json({ ...data });
     } catch (error) {
         // TODO: Brittle string match — refactor getMeetingData to return null instead of throwing

--- a/src/components/admin/meetings/BulkExportActions.tsx
+++ b/src/components/admin/meetings/BulkExportActions.tsx
@@ -12,7 +12,7 @@ import {
     generateMeetingFileName, 
     downloadFile
 } from "@/lib/export/meetings";
-import { MeetingData } from "@/lib/getMeetingData";
+import { MeetingDataCore } from "@/lib/getMeetingData";
 import { useToast } from '@/hooks/use-toast';
 
 interface BulkExportActionsProps {
@@ -41,7 +41,7 @@ export function BulkExportActions({
     const selectedMeetings = meetings.filter(meeting => selectedMeetingIds.has(meeting.id));
     const hasSelectedMeetings = selectedMeetingIds.size > 0;
 
-    const fetchCompleteMeetingData = async (meetingId: string): Promise<MeetingData> => {
+    const fetchCompleteMeetingData = async (meetingId: string): Promise<MeetingDataCore> => {
         const response = await fetch(`/api/cities/${selectedCityId}/meetings/${meetingId}`);
         if (!response.ok) {
             throw new Error(`Failed to fetch meeting data for ${meetingId}`);

--- a/src/components/admin/meetings/ExpandableMeetingRow.tsx
+++ b/src/components/admin/meetings/ExpandableMeetingRow.tsx
@@ -18,7 +18,7 @@ import {
     ListChecks
 } from "lucide-react";
 import { MeetingExportButtons } from "@/components/meetings/MeetingExportButtons";
-import { MeetingData } from "@/lib/getMeetingData";
+import { MeetingDataCore } from "@/lib/getMeetingData";
 import { ExpandableTableRow } from "@/components/ui/expandable-table-row";
 import { MeetingStatusBadge } from "@/components/meetings/MeetingStatusBadge";
 import Link from "next/link";
@@ -42,7 +42,7 @@ export function ExpandableMeetingRow({
     const subjectCount = meeting.subjects.length;
     const meetingDate = format(new Date(meeting.dateTime), "MMM dd, yyyy");
 
-    const fetchCompleteMeetingData = async (): Promise<MeetingData> => {
+    const fetchCompleteMeetingData = async (): Promise<MeetingDataCore> => {
         const response = await fetch(`/api/cities/${selectedCityId}/meetings/${meeting.id}`);
         if (!response.ok) {
             throw new Error('Failed to fetch meeting data');

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -1,32 +1,48 @@
 import { unstable_cache } from 'next/cache';
 
 /**
- * Creates a cached version of a function with logging
- * 
- * @param fn The function to cache
- * @param keyParts Parts that make up the cache key
- * @param options Options for the cache including tags
- * @returns A cached version of the function
+ * Creates a cached version of a function with logging.
+ * Logs CACHE HIT or CACHE MISS with timing for each call.
+ *
+ * IMPORTANT: Always use as `createCache(...)()` (create and immediately invoke).
+ * Do NOT store the returned function and reuse it across requests — the `wasMiss`
+ * flag is shared within the closure and will produce incorrect HIT/MISS logs
+ * under concurrent access.
  */
 export function createCache<T>(
   fn: () => Promise<T>,
   keyParts: string[],
   options?: { tags?: string[]; }
 ): () => Promise<T> {
-  return unstable_cache(
+  const key = keyParts.join(':');
+  let wasMiss = false;
+
+  const cached = unstable_cache(
     async () => {
+      wasMiss = true;
       const start = performance.now();
       try {
         const result = await fn();
-        const duration = (performance.now() - start) / 1000;
-        console.log(`CACHE MISS: [${keyParts.join(':')}] ${duration.toFixed(2)}s`);
+        const ms = (performance.now() - start).toFixed(0);
+        console.log(`  MISS [${key}] ${ms}ms`);
         return result;
       } catch (error) {
-        console.error(`[${keyParts.join(':')}] ERROR:`, error);
+        console.error(`  ERR  [${key}]`, error);
         throw error;
       }
     },
     keyParts,
     options
   );
+
+  return async () => {
+    wasMiss = false;
+    const start = performance.now();
+    const result = await cached();
+    const ms = (performance.now() - start).toFixed(0);
+    if (!wasMiss) {
+      console.log(`  HIT  [${key}] ${ms}ms`);
+    }
+    return result;
+  };
 }

--- a/src/lib/cache/queries.ts
+++ b/src/lib/cache/queries.ts
@@ -6,29 +6,37 @@ import { getCouncilMeetingsForCity } from "@/lib/db/meetings";
 import { getPartiesForCity } from "@/lib/db/parties";
 import { getPeopleForCity } from "@/lib/db/people";
 import { getAdministrativeBodiesForCity } from "@/lib/db/administrativeBodies";
-import { getMeetingData, MeetingData } from "@/lib/getMeetingData";
+import { getMeetingDataCore, MeetingData } from "@/lib/getMeetingData";
+import { getHighlightsForMeeting } from "@/lib/db/highlights";
 import { getMeetingStatus } from "@/lib/meetingStatus";
 import { createCache } from "./index";
 import { fetchLatestSubstackPost } from "@/lib/db/landing";
 
 /**
- * Cached version of getMeetingData that fetches and caches all data for a meeting.
- * User-specific highlight visibility is handled internally via getCurrentUser(),
- * and cache() is request-scoped so each user gets their own cached results.
+ * Cached version of getMeetingData that composes:
+ * 1. Core data (sub-queries individually cached inside getMeetingDataCore)
+ * 2. Fresh user-specific highlights (fetched per-request)
+ *
+ * Outer React cache() deduplicates within a single request (layout calls this 3x).
+ * Note: the transcript is NOT cached (too large for 2MB unstable_cache limit),
+ * but all other sub-queries are individually cached inside getMeetingDataCore.
  */
 export const getMeetingDataCached = cache(async (
   cityId: string,
   meetingId: string
 ): Promise<MeetingData | null> => {
   const startTime = performance.now();
-  console.log(`Fetching meeting data for`, cityId, meetingId);
 
   try {
-    const data = await getMeetingData(cityId, meetingId);
-    console.log(`Got meeting data in ${performance.now() - startTime}ms`);
-    return data;
+    const [core, highlights] = await Promise.all([
+      getMeetingDataCore(cityId, meetingId),
+      getHighlightsForMeeting(cityId, meetingId)
+    ]);
+    const ms = (performance.now() - startTime).toFixed(0);
+    console.log(`getMeetingDataCached ${cityId}/${meetingId} done in ${ms}ms (${highlights.length} highlights)`);
+    return { ...core, highlights };
   } catch (error) {
-    console.error(`Error fetching meeting data for ${cityId}/${meetingId}:`, error);
+    console.error(`getMeetingDataCached ${cityId}/${meetingId} ERROR:`, error);
     return null;
   }
 });

--- a/src/lib/cache/queries.ts
+++ b/src/lib/cache/queries.ts
@@ -1,4 +1,3 @@
-import { cache } from "react";
 import { isUserAuthorizedToEdit } from "@/lib/auth";
 import { getCity, getAllCitiesMinimal, getSupportedCitiesWithLogos } from "@/lib/db/cities";
 import { getCityMessage } from "@/lib/db/cityMessages";
@@ -6,54 +5,9 @@ import { getCouncilMeetingsForCity } from "@/lib/db/meetings";
 import { getPartiesForCity } from "@/lib/db/parties";
 import { getPeopleForCity } from "@/lib/db/people";
 import { getAdministrativeBodiesForCity } from "@/lib/db/administrativeBodies";
-import { getMeetingDataCore, MeetingData } from "@/lib/getMeetingData";
-import { getHighlightsForMeeting } from "@/lib/db/highlights";
 import { getMeetingStatus } from "@/lib/meetingStatus";
 import { createCache } from "./index";
 import { fetchLatestSubstackPost } from "@/lib/db/landing";
-
-/**
- * Cached version of getMeetingData that composes:
- * 1. Core data (sub-queries individually cached inside getMeetingDataCore)
- * 2. Fresh user-specific highlights (fetched per-request)
- *
- * Outer React cache() deduplicates within a single request (layout calls this 3x).
- * Note: the transcript is NOT cached (too large for 2MB unstable_cache limit),
- * but all other sub-queries are individually cached inside getMeetingDataCore.
- */
-export const getMeetingDataCached = cache(async (
-  cityId: string,
-  meetingId: string
-): Promise<MeetingData | null> => {
-  const startTime = performance.now();
-
-  try {
-    const [core, highlights] = await Promise.all([
-      getMeetingDataCore(cityId, meetingId),
-      getHighlightsForMeeting(cityId, meetingId)
-    ]);
-    const ms = (performance.now() - startTime).toFixed(0);
-    console.log(`getMeetingDataCached ${cityId}/${meetingId} done in ${ms}ms (${highlights.length} highlights)`);
-    return { ...core, highlights };
-  } catch (error) {
-    console.error(`getMeetingDataCached ${cityId}/${meetingId} ERROR:`, error);
-    return null;
-  }
-});
-
-/**
- * Helper function to get a specific subject from cached meeting data
- */
-export async function getSubjectFromMeetingCached(cityId: string, meetingId: string, subjectId: string) {
-  const meetingData = await getMeetingDataCached(cityId, meetingId);
-
-  if (!meetingData) {
-    return null;
-  }
-
-  const subject = meetingData.subjects.find(s => s.id === subjectId);
-  return subject || null;
-}
 
 /**
  * Cached version of getCity that fetches and caches basic city data

--- a/src/lib/getMeetingData.ts
+++ b/src/lib/getMeetingData.ts
@@ -1,9 +1,10 @@
 import { getCouncilMeeting } from '@/lib/db/meetings';
 import { getTranscript, Transcript } from '@/lib/db/transcript';
 import { CityWithGeometry, getCity } from '@/lib/db/cities';
-import { getPeopleForCity, PersonWithRelations } from '@/lib/db/people';
-import { getPartiesForCity } from '@/lib/db/parties';
-import { HighlightWithUtterances } from '@/lib/db/highlights';
+import { PersonWithRelations } from '@/lib/db/people';
+import { getHighlightsForMeeting, HighlightWithUtterances } from '@/lib/db/highlights';
+import { cache } from 'react';
+import { getPeopleForCityCached, getPartiesForCityCached } from '@/lib/cache/queries';
 import { getSubjectsForMeeting, SubjectWithRelations } from '@/lib/db/subject';
 import { getBatchStatisticsForSubjects, Statistics } from '@/lib/statistics';
 import { getMeetingTaskStatus, MeetingTaskStatus } from '@/lib/db/tasks';
@@ -54,16 +55,8 @@ export const getMeetingDataCore = async (cityId: string, meetingId: string): Pro
             ['city', cityId, 'withGeometry'],
             cityTags
         )(),
-        createCache(
-            () => getPeopleForCity(cityId),
-            ['city', cityId, 'people'],
-            { tags: ['city', `city:${cityId}`, `city:${cityId}:people`] }
-        )(),
-        createCache(
-            () => getPartiesForCity(cityId),
-            ['city', cityId, 'parties'],
-            { tags: ['city', `city:${cityId}`, `city:${cityId}:parties`] }
-        )(),
+        getPeopleForCityCached(cityId),
+        getPartiesForCityCached(cityId),
         createCache(
             () => getSubjectsForMeeting(cityId, meetingId),
             ['city', cityId, 'meeting', meetingId, 'subjects'],
@@ -113,4 +106,47 @@ export const getMeetingDataCore = async (cityId: string, meetingId: string): Pro
         speakerTags,
         taskStatus
     };
+}
+
+/**
+ * Cached version of getMeetingData that composes:
+ * 1. Core data (sub-queries individually cached inside getMeetingDataCore)
+ * 2. Fresh user-specific highlights (fetched per-request)
+ *
+ * Outer React cache() deduplicates within a single request (layout calls this 3x).
+ * Note: the transcript is NOT cached (too large for 2MB unstable_cache limit),
+ * but all other sub-queries are individually cached inside getMeetingDataCore.
+ */
+export const getMeetingDataCached = cache(async (
+  cityId: string,
+  meetingId: string
+): Promise<MeetingData | null> => {
+  const startTime = performance.now();
+
+  try {
+    const [core, highlights] = await Promise.all([
+      getMeetingDataCore(cityId, meetingId),
+      getHighlightsForMeeting(cityId, meetingId)
+    ]);
+    const ms = (performance.now() - startTime).toFixed(0);
+    console.log(`getMeetingDataCached ${cityId}/${meetingId} done in ${ms}ms (${highlights.length} highlights)`);
+    return { ...core, highlights };
+  } catch (error) {
+    console.error(`getMeetingDataCached ${cityId}/${meetingId} ERROR:`, error);
+    return null;
+  }
+});
+
+/**
+ * Helper function to get a specific subject from cached meeting data
+ */
+export async function getSubjectFromMeetingCached(cityId: string, meetingId: string, subjectId: string) {
+  const meetingData = await getMeetingDataCached(cityId, meetingId);
+
+  if (!meetingData) {
+    return null;
+  }
+
+  const subject = meetingData.subjects.find(s => s.id === subjectId);
+  return subject || null;
 }

--- a/src/lib/getMeetingData.ts
+++ b/src/lib/getMeetingData.ts
@@ -3,46 +3,96 @@ import { getTranscript, Transcript } from '@/lib/db/transcript';
 import { CityWithGeometry, getCity } from '@/lib/db/cities';
 import { getPeopleForCity, PersonWithRelations } from '@/lib/db/people';
 import { getPartiesForCity } from '@/lib/db/parties';
-import { getHighlightsForMeeting, HighlightWithUtterances } from '@/lib/db/highlights';
+import { HighlightWithUtterances } from '@/lib/db/highlights';
 import { getSubjectsForMeeting, SubjectWithRelations } from '@/lib/db/subject';
-import { getStatisticsFor, Statistics } from '@/lib/statistics';
+import { getBatchStatisticsForSubjects, Statistics } from '@/lib/statistics';
 import { getMeetingTaskStatus, MeetingTaskStatus } from '@/lib/db/tasks';
-import { CouncilMeeting, SpeakerTag, TaskStatus } from '@prisma/client';
+import { createCache } from '@/lib/cache';
+import { CouncilMeeting, SpeakerTag } from '@prisma/client';
 import { Party } from '@prisma/client';
 
-export type MeetingData = {
+const EMPTY_STATISTICS: Statistics = {
+    speakingSeconds: 0,
+    people: [],
+    parties: [],
+    topics: []
+};
+
+export type MeetingDataCore = {
     meeting: CouncilMeeting;
     transcript: Transcript;
     city: CityWithGeometry;
     people: PersonWithRelations[];
     parties: Party[];
-    highlights: HighlightWithUtterances[];
     subjects: (SubjectWithRelations & { statistics?: Statistics })[];
     speakerTags: SpeakerTag[];
     taskStatus: MeetingTaskStatus;
 }
 
-export const getMeetingData = async (cityId: string, meetingId: string): Promise<MeetingData> => {
-    console.log('getting meeting data for', cityId, meetingId);
-    const [meeting, transcript, city, people, parties, highlights, subjects, taskStatus] = await Promise.all([
+export type MeetingData = MeetingDataCore & {
+    highlights: HighlightWithUtterances[];
+}
+
+/**
+ * Fetches all meeting data except user-specific highlights.
+ * Individual sub-queries are cached with unstable_cache where possible.
+ * The meeting query and transcript are NOT cached (auth + size constraints).
+ */
+export const getMeetingDataCore = async (cityId: string, meetingId: string): Promise<MeetingDataCore> => {
+    console.log(`getMeetingDataCore ${cityId}/${meetingId}`);
+    const meetingTags = { tags: ['city', `city:${cityId}`, `city:${cityId}:meetings`, `city:${cityId}:meeting:${meetingId}`] };
+    const cityTags = { tags: ['city', `city:${cityId}`, `city:${cityId}:basic`] };
+
+    const [meeting, transcript, city, people, parties, subjects, taskStatus] = await Promise.all([
+        // Meeting query is NOT cached — it calls isUserAuthorizedToEdit (uses headers())
+        // to allow admins to view unreleased meetings. It's a fast PK lookup anyway.
         getCouncilMeeting(cityId, meetingId),
+        // Transcript is NOT cached — too large for the 2MB unstable_cache limit
         getTranscript(meetingId, cityId),
-        getCity(cityId, { includeGeometry: true }),
-        getPeopleForCity(cityId),
-        getPartiesForCity(cityId),
-        getHighlightsForMeeting(cityId, meetingId),
-        getSubjectsForMeeting(cityId, meetingId),
-        getMeetingTaskStatus(cityId, meetingId)
+        createCache(
+            () => getCity(cityId, { includeGeometry: true }),
+            ['city', cityId, 'withGeometry'],
+            cityTags
+        )(),
+        createCache(
+            () => getPeopleForCity(cityId),
+            ['city', cityId, 'people'],
+            { tags: ['city', `city:${cityId}`, `city:${cityId}:people`] }
+        )(),
+        createCache(
+            () => getPartiesForCity(cityId),
+            ['city', cityId, 'parties'],
+            { tags: ['city', `city:${cityId}`, `city:${cityId}:parties`] }
+        )(),
+        createCache(
+            () => getSubjectsForMeeting(cityId, meetingId),
+            ['city', cityId, 'meeting', meetingId, 'subjects'],
+            meetingTags
+        )(),
+        createCache(
+            () => getMeetingTaskStatus(cityId, meetingId),
+            ['city', cityId, 'meeting', meetingId, 'taskStatus'],
+            meetingTags
+        )()
     ]);
 
     if (!meeting || !city || !transcript || !subjects) {
         throw new Error('Required data not found');
     }
 
-    const subjectsWithStatistics = await Promise.all(subjects.map(async (subject) => ({
+    // Cache statistics as a plain object (Map doesn't JSON-serialize)
+    const statisticsRecord = await createCache(
+        async () => {
+            const map = await getBatchStatisticsForSubjects(subjects.map(s => s.id), meeting.dateTime);
+            return Object.fromEntries(map);
+        },
+        ['city', cityId, 'meeting', meetingId, 'subjectStatistics'],
+        meetingTags
+    )();
+    const subjectsWithStatistics = subjects.map(subject => ({
         ...subject,
-        statistics: await getStatisticsFor({ subjectId: subject.id }, ["person", "party"])
-    })));
+        statistics: statisticsRecord[subject.id] ?? EMPTY_STATISTICS
+    }));
 
     // Extract unique speaker tags in O(n) using Map
     const speakerTagsMap = new Map<string, SpeakerTag>();
@@ -53,14 +103,13 @@ export const getMeetingData = async (cityId: string, meetingId: string): Promise
     }
     const speakerTags = Array.from(speakerTagsMap.values());
 
-    return { 
-        meeting, 
-        transcript, 
-        city, 
-        people, 
-        parties, 
-        highlights, 
-        subjects: subjectsWithStatistics, 
+    return {
+        meeting,
+        transcript,
+        city,
+        people,
+        parties,
+        subjects: subjectsWithStatistics,
         speakerTags,
         taskStatus
     };

--- a/src/lib/statistics.ts
+++ b/src/lib/statistics.ts
@@ -164,6 +164,163 @@ export async function getStatisticsFor(
     return getStatisticsForTranscript(transcript, groupBy, meetingDate, utteranceDurationsBySegment);
 }
 
+/**
+ * Batch-fetch statistics for multiple subjects in 2-3 DB queries instead of N×2.
+ * Groups by ["person", "party"] (matching the meeting page usage).
+ */
+export async function getBatchStatisticsForSubjects(
+    subjectIds: string[],
+    meetingDate?: Date
+): Promise<Map<string, Statistics>> {
+    const result = new Map<string, Statistics>();
+    if (subjectIds.length === 0) return result;
+
+    // 1. Batch-fetch all utterances for all subjects (new system)
+    const allUtterances = await prisma.utterance.findMany({
+        where: {
+            discussionSubjectId: { in: subjectIds },
+            discussionStatus: 'SUBJECT_DISCUSSION'
+        },
+        select: {
+            discussionSubjectId: true,
+            speakerSegmentId: true,
+            startTimestamp: true,
+            endTimestamp: true
+        }
+    });
+
+    // Group utterances by subject
+    const utterancesBySubject = new Map<string, typeof allUtterances>();
+    for (const u of allUtterances) {
+        if (!u.discussionSubjectId) continue;
+        const list = utterancesBySubject.get(u.discussionSubjectId);
+        if (list) {
+            list.push(u);
+        } else {
+            utterancesBySubject.set(u.discussionSubjectId, [u]);
+        }
+    }
+
+    // Determine which subjects need old system fallback
+    const subjectsWithNewSystem = new Set(utterancesBySubject.keys());
+    const subjectsNeedingFallback = subjectIds.filter(id => !subjectsWithNewSystem.has(id));
+
+    // 2. Batch-fetch old system SubjectSpeakerSegment for remaining subjects
+    let oldSystemBySubject = new Map<string, string[]>();
+    if (subjectsNeedingFallback.length > 0) {
+        const subjectSpeakerSegments = await prisma.subjectSpeakerSegment.findMany({
+            where: { subjectId: { in: subjectsNeedingFallback } },
+            select: { subjectId: true, speakerSegmentId: true }
+        });
+        for (const sss of subjectSpeakerSegments) {
+            const list = oldSystemBySubject.get(sss.subjectId);
+            if (list) {
+                list.push(sss.speakerSegmentId);
+            } else {
+                oldSystemBySubject.set(sss.subjectId, [sss.speakerSegmentId]);
+            }
+        }
+    }
+
+    // Collect all unique speaker segment IDs we need to fetch
+    const allSegmentIds = new Set<string>();
+
+    // From new system: extract segment IDs from utterances
+    const utteranceDurationsBySubjectAndSegment = new Map<string, Map<string, number>>();
+    for (const [subjectId, utterances] of utterancesBySubject) {
+        const durMap = new Map<string, number>();
+        for (const u of utterances) {
+            const duration = Math.max(0, u.endTimestamp - u.startTimestamp);
+            durMap.set(u.speakerSegmentId, (durMap.get(u.speakerSegmentId) || 0) + duration);
+            allSegmentIds.add(u.speakerSegmentId);
+        }
+        utteranceDurationsBySubjectAndSegment.set(subjectId, durMap);
+    }
+
+    // From old system: add segment IDs
+    for (const segIds of oldSystemBySubject.values()) {
+        for (const id of segIds) {
+            allSegmentIds.add(id);
+        }
+    }
+
+    // 3. Single batch fetch for all speaker segments with person/party includes
+    if (allSegmentIds.size === 0) {
+        // All subjects have no data
+        for (const id of subjectIds) {
+            result.set(id, { ...EMPTY_STATISTICS });
+        }
+        return result;
+    }
+
+    const speakerTagInclude = {
+        include: {
+            person: {
+                include: {
+                    roles: {
+                        include: {
+                            party: true,
+                            administrativeBody: true,
+                            city: true
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    const segments = await prisma.speakerSegment.findMany({
+        where: {
+            id: { in: [...allSegmentIds] },
+            NOT: { summary: { type: "procedural" as const } }
+        },
+        include: { speakerTag: speakerTagInclude }
+    });
+
+    // Index segments by ID for fast lookup
+    const segmentById = new Map(segments.map(s => [s.id, s]));
+
+    // 4. Compute statistics per subject
+    const groupBy: ("person" | "party")[] = ["person", "party"];
+
+    for (const subjectId of subjectIds) {
+        const subjectUtteranceDurations = utteranceDurationsBySubjectAndSegment.get(subjectId);
+
+        if (subjectUtteranceDurations) {
+            // New system: use utterance-based durations
+            const segmentIds = [...subjectUtteranceDurations.keys()];
+            const subjectSegments = segmentIds
+                .map(id => segmentById.get(id))
+                .filter((s): s is NonNullable<typeof s> => s != null)
+                .map(seg => ({ ...seg, topicLabels: [] as (TopicLabel & { topic: Topic })[] }));
+
+            result.set(subjectId, await getStatisticsForTranscript(
+                subjectSegments as SpeakerSegmentInfo[],
+                groupBy,
+                meetingDate,
+                subjectUtteranceDurations
+            ));
+        } else if (oldSystemBySubject.has(subjectId)) {
+            // Old system: use full segment durations
+            const segmentIds = oldSystemBySubject.get(subjectId)!;
+            const subjectSegments = segmentIds
+                .map(id => segmentById.get(id))
+                .filter((s): s is NonNullable<typeof s> => s != null)
+                .map(seg => ({ ...seg, topicLabels: [] as (TopicLabel & { topic: Topic })[] }));
+
+            result.set(subjectId, await getStatisticsForTranscript(
+                subjectSegments as SpeakerSegmentInfo[],
+                groupBy,
+                meetingDate
+            ));
+        } else {
+            result.set(subjectId, { ...EMPTY_STATISTICS });
+        }
+    }
+
+    return result;
+}
+
 function joinAdjacentSpeakerSegments(segments: SpeakerSegmentInfo[]): SpeakerSegmentInfo[] {
     if (segments.length === 0) {
         return segments;


### PR DESCRIPTION
## Summary
- **Batch statistics**: Replace N×2 per-subject DB queries with 2-3 batched queries via `getBatchStatisticsForSubjects()`
- **Cache sub-queries**: Wrap city, people, parties, subjects, taskStatus, and statistics in `unstable_cache` with proper tag-based invalidation
- **Split highlights**: Fetch user-specific highlights separately (per-request) from cacheable core data
- **Cache hit/miss logging**: `createCache` now logs HIT/MISS per sub-query for visibility

## Manual testing plan
- [x] Load meeting page — verify data renders correctly, check logs for MISS on first load
- [x] Reload — verify HIT logs for cached queries, faster load
- [x] Navigate to subject page — should not trigger full re-fetch
- [x] Test with admin on unreleased meeting — verify it still loads
- [x] Trigger task completion — verify cache invalidation and fresh data on next load


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core meeting data assembly and statistics calculation plus caching behavior; mistakes could cause stale/incorrect meeting page data or performance regressions despite being largely read-path changes.
> 
> **Overview**
> Meeting data fetching is refactored to improve performance by splitting `getMeetingData` into cacheable `getMeetingDataCore` and per-request composition of user-specific `highlights` in `getMeetingDataCached`.
> 
> Core meeting sub-queries (city, people, parties, subjects, task status, and subject statistics) are wrapped in `unstable_cache` with tag-based invalidation, and `createCache` now logs `HIT`/`MISS`/`ERR` timing per key for visibility. Subject statistics are optimized via a new `getBatchStatisticsForSubjects()` path that replaces per-subject DB querying with batched queries (with legacy fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e0919cb5fe23ae2cbbd233475655bbed3100e14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored meeting data fetching to improve performance by splitting `getMeetingData` into cacheable `getMeetingDataCore` and per-request composition with user-specific `highlights`. Core sub-queries (city, people, parties, subjects, task status, statistics) are wrapped in `unstable_cache` with tag-based invalidation. Statistics optimized via `getBatchStatisticsForSubjects()` replacing N×2 per-subject queries with 2-3 batched queries, supporting both new utterance-based and legacy systems.

**Key changes:**
- `getMeetingDataCore` returns `MeetingDataCore` (without highlights) with individually cached sub-queries
- `getMeetingDataCached` composes core data with fresh per-user highlights
- `getBatchStatisticsForSubjects` batches all utterances and speaker segments into 2-3 queries
- `createCache` now logs HIT/MISS/ERR with timing per key
- API route `/api/cities/[cityId]/meetings/[meetingId]` now returns `MeetingDataCore` (highlights were never used by consumers)

**Potential concerns:**
- Statistics cache uses `Object.fromEntries(map)` - Map doesn't JSON-serialize, so conversion is necessary but adds overhead
- Meeting and transcript queries remain uncached (auth dependencies and 2MB size limit)
- Cache invalidation uses broad `city:${cityId}:meetings` tag which invalidates all meeting sub-queries together

<h3>Confidence Score: 4/5</h3>

- Safe to merge with thorough testing of cache behavior and statistics accuracy
- Well-structured refactoring with clear separation of cacheable and per-request data. The batching logic is sound and maintains backward compatibility with legacy system. Main risks are around cache invalidation timing and potential performance regressions if caching doesn't work as expected, but the changes are largely on the read path with proper fallbacks
- Focus testing on `src/lib/getMeetingData.ts` and `src/lib/statistics.ts` to verify cache hit rates and statistics accuracy across both new and old subject systems

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/cache/index.ts | Added HIT/MISS logging with timing for cache visibility |
| src/lib/getMeetingData.ts | Split into `MeetingDataCore` and cacheable sub-queries with highlights fetched separately; statistics now batched |
| src/lib/statistics.ts | Added `getBatchStatisticsForSubjects()` to replace N×2 queries with 2-3 batched queries with dual-system support |
| src/app/api/cities/[cityId]/meetings/[meetingId]/route.ts | Changed to use `getMeetingDataCore` instead of `getMeetingData` (no highlights) |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request getMeetingDataCached] --> B[React cache dedup check]
    B --> C[getMeetingDataCore + getHighlights in parallel]
    
    C --> D[Meeting + Transcript uncached]
    C --> E[Cached: city with geometry]
    C --> F[Cached: people]
    C --> G[Cached: parties]
    C --> H[Cached: subjects]
    C --> I[Cached: taskStatus]
    
    H --> K[Cached: subjectStatistics]
    K --> L[getBatchStatisticsForSubjects]
    
    L --> M[Query 1: All utterances batch]
    L --> N[Query 2: Old system fallback batch]
    L --> O[Query 3: Speaker segments batch]
    
    O --> P[Compute stats per subject]
    P --> Q[Map to Object for cache]
    
    Q --> R[Merge with subjects]
    D --> R
    E --> R
    F --> R
    G --> R
    I --> R
    
    R --> S[MeetingDataCore ready]
    C --> T[Fresh highlights per user]
    S --> U[Combine into MeetingData]
    T --> U
    
    style L fill:#90EE90
    style M fill:#90EE90
    style N fill:#90EE90
    style O fill:#90EE90
    style E fill:#87CEEB
    style F fill:#87CEEB
    style G fill:#87CEEB
    style H fill:#87CEEB
    style I fill:#87CEEB
    style K fill:#87CEEB
    style D fill:#FFB6C1
    style T fill:#FFB6C1
```

<sub>Last reviewed commit: 715690e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->