### PR TITLE
feat: group sidebar subjects by agenda category

### DIFF
--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/page.tsx
@@ -7,6 +7,7 @@ import { formatDate } from "date-fns";
 import { CalendarIcon, ExternalLink, FileIcon, FileText, Youtube } from "lucide-react";
 import { formatDateTime, formatRelativeTime } from "@/lib/formatters/time";
 import { sortSubjectsBySpeakingTime, sortSubjectsByAgendaIndex, subjectToMapFeature } from "@/lib/utils";
+import { categorizeSubjects, SUBJECT_CATEGORIES } from "@/lib/utils/subjects";
 import { Link } from "@/i18n/routing";
 import { HighlightCards } from "@/components/meetings/highlight-cards";
 import { el } from "date-fns/locale";
@@ -43,22 +44,17 @@ export default function MeetingPage() {
     }, [subjects, selectedTopicId]);
 
     // Categorize subjects
-    const beforeAgendaSubjects = useMemo(() =>
-        sortSubjectsBySpeakingTime(filteredSubjects.filter(s => s.nonAgendaReason === 'beforeAgenda' && s.agendaItemIndex === null)),
+    const { beforeAgenda: beforeAgendaSubjects, outOfAgenda: outOfAgendaSubjects, agenda: categorizedAgenda } = useMemo(() =>
+        categorizeSubjects(filteredSubjects),
         [filteredSubjects]
     );
 
-    const outOfAgendaSubjects = useMemo(() =>
-        sortSubjectsBySpeakingTime(filteredSubjects.filter(s => s.nonAgendaReason === 'outOfAgenda' && s.agendaItemIndex === null)),
-        [filteredSubjects]
+    const agendaSubjects = useMemo(() =>
+        agendaSortMode === 'agendaIndex'
+            ? sortSubjectsByAgendaIndex(categorizedAgenda)
+            : sortSubjectsBySpeakingTime(categorizedAgenda),
+        [categorizedAgenda, agendaSortMode]
     );
-
-    const agendaSubjects = useMemo(() => {
-        const agenda = filteredSubjects.filter(s => s.agendaItemIndex !== null);
-        return agendaSortMode === 'agendaIndex'
-            ? sortSubjectsByAgendaIndex(agenda)
-            : sortSubjectsBySpeakingTime(agenda);
-    }, [filteredSubjects, agendaSortMode]);
 
     return (
         <div className="flex flex-col w-full">
@@ -102,14 +98,14 @@ export default function MeetingPage() {
                 {(beforeAgendaSubjects.length > 0 || outOfAgendaSubjects.length > 0) && (
                     <div className={`max-w-4xl mx-auto ${beforeAgendaSubjects.length <= 1 && outOfAgendaSubjects.length <= 1 ? "flex flex-col lg:flex-row lg:flex-wrap gap-x-8" : "flex flex-col"}`}>
                         <SubjectSection
-                            title="Προ ημερησίας, συζήτηση και ανακοινώσεις"
-                            explainerText="Αυτά τα θέματα είναι ανακοινώσεις, ερωτήματα και συζήτηση για τα οποία δεν υπάρχει ψηφοφορία και δεν λαμβάνονται αποφάσεις, συνήθως στην αρχή της συνεδρίασης."
+                            title={SUBJECT_CATEGORIES.beforeAgenda.label}
+                            explainerText={SUBJECT_CATEGORIES.beforeAgenda.explainerText}
                             subjects={beforeAgendaSubjects}
                             className="flex-1 min-w-0"
                         />
                         <SubjectSection
-                            title="Εκτός ημερησίας θέματα"
-                            explainerText="Τα εκτός ημερησίας θέματα είναι έκτακτα θέματα που δεν πρόλαβαν να ενταχτούν στην ημερήσια διάταξη της συνεδρίασης. Ψηφίζονται από το σώμα, πρώτα για το κατ'επείγον, και έπειτα για την ουσία του θέματος."
+                            title={SUBJECT_CATEGORIES.outOfAgenda.label}
+                            explainerText={SUBJECT_CATEGORIES.outOfAgenda.explainerText}
                             subjects={outOfAgendaSubjects}
                             className="flex-1 min-w-0"
                         />
@@ -121,8 +117,8 @@ export default function MeetingPage() {
                 )}
 
                 <SubjectSection
-                    title="Θέματα ημερησίας διάταξης"
-                    explainerText="Τα θέματα της ημερησίας διάταξης συζητούνται και ψηφίζονται από το σώμα και αποτελούν το κύριο μέρος της συνεδρίασης."
+                    title={SUBJECT_CATEGORIES.agenda.label}
+                    explainerText={SUBJECT_CATEGORIES.agenda.explainerText}
                     subjects={agendaSubjects}
                     sortMode={agendaSortMode}
                     onSortModeChange={setAgendaSortMode}

--- a/src/components/meetings/sidebar.tsx
+++ b/src/components/meetings/sidebar.tsx
@@ -19,13 +19,14 @@ import { useCouncilMeetingData } from "./CouncilMeetingDataContext"
 import { useState, useEffect, useMemo } from "react"
 import { useVideo } from "./VideoProvider"
 import { usePathname } from "next/navigation"
-import { cn, formatTime, sortSubjectsBySpeakingTime, sortSubjectsByAgendaIndex } from "@/lib/utils"
+import { cn, formatTime, sortSubjectsByAgendaIndex } from "@/lib/utils"
+import { categorizeSubjects, SUBJECT_CATEGORIES } from "@/lib/utils/subjects"
 import { useTranscriptOptions } from "./options/OptionsContext"
 
 export default function MeetingSidebar() {
     const { city, meeting, subjects } = useCouncilMeetingData()
     const [subjectsExpanded, setSubjectsExpanded] = useState(true)
-    const { isMobile, setOpenMobile } = useSidebar()
+    const { isMobile, setOpenMobile, state: sidebarState } = useSidebar()
     const pathname = usePathname()
     // State to track both actual path and anticipated path during navigation
     const [activeItem, setActiveItem] = useState(pathname)
@@ -33,20 +34,13 @@ export default function MeetingSidebar() {
     const canEdit = options.editsAllowed
     const canCreateHighlights = options.canCreateHighlights
 
-    const beforeAgendaSubjects = useMemo(() =>
-        sortSubjectsBySpeakingTime(subjects.filter(s => s.nonAgendaReason === 'beforeAgenda' && s.agendaItemIndex === null)),
-        [subjects]
-    )
-
-    const outOfAgendaSubjects = useMemo(() =>
-        sortSubjectsBySpeakingTime(subjects.filter(s => s.nonAgendaReason === 'outOfAgenda' && s.agendaItemIndex === null)),
-        [subjects]
-    )
-
-    const agendaSubjects = useMemo(() =>
-        sortSubjectsByAgendaIndex(subjects.filter(s => s.agendaItemIndex !== null)),
-        [subjects]
-    )
+    const { beforeAgenda, outOfAgenda, agenda } = useMemo(() => {
+        const categorized = categorizeSubjects(subjects)
+        return {
+            ...categorized,
+            agenda: sortSubjectsByAgendaIndex(categorized.agenda),
+        }
+    }, [subjects])
 
     // Sync with pathname when it changes
     useEffect(() => {
@@ -90,6 +84,41 @@ export default function MeetingSidebar() {
     // Check if subjects section is active
     const isSubjectsActive = () => {
         return activeItem.includes(`/${city.id}/${meeting.id}/subjects`)
+    }
+
+    type Subject = typeof subjects[number]
+    const renderSubjectSection = (title: string, sectionSubjects: Subject[], getPrefix?: (subject: Subject, index: number) => string) => {
+        if (sectionSubjects.length === 0) return null
+        return (
+            <>
+                <SidebarMenuItem className="pl-4">
+                    <span className="text-xs font-semibold text-muted-foreground tracking-wide py-1">
+                        {title}
+                    </span>
+                </SidebarMenuItem>
+                {sectionSubjects.map((subject, index) => {
+                    const subjectUrl = `/${city.id}/${meeting.id}/subjects/${subject.id}`
+                    return (
+                        <SidebarMenuItem key={subject.id} className="pl-8">
+                            <SidebarMenuButton
+                                asChild
+                                onClick={handleMenuItemClick}
+                                isActive={activeItem === subjectUrl}
+                            >
+                                <Link
+                                    href={subjectUrl}
+                                    className={cn(
+                                        activeItem === subjectUrl && "text-primary font-medium"
+                                    )}
+                                >
+                                    <span className="text-sm">{getPrefix ? `${getPrefix(subject, index)} ` : ''}{subject.name}</span>
+                                </Link>
+                            </SidebarMenuButton>
+                        </SidebarMenuItem>
+                    )
+                })}
+            </>
+        )
     }
 
     const mainMenuItems = [
@@ -168,89 +197,11 @@ export default function MeetingSidebar() {
                                 </SidebarMenuButton>
                             </SidebarMenuItem>
 
-                            {subjectsExpanded && (
+                            {subjectsExpanded && sidebarState !== 'collapsed' && (
                                 <>
-                                    {beforeAgendaSubjects.length > 0 && (
-                                        <>
-                                            <SidebarMenuItem className="pl-4">
-                                                <span className="text-xs font-semibold text-muted-foreground tracking-wide py-1">
-                                                    Προ ημερησίας
-                                                </span>
-                                            </SidebarMenuItem>
-                                            {beforeAgendaSubjects.map((subject, index) => (
-                                                <SidebarMenuItem key={subject.id} className="pl-8">
-                                                    <SidebarMenuButton
-                                                        asChild
-                                                        onClick={handleMenuItemClick}
-                                                        isActive={activeItem === `/${city.id}/${meeting.id}/subjects/${subject.id}`}
-                                                    >
-                                                        <Link
-                                                            href={`/${city.id}/${meeting.id}/subjects/${subject.id}`}
-                                                            className={cn(
-                                                                activeItem === `/${city.id}/${meeting.id}/subjects/${subject.id}` && "text-primary font-medium"
-                                                            )}
-                                                        >
-                                                            <span className="text-sm">{index + 1}. {subject.name}</span>
-                                                        </Link>
-                                                    </SidebarMenuButton>
-                                                </SidebarMenuItem>
-                                            ))}
-                                        </>
-                                    )}
-                                    {outOfAgendaSubjects.length > 0 && (
-                                        <>
-                                            <SidebarMenuItem className="pl-4">
-                                                <span className="text-xs font-semibold text-muted-foreground tracking-wide py-1">
-                                                    Εκτός ημερησίας
-                                                </span>
-                                            </SidebarMenuItem>
-                                            {outOfAgendaSubjects.map((subject, index) => (
-                                                <SidebarMenuItem key={subject.id} className="pl-8">
-                                                    <SidebarMenuButton
-                                                        asChild
-                                                        onClick={handleMenuItemClick}
-                                                        isActive={activeItem === `/${city.id}/${meeting.id}/subjects/${subject.id}`}
-                                                    >
-                                                        <Link
-                                                            href={`/${city.id}/${meeting.id}/subjects/${subject.id}`}
-                                                            className={cn(
-                                                                activeItem === `/${city.id}/${meeting.id}/subjects/${subject.id}` && "text-primary font-medium"
-                                                            )}
-                                                        >
-                                                            <span className="text-sm">{index + 1}. {subject.name}</span>
-                                                        </Link>
-                                                    </SidebarMenuButton>
-                                                </SidebarMenuItem>
-                                            ))}
-                                        </>
-                                    )}
-                                    {agendaSubjects.length > 0 && (
-                                        <>
-                                            <SidebarMenuItem className="pl-4">
-                                                <span className="text-xs font-semibold text-muted-foreground tracking-wide py-1">
-                                                    Ημερησίας διάταξης
-                                                </span>
-                                            </SidebarMenuItem>
-                                            {agendaSubjects.map((subject) => (
-                                                <SidebarMenuItem key={subject.id} className="pl-8">
-                                                    <SidebarMenuButton
-                                                        asChild
-                                                        onClick={handleMenuItemClick}
-                                                        isActive={activeItem === `/${city.id}/${meeting.id}/subjects/${subject.id}`}
-                                                    >
-                                                        <Link
-                                                            href={`/${city.id}/${meeting.id}/subjects/${subject.id}`}
-                                                            className={cn(
-                                                                activeItem === `/${city.id}/${meeting.id}/subjects/${subject.id}` && "text-primary font-medium"
-                                                            )}
-                                                        >
-                                                            <span className="text-sm">{subject.agendaItemIndex}. {subject.name}</span>
-                                                        </Link>
-                                                    </SidebarMenuButton>
-                                                </SidebarMenuItem>
-                                            ))}
-                                        </>
-                                    )}
+                                    {renderSubjectSection(SUBJECT_CATEGORIES.beforeAgenda.shortLabel, beforeAgenda)}
+                                    {renderSubjectSection(SUBJECT_CATEGORIES.outOfAgenda.shortLabel, outOfAgenda)}
+                                    {renderSubjectSection(SUBJECT_CATEGORIES.agenda.shortLabel, agenda, (s) => `${s.agendaItemIndex}.`)}
                                 </>
                             )}
                         </SidebarMenu>

--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -11,6 +11,7 @@ import { Link } from "@/i18n/routing";
 import { ColorPercentageRing } from "@/components/ui/color-percentage-ring";
 import Icon from "@/components/icon";
 import { subjectToMapFeature } from "@/lib/utils";
+import { getNonAgendaLabel } from "@/lib/utils/subjects";
 import { notFound } from "next/navigation";
 import { SubjectContext } from "./context";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -171,7 +172,7 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                                     <>
                                         <span className="w-1 h-1 rounded-full bg-muted-foreground/40" />
                                         <span className="font-medium">
-                                            {subject.nonAgendaReason === 'beforeAgenda' ? "Προ ημερησίας" : "Εκτός ημερησίας"}
+                                            {getNonAgendaLabel(subject.nonAgendaReason as 'beforeAgenda' | 'outOfAgenda')}
                                         </span>
                                     </>
                                 )}

--- a/src/components/subject-card.tsx
+++ b/src/components/subject-card.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "./ui/card"
 import Icon from "./icon";
 import { MapPin, ScrollText, Calendar, Loader2, Clock, MessageSquare } from "lucide-react";
 import { cn, getPartyFromRoles } from "@/lib/utils";
+import { getNonAgendaLabel } from "@/lib/utils/subjects";
 import { Link, useRouter } from "@/i18n/routing";
 import { PersonAvatarList } from "./persons/PersonAvatarList";
 import { PersonWithRelations } from '@/lib/db/people';
@@ -123,9 +124,7 @@ export function SubjectCard({ subject, city, meeting, parties, persons, fullWidt
                             <div className="text-xs text-muted-foreground">
                                 {subject.agendaItemIndex ?
                                     `#${subject.agendaItemIndex}` :
-                                    subject.nonAgendaReason === 'beforeAgenda' ?
-                                        "Προ ημερησίας" :
-                                        "Εκτός ημερησίας"
+                                    getNonAgendaLabel(subject.nonAgendaReason as 'beforeAgenda' | 'outOfAgenda')
                                 }
                             </div>
                         </div>

--- a/src/lib/utils/__tests__/subjects.test.ts
+++ b/src/lib/utils/__tests__/subjects.test.ts
@@ -1,0 +1,118 @@
+import { categorizeSubjects, getNonAgendaLabel, SUBJECT_CATEGORIES } from '../subjects';
+
+function makeSubject(overrides: Partial<{
+    name: string;
+    nonAgendaReason: string | null;
+    agendaItemIndex: number | null;
+    statistics: { speakingSeconds: number };
+}> = {}) {
+    return {
+        name: 'Test subject',
+        nonAgendaReason: null,
+        agendaItemIndex: null,
+        statistics: { speakingSeconds: 0 },
+        speakerSegments: [],
+        ...overrides,
+    };
+}
+
+describe('categorizeSubjects', () => {
+    it('separates subjects into three categories', () => {
+        const subjects = [
+            makeSubject({ name: 'Before 1', nonAgendaReason: 'beforeAgenda' }),
+            makeSubject({ name: 'Agenda 1', agendaItemIndex: 1 }),
+            makeSubject({ name: 'Out 1', nonAgendaReason: 'outOfAgenda' }),
+            makeSubject({ name: 'Agenda 2', agendaItemIndex: 2 }),
+            makeSubject({ name: 'Before 2', nonAgendaReason: 'beforeAgenda' }),
+        ];
+
+        const result = categorizeSubjects(subjects);
+
+        expect(result.beforeAgenda.map(s => s.name)).toEqual(['Before 1', 'Before 2']);
+        expect(result.outOfAgenda.map(s => s.name)).toEqual(['Out 1']);
+        expect(result.agenda.map(s => s.name)).toEqual(['Agenda 1', 'Agenda 2']);
+    });
+
+    it('returns empty arrays when no subjects match a category', () => {
+        const subjects = [
+            makeSubject({ name: 'Agenda only', agendaItemIndex: 1 }),
+        ];
+
+        const result = categorizeSubjects(subjects);
+
+        expect(result.beforeAgenda).toEqual([]);
+        expect(result.outOfAgenda).toEqual([]);
+        expect(result.agenda).toHaveLength(1);
+    });
+
+    it('sorts beforeAgenda and outOfAgenda by speaking time (descending)', () => {
+        const subjects = [
+            makeSubject({ name: 'Low', nonAgendaReason: 'beforeAgenda', statistics: { speakingSeconds: 10 } }),
+            makeSubject({ name: 'High', nonAgendaReason: 'beforeAgenda', statistics: { speakingSeconds: 100 } }),
+            makeSubject({ name: 'Mid', nonAgendaReason: 'beforeAgenda', statistics: { speakingSeconds: 50 } }),
+        ];
+
+        const result = categorizeSubjects(subjects);
+
+        expect(result.beforeAgenda.map(s => s.name)).toEqual(['High', 'Mid', 'Low']);
+    });
+
+    it('does not sort agenda subjects (consumer decides)', () => {
+        const subjects = [
+            makeSubject({ name: 'Third', agendaItemIndex: 3 }),
+            makeSubject({ name: 'First', agendaItemIndex: 1 }),
+            makeSubject({ name: 'Second', agendaItemIndex: 2 }),
+        ];
+
+        const result = categorizeSubjects(subjects);
+
+        // Preserves input order — no sorting applied
+        expect(result.agenda.map(s => s.name)).toEqual(['Third', 'First', 'Second']);
+    });
+
+    it('excludes subjects that have both nonAgendaReason and agendaItemIndex', () => {
+        const subjects = [
+            makeSubject({ name: 'Weird', nonAgendaReason: 'beforeAgenda', agendaItemIndex: 5 }),
+        ];
+
+        const result = categorizeSubjects(subjects);
+
+        // Has agendaItemIndex, so it goes to agenda (not beforeAgenda)
+        expect(result.beforeAgenda).toEqual([]);
+        expect(result.agenda).toHaveLength(1);
+    });
+
+    it('handles empty input', () => {
+        const result = categorizeSubjects([]);
+
+        expect(result.beforeAgenda).toEqual([]);
+        expect(result.outOfAgenda).toEqual([]);
+        expect(result.agenda).toEqual([]);
+    });
+});
+
+describe('getNonAgendaLabel', () => {
+    it('returns short label for beforeAgenda', () => {
+        expect(getNonAgendaLabel('beforeAgenda')).toBe('Προ ημερησίας');
+    });
+
+    it('returns short label for outOfAgenda', () => {
+        expect(getNonAgendaLabel('outOfAgenda')).toBe('Εκτός ημερησίας');
+    });
+});
+
+describe('SUBJECT_CATEGORIES', () => {
+    it('has all three categories defined', () => {
+        expect(SUBJECT_CATEGORIES).toHaveProperty('beforeAgenda');
+        expect(SUBJECT_CATEGORIES).toHaveProperty('outOfAgenda');
+        expect(SUBJECT_CATEGORIES).toHaveProperty('agenda');
+    });
+
+    it('each category has label, shortLabel, and explainerText', () => {
+        for (const category of Object.values(SUBJECT_CATEGORIES)) {
+            expect(category.label).toBeTruthy();
+            expect(category.shortLabel).toBeTruthy();
+            expect(category.explainerText).toBeTruthy();
+        }
+    });
+});

--- a/src/lib/utils/subjects.ts
+++ b/src/lib/utils/subjects.ts
@@ -1,0 +1,49 @@
+import { sortSubjectsBySpeakingTime } from "@/lib/utils";
+import type { Statistics } from "@/lib/statistics";
+
+interface CategorizableSubject {
+    name: string;
+    nonAgendaReason: string | null;
+    agendaItemIndex: number | null;
+    statistics?: Statistics;
+    speakerSegments?: unknown[];
+}
+
+export const SUBJECT_CATEGORIES = {
+    beforeAgenda: {
+        label: 'Προ ημερησίας, συζήτηση και ανακοινώσεις',
+        shortLabel: 'Προ ημερησίας',
+        explainerText: 'Αυτά τα θέματα είναι ανακοινώσεις, ερωτήματα και συζήτηση για τα οποία δεν υπάρχει ψηφοφορία και δεν λαμβάνονται αποφάσεις, συνήθως στην αρχή της συνεδρίασης.',
+    },
+    outOfAgenda: {
+        label: 'Εκτός ημερησίας θέματα',
+        shortLabel: 'Εκτός ημερησίας',
+        explainerText: 'Τα εκτός ημερησίας θέματα είναι έκτακτα θέματα που δεν πρόλαβαν να ενταχτούν στην ημερήσια διάταξη της συνεδρίασης. Ψηφίζονται από το σώμα, πρώτα για το κατ\'επείγον, και έπειτα για την ουσία του θέματος.',
+    },
+    agenda: {
+        label: 'Θέματα ημερησίας διάταξης',
+        shortLabel: 'Ημερησίας διάταξης',
+        explainerText: 'Τα θέματα της ημερησίας διάταξης συζητούνται και ψηφίζονται από το σώμα και αποτελούν το κύριο μέρος της συνεδρίασης.',
+    },
+} as const;
+
+/**
+ * Categorize subjects into their three agenda groups.
+ * beforeAgenda and outOfAgenda are sorted by speaking time.
+ * agenda is returned unsorted — the consumer decides (agenda index vs speaking time).
+ */
+export function categorizeSubjects<T extends CategorizableSubject>(subjects: T[]) {
+    return {
+        beforeAgenda: sortSubjectsBySpeakingTime(
+            subjects.filter(s => s.nonAgendaReason === 'beforeAgenda' && s.agendaItemIndex === null)
+        ),
+        outOfAgenda: sortSubjectsBySpeakingTime(
+            subjects.filter(s => s.nonAgendaReason === 'outOfAgenda' && s.agendaItemIndex === null)
+        ),
+        agenda: subjects.filter(s => s.agendaItemIndex !== null),
+    };
+}
+
+export function getNonAgendaLabel(reason: 'beforeAgenda' | 'outOfAgenda'): string {
+    return SUBJECT_CATEGORIES[reason].shortLabel;
+}


### PR DESCRIPTION
**Description:**
This PR closes issue #172. Added sequential numbering (1. 2. 3...) to subject titles in the meeting sidebar 'Θέματα' dropdown for easier reference and navigation.

**Key Changes:**
- `src/components/meetings/sidebar.tsx`: Added index prefix to subject names in the sidebar list

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts duplicated subject categorization logic and hardcoded Greek label strings into a shared `src/lib/utils/subjects.ts` utility module, then refactors the sidebar to display subjects grouped by category (before-agenda, out-of-agenda, agenda) with agenda items prefixed by their `agendaItemIndex`. The refactoring follows the project's DRY principle (CLAUDE.md) by centralizing `categorizeSubjects()`, `SUBJECT_CATEGORIES`, and `getNonAgendaLabel()` — used across 4 files — and includes a comprehensive test suite.

- Extracted `categorizeSubjects`, `SUBJECT_CATEGORIES`, and `getNonAgendaLabel` into `src/lib/utils/subjects.ts`, eliminating duplicate filtering logic from the meeting page and sidebar
- Sidebar now displays subjects in three labeled sections with agenda items prefixed by their `agendaItemIndex` (e.g., "1. Subject name")
- Added `sidebarState !== 'collapsed'` guard to prevent rendering subject list items when the sidebar is in icon-only mode
- Added 118-line test suite covering categorization, sorting, edge cases, and label lookups

<h3>Confidence Score: 4/5</h3>

- This PR is a well-structured refactoring with good test coverage and low risk of runtime issues.
- Score of 4 reflects clean extraction of shared utilities following project DRY conventions, comprehensive test coverage, and no new security or logic concerns introduced. Docked one point because the numbering consistency concern (agendaItemIndex display vs array index) flagged in previous reviews remains an open design question worth resolving.
- `src/components/meetings/sidebar.tsx` — the core change (subject sectioning and numbering) lives here and warrants manual verification of the UX.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/utils/subjects.ts | New shared utility extracting subject categorization logic and label constants. Clean generic implementation with proper type constraints. |
| src/lib/utils/__tests__/subjects.test.ts | Comprehensive test suite covering categorization, sorting, edge cases (empty input, dual-reason subjects), and label lookups. |
| src/components/meetings/sidebar.tsx | Refactored to use shared categorizeSubjects, adds section headers and agenda index prefixes. Good UX fix hiding subjects when sidebar is collapsed. Uses `next/link` instead of `@/i18n/routing` (pre-existing). |
| src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/page.tsx | Replaced inline filtering/hardcoded Greek strings with shared categorizeSubjects and SUBJECT_CATEGORIES constants. Cleaner separation of concerns. |
| src/components/meetings/subject/subject.tsx | Replaced inline label ternary with getNonAgendaLabel utility call. Minimal, focused change. |
| src/components/subject-card.tsx | Replaced inline label ternary with getNonAgendaLabel utility call, consistent with subject.tsx change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[subjects array] --> B[categorizeSubjects]
    B --> C[beforeAgenda\nsortBySpkTime]
    B --> D[outOfAgenda\nsortBySpkTime]
    B --> E[agenda\nunsorted]

    subgraph Sidebar
        E --> F[sortByAgendaIndex]
        C --> G[renderSubjectSection\nno prefix]
        D --> H[renderSubjectSection\nno prefix]
        F --> I[renderSubjectSection\nagendaItemIndex prefix]
    end

    subgraph MeetingPage
        E --> J{agendaSortMode}
        J -->|agendaIndex| K[sortByAgendaIndex]
        J -->|speakingTime| L[sortBySpkTime]
        C --> M[SubjectSection]
        D --> N[SubjectSection]
        K --> O[SubjectSection]
        L --> O
    end

    subgraph SharedLabels
        P[SUBJECT_CATEGORIES] --> G
        P --> H
        P --> I
        P --> M
        P --> N
        P --> O
    end
```

<sub>Last reviewed commit: ["refactor: extract su..."](https://github.com/schemalabz/opencouncil/commit/6ab6cc896b8735cbe73ebeed6bbf2f036fe7d3d5)</sub>

<!-- /greptile_comment -->