### PR TITLE
fix(highlights): exclude AI-generated highlights from list

### DIFF
--- a/src/lib/db/highlights.ts
+++ b/src/lib/db/highlights.ts
@@ -119,6 +119,10 @@ export async function getHighlightsForMeeting(
     // City editors (including super admins) see all highlights
     // Regular users only see their own
     if (!permissions.canEditCity) {
+         // City editors: all user-created highlights (exclude AI)  #issue236
+        where.createdById = {not: null};
+    }   else{
+        // Regular users: only their own highlights (implicitly excludes AI) #issue236
         where.createdById = permissions.userId;
     }
 


### PR DESCRIPTION
City editors see all user-created highlights (createdById: { not: null }) Regular users see only their own (implicitly excludes AI)

Closes #236

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attempts to exclude AI-generated highlights by filtering for `createdById: { not: null }`, which correctly excludes AI highlights (where `createdById` is null). However, the implementation contains a critical logic error that completely reverses the intended behavior.

- **Critical issue**: The conditional logic is inverted - regular users now see ALL user-created highlights, while city editors only see their own
- The condition `!permissions.canEditCity` applies city editor logic to regular users and vice versa
- This breaks the fundamental permission model and creates a severe security/privacy issue

<h3>Confidence Score: 0/5</h3>

- This PR is NOT safe to merge - contains a critical logic inversion that breaks permissions
- Score of 0 reflects a fundamental logic error that reverses the entire permission model. Regular users would see all highlights instead of only their own, while city editors would be restricted to their own. This is a critical security/privacy issue that must be fixed before merging.
- src/lib/db/highlights.ts requires immediate attention to fix the inverted conditional logic

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/db/highlights.ts | Critical logic inversion: regular users get all highlights while city editors get only their own - opposite of intended behavior |

</details>



<sub>Last reviewed commit: dd209c2</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->