### PR TITLE
feat: #223 Welcome Brief — personalized catch-up after notification onboarding

### DIFF
--- a/src/app/api/cities/[cityId]/welcome-brief/route.ts
+++ b/src/app/api/cities/[cityId]/welcome-brief/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { getSubjectsForWelcomeBrief } from '@/lib/db/welcomeBrief';
+import { aiChat } from '@/lib/ai';
+import { formatDate } from '@/lib/formatters/time';
+
+export async function POST(
+    request: Request,
+    { params }: { params: { cityId: string } }
+) {
+    const body = await request.json();
+    const { topicIds } = body;
+
+    if (!Array.isArray(topicIds) || !topicIds.every((id): id is string => typeof id === 'string')) {
+        return NextResponse.json({ error: 'Invalid topicIds' }, { status: 400 });
+    }
+
+    const since = new Date();
+    since.setMonth(since.getMonth() - 6);
+
+    const data = await getSubjectsForWelcomeBrief(params.cityId, topicIds, since);
+
+    if (data.matchedSubjects.length === 0) {
+        return NextResponse.json({ brief: null });
+    }
+
+    const systemPrompt = `You are a friendly expert on local government who follows municipal council meetings closely.
+A new resident just signed up for notifications about their city council.
+Your job: write them a short, engaging catch-up in Greek — like a smart friend who follows local politics, not an official report. Be warm, direct, and concrete.
+Use markdown (headers, bullets). Stay under 300 words.
+Return your response as a JSON object with this exact format: {"brief": "your markdown text here"}`;
+
+    const topicNames = [...new Set(data.matchedSubjects.map(s => s.topicName))].join(', ');
+
+    const subjectLines = data.matchedSubjects.map(s => {
+        const date = formatDate(s.meetingDate);
+        let line = `📅 ${date} — ${s.meetingName}\nΘέμα: ${s.subjectName} (Κατηγορία: ${s.topicName})`;
+        if (s.description) line += `\n${s.description}`;
+        if (s.context) line += `\n${s.context}`;
+        if (s.hot) line += '\n⚡ Καυτό θέμα';
+        return line;
+    }).join('\n---\n');
+
+    const userPrompt = `Πόλη: ${data.cityName}
+Ενδιαφέροντα: ${topicNames}
+
+Τελευταίοι 6 μήνες:
+- Συνολικές συνεδριάσεις: ${data.totalMeetingCount}
+- Συζητήσεις σε θέματα που σε αφορούν: ${data.matchedSubjectCount}
+
+Σχετικές συζητήσεις:
+${subjectLines}`;
+
+    const { result } = await aiChat<{ brief: string }>(
+        systemPrompt,
+        userPrompt,
+        undefined,
+        undefined,
+        { maxTokens: 1024 }
+    );
+
+    return NextResponse.json({ brief: result.brief });
+}

--- a/src/app/api/map/subjects/route.ts
+++ b/src/app/api/map/subjects/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import prisma from '@/lib/db/prisma'
 import { Prisma } from '@prisma/client'
+import { buildSubjectsByTopicsWhere } from '@/lib/db/subject'
 
 // Disable caching for dynamic queries with different filters
 export const dynamic = 'force-dynamic';
@@ -29,27 +30,14 @@ export async function GET(request: Request) {
         console.log('📅 Date threshold:', dateThreshold.toISOString());
 
         // Build where clause
-        const whereClause: any = {
-            locationId: {
-                not: null
-            },
-            councilMeeting: {
-                city: {
-                    officialSupport: true
-                },
-                released: true,
-                dateTime: {
-                    gte: dateThreshold
-                }
-            }
+        const whereClause = {
+            locationId: { not: null },
+            ...buildSubjectsByTopicsWhere({
+                requireOfficialSupport: true,
+                since: dateThreshold,
+                topicIds,
+            }),
         };
-
-        // Add topic filter if specified
-        if (topicIds.length > 0) {
-            whereClause.topicId = {
-                in: topicIds
-            };
-        }
 
         // Get all subjects from officially supported cities that have locations
         const subjects = await prisma.subject.findMany({

--- a/src/components/onboarding/containers/FormContainer.tsx
+++ b/src/components/onboarding/containers/FormContainer.tsx
@@ -14,6 +14,7 @@ import { useRouter } from 'next/navigation';
 import { useMediaQuery } from '@/hooks/use-media-query';
 import { PetitionFormStep } from '../steps/petition/PetitionFormStep';
 import { NotificationInfoStep } from '../steps/notification/NotificationInfoStep';
+import { WelcomeBriefStep } from '../steps/notification/WelcomeBriefStep';
 
 export function FormContainer() {
     const {
@@ -88,6 +89,8 @@ export function FormContainer() {
                         onBack={handleBack}
                     />
                 );
+            case OnboardingStage.NOTIFICATION_WELCOME_BRIEF:
+                return <WelcomeBriefStep />;
             case OnboardingStage.NOTIFICATION_COMPLETE:
                 return <CompleteStep />;
             default:

--- a/src/components/onboarding/steps/notification/WelcomeBriefStep.tsx
+++ b/src/components/onboarding/steps/notification/WelcomeBriefStep.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { motion } from 'framer-motion';
+import { useOnboarding } from '@/contexts/OnboardingContext';
+import { OnboardingStepTemplate } from '@/components/onboarding/OnboardingStepTemplate';
+import { OnboardingFooter } from '@/components/onboarding/OnboardingFooter';
+import { OnboardingStage } from '@/lib/types/onboarding';
+
+type Status = 'loading' | 'done' | 'error' | 'no_matches';
+
+export function WelcomeBriefStep() {
+    const { city, selectedTopics, setStage } = useOnboarding();
+    const [brief, setBrief] = useState<string | null>(null);
+    const [status, setStatus] = useState<Status>('loading');
+
+    useEffect(() => {
+        if (!city) {
+            setStatus('error');
+            return;
+        }
+        const topicIds = selectedTopics.map(t => t.id);
+
+        fetch(`/api/cities/${city.id}/welcome-brief`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ topicIds }),
+        })
+            .then(res => res.json())
+            .then((data: { brief: string | null }) => {
+                if (data.brief) {
+                    setBrief(data.brief);
+                    setStatus('done');
+                } else {
+                    setStatus('no_matches');
+                }
+            })
+            .catch(() => {
+                setStatus('error');
+            });
+    }, [city, selectedTopics]);
+
+    const handleContinue = () => {
+        setStage(OnboardingStage.NOTIFICATION_COMPLETE);
+    };
+
+    return (
+        <OnboardingStepTemplate
+            title="Να τι έχεις χάσει"
+            footer={
+                <OnboardingFooter
+                    currentStep={0}
+                    totalSteps={0}
+                    onBack={() => {}}
+                    onAction={handleContinue}
+                    actionLabel="Συνέχεια →"
+                    isActionDisabled={status === 'loading'}
+                    hideBack={true}
+                />
+            }
+        >
+            {status === 'loading' && (
+                <div className="space-y-3">
+                    {[1, 2, 3, 4, 5].map(i => (
+                        <motion.div
+                            key={i}
+                            className="h-4 bg-gray-200 rounded"
+                            style={{ width: `${100 - (i % 3) * 15}%` }}
+                            animate={{ opacity: [0.4, 0.8, 0.4] }}
+                            transition={{ duration: 1.4, repeat: Infinity, delay: i * 0.1 }}
+                        />
+                    ))}
+                    <p className="text-sm text-muted-foreground mt-4">
+                        Ετοιμάζουμε το προσωπικό σου briefing…
+                    </p>
+                </div>
+            )}
+
+            {status === 'done' && brief && (
+                <div className="prose prose-sm max-w-none text-sm
+                    [&_h1]:text-base [&_h1]:font-bold [&_h1]:mb-2
+                    [&_h2]:text-sm [&_h2]:font-semibold [&_h2]:mb-1 [&_h2]:mt-3
+                    [&_h3]:text-sm [&_h3]:font-semibold [&_h3]:mb-1
+                    [&_p]:mb-2 [&_p]:leading-relaxed
+                    [&_ul]:mb-2 [&_ul]:ml-4 [&_ul]:list-disc [&_ul]:space-y-1
+                    [&_li]:leading-relaxed
+                    [&_strong]:font-semibold
+                ">
+                    <ReactMarkdown>{brief}</ReactMarkdown>
+                </div>
+            )}
+
+            {status === 'no_matches' && (
+                <p className="text-sm text-muted-foreground">
+                    Δεν βρήκαμε ακόμα συζητήσεις για τα θέματα σου, αλλά μείνε συνδεδεμένος! Θα σε ειδοποιήσουμε μόλις ξεκινήσουν.
+                </p>
+            )}
+
+            {status === 'error' && (
+                <div className="space-y-2">
+                    <p className="text-sm text-muted-foreground">
+                        Κάτι πήγε στραβά με την προετοιμασία του briefing σου.
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                        Μπορείς να συνεχίσεις κανονικά — θα λαμβάνεις ειδοποιήσεις για τα θέματα που επέλεξες.
+                    </p>
+                </div>
+            )}
+        </OnboardingStepTemplate>
+    );
+}

--- a/src/contexts/OnboardingContext.tsx
+++ b/src/contexts/OnboardingContext.tsx
@@ -192,8 +192,8 @@ export function OnboardingProvider({
                     setError('genericError');
                 }
             } else {
-                // Move to completion stage
-                setStage(OnboardingStage.NOTIFICATION_COMPLETE);
+                // Move to welcome brief stage
+                setStage(OnboardingStage.NOTIFICATION_WELCOME_BRIEF);
             }
         } catch (error: any) {
             console.error('Error saving notification preferences:', error);

--- a/src/lib/db/subject.ts
+++ b/src/lib/db/subject.ts
@@ -11,6 +11,35 @@ import {
     CouncilMeeting,
     Prisma,
 } from '@prisma/client';
+
+export interface GetSubjectsByTopicsParams {
+    /** Filter to a single city. Mutually exclusive with requireOfficialSupport. */
+    cityId?: string;
+    /** When true, only include subjects from cities with officialSupport: true. */
+    requireOfficialSupport?: boolean;
+    since: Date;
+    topicIds: string[];
+}
+
+/**
+ * Builds the Prisma `where` clause for fetching subjects filtered by topics and date.
+ * Shared by the map subjects API route and the welcome brief API route.
+ */
+export function buildSubjectsByTopicsWhere(params: GetSubjectsByTopicsParams): Prisma.SubjectWhereInput {
+    const { cityId, requireOfficialSupport, since, topicIds } = params;
+
+    const councilMeetingFilter: Prisma.CouncilMeetingWhereInput = {
+        released: true,
+        dateTime: { gte: since },
+        ...(cityId ? { cityId } : {}),
+        ...(requireOfficialSupport ? { city: { officialSupport: true } } : {}),
+    };
+
+    return {
+        councilMeeting: councilMeetingFilter,
+        ...(topicIds.length > 0 ? { topicId: { in: topicIds } } : {}),
+    };
+}
 import { PersonWithRelations } from '@/lib/db/people';
 import { getCity } from './cities';
 import { getCouncilMeeting } from './meetings';

--- a/src/lib/db/welcomeBrief.ts
+++ b/src/lib/db/welcomeBrief.ts
@@ -1,0 +1,66 @@
+import prisma from './prisma';
+import { buildSubjectsByTopicsWhere } from './subject';
+
+export interface WelcomeBriefData {
+    cityName: string;
+    totalMeetingCount: number;
+    matchedSubjectCount: number;
+    matchedSubjects: Array<{
+        subjectName: string;
+        description: string | null;
+        topicName: string;
+        meetingDate: Date;
+        meetingName: string;
+        hot: boolean;
+        context: string | null;
+    }>;
+}
+
+export async function getSubjectsForWelcomeBrief(
+    cityId: string,
+    topicIds: string[],
+    since: Date
+): Promise<WelcomeBriefData> {
+    const city = await prisma.city.findUnique({ where: { id: cityId }, select: { name: true } });
+
+    if (topicIds.length === 0) {
+        return {
+            cityName: city?.name ?? cityId,
+            totalMeetingCount: 0,
+            matchedSubjectCount: 0,
+            matchedSubjects: [],
+        };
+    }
+
+    const [totalMeetingCount, subjects] = await Promise.all([
+        prisma.councilMeeting.count({
+            where: { cityId, released: true, dateTime: { gte: since } },
+        }),
+        prisma.subject.findMany({
+            where: buildSubjectsByTopicsWhere({ cityId, since, topicIds }),
+            include: {
+                councilMeeting: { select: { dateTime: true, name: true } },
+                topic: { select: { name: true } },
+            },
+            orderBy: { councilMeeting: { dateTime: 'desc' } },
+            take: 20,
+        }),
+    ]);
+
+    const matchedSubjects = subjects.map(s => ({
+        subjectName: s.name,
+        description: s.description,
+        topicName: s.topic?.name ?? '',
+        meetingDate: s.councilMeeting?.dateTime ?? new Date(),
+        meetingName: s.councilMeeting?.name ?? '',
+        hot: s.hot,
+        context: s.context,
+    }));
+
+    return {
+        cityName: city?.name ?? cityId,
+        totalMeetingCount,
+        matchedSubjectCount: subjects.length,
+        matchedSubjects,
+    };
+}

--- a/src/lib/types/onboarding.ts
+++ b/src/lib/types/onboarding.ts
@@ -13,6 +13,7 @@ export enum OnboardingStage {
     NOTIFICATION_LOCATION_SELECTION = 'NOTIFICATION_LOCATION_SELECTION',
     NOTIFICATION_TOPIC_SELECTION = 'NOTIFICATION_TOPIC_SELECTION',
     NOTIFICATION_REGISTRATION = 'NOTIFICATION_REGISTRATION',
+    NOTIFICATION_WELCOME_BRIEF = 'NOTIFICATION_WELCOME_BRIEF',
     NOTIFICATION_COMPLETE = 'NOTIFICATION_COMPLETE',
     
     // Petition Flow
@@ -48,6 +49,7 @@ export const notificationFlow: Flow = {
         { id: OnboardingStage.NOTIFICATION_LOCATION_SELECTION, showInProgress: true },
         { id: OnboardingStage.NOTIFICATION_TOPIC_SELECTION, showInProgress: true },
         { id: OnboardingStage.NOTIFICATION_REGISTRATION, showInProgress: true },
+        { id: OnboardingStage.NOTIFICATION_WELCOME_BRIEF, showInProgress: false },
         { id: OnboardingStage.NOTIFICATION_COMPLETE, showInProgress: false }
     ],
     getNextStep: (currentStep) => {


### PR DESCRIPTION
Implements the Welcome Brief feature: a personalized catch-up screen shown after notification onboarding.

## Changes

**Refactoring (reuse existing patterns):**
- Extracted shared `buildSubjectsByTopicsWhere` helper in `src/lib/db/subject.ts`
- Refactored `/api/map/subjects` route to use the shared helper (removes query duplication)

**New files:**
- `src/lib/db/welcomeBrief.ts` — `getSubjectsForWelcomeBrief` DB query using the shared helper
- `src/app/api/cities/[cityId]/welcome-brief/route.ts` — POST endpoint, returns `{ brief: string | null }`
- `src/components/onboarding/steps/notification/WelcomeBriefStep.tsx` — UI with loading skeleton + full brief render

**Modified files:**
- `src/lib/types/onboarding.ts` — Added `NOTIFICATION_WELCOME_BRIEF` stage
- `src/contexts/OnboardingContext.tsx` — Redirect to brief after registration
- `src/components/onboarding/containers/FormContainer.tsx` — Render new step

## Flow
```
NOTIFICATION_REGISTRATION → NOTIFICATION_WELCOME_BRIEF → NOTIFICATION_COMPLETE
```

The brief step shows a skeleton loading animation while Claude generates a ~300 word Greek-language catch-up based on the user's selected topics and their city's recent council meetings. No streaming — the brief loads in 3-6 seconds with a clean loading state.

Closes #223

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new AI-backed API endpoint and onboarding step, which can impact latency/cost and adds new failure modes during signup. Also refactors subject filtering logic used by the map API, which could subtly change query results if the new shared `where` builder differs from the prior inline filters.
> 
> **Overview**
> Adds a new *Welcome Brief* step to the notification onboarding flow (`NOTIFICATION_REGISTRATION → NOTIFICATION_WELCOME_BRIEF → NOTIFICATION_COMPLETE`) that fetches and renders an AI-generated, Greek-language markdown catch-up with loading/error/empty states.
> 
> Implements `POST /api/cities/[cityId]/welcome-brief` to validate `topicIds`, query the last 6 months of relevant council-meeting subjects, and call `aiChat` to return `{ brief: string | null }`.
> 
> Extracts a shared Prisma filter helper `buildSubjectsByTopicsWhere` in `src/lib/db/subject.ts` and refactors `/api/map/subjects` to use it, reducing duplicated query logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 964132c3e7c18e5ab541341a5c2e2ef3fea997b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds personalized welcome brief after notification onboarding. Shows users a 300-word AI-generated Greek summary of recent council discussions matching their selected topics from the last 6 months.

**Key changes:**
- Refactored shared query logic into `buildSubjectsByTopicsWhere` helper (removes duplication from map route)
- New POST `/api/cities/[cityId]/welcome-brief` endpoint generates brief via Claude
- Added `NOTIFICATION_WELCOME_BRIEF` stage between registration and completion
- Clean loading skeleton with 3-6 second wait for AI generation

**Issues found:**
- Missing authentication in welcome-brief endpoint allows unauthorized AI generation
- No try-catch error handling around database queries and AI calls

<h3>Confidence Score: 3/5</h3>

- Unsafe to merge without authentication and error handling fixes
- Good refactoring and clean UX, but the welcome-brief endpoint has critical security issues (no auth check) and will crash on errors (no try-catch). These must be fixed before merge.
- Pay close attention to `src/app/api/cities/[cityId]/welcome-brief/route.ts` — needs auth and error handling before deploy

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/api/cities/[cityId]/welcome-brief/route.ts | new POST endpoint to generate AI welcome brief — missing auth check and error handling |
| src/lib/db/subject.ts | extracted shared `buildSubjectsByTopicsWhere` helper for filtering subjects by topics and date |
| src/lib/db/welcomeBrief.ts | new DB query using shared helper to fetch subjects for welcome brief generation |
| src/components/onboarding/steps/notification/WelcomeBriefStep.tsx | new component with loading skeleton and markdown rendering — clean error states |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant WelcomeBriefStep
    participant API as /api/cities/[cityId]/welcome-brief
    participant DB as getSubjectsForWelcomeBrief
    participant AI as aiChat (Claude)
    
    User->>WelcomeBriefStep: Complete registration
    WelcomeBriefStep->>WelcomeBriefStep: Set status: loading
    WelcomeBriefStep->>API: POST {topicIds}
    API->>DB: Query subjects (last 6 months)
    DB-->>API: Return matched subjects + stats
    
    alt No matching subjects
        API-->>WelcomeBriefStep: {brief: null}
        WelcomeBriefStep->>WelcomeBriefStep: Set status: no_matches
    else Has matching subjects
        API->>AI: Generate Greek brief (~300 words)
        AI-->>API: {brief: markdown text}
        API-->>WelcomeBriefStep: {brief: markdown}
        WelcomeBriefStep->>WelcomeBriefStep: Set status: done
        WelcomeBriefStep->>User: Render markdown brief
    end
    
    User->>WelcomeBriefStep: Click Continue
    WelcomeBriefStep->>User: Navigate to NOTIFICATION_COMPLETE
```

<sub>Last reviewed commit: 964132c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->