### PR TITLE
fix: use city timezone for .docx transcript date formatting

### DIFF
--- a/src/components/meetings/docx/CouncilMeetingDocx.tsx
+++ b/src/components/meetings/docx/CouncilMeetingDocx.tsx
@@ -1,5 +1,5 @@
 import { el } from 'date-fns/locale';
-import { format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 import { Document, Paragraph, TextRun, HeadingLevel, ExternalHyperlink, Packer, AlignmentType } from 'docx';
 import { getPartyFromRoles, getSingleCityRole, formatTimestamp } from '@/lib/utils';
 import { MeetingDataForExport } from '@/lib/export/meetings';
@@ -32,7 +32,7 @@ const createTitlePage = ({ meeting, city }: Pick<MeetingDataForExport, 'meeting'
             alignment: AlignmentType.CENTER,
             spacing: { after: 480 },
             children: [new TextRun({
-                text: format(meeting.dateTime, 'EEEE, d MMMM yyyy, HH:mm', { locale: el }),
+                text: formatInTimeZone(meeting.dateTime, city.timezone, 'EEEE, d MMMM yyyy, HH:mm', { locale: el }),
                 size: 24 // 12pt
             })],
         }),


### PR DESCRIPTION
## Problem

The .docx transcript export formats the meeting date using `date-fns/format()`, which uses the server's local timezone (UTC). This means Greek council meetings show UTC times instead of the city's actual timezone (e.g. `Europe/Athens`).

## Fix

Replace `format()` with `formatInTimeZone()` from `date-fns-tz` (already a project dependency), using `city.timezone` to render dates correctly.

### Changes
- `src/components/meetings/docx/CouncilMeetingDocx.tsx`: 2 lines changed
  - Import `formatInTimeZone` from `date-fns-tz` instead of `format` from `date-fns`
  - Use `city.timezone` when formatting the meeting date on the title page

The speaker segment timestamps (relative offsets) are unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to `.docx` title-page date rendering; main risk is incorrect output if `city.timezone` is missing/invalid.
> 
> **Overview**
> Fixes `.docx` transcript export to render the meeting date/time in the **city’s configured timezone** rather than the server timezone.
> 
> Replaces `date-fns` `format()` with `date-fns-tz` `formatInTimeZone()` in `CouncilMeetingDocx.tsx`, using `city.timezone` while keeping the same date format and locale.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec918c5f97bf3a4adf4e4940a5a504c527d1a864. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a timezone bug where .docx transcript exports were showing meeting dates in UTC instead of the city's local timezone. The fix replaces `format()` from `date-fns` with `formatInTimeZone()` from `date-fns-tz` (already a project dependency), correctly using the `city.timezone` field from the database.

**Changes:**
- Import changed from `date-fns` to `date-fns-tz`
- Meeting date formatting now uses city timezone (e.g., `Europe/Athens`)
- Format pattern and Greek locale preserved correctly
- Speaker timestamps unaffected (relative offsets, not absolute times)

The implementation is correct: `city.timezone` is a required field in the Prisma schema, and the `formatInTimeZone` function is used properly.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Score reflects a simple, well-implemented bug fix that correctly addresses the timezone issue. The change is minimal (2 lines), uses an existing dependency (`date-fns-tz`), and `city.timezone` is a required database field. No TypeScript errors and no functional risks.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/meetings/docx/CouncilMeetingDocx.tsx | Fixed timezone issue by replacing `format` with `formatInTimeZone` to use city timezone instead of UTC |

</details>



<sub>Last reviewed commit: ec918c5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->