### PR TITLE
fix: validate FK ordering and abort on copy failure in copy_db.sh

### DIFF
--- a/scripts/copy_db.sh
+++ b/scripts/copy_db.sh
@@ -151,6 +151,42 @@ if [ "$FK_ERRORS" -gt 0 ]; then
 fi
 echo "Table order is valid."
 
+# Find nullable FK columns that reference tables NOT in our copy list (e.g. User).
+# Since we intentionally exclude user data for privacy, these columns must be NULLed
+# during copy to avoid FK violations against non-existent rows.
+declare -A NULLIFY_COLUMNS  # TABLE -> space-separated column names to NULL
+ORPHAN_FK_OUTPUT=$(psql --set ON_ERROR_STOP=on "$SOURCE" -t -A -F $'\t' -c "
+    SELECT
+        cl_child.relname,
+        a.attname,
+        cl_parent.relname,
+        CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END
+    FROM pg_constraint con
+    JOIN pg_class cl_child ON con.conrelid = cl_child.oid
+    JOIN pg_class cl_parent ON con.confrelid = cl_parent.oid
+    JOIN pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = ANY(con.conkey)
+    WHERE con.contype = 'f' AND cl_child.relname != cl_parent.relname;
+")
+if [ $? -ne 0 ]; then
+    echo -e "\033[31mFailed to query orphan FK columns. Aborting.\033[0m"
+    exit 1
+fi
+while IFS=$'\t' read -r child_table col_name parent_table is_nullable; do
+    [ -z "$child_table" ] && continue
+    # Only care about tables we're copying that reference tables we're NOT copying
+    if [ -z "${TABLE_INDEX[$child_table]+x}" ]; then continue; fi
+    if [ -n "${TABLE_INDEX[$parent_table]+x}" ]; then continue; fi
+    if [ "$is_nullable" != "YES" ]; then
+        echo -e "\033[31mERROR: \"$child_table\".\"$col_name\" has a non-nullable FK to \"$parent_table\" which is not being copied. Cannot proceed.\033[0m"
+        exit 1
+    fi
+    NULLIFY_COLUMNS[$child_table]="${NULLIFY_COLUMNS[$child_table]:+${NULLIFY_COLUMNS[$child_table]} }$col_name"
+done <<< "$ORPHAN_FK_OUTPUT"
+
+for tbl in "${!NULLIFY_COLUMNS[@]}"; do
+    echo "Note: will NULL out [${NULLIFY_COLUMNS[$tbl]}] in \"$tbl\" (FK to non-copied table)"
+done
+
 # Delete all rows from destination tables if --clear flag is set
 if [ "$CLEAR" = true ]; then
     for TABLE in "${TABLES[@]}"; do
@@ -165,8 +201,32 @@ fi
 
 # Proceed with data copying
 for TABLE in "${TABLES[@]}"; do
-    echo "Copying data for $TABLE"
-    pg_dump --data-only -t "\"$TABLE\"" "$SOURCE" | psql --set ON_ERROR_STOP=on "$TARGET"
+    if [ -n "${NULLIFY_COLUMNS[$TABLE]+x}" ]; then
+        # Table has FK columns pointing to non-copied tables — use custom SELECT that NULLs them
+        COLS_TO_NULL="${NULLIFY_COLUMNS[$TABLE]}"
+        echo "Copying data for $TABLE (NULLing: $COLS_TO_NULL)"
+
+        # Build SELECT: replace each column-to-NULL with "NULL AS col", keep the rest
+        ALL_COLUMNS=$(psql --set ON_ERROR_STOP=on "$SOURCE" -t -A -c "
+            SELECT string_agg('\"' || column_name || '\"', ', ' ORDER BY ordinal_position)
+            FROM information_schema.columns
+            WHERE table_name = '$TABLE' AND table_schema = 'public';
+        ")
+        if [ $? -ne 0 ] || [ -z "$ALL_COLUMNS" ]; then
+            echo -e "\033[31mERROR: Failed to retrieve column list for $TABLE. Aborting.\033[0m"
+            exit 1
+        fi
+        SELECT_COLUMNS="$ALL_COLUMNS"
+        for col in $COLS_TO_NULL; do
+            SELECT_COLUMNS=$(echo "$SELECT_COLUMNS" | sed "s/\"$col\"/NULL AS \"$col\"/g")
+        done
+
+        psql --set ON_ERROR_STOP=on "$SOURCE" -c "COPY (SELECT $SELECT_COLUMNS FROM \"$TABLE\") TO STDOUT" \
+            | psql --set ON_ERROR_STOP=on "$TARGET" -c "COPY \"$TABLE\" ($ALL_COLUMNS) FROM STDIN"
+    else
+        echo "Copying data for $TABLE"
+        pg_dump --data-only -t "\"$TABLE\"" "$SOURCE" | psql --set ON_ERROR_STOP=on "$TARGET"
+    fi
     if [ $? -ne 0 ]; then
         echo -e "\033[31mERROR: Failed to copy $TABLE. Aborting.\033[0m"
         exit 1


### PR DESCRIPTION
## Summary
- Adds a pre-flight validation step that queries `pg_constraint` to verify the table order respects FK dependencies before any data operations
- Adds `ON_ERROR_STOP` and `set -o pipefail` so failures abort immediately instead of silently continuing

## Context
This was built as a safeguard to prevent issues like the one fixed in 4204535dacd6ac01d3d3f9b22ccb95cd2cc10d50, where `Utterance` was copied before `Subject` even though `Utterance.discussionSubjectId` references `Subject`. Because `pg_dump`'s `COPY` is atomic per table, the entire Utterance table silently failed to copy — resulting in staging having speaker segments with no transcript text.

The validation now catches FK ordering errors before any data is deleted or copied, and clearly reports which tables need reordering.

## Test plan
- [x] Verified validation passes with correct table order against staging DB
- [x] Verified validation catches the original bug (Subject after Utterance) with a clear error message


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a destructive DB copy/clear script and changes execution behavior to fail fast; could now abort earlier (e.g., `--clear` deletes may hit FK constraints) and alter staging/ops workflows.
> 
> **Overview**
> Hardens `scripts/copy_db.sh` to *fail fast* and avoid silent partial copies by enabling `set -o pipefail`, adding `ON_ERROR_STOP`, and aborting on delete/copy failures.
> 
> Adds pre-flight checks before any destructive work: verifies the target DB is not missing any completed source Prisma migrations, validates `TABLES` ordering against actual FK dependencies from `pg_constraint`, and detects nullable FK columns pointing to non-copied tables and copies those tables via a custom `COPY (SELECT …)` that NULLs the offending columns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2faa18574633d7ed7c47cce4ac22f63d24087cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR significantly hardens `scripts/copy_db.sh` — a production-adjacent database copy script — by adding several layers of pre-flight safety: migration state validation (source vs. target), FK dependency ordering validation via `pg_constraint`, orphan FK detection and NULLing for privacy-excluded tables, `set -o pipefail`, `ON_ERROR_STOP` on all `psql` invocations, and explicit exit code checks throughout.

Key changes:
- **Migration check**: Aborts if the target DB is missing any applied migration from the source, preventing column-not-found errors during `COPY`.
- **FK ordering validation**: Queries `pg_constraint` to confirm the `TABLES` array respects FK dependencies before any data is deleted or inserted.
- **Orphan FK NULLing**: For tables that have nullable FK columns pointing to intentionally-excluded tables (e.g., `User`), the script builds a custom `COPY (SELECT ...) TO STDOUT` that substitutes `NULL` for those columns, preventing FK violations during insert.
- **Error propagation**: `ON_ERROR_STOP`, `pipefail`, and `$?` checks ensure any failure aborts immediately rather than silently continuing.
- **Bug (flagged)**: The `--clear` delete loop iterates `TABLES` in forward (parent-first) order, which is the correct order for *insertion* but the *wrong* order for deletion. Because the FK validation now enforces parent-before-child ordering in `TABLES`, running `--clear` against a staging DB that has existing rows will produce FK violation errors on the very first `DELETE`. Deletion should use the reverse order (children first).

<h3>Confidence Score: 3/5</h3>

- Safe to merge without --clear; using --clear on a populated staging DB will abort with FK violations due to incorrect delete ordering.
- The validation and error-propagation improvements are solid and correctly implemented. However, the --clear delete path iterates TABLES in parent-first order — guaranteed by the new FK validation — which is the wrong direction for deletions. This will break any --clear invocation against a non-empty target. Fixing this requires reversing the delete loop iteration.
- scripts/copy_db.sh — specifically the --clear delete loop at lines 191–200

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/copy_db.sh | Significantly hardens copy_db.sh with migration state checks, FK ordering validation, orphan FK NULLing, ON_ERROR_STOP, and pipefail — but introduces a deletion-order bug: the new FK validation enforces parent-before-child ordering in TABLES, yet the --clear delete loop iterates the same (forward) order, causing FK violations when the target has existing data. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start copy_db.sh] --> B[Parse args & confirm]
    B --> C[Check migration state\nsource vs target]
    C -->|missing migrations| ABORT1[Abort ❌]
    C -->|OK| D[Build TABLE_INDEX map]
    D --> E[Query pg_constraint for FK deps]
    E -->|query fails| ABORT2[Abort ❌]
    E --> F{For each FK:\nchild position < parent position?}
    F -->|FK ordering error| ABORT3[Abort ❌]
    F -->|all OK| G[Query orphan FK columns\nrefs to non-copied tables]
    G -->|non-nullable orphan FK| ABORT4[Abort ❌]
    G -->|nullable| H[Record NULLIFY_COLUMNS per table]
    H --> I{--clear flag?}
    I -->|yes| J[Delete TABLES in forward order ⚠️\nparent-first = FK violations if data exists]
    I -->|no| K[Copy loop]
    J --> K
    K --> L{Table in NULLIFY_COLUMNS?}
    L -->|yes| M[Get column list via\ninformation_schema\nBuild SELECT with NULLed FKs\nCOPY TO STDOUT → FROM STDIN]
    L -->|no| N[pg_dump --data-only\npiped to psql]
    M --> O{Copy exit code != 0?}
    N --> O
    O -->|fail| ABORT5[Abort ❌]
    O -->|OK| P{More tables?}
    P -->|yes| K
    P -->|no| Q[Done ✅]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `scripts/copy_db.sh`, line 192-199 ([link](https://github.com/schemalabz/opencouncil/blob/a3c2bdde385248cd2791768ae4a8e242577ee173/scripts/copy_db.sh#L192-L199)) 

   **Delete loop iterates in wrong order for FK-constrained schemas**

   The `TABLES` array is intentionally ordered parents-before-children so that INSERT/COPY respects FK dependencies. But this same order is used when deleting — deleting a parent table (`City`, index 0) while child rows in tables like `CouncilMeeting` or `SpeakerTag` still reference it will trigger a FK violation on the first iteration and immediately abort (due to the new `exit 1` on line 195-198), leaving the target **completely un-cleared**.

   The fix is to iterate in reverse so children are deleted before their parents:

2. `scripts/copy_db.sh`, line 191-200 ([link](https://github.com/schemalabz/opencouncil/blob/a2faa18574633d7ed7c47cce4ac22f63d24087cb/scripts/copy_db.sh#L191-L200)) 

   **Delete loop order causes FK violations**

   The new FK validation explicitly ensures `TABLES` is in **parent-first** order (parents before children). However, the `--clear` delete loop iterates over `TABLES` in the same parent-first order — which is the *wrong* order for deletion.

   When staging already contains data from a previous run, `DELETE FROM "City"` will fail with a FK violation because child table rows (e.g., in `CouncilMeeting`, which references `City`) still exist. Adding `ON_ERROR_STOP` makes this fatal: the script will now abort before deleting any child data, leaving the staging DB in whatever state it was in.

   The fix is to delete in reverse `TABLES` order (children first, then parents):

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/copy_db.sh
Line: 191-200

Comment:
**Delete loop order causes FK violations**

The new FK validation explicitly ensures `TABLES` is in **parent-first** order (parents before children). However, the `--clear` delete loop iterates over `TABLES` in the same parent-first order — which is the *wrong* order for deletion.

When staging already contains data from a previous run, `DELETE FROM "City"` will fail with a FK violation because child table rows (e.g., in `CouncilMeeting`, which references `City`) still exist. Adding `ON_ERROR_STOP` makes this fatal: the script will now abort before deleting any child data, leaving the staging DB in whatever state it was in.

The fix is to delete in reverse `TABLES` order (children first, then parents):

```suggestion
if [ "$CLEAR" = true ]; then
    for (( i=${#TABLES[@]}-1; i>=0; i-- )); do
        TABLE="${TABLES[$i]}"
        echo "Deleting all rows from $TABLE"
        psql --set ON_ERROR_STOP=on "$TARGET" -c "DELETE FROM \"$TABLE\";"
        if [ $? -ne 0 ]; then
            echo -e "\033[31mERROR: Failed to delete from $TABLE. Aborting.\033[0m"
            exit 1
        fi
    done
fi
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: a2faa18</sub>

<!-- /greptile_comment -->