### PR TITLE
Fix: Prevent dialog overflow on all dialogs

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 max-h-[90vh] overflow-y-auto data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       // Marker used by components (e.g., Combobox) to portal overlays inside this dialog


### PR DESCRIPTION
Adds max-h-[90vh] and overflow-y-auto to the shared DialogContent component so all dialogs are constrained to the viewport and scroll when content is too tall. Fixes the admin body edit form overflow issue and prevents it from happening on any future dialog.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds global overflow constraints to all dialogs by setting `max-h-[90vh] overflow-y-auto` on the base `DialogContent` component. This fixes dialogs overflowing on small viewports by capping height at 90% viewport and enabling internal scrolling.

**Key changes:**
- Added `max-h-[90vh]` to constrain maximum dialog height
- Added `overflow-y-auto` to enable scrolling when content exceeds max height

**Concerns:**
- May cause double scrollbars in 4 dialogs using `flex flex-col` layout pattern with nested scrollable children (`json-metadata-dialog.tsx`, `HighlightGuideDialog.tsx`, `SpeakerSegmentMetadataDialog.tsx`, `NotificationMapDialog.tsx`)
- PR description mentions cleaning up `AdministrativeBodiesList.tsx` but that file is not in the changeset
- Several dialogs now have redundant `max-h-[90vh] overflow-y-auto` in custom classNames that could be cleaned up

<h3>Confidence Score: 3/5</h3>

- Safe to merge with potential UX issues in specific dialogs that should be monitored
- The change is UI-only with no data/auth impact, but adds global scrolling behavior that may conflict with 4 existing dialogs using flex layout patterns. The issue is non-critical but could create double scrollbars or awkward scroll behavior. Worth testing those specific dialogs after merge.
- Test dialogs using `flex flex-col` pattern: `json-metadata-dialog.tsx`, `HighlightGuideDialog.tsx`, `SpeakerSegmentMetadataDialog.tsx`, `NotificationMapDialog.tsx` for potential double scrollbar issues

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/ui/dialog.tsx | Added `max-h-[90vh] overflow-y-auto` to base DialogContent, which fixes most dialogs but may cause double scrollbars in dialogs using flex layout patterns |

</details>



<sub>Last reviewed commit: 2225e03</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->