### PR TITLE
fix: prevent scroll-to-top when entering highlight edit mode (#179)

### DIFF
--- a/src/components/meetings/HighlightContext.tsx
+++ b/src/components/meetings/HighlightContext.tsx
@@ -324,10 +324,10 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     // Check if we're already on the transcript page
     if (pathname === expectedPath) {
       // We're on transcript page, just add/update the highlight parameter
-      router.replace(`${expectedPath}?highlight=${highlight.id}`);
+      router.replace(`${expectedPath}?highlight=${highlight.id}`, { scroll: false });
     } else if (!pathname.includes('/transcript')) {
       // We're not on transcript page, navigate to it with highlight parameter
-      router.push(expectedUrl);
+      router.push(expectedUrl, { scroll: false });
     }
   }, [setEditingHighlight, setOriginalHighlight, setIsDirty, router, pathname]);
 

--- a/src/components/meetings/transcript/Transcript.tsx
+++ b/src/components/meetings/transcript/Transcript.tsx
@@ -29,7 +29,7 @@ export default function Transcript() {
     const { transcript: speakerSegments, getHighlight, taskStatus } = useCouncilMeetingData();
     const { options } = useTranscriptOptions();
     const { setCurrentScrollInterval, currentTime } = useVideo();
-    const { enterEditMode } = useHighlight();
+    const { enterEditMode, editingHighlight } = useHighlight();
     const containerRef = useRef<HTMLDivElement>(null);
     const [visibleSegments, setVisibleSegments] = useState<Set<number>>(new Set());
     const [bannerHeight, setBannerHeight] = useState(BANNER_HEIGHT_FULL);
@@ -94,13 +94,13 @@ export default function Transcript() {
     // Handle highlight editing initialization from URL
     useEffect(() => {
         const highlightId = searchParams.get('highlight');
-        if (highlightId) {
+        if (highlightId && highlightId !== editingHighlight?.id) {
             const highlight = getHighlight(highlightId);
             if (highlight) {
                 enterEditMode(highlight);
             }
         }
-    }, [searchParams, getHighlight, enterEditMode]);
+    }, [searchParams, getHighlight, enterEditMode, editingHighlight?.id]);
 
     const debouncedSetCurrentScrollInterval = useMemo(
         () => debounce(setCurrentScrollInterval, 500),


### PR DESCRIPTION
## Fix: "Start highlight from here" jumps to top of page

Closes #179

### Root Cause
Two issues caused the scroll jump:
1. `router.replace()` in `enterEditMode()` scrolls to top by default in Next.js App Router
2. A `useEffect` watching `searchParams` in `Transcript.tsx` re-triggered `enterEditMode()` on URL change, causing a second scroll-to-top

### Changes
- **HighlightContext.tsx** — Added `{ scroll: false }` to `router.replace()` and `router.push()` calls in `enterEditMode()`
- **Transcript.tsx** — Guarded the searchParams `useEffect` to skip `enterEditMode()` if already editing the same highlight

### Testing
- Start highlight from utterance mid-page → page stays in position ✅
- Direct URL with `?highlight=ID` still works ✅
- Browser back/forward between highlights still works ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed scroll-to-top issue when entering highlight edit mode by adding `{ scroll: false }` to Next.js router navigation calls and preventing duplicate `enterEditMode()` calls from URL parameter changes.

- Added `{ scroll: false }` option to `router.replace()` and `router.push()` in `HighlightContext.tsx:327,330`
- Added guard condition `highlightId !== editingHighlight?.id` to prevent re-triggering `enterEditMode()` in `Transcript.tsx:97`
- Updated dependency array to include `editingHighlight?.id` in `Transcript.tsx:103`

The fix correctly addresses both root causes identified in the PR description and follows existing patterns in the codebase (`ConsultationViewer.tsx` and `SearchPage.tsx` use the same `{ scroll: false }` pattern).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-tested, and follow established patterns in the codebase. Both fixes directly address the root causes identified (Next.js router scroll behavior and redundant useEffect triggering). The `{ scroll: false }` option is already used elsewhere in the codebase, and the guard condition properly prevents duplicate calls while maintaining correct behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/meetings/HighlightContext.tsx | Added `{ scroll: false }` to router calls to prevent unwanted scroll-to-top behavior |
| src/components/meetings/transcript/Transcript.tsx | Added guard to prevent redundant `enterEditMode` calls and updated dependency array |

</details>



<sub>Last reviewed commit: ca4f5cf</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized routing/effect guard changes in the transcript highlight-edit flow; main risk is missing an intended re-entry to edit mode in some edge navigation cases.
> 
> **Overview**
> Prevents the transcript view from jumping to the top when starting highlight editing from a mid-page utterance.
> 
> This updates `enterEditMode()` navigation to use Next.js App Router `{ scroll: false }` on both `router.replace()` and `router.push()`, and adds a guard in `Transcript.tsx` to avoid re-calling `enterEditMode()` when the `?highlight=` URL param matches the currently edited highlight.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca4f5cf6661a3f37c4dddf153941d52774ae2ff8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->