### PR TITLE
Remove hot field for subjects

### DIFF
--- a/prisma/migrations/20260302000000_remove_subject_hot_field/migration.sql
+++ b/prisma/migrations/20260302000000_remove_subject_hot_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Subject" DROP COLUMN "hot";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -397,7 +397,6 @@ model Subject {
   cityId String
   councilMeetingId String
 
-  hot Boolean @default(false)
   agendaItemIndex Int?
   nonAgendaReason NonAgendaReason?
   topicId String?

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -647,7 +647,6 @@ async function seedSubjects(subjects: any[], meeting: any) {
     id: subject.id,
     name: subject.name,
     description: subject.description,
-    hot: subject.hot || false,
     agendaItemIndex: subject.agendaItemIndex,
     nonAgendaReason: subject.nonAgendaReason,
     topicId: subject.topicId,

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -23,7 +23,6 @@ const MeetingOGImage = async (cityId: string, meetingId: string) => {
         day: 'numeric',
     });
 
-    // Sort subjects by importance (hot subjects first, then by speaking time)
     const sortedSubjects = sortSubjectsByImportance(data.subjects);
 
     return (
@@ -171,11 +170,10 @@ const MeetingStoryOGImage = async (cityId: string, meetingId: string) => {
         day: 'numeric',
     });
 
-    // Sort subjects by importance (hot subjects first, then by speaking time)
     const sortedSubjects = sortSubjectsByImportance(data.subjects);
 
     return (
-        <Container 
+        <Container
             watermarkProps={{ size: 120, fontSize: 50, bottom: 52, right: 52 }}
             containerPadding="64px 48px"
         >

--- a/src/components/meetings/MeetingCard.tsx
+++ b/src/components/meetings/MeetingCard.tsx
@@ -66,8 +66,6 @@ export default function MeetingCard({ item: meeting, editable, mostRecent, cityT
         setIsLoading(false);
     }, [pathname]);
 
-    // Since data comes from the backend as ordered by hot status already (due to db query order),d
-    // we maintain that order but use our utility for consistency
     const sortedSubjects = useMemo(() => {
         const result = sortSubjectsByImportance(meeting.subjects, 'importance');
 
@@ -81,7 +79,6 @@ export default function MeetingCard({ item: meeting, editable, mostRecent, cityT
                 topSubjects: topThree.map(s => ({
                     id: s.id,
                     name: s.name,
-                    isHot: s.hot,
                     segmentCount: s.speakerSegments?.length || 0,
                     agendaItemIndex: s.agendaItemIndex,
                     hasTopic: !!s.topic

--- a/src/lib/__tests__/db-utils.test.ts
+++ b/src/lib/__tests__/db-utils.test.ts
@@ -100,7 +100,6 @@ describe('DB Utils', () => {
           name: 'Test Subject',
           description: 'Description',
           topicLabel: 'Environment',
-          hot: true,
           agendaItemIndex: 1,
           introducedByPersonId: 'person-1',
           speakerSegments: [{ speakerSegmentId: 'segment-1', summary: 'Summary' }],

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -236,21 +236,10 @@ describe('subjectToMapFeature', () => {
 });
 
 describe('sortSubjectsByImportance', () => {
-  it('should prioritize hot subjects', () => {
+  it('should sort by speaking time', () => {
     const subjects = [
-      { id: '1', name: 'Subject 1', hot: false },
-      { id: '2', name: 'Subject 2', hot: true }
-    ];
-
-    const sorted = sortSubjectsByImportance(subjects as any);
-    expect(sorted[0].id).toBe('2');
-    expect(sorted[1].id).toBe('1');
-  });
-
-  it('should sort by speaking time for subjects with same hot status', () => {
-    const subjects = [
-      { id: '1', name: 'Subject 1', hot: false, statistics: { speakingSeconds: 100 } },
-      { id: '2', name: 'Subject 2', hot: false, statistics: { speakingSeconds: 200 } }
+      { id: '1', name: 'Subject 1', statistics: { speakingSeconds: 100 } },
+      { id: '2', name: 'Subject 2', statistics: { speakingSeconds: 200 } }
     ];
 
     const sorted = sortSubjectsByImportance(subjects as any);
@@ -260,8 +249,8 @@ describe('sortSubjectsByImportance', () => {
 
   it('should handle subjects without statistics', () => {
     const subjects = [
-      { id: '1', name: 'Subject 1', hot: false },
-      { id: '2', name: 'Subject 2', hot: false, statistics: { speakingSeconds: 200 } }
+      { id: '1', name: 'Subject 1' },
+      { id: '2', name: 'Subject 2', statistics: { speakingSeconds: 200 } }
     ];
 
     // Should not throw error

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -98,9 +98,6 @@ export async function getCouncilMeetingsForCity(cityId: string, { includeUnrelea
             include: {
                 subjects: {
                     orderBy: [
-                        // Ensure hot subjects are first in the list 
-                        { hot: 'desc' },
-                        // Secondary ordering by agenda item index when available
                         { agendaItemIndex: 'asc' },
                         { name: 'asc' }
                     ],
@@ -155,7 +152,6 @@ export async function getMeetingDataForOG(cityId: string, meetingId: string) {
                     select: {
                         id: true,
                         name: true,
-                        hot: true,
                         topic: {
                             select: {
                                 colorHex: true

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -111,7 +111,6 @@ export function monthsBetween(startDate: Date, endDate: Date): number {
  */
 interface SortableSubject {
   name: string;
-  hot: boolean;
   // Optional fields used for advanced sorting
   statistics?: Statistics;
   speakerSegments?: any[];
@@ -123,12 +122,8 @@ export function sortSubjectsByImportance<T extends SortableSubject>(
   orderBy: 'importance' | 'appearance' = 'importance'
 ) {
   return [...subjects].sort((a, b) => {
-    // First priority: hot subjects (regardless of ordering mode)
-    if (b.hot && !a.hot) return 1;
-    if (a.hot && !b.hot) return -1;
-
     if (orderBy === 'importance') {
-      // Second priority: speaking time from statistics
+      // First priority: speaking time from statistics
       if (a.statistics && b.statistics) {
         const timeComparison = b.statistics.speakingSeconds - a.statistics.speakingSeconds;
         // Add tie breaker for equal statistics


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Includes a database migration dropping `Subject.hot` and updates query/sorting logic; if any external integrations or older deployments still rely on `hot`, they could break or see reordered subjects.
> 
> **Overview**
> Drops the `Subject.hot` column via Prisma migration and removes it from the Prisma model and seed data.
> 
> Updates subject ordering to no longer prioritize *hot* subjects: `sortSubjectsByImportance` drops `hot` from its contract/logic, meeting queries stop ordering by `hot`, and OG/meeting UI code and tests are adjusted accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f607d4551781d4263dcce0d2a0ae18e71acb650. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `Subject.hot` boolean field across the entire stack — dropping it via a Prisma migration, removing it from the schema, seed data, sorting logic, queries, UI components, and tests. The change is clean and well-executed throughout most of the codebase.

Key changes:
- **Migration & schema**: Drops the `hot` column from the `Subject` table via an `ALTER TABLE` migration and removes the field from `prisma/schema.prisma`.
- **Sorting logic**: `sortSubjectsByImportance` in `src/lib/utils.ts` removes the `hot`-first priority; speaking time (`statistics.speakingSeconds`) is now the primary sort criterion.
- **DB queries**: `getCouncilMeetingsForCity` removes the `{ hot: 'desc' }` `orderBy` clause; `getMeetingDataForOG` removes the `hot: true` select.
- **UI & tests**: `MeetingCard.tsx` drops the `isHot` debug-log field; test fixtures and test cases are updated accordingly.

**Verification Issue**: `getMeetingDataForOG` is missing `agendaItemIndex` in the subjects select. When subjects without `agendaItemIndex`, `statistics`, or `speakerSegments` are passed to `sortSubjectsByImportance`, the code evaluates `a.agendaItemIndex !== null` as `true` (since `undefined !== null`), then computes `(undefined ?? Infinity) - (undefined ?? Infinity)` = `NaN`, producing undefined sort behavior. Adding `agendaItemIndex: true` to the subjects select would restore deterministic ordering for OG images aligned with agenda order.

<h3>Confidence Score: 3/5</h3>

- Safe to merge once `agendaItemIndex` is added to the OG subjects select to prevent NaN sort behavior.
- The PR successfully removes the `hot` field across migration, schema, seed, sorting logic, queries, and tests. However, `getMeetingDataForOG` in `src/lib/db/meetings.ts` is missing `agendaItemIndex` in its subjects select. This causes `sortSubjectsByImportance` to perform NaN comparisons when sorting OG subjects, resulting in undefined ordering. This is a low-impact presentational issue affecting only OG image generation, not core application behavior, but it requires a simple fix.
- `src/lib/db/meetings.ts` — add `agendaItemIndex: true` to the subjects select in `getMeetingDataForOG` to restore deterministic ordering for OG images.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[sortSubjectsByImportance called] --> B{orderBy === 'importance'?}
    B -- Yes --> C{Both subjects have statistics?}
    C -- Yes --> D[Sort by speakingSeconds desc\nTie-break: agendaItemIndex, then name]
    C -- No --> E{Both subjects have speakerSegments?}
    E -- Yes --> F[Sort by segment count desc\nTie-break: agendaItemIndex, then name]
    E -- No --> G{Both agendaItemIndex !== null?}
    G -- Yes --> H[Sort by agendaItemIndex asc]
    G -- No --> I[Alphabetical by name]
    B -- No, appearance --> J{Both have speakerSegments with timestamps?}
    J -- Yes --> K[Sort by earliest timestamp asc\nTie-break: agendaItemIndex, then name]
    J -- No --> L{Both agendaItemIndex !== null?}
    L -- Yes --> M[Sort by agendaItemIndex asc]
    L -- No --> N[Alphabetical by name]

    style D fill:#22c55e,color:#fff
    style F fill:#22c55e,color:#fff
    style H fill:#22c55e,color:#fff
    style I fill:#f59e0b,color:#fff
    style K fill:#22c55e,color:#fff
    style M fill:#22c55e,color:#fff
    style N fill:#f59e0b,color:#fff
```

<sub>Last reviewed commit: 1aeab77</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->