### PR TITLE
fix: replace soft 404s with proper notFound() and 404 status codes

### DIFF
--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
@@ -1,52 +1,48 @@
 import { Metadata } from "next";
 import Subject from "@/components/meetings/subject/subject";
 import { getMeetingDataCached, getSubjectFromMeetingCached } from "@/lib/cache";
+import { notFound } from "next/navigation";
 
 export async function generateMetadata({
     params,
 }: {
     params: { cityId: string; meetingId: string; subjectId: string };
 }): Promise<Metadata> {
-    try {
-        // First try to get the subject from the cached meeting data
-        const subject = await getSubjectFromMeetingCached(params.cityId, params.meetingId, params.subjectId);
+    // First try to get the subject from the cached meeting data
+    const subject = await getSubjectFromMeetingCached(params.cityId, params.meetingId, params.subjectId);
 
-        if (!subject) {
-            return { title: "Subject not found" };
-        }
+    if (!subject) {
+        notFound();
+    }
 
-        // Get the full meeting data for city information
-        const meetingData = await getMeetingDataCached(params.cityId, params.meetingId);
+    // Get the full meeting data for city information
+    const meetingData = await getMeetingDataCached(params.cityId, params.meetingId);
 
-        if (!meetingData) {
-            return { title: subject.name };
-        }
+    if (!meetingData) {
+        return { title: subject.name };
+    }
 
-        // Create a concise title
-        const title = `${meetingData.city.name} - ${subject.name} | OpenCouncil`;
+    // Create a concise title
+    const title = `${meetingData.city.name} - ${subject.name} | OpenCouncil`;
 
-        // Create a meaningful description
-        const description =
-            subject.description ||
-            `Θέμα που συζητήθηκε | ${meetingData.city.name} | ${new Date(meetingData.meeting.dateTime).toLocaleDateString("el-GR")}`;
+    // Create a meaningful description
+    const description =
+        subject.description ||
+        `Θέμα που συζητήθηκε | ${meetingData.city.name} | ${new Date(meetingData.meeting.dateTime).toLocaleDateString("el-GR")}`;
 
-        return {
+    return {
+        title,
+        description,
+        openGraph: {
             title,
             description,
-            openGraph: {
-                title,
-                description,
-            },
-            twitter: {
-                card: "summary_large_image",
-                title,
-                description,
-            },
-        };
-    } catch (error) {
-        console.error("Error generating subject metadata:", error);
-        return { title: "Subject" };
-    }
+        },
+        twitter: {
+            card: "summary_large_image",
+            title,
+            description,
+        },
+    };
 }
 
 // Server component that renders the Subject component

--- a/src/app/[locale]/(city)/[cityId]/(other)/layout.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/layout.tsx
@@ -2,6 +2,7 @@ import Header from "@/components/layout/Header";
 import { PathElement } from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 import { getCityCached } from "@/lib/cache";
+import { notFound } from "next/navigation";
 
 export default async function CityInnerLayout({
     children,
@@ -12,7 +13,7 @@ export default async function CityInnerLayout({
 }) {
 
     const city = await getCityCached(cityId);
-    if (!city) return null;
+    if (!city) notFound();
 
     // Build the path elements
     const pathElements: PathElement[] = [

--- a/src/app/[locale]/(city)/[cityId]/(other)/notifications/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/notifications/page.tsx
@@ -3,7 +3,7 @@ import { OnboardingPageContent } from "@/components/onboarding/OnboardingPageCon
 import { OnboardingStage } from '@/lib/types/onboarding';
 import { Suspense } from "react";
 import { getCity } from "@/lib/db/cities";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 export const metadata: Metadata = {
     title: "Εγγραφή για ενημερώσεις | OpenCouncil",
@@ -19,8 +19,7 @@ export default async function NotificationSignupPage({ params }: PageProps) {
     const city = await getCity(params.cityId, { includeGeometry: true });
     
     if (!city) {
-        // Handle city not found
-        return <div>City not found</div>;
+        notFound();
     }
 
     if (!city.supportsNotifications) {

--- a/src/app/[locale]/(city)/[cityId]/(other)/petition/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/petition/page.tsx
@@ -3,7 +3,7 @@ import { OnboardingPageContent } from "@/components/onboarding/OnboardingPageCon
 import { OnboardingStage } from '@/lib/types/onboarding';
 import { Suspense } from "react";
 import { getCity } from "@/lib/db/cities";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 export const metadata: Metadata = {
     title: "Υποστήριξη Δήμου | OpenCouncil",
@@ -19,8 +19,7 @@ export default async function PetitionSignupPage({ params }: PageProps) {
     const city = await getCity(params.cityId, { includeGeometry: true });
     
     if (!city) {
-        // Handle city not found
-        return <div>City not found</div>;
+        notFound();
     }
 
     if (city.supportsNotifications) {

--- a/src/app/api/cities/[cityId]/meetings/[meetingId]/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/[meetingId]/route.ts
@@ -33,8 +33,23 @@ export async function GET(
     request: Request,
     { params }: { params: { cityId: string; meetingId: string } }
 ) {
-    const data = await getMeetingData(params.cityId, params.meetingId);
-    return NextResponse.json({ ...data });
+    try {
+        const data = await getMeetingData(params.cityId, params.meetingId);
+        return NextResponse.json({ ...data });
+    } catch (error) {
+        // TODO: Brittle string match — refactor getMeetingData to return null instead of throwing
+        if (error instanceof Error && error.message === 'Required data not found') {
+            return NextResponse.json(
+                { error: 'Meeting not found' },
+                { status: 404 }
+            );
+        }
+        console.error('Failed to fetch meeting:', error);
+        return NextResponse.json(
+            { error: 'Failed to fetch meeting' },
+            { status: 500 }
+        );
+    }
 }
 
 export async function PUT(


### PR DESCRIPTION
## Summary
- Replace `return null` and `return <div>City not found</div>` with `notFound()` in layouts/pages (`(other)/layout.tsx`, `petition/page.tsx`, `notifications/page.tsx`)
- Fix meeting API GET route to return 404 instead of 500 when meeting data not found
- Fix subject page `generateMetadata` to call `notFound()` instead of returning `{ title: "Subject not found" }` (previously swallowed by try/catch)

## Test plan
- [ ] Visit a non-existent city URL → should show 404 page
- [ ] Visit a non-existent meeting URL → should show 404 page
- [ ] Visit a non-existent subject URL → should show 404 page
- [ ] `GET /api/cities/{cityId}/meetings/{nonexistent}` → should return 404 JSON
- [ ] Existing pages continue to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced soft 404s (`return null`, hardcoded error divs, try-catch swallowing) with proper Next.js `notFound()` calls and 404 status codes.

**Key Changes:**
- Server components now call `notFound()` instead of returning null/error JSX when resources are missing
- API GET route returns proper 404 JSON response instead of 500 when meeting data is not found
- Removed unnecessary try-catch in `generateMetadata` that was swallowing the not-found condition
- Added error handling to API route with specific 404 handling for 'Required data not found' errors

**Notes:**
- API route includes TODO about refactoring `getMeetingData` to return null instead of throwing (acknowledged technical debt)
- Changes align with Next.js App Router best practices for error handling
- All soft 404s have been eliminated in favor of proper HTTP status codes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no blocking issues
- Changes are straightforward replacements of incorrect error handling patterns with proper Next.js conventions, improving UX and API correctness. No logic changes or risky refactoring.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx | Removed try-catch block in `generateMetadata`, now properly calls `notFound()` when subject is missing |
| src/app/api/cities/[cityId]/meetings/[meetingId]/route.ts | Added error handling to GET route to return 404 for missing meetings, includes TODO note about brittle string matching |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request to Page/API] --> B{Resource Exists?}
    B -->|Yes| C[Return Content/Data]
    B -->|No - Page| D[notFound Call]
    B -->|No - API| E[Catch Error]
    D --> F[Next.js 404 Page]
    E --> G{Error Type?}
    G -->|Required data not found| H[Return 404 JSON]
    G -->|Other Error| I[Return 500 JSON]
    
    style D fill:#90EE90
    style E fill:#90EE90
    style F fill:#FFE4B5
    style H fill:#FFE4B5
    style I fill:#FFB6C6
```

<sub>Last reviewed commit: df2f6db</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to error handling and HTTP status codes for missing resources. Main risk is the API’s brittle string-match on the thrown error message potentially misclassifying failures.
> 
> **Overview**
> Fixes several routes that previously rendered *soft 404s* by switching missing-resource handling to Next.js `notFound()` so users get the real 404 page.
> 
> This updates city-scoped pages/layouts (`(other)/layout.tsx`, `petition`, `notifications`) and the subject page `generateMetadata` to stop returning `null`/inline “not found” UI or metadata and instead invoke `notFound()`.
> 
> The `GET /api/cities/[cityId]/meetings/[meetingId]` handler now catches `getMeetingData` failures and returns **404** for the specific “Required data not found” case, otherwise returning **500** with logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df2f6db0d0d3f847bf283fd2218f9e0d59e9f0e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->