### PR TITLE
feat: ADA conflict detection & admin resolution

### DIFF
--- a/prisma/migrations/20260305000000_add_claimed_ada/migration.sql
+++ b/prisma/migrations/20260305000000_add_claimed_ada/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Subject" ADD COLUMN "claimedAda" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -437,6 +437,11 @@ model Subject {
 
   decision Decision?
 
+  // Temporary field for ADA conflict resolution.
+  // Set when a poll detects that an ADA already belongs to another subject's decision.
+  // Cleared to null once admin resolves the conflict (reassign or dismiss).
+  claimedAda String?
+
   @@index([cityId, councilMeetingId])
   @@index([discussedInId])
 }

--- a/src/components/admin/diavgeia/PollingStats.tsx
+++ b/src/components/admin/diavgeia/PollingStats.tsx
@@ -22,7 +22,16 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
-import { Search, Clock, Activity, CalendarClock, ArrowUpDown, ChevronDown, Eye, Copy, Check, ExternalLink, Loader2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Search, Clock, Activity, CalendarClock, ArrowUpDown, ChevronDown, Eye, Copy, Check, ExternalLink, Loader2, AlertTriangle } from 'lucide-react';
+import { resolveAdaConflict } from '@/lib/tasks/pollDecisions';
 import { useUrlParams } from '@/hooks/useUrlParams';
 import { formatRelativeTime } from '@/lib/formatters/time';
 
@@ -74,10 +83,31 @@ interface StillPollingMeeting {
   nextPollEligible: string | null;
 }
 
+interface AdaConflict {
+  claimingSubject: {
+    id: string;
+    name: string;
+    cityId: string;
+    councilMeetingId: string;
+  };
+  ada: string;
+  existingDecision: {
+    title: string | null;
+    pdfUrl: string;
+    currentSubject: {
+      id: string;
+      name: string;
+      cityId: string;
+      councilMeetingId: string;
+    };
+  } | null;
+}
+
 interface PollingStatsData {
   backoffSchedule: BackoffTier[];
   maxPollingDays: number;
   meetingsStillPolling: StillPollingMeeting[];
+  conflicts: AdaConflict[];
   summary: {
     totalDiscoveries: number;
     meetingsStillPolling: number;
@@ -186,12 +216,14 @@ function CollapsibleSection({
   id,
   title,
   badge,
+  description,
   defaultOpen = false,
   children,
 }: {
   id?: string;
   title: string;
   badge: string;
+  description?: string;
   defaultOpen?: boolean;
   children: React.ReactNode;
 }) {
@@ -202,11 +234,14 @@ function CollapsibleSection({
       <div id={id} className="border rounded-lg">
         <CollapsibleTrigger asChild>
           <button className="flex w-full items-center justify-between px-4 py-3 hover:bg-muted/30 transition-colors">
-            <div className="flex items-center gap-2">
-              <h2 className="text-lg font-semibold">{title}</h2>
-              <Badge variant="secondary" className="font-normal">{badge}</Badge>
+            <div className="flex items-center gap-2 min-w-0">
+              <h2 className="text-lg font-semibold shrink-0">{title}</h2>
+              <Badge variant="secondary" className="font-normal shrink-0">{badge}</Badge>
+              {description && (
+                <span className="text-xs text-muted-foreground truncate hidden sm:inline">{description}</span>
+              )}
             </div>
-            <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform duration-200 ${open ? 'rotate-180' : ''}`} />
+            <ChevronDown className={`h-4 w-4 text-muted-foreground transition-transform duration-200 shrink-0 ${open ? 'rotate-180' : ''}`} />
           </button>
         </CollapsibleTrigger>
         <CollapsibleContent>
@@ -216,6 +251,229 @@ function CollapsibleSection({
         </CollapsibleContent>
       </div>
     </Collapsible>
+  );
+}
+
+function SubjectCell({ subjectId, name, cityId, meetingId }: { subjectId: string; name: string; cityId: string; meetingId: string }) {
+  return (
+    <div>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Link
+            href={`/${cityId}/${meetingId}/subjects/${subjectId}`}
+            className="block truncate hover:underline"
+          >
+            {name}
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-sm">{name}</TooltipContent>
+      </Tooltip>
+      <Link
+        href={`/${cityId}/${meetingId}/admin`}
+        className="text-xs text-muted-foreground hover:underline"
+      >
+        {cityId}/{meetingId}
+      </Link>
+    </div>
+  );
+}
+
+function ConflictsSection({ conflicts }: { conflicts: AdaConflict[] }) {
+  const [resolvingAda, setResolvingAda] = useState<string | null>(null);
+  const [confirmAction, setConfirmAction] = useState<{ conflict: AdaConflict; resolution: 'reassign' | 'dismiss' } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const { updateParam } = useUrlParams('filters');
+
+  const handleResolve = async () => {
+    if (!confirmAction) return;
+    const { conflict, resolution } = confirmAction;
+    setConfirmAction(null);
+    setResolvingAda(conflict.ada);
+    setError(null);
+    try {
+      await resolveAdaConflict(conflict.claimingSubject.id, resolution);
+      updateParam('_t', String(Date.now()));
+    } catch (err) {
+      console.error('Failed to resolve conflict:', err);
+      setError((err as Error).message ?? 'Failed to resolve conflict');
+    } finally {
+      setResolvingAda(null);
+    }
+  };
+
+  // Group conflicts by ADA so multiple claimants for the same ADA are shown together
+  const groupedByAda = useMemo(() => {
+    const groups: { ada: string; existingDecision: AdaConflict['existingDecision']; claimants: AdaConflict['claimingSubject'][] }[] = [];
+    const map = new Map<string, typeof groups[number]>();
+    for (const c of conflicts) {
+      const existing = map.get(c.ada);
+      if (existing) {
+        existing.claimants.push(c.claimingSubject);
+      } else {
+        const group = { ada: c.ada, existingDecision: c.existingDecision, claimants: [c.claimingSubject] };
+        map.set(c.ada, group);
+        groups.push(group);
+      }
+    }
+    return groups;
+  }, [conflicts]);
+
+  // Helper to find the full conflict object for a claimant
+  const findConflict = (claimantId: string) => conflicts.find(c => c.claimingSubject.id === claimantId)!;
+
+  return (
+    <>
+    <CollapsibleSection
+      id="ada-conflicts"
+      title="ADA Conflicts"
+      badge={`${conflicts.length} conflicts`}
+      description="Decisions matched to multiple subjects — reassign or dismiss each claim"
+      defaultOpen
+    >
+      {error && (
+        <div className="mx-4 mt-2 mb-0 p-2 text-sm text-red-600 bg-red-50 rounded border border-red-200">
+          {error}
+        </div>
+      )}
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-muted/50 border-b text-muted-foreground">
+              <th className="text-left px-4 py-2 font-medium">ADA</th>
+              <th className="text-left px-4 py-2 font-medium">Decision Title</th>
+              <th className="text-left px-4 py-2 font-medium">Current Subject</th>
+              <th className="text-left px-4 py-2 font-medium">Claiming Subject</th>
+              <th className="text-right px-4 py-2 font-medium">Actions</th>
+            </tr>
+          </thead>
+          <TooltipProvider>
+          <tbody>
+            {groupedByAda.map(group => (
+              group.claimants.map((claimant, idx) => (
+                <tr key={claimant.id} className={`hover:bg-muted/30 ${idx === group.claimants.length - 1 ? 'border-b' : ''}`}>
+                  {idx === 0 ? (
+                    <>
+                      <td className="px-4 py-2 whitespace-nowrap font-mono text-xs align-top" rowSpan={group.claimants.length}>
+                        {group.ada}
+                      </td>
+                      <td className="px-4 py-2 max-w-[200px] align-top" rowSpan={group.claimants.length}>
+                        {group.existingDecision ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="block truncate">{group.existingDecision.title ?? '—'}</span>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom" className="max-w-sm">
+                              {group.existingDecision.title}
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <span className="text-muted-foreground">Decision deleted</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-2 max-w-[200px] align-top" rowSpan={group.claimants.length}>
+                        {group.existingDecision ? (
+                          <SubjectCell
+                            subjectId={group.existingDecision.currentSubject.id}
+                            name={group.existingDecision.currentSubject.name}
+                            cityId={group.existingDecision.currentSubject.cityId}
+                            meetingId={group.existingDecision.currentSubject.councilMeetingId}
+                          />
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                    </>
+                  ) : null}
+                  <td className="px-4 py-2 max-w-[200px]">
+                    <SubjectCell
+                      subjectId={claimant.id}
+                      name={claimant.name}
+                      cityId={claimant.cityId}
+                      meetingId={claimant.councilMeetingId}
+                    />
+                  </td>
+                  <td className="px-4 py-2 text-right whitespace-nowrap">
+                    <div className="flex items-center justify-end gap-2">
+                      {group.existingDecision && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={resolvingAda === group.ada}
+                          onClick={() => setConfirmAction({ conflict: findConflict(claimant.id), resolution: 'reassign' })}
+                        >
+                          {resolvingAda === group.ada ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : null}
+                          Reassign
+                        </Button>
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={resolvingAda === group.ada}
+                        onClick={() => setConfirmAction({ conflict: findConflict(claimant.id), resolution: 'dismiss' })}
+                      >
+                        {resolvingAda === group.ada ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : null}
+                        Dismiss
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            ))}
+          </tbody>
+          </TooltipProvider>
+        </table>
+      </div>
+    </CollapsibleSection>
+
+    {/* Confirmation Dialog */}
+    <Dialog open={!!confirmAction} onOpenChange={(open) => !open && setConfirmAction(null)}>
+      {confirmAction && (
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {confirmAction.resolution === 'reassign' ? 'Reassign Decision' : 'Dismiss Claim'}
+            </DialogTitle>
+            <DialogDescription>
+              {confirmAction.resolution === 'reassign'
+                ? 'This will move the decision from the current subject to the claiming subject. The current subject will lose its linked decision.'
+                : 'This will discard the claim. The decision stays with the current subject.'}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 text-sm">
+            <div>
+              <span className="text-muted-foreground">ADA:</span>{' '}
+              <span className="font-mono">{confirmAction.conflict.ada}</span>
+            </div>
+            {confirmAction.conflict.existingDecision && (
+              <div>
+                <span className="text-muted-foreground">Current subject:</span>{' '}
+                <span>{confirmAction.conflict.existingDecision.currentSubject.name}</span>
+                <span className="text-muted-foreground text-xs ml-1">
+                  ({confirmAction.conflict.existingDecision.currentSubject.cityId}/{confirmAction.conflict.existingDecision.currentSubject.councilMeetingId})
+                </span>
+              </div>
+            )}
+            <div>
+              <span className="text-muted-foreground">Claiming subject:</span>{' '}
+              <span>{confirmAction.conflict.claimingSubject.name}</span>
+              <span className="text-muted-foreground text-xs ml-1">
+                ({confirmAction.conflict.claimingSubject.cityId}/{confirmAction.conflict.claimingSubject.councilMeetingId})
+              </span>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmAction(null)}>Cancel</Button>
+            <Button
+              variant={confirmAction.resolution === 'reassign' ? 'default' : 'secondary'}
+              onClick={handleResolve}
+            >
+              {confirmAction.resolution === 'reassign' ? 'Reassign' : 'Dismiss'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      )}
+    </Dialog>
+    </>
   );
 }
 
@@ -265,6 +523,12 @@ export function PollingStats({ stats, pollCities, cityFilter, pollMeetings, meet
       icon: <Activity className="h-4 w-4" />,
       description: 'With unlinked subjects',
     },
+    ...(stats.conflicts.length > 0 ? [{
+      title: 'ADA Conflicts',
+      value: stats.conflicts.length,
+      icon: <AlertTriangle className="h-4 w-4" />,
+      description: 'Require admin resolution',
+    }] : []),
     {
       title: 'Avg Discovery Delay',
       value: formatDays(stats.summary.discoveryDelay.avgDays),
@@ -298,7 +562,7 @@ export function PollingStats({ stats, pollCities, cityFilter, pollMeetings, meet
     <Sheet open={!!selectedPoll} onOpenChange={(open) => !open && setSelectedPoll(null)}>
     <div className="space-y-6">
       {/* Summary Cards */}
-      <StatsCard items={summaryItems} columns={4} />
+      <StatsCard items={summaryItems} columns={summaryItems.length as 4 | 5} />
 
       {/* Filters */}
       {pollCities.length > 1 && (
@@ -340,6 +604,11 @@ export function PollingStats({ stats, pollCities, cityFilter, pollMeetings, meet
           )}
           {isPending && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
         </div>
+      )}
+
+      {/* ADA Conflicts */}
+      {stats.conflicts.length > 0 && (
+        <ConflictsSection conflicts={stats.conflicts} />
       )}
 
       {/* Meetings Still Polling */}

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -438,6 +438,68 @@ export async function getPollingStats(cityId?: string, councilMeetingId?: string
         ])];
     }
 
+    // ADA conflicts: subjects with claimedAda set
+    const claimingSubjects = await prisma.subject.findMany({
+        where: {
+            claimedAda: { not: null },
+            ...(cityId && { cityId }),
+            ...(councilMeetingId && { councilMeetingId }),
+        },
+        select: {
+            id: true,
+            name: true,
+            cityId: true,
+            councilMeetingId: true,
+            claimedAda: true,
+        },
+    });
+
+    // Look up existing decisions for the claimed ADAs
+    const claimedAdas = claimingSubjects.map(s => s.claimedAda!);
+    const existingDecisionsForClaims = claimedAdas.length > 0
+        ? await prisma.decision.findMany({
+            where: { ada: { in: claimedAdas } },
+            select: {
+                ada: true,
+                title: true,
+                pdfUrl: true,
+                subjectId: true,
+                subject: {
+                    select: {
+                        id: true,
+                        name: true,
+                        cityId: true,
+                        councilMeetingId: true,
+                    },
+                },
+            },
+        })
+        : [];
+    const decisionByAda = new Map(existingDecisionsForClaims.map(d => [d.ada!, d]));
+
+    const conflicts = claimingSubjects.map(claiming => {
+        const existingDecision = decisionByAda.get(claiming.claimedAda!);
+        return {
+            claimingSubject: {
+                id: claiming.id,
+                name: claiming.name,
+                cityId: claiming.cityId,
+                councilMeetingId: claiming.councilMeetingId,
+            },
+            ada: claiming.claimedAda!,
+            existingDecision: existingDecision ? {
+                title: existingDecision.title,
+                pdfUrl: existingDecision.pdfUrl,
+                currentSubject: {
+                    id: existingDecision.subject.id,
+                    name: existingDecision.subject.name,
+                    cityId: existingDecision.subject.cityId,
+                    councilMeetingId: existingDecision.subject.councilMeetingId,
+                },
+            } : null,
+        };
+    });
+
     // Recent poll tasks for the "Recent Polls" table
     const recentPollTasks = await prisma.taskStatus.findMany({
         where: {
@@ -501,6 +563,7 @@ export async function getPollingStats(cityId?: string, councilMeetingId?: string
         backoffSchedule: BACKOFF_SCHEDULE,
         maxPollingDays: MAX_POLLING_DAYS,
         meetingsStillPolling,
+        conflicts,
         summary: {
             totalDiscoveries: discoveryDetails.length,
             meetingsStillPolling: meetingsStillPolling.length,
@@ -660,6 +723,89 @@ export async function getLastPollTimeForMeeting(
     return lastTask?.createdAt.toISOString() ?? null;
 }
 
+export async function resolveAdaConflict(
+    subjectId: string,
+    resolution: 'reassign' | 'dismiss',
+) {
+    const subject = await prisma.subject.findUnique({
+        where: { id: subjectId },
+        select: { id: true, cityId: true, claimedAda: true },
+    });
+
+    if (!subject) {
+        throw new Error("Subject not found");
+    }
+
+    await withUserAuthorizedToEdit({ cityId: subject.cityId });
+
+    if (!subject.claimedAda) {
+        throw new Error("Subject has no claimed ADA");
+    }
+
+    if (resolution === 'dismiss') {
+        await prisma.subject.update({
+            where: { id: subjectId },
+            data: { claimedAda: null },
+        });
+        return;
+    }
+
+    // resolution === 'reassign'
+    await prisma.$transaction(async (tx) => {
+        // Re-read claimedAda inside the transaction to avoid using a stale value
+        const freshSubject = await tx.subject.findUnique({
+            where: { id: subjectId },
+            select: { claimedAda: true },
+        });
+
+        if (!freshSubject?.claimedAda) {
+            // Claim was resolved concurrently — nothing to do
+            return;
+        }
+
+        // Only move the decision if the claiming subject doesn't already have one
+        const existingOnClaiming = await tx.decision.findUnique({
+            where: { subjectId },
+        });
+
+        if (!existingOnClaiming) {
+            const existingDecision = await tx.decision.findUnique({
+                where: { ada: freshSubject.claimedAda },
+                include: { subject: { select: { cityId: true } } },
+            });
+
+            if (existingDecision) {
+                // Defensive: polls are per-city so cross-city conflicts shouldn't occur,
+                // but guard against it to prevent modifying another city's data.
+                if (existingDecision.subject.cityId !== subject.cityId) {
+                    throw new Error("Cannot reassign a decision that belongs to a different city");
+                }
+
+                // Delete existing decision to free ADA unique constraint, then recreate on claiming subject
+                await tx.decision.delete({ where: { id: existingDecision.id } });
+                await tx.decision.create({
+                    data: {
+                        subjectId,
+                        ada: existingDecision.ada,
+                        pdfUrl: existingDecision.pdfUrl,
+                        protocolNumber: existingDecision.protocolNumber,
+                        title: existingDecision.title,
+                        publishDate: existingDecision.publishDate,
+                        taskId: existingDecision.taskId,
+                        createdById: existingDecision.createdById,
+                    },
+                });
+            }
+        }
+
+        // Always clear the claim
+        await tx.subject.update({
+            where: { id: subjectId },
+            data: { claimedAda: null },
+        });
+    });
+}
+
 export async function handlePollDecisionsResult(taskId: string, result: PollDecisionsResult) {
     const task = await prisma.taskStatus.findUnique({
         where: { id: taskId },
@@ -700,9 +846,20 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
     // successful delete would permanently lose decision data.
     let reassignmentCount = 0;
     let processedCount = 0;
+    let conflictCount = 0;
 
     await prisma.$transaction(async (tx) => {
-        // Step 1: Process reassignments — delete old decisions to free ADA unique constraint
+        // Step 1: Detect ADA conflicts — find ADAs that already exist on other subjects
+        const matchAdas = result.matches.map(m => m.ada).filter((ada): ada is string => ada != null);
+        const existingDecisions = matchAdas.length > 0
+            ? await tx.decision.findMany({ where: { ada: { in: matchAdas } }, select: { ada: true, subjectId: true } })
+            : [];
+        const adaToExistingSubject = new Map(existingDecisions.map(d => [d.ada!, d.subjectId]));
+
+        // Build set of ADAs being reassigned — these are handled explicitly, not conflicts
+        const reassignedAdas = new Set(result.reassignments.map(r => r.ada));
+
+        // Step 2: Process reassignments — delete old decisions to free ADA unique constraint
         if (result.reassignments.length > 0) {
             for (const r of result.reassignments) {
                 if (!validSubjectIdSet.has(r.fromSubjectId) || !validSubjectIdSet.has(r.toSubjectId)) {
@@ -715,7 +872,7 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
             }
         }
 
-        // Step 2: Upsert new matches (including reassigned ones)
+        // Step 3: Upsert new matches (including reassigned ones), recording conflicts
         for (const match of result.matches) {
             // Skip any subjectIds that don't belong to this meeting
             if (!validSubjectIdSet.has(match.subjectId)) {
@@ -723,28 +880,70 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
                 continue;
             }
 
-            await tx.decision.upsert({
-                where: { subjectId: match.subjectId },
-                create: {
-                    subjectId: match.subjectId,
-                    pdfUrl: match.pdfUrl,
-                    protocolNumber: match.protocolNumber ?? null,
-                    ada: match.ada ?? null,
-                    title: match.decisionTitle ?? null,
-                    publishDate: match.publishDate ? new Date(match.publishDate) : null,
-                    taskId,
-                },
-                update: {
-                    pdfUrl: match.pdfUrl,
-                    protocolNumber: match.protocolNumber ?? null,
-                    ada: match.ada ?? null,
-                    title: match.decisionTitle ?? null,
-                    publishDate: match.publishDate ? new Date(match.publishDate) : null,
-                },
+            // Check for ADA conflict: ADA exists on a different subject and isn't being reassigned
+            if (match.ada) {
+                const existingSubjectId = adaToExistingSubject.get(match.ada);
+                if (existingSubjectId && existingSubjectId !== match.subjectId && !reassignedAdas.has(match.ada)) {
+                    // Record the claim on the incoming subject, skip the upsert
+                    await tx.subject.update({
+                        where: { id: match.subjectId },
+                        data: { claimedAda: match.ada },
+                    });
+                    conflictCount++;
+                    console.log(`ADA conflict: ${match.ada} already belongs to subject ${existingSubjectId}, claimed by subject ${match.subjectId}`);
+                    continue;
+                }
+            }
+
+            try {
+                await tx.decision.upsert({
+                    where: { subjectId: match.subjectId },
+                    create: {
+                        subjectId: match.subjectId,
+                        pdfUrl: match.pdfUrl,
+                        protocolNumber: match.protocolNumber ?? null,
+                        ada: match.ada ?? null,
+                        title: match.decisionTitle ?? null,
+                        publishDate: match.publishDate ? new Date(match.publishDate) : null,
+                        taskId,
+                    },
+                    update: {
+                        pdfUrl: match.pdfUrl,
+                        protocolNumber: match.protocolNumber ?? null,
+                        ada: match.ada ?? null,
+                        title: match.decisionTitle ?? null,
+                        publishDate: match.publishDate ? new Date(match.publishDate) : null,
+                    },
+                });
+            } catch (e) {
+                // Concurrent poll race: another transaction committed a decision with the same
+                // ADA between our conflict check and this upsert. Fall back to recording a claim.
+                if (match.ada && (e as { code?: string })?.code === 'P2002') {
+                    await tx.subject.update({
+                        where: { id: match.subjectId },
+                        data: { claimedAda: match.ada },
+                    });
+                    conflictCount++;
+                    console.log(`ADA conflict (concurrent): ${match.ada} claimed by subject ${match.subjectId}`);
+                    continue;
+                }
+                throw e;
+            }
+
+            // Clear any stale conflict claim now that this subject has a valid decision
+            await tx.subject.updateMany({
+                where: { id: match.subjectId, claimedAda: { not: null } },
+                data: { claimedAda: null },
             });
+
             processedCount++;
+
+            // Track this ADA so later matches in the same batch see it as taken
+            if (match.ada) {
+                adaToExistingSubject.set(match.ada, match.subjectId);
+            }
         }
     });
 
-    console.log(`Poll decisions completed: ${processedCount} processed, ${reassignmentCount} reassigned, ${result.unmatchedSubjects.length} unmatched, ${result.ambiguousSubjects.length} ambiguous`);
+    console.log(`Poll decisions completed: ${processedCount} processed, ${reassignmentCount} reassigned, ${conflictCount} conflicts, ${result.unmatchedSubjects.length} unmatched, ${result.ambiguousSubjects.length} ambiguous`);
 }

--- a/tests/helpers/builders.ts
+++ b/tests/helpers/builders.ts
@@ -1,4 +1,4 @@
-import { Subject, ProcessAgendaResult, SummarizeResult } from '@/lib/apiTypes'
+import { Subject, ProcessAgendaResult, SummarizeResult, PollDecisionsResult, PollDecisionsMatch } from '@/lib/apiTypes'
 
 export function makeSubject(overrides: Partial<Subject> & { name: string; agendaItemIndex: Subject['agendaItemIndex'] }): Subject {
     return {
@@ -27,5 +27,30 @@ export function makeSummarizeResult(params: {
         speakerSegmentSummaries: params.speakerSegmentSummaries ?? [],
         subjects: params.subjects ?? [],
         utteranceDiscussionStatuses: params.utteranceDiscussionStatuses ?? [],
+    }
+}
+
+export function makePollDecisionsMatch(overrides: Partial<PollDecisionsMatch> & { subjectId: string; ada: string }): PollDecisionsMatch {
+    return {
+        decisionTitle: 'Decision Title',
+        pdfUrl: 'https://example.com/decision.pdf',
+        protocolNumber: '1/2025',
+        publishDate: '2025-01-15',
+        matchConfidence: 0.95,
+        ...overrides,
+    }
+}
+
+export function makePollDecisionsResult(params: {
+    matches?: PollDecisionsMatch[]
+    reassignments?: PollDecisionsResult['reassignments']
+    unmatchedSubjects?: PollDecisionsResult['unmatchedSubjects']
+    ambiguousSubjects?: PollDecisionsResult['ambiguousSubjects']
+}): PollDecisionsResult {
+    return {
+        matches: params.matches ?? [],
+        reassignments: params.reassignments ?? [],
+        unmatchedSubjects: params.unmatchedSubjects ?? [],
+        ambiguousSubjects: params.ambiguousSubjects ?? [],
     }
 }

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -87,7 +87,7 @@ export async function createLocation({ id, text, lng, lat }: { id: string; text?
     return { id: res[0]?.id ?? id }
 }
 
-export async function createSubject(meetingId: string, cityId: string, data?: { id?: string; name?: string; description?: string; topicId?: string | null; locationId?: string | null }) {
+export async function createSubject(meetingId: string, cityId: string, data?: { id?: string; name?: string; description?: string; topicId?: string | null; locationId?: string | null; agendaItemIndex?: number | null }) {
     return prisma.subject.create({
         data: {
             id: data?.id,
@@ -95,6 +95,7 @@ export async function createSubject(meetingId: string, cityId: string, data?: { 
             description: data?.description ?? 'Subject description',
             topicId: data?.topicId ?? null,
             locationId: data?.locationId ?? null,
+            agendaItemIndex: data?.agendaItemIndex ?? null,
             councilMeetingId: meetingId,
             cityId,
         },

--- a/tests/integration/task-handlers.test.ts
+++ b/tests/integration/task-handlers.test.ts
@@ -5,21 +5,29 @@ jest.mock('@/lib/tasks/generateHighlight', () => ({
     handleGenerateHighlightResult: jest.fn(),
 }))
 
+// Mock auth for resolveAdaConflict tests
+jest.mock('@/lib/auth', () => ({
+    withUserAuthorizedToEdit: jest.fn(),
+    isUserAuthorizedToEdit: jest.fn().mockResolvedValue(true),
+}))
+
 import prisma from '@/lib/db/prisma'
 import { handleProcessAgendaResult } from '@/lib/tasks/processAgenda'
 import { handleSummarizeResult } from '@/lib/tasks/summarize'
+import { handlePollDecisionsResult, resolveAdaConflict } from '@/lib/tasks/pollDecisions'
 import { resetDatabase } from '../helpers/test-db'
 import {
     createAdministrativeBody,
     createCity,
     createMeeting,
+    createSubject,
     createSpeakerSegment,
     createSpeakerTag,
     createTaskStatus,
     createUser,
     createUtterance,
 } from '../helpers/factories'
-import { makeSubject, makeProcessAgendaResult, makeSummarizeResult } from '../helpers/builders'
+import { makeSubject, makeProcessAgendaResult, makeSummarizeResult, makePollDecisionsMatch, makePollDecisionsResult } from '../helpers/builders'
 
 describe('handleProcessAgendaResult', () => {
     let cityId: string
@@ -524,5 +532,351 @@ describe('Pipeline: processAgenda → summarize', () => {
         const updatedUtt = await prisma.utterance.findUnique({ where: { id: utt.id } })
         expect(updatedUtt!.discussionStatus).toBe('SUBJECT_DISCUSSION')
         expect(updatedUtt!.discussionSubjectId).toBe(agendaIds[0])
+    })
+})
+
+describe('handlePollDecisionsResult', () => {
+    let cityId: string
+    let meetingId1: string
+    let meetingId2: string
+
+    beforeEach(async () => {
+        await resetDatabase(prisma as any)
+
+        const city = await createCity({ id: 'c1' })
+        cityId = city.id
+        const body = await createAdministrativeBody(cityId, {
+            notificationBehavior: 'NOTIFICATIONS_DISABLED',
+        })
+        const meeting1 = await createMeeting(cityId, {
+            id: 'm1',
+            administrativeBodyId: body.id,
+        })
+        const meeting2 = await createMeeting(cityId, {
+            id: 'm2',
+            administrativeBodyId: body.id,
+        })
+        meetingId1 = meeting1.id
+        meetingId2 = meeting2.id
+    })
+
+    test('normal matches (no conflict) — both decisions created', async () => {
+        const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
+        const subjectB = await createSubject(meetingId1, cityId, { name: 'Subject B', agendaItemIndex: 2 })
+        const task = await createTaskStatus(meetingId1, cityId, { type: 'pollDecisions' })
+
+        await handlePollDecisionsResult(task.id, makePollDecisionsResult({
+            matches: [
+                makePollDecisionsMatch({ subjectId: subjectA.id, ada: 'ADA-1' }),
+                makePollDecisionsMatch({ subjectId: subjectB.id, ada: 'ADA-2' }),
+            ],
+        }))
+
+        const decisions = await prisma.decision.findMany({ orderBy: { ada: 'asc' } })
+        expect(decisions).toHaveLength(2)
+        expect(decisions[0].ada).toBe('ADA-1')
+        expect(decisions[0].subjectId).toBe(subjectA.id)
+        expect(decisions[1].ada).toBe('ADA-2')
+        expect(decisions[1].subjectId).toBe(subjectB.id)
+
+        // No claimedAda set
+        const subjects = await prisma.subject.findMany({
+            where: { claimedAda: { not: null } },
+        })
+        expect(subjects).toHaveLength(0)
+    })
+
+    test('ADA conflict detected — claim set, other matches still saved', async () => {
+        // Meeting 1 subject already has a decision with ADA-X
+        const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
+        await prisma.decision.create({
+            data: { subjectId: subjectA.id, ada: 'ADA-X', pdfUrl: 'https://example.com/a.pdf' },
+        })
+
+        // Meeting 2 subjects — poll returns ADA-X for subjectB (conflict) and ADA-Y for subjectC (no conflict)
+        const subjectB = await createSubject(meetingId2, cityId, { name: 'Subject B', agendaItemIndex: 1 })
+        const subjectC = await createSubject(meetingId2, cityId, { name: 'Subject C', agendaItemIndex: 2 })
+        const task = await createTaskStatus(meetingId2, cityId, { type: 'pollDecisions' })
+
+        await handlePollDecisionsResult(task.id, makePollDecisionsResult({
+            matches: [
+                makePollDecisionsMatch({ subjectId: subjectB.id, ada: 'ADA-X' }),
+                makePollDecisionsMatch({ subjectId: subjectC.id, ada: 'ADA-Y' }),
+            ],
+        }))
+
+        // SubjectB should have claimedAda set, no decision created
+        const updatedB = await prisma.subject.findUnique({ where: { id: subjectB.id } })
+        expect(updatedB!.claimedAda).toBe('ADA-X')
+        const decisionB = await prisma.decision.findUnique({ where: { subjectId: subjectB.id } })
+        expect(decisionB).toBeNull()
+
+        // SubjectC should have a normal decision, no claimedAda
+        const updatedC = await prisma.subject.findUnique({ where: { id: subjectC.id } })
+        expect(updatedC!.claimedAda).toBeNull()
+        const decisionC = await prisma.decision.findUnique({ where: { subjectId: subjectC.id } })
+        expect(decisionC).not.toBeNull()
+        expect(decisionC!.ada).toBe('ADA-Y')
+
+        // Original decision on subjectA is untouched
+        const decisionA = await prisma.decision.findUnique({ where: { subjectId: subjectA.id } })
+        expect(decisionA).not.toBeNull()
+        expect(decisionA!.ada).toBe('ADA-X')
+    })
+
+    test('same-subject update (not a conflict) — normal upsert', async () => {
+        const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
+        // SubjectA already has a decision with ADA-X
+        await prisma.decision.create({
+            data: { subjectId: subjectA.id, ada: 'ADA-X', pdfUrl: 'https://example.com/old.pdf' },
+        })
+
+        const task = await createTaskStatus(meetingId1, cityId, { type: 'pollDecisions' })
+
+        await handlePollDecisionsResult(task.id, makePollDecisionsResult({
+            matches: [
+                makePollDecisionsMatch({
+                    subjectId: subjectA.id,
+                    ada: 'ADA-X',
+                    pdfUrl: 'https://example.com/new.pdf',
+                }),
+            ],
+        }))
+
+        // Decision should be updated (not conflict)
+        const decision = await prisma.decision.findUnique({ where: { subjectId: subjectA.id } })
+        expect(decision).not.toBeNull()
+        expect(decision!.ada).toBe('ADA-X')
+        expect(decision!.pdfUrl).toBe('https://example.com/new.pdf')
+
+        // No claimedAda set
+        const subject = await prisma.subject.findUnique({ where: { id: subjectA.id } })
+        expect(subject!.claimedAda).toBeNull()
+    })
+
+    test('multiple conflicts in one poll — both get claimedAda, non-conflicting matches saved', async () => {
+        // Existing decisions in meeting 1
+        const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
+        const subjectB = await createSubject(meetingId1, cityId, { name: 'Subject B', agendaItemIndex: 2 })
+        await prisma.decision.create({
+            data: { subjectId: subjectA.id, ada: 'ADA-X', pdfUrl: 'https://example.com/x.pdf' },
+        })
+        await prisma.decision.create({
+            data: { subjectId: subjectB.id, ada: 'ADA-Y', pdfUrl: 'https://example.com/y.pdf' },
+        })
+
+        // Meeting 2 subjects — poll returns conflicting ADAs for two subjects, one clean match
+        const subjectC = await createSubject(meetingId2, cityId, { name: 'Subject C', agendaItemIndex: 1 })
+        const subjectD = await createSubject(meetingId2, cityId, { name: 'Subject D', agendaItemIndex: 2 })
+        const subjectE = await createSubject(meetingId2, cityId, { name: 'Subject E', agendaItemIndex: 3 })
+        const task = await createTaskStatus(meetingId2, cityId, { type: 'pollDecisions' })
+
+        await handlePollDecisionsResult(task.id, makePollDecisionsResult({
+            matches: [
+                makePollDecisionsMatch({ subjectId: subjectC.id, ada: 'ADA-X' }),
+                makePollDecisionsMatch({ subjectId: subjectD.id, ada: 'ADA-Y' }),
+                makePollDecisionsMatch({ subjectId: subjectE.id, ada: 'ADA-Z' }),
+            ],
+        }))
+
+        // SubjectC and SubjectD should have claimedAda
+        const updatedC = await prisma.subject.findUnique({ where: { id: subjectC.id } })
+        expect(updatedC!.claimedAda).toBe('ADA-X')
+        const updatedD = await prisma.subject.findUnique({ where: { id: subjectD.id } })
+        expect(updatedD!.claimedAda).toBe('ADA-Y')
+
+        // SubjectE should have a normal decision
+        const decisionE = await prisma.decision.findUnique({ where: { subjectId: subjectE.id } })
+        expect(decisionE).not.toBeNull()
+        expect(decisionE!.ada).toBe('ADA-Z')
+
+        // No decisions created for the conflicting subjects
+        const decisionC = await prisma.decision.findUnique({ where: { subjectId: subjectC.id } })
+        expect(decisionC).toBeNull()
+        const decisionD = await prisma.decision.findUnique({ where: { subjectId: subjectD.id } })
+        expect(decisionD).toBeNull()
+    })
+
+    test('subsequent poll overwrites prior unresolved claimedAda', async () => {
+        // SubjectA in meeting 1 already owns ADA-X
+        const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
+        await prisma.decision.create({
+            data: { subjectId: subjectA.id, ada: 'ADA-X', pdfUrl: 'https://example.com/x.pdf' },
+        })
+
+        // SubjectB in meeting 2 — first poll claims ADA-X
+        const subjectB = await createSubject(meetingId2, cityId, { name: 'Subject B', agendaItemIndex: 1 })
+        const task1 = await createTaskStatus(meetingId2, cityId, { type: 'pollDecisions' })
+
+        await handlePollDecisionsResult(task1.id, makePollDecisionsResult({
+            matches: [makePollDecisionsMatch({ subjectId: subjectB.id, ada: 'ADA-X' })],
+        }))
+
+        const afterPoll1 = await prisma.subject.findUnique({ where: { id: subjectB.id } })
+        expect(afterPoll1!.claimedAda).toBe('ADA-X')
+
+        // Second poll — same subject now matches ADA-Y (also owned by someone else)
+        const subjectC = await createSubject(meetingId1, cityId, { name: 'Subject C', agendaItemIndex: 2 })
+        await prisma.decision.create({
+            data: { subjectId: subjectC.id, ada: 'ADA-Y', pdfUrl: 'https://example.com/y.pdf' },
+        })
+
+        const task2 = await createTaskStatus(meetingId2, cityId, { type: 'pollDecisions' })
+
+        await handlePollDecisionsResult(task2.id, makePollDecisionsResult({
+            matches: [makePollDecisionsMatch({ subjectId: subjectB.id, ada: 'ADA-Y' })],
+        }))
+
+        // claimedAda is overwritten — only the latest claim is preserved
+        const afterPoll2 = await prisma.subject.findUnique({ where: { id: subjectB.id } })
+        expect(afterPoll2!.claimedAda).toBe('ADA-Y')
+    })
+
+    test('successful upsert clears stale claimedAda', async () => {
+        // SubjectA owns ADA-X, SubjectB previously claimed it
+        const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
+        await prisma.decision.create({
+            data: { subjectId: subjectA.id, ada: 'ADA-X', pdfUrl: 'https://example.com/x.pdf' },
+        })
+        const subjectB = await createSubject(meetingId2, cityId, { name: 'Subject B', agendaItemIndex: 1 })
+        await prisma.subject.update({ where: { id: subjectB.id }, data: { claimedAda: 'ADA-X' } })
+
+        // New poll gives subjectB a different, non-conflicting ADA
+        const task = await createTaskStatus(meetingId2, cityId, { type: 'pollDecisions' })
+
+        await handlePollDecisionsResult(task.id, makePollDecisionsResult({
+            matches: [makePollDecisionsMatch({ subjectId: subjectB.id, ada: 'ADA-NEW' })],
+        }))
+
+        // Decision created and stale claimedAda cleared
+        const decision = await prisma.decision.findUnique({ where: { subjectId: subjectB.id } })
+        expect(decision).not.toBeNull()
+        expect(decision!.ada).toBe('ADA-NEW')
+
+        const updated = await prisma.subject.findUnique({ where: { id: subjectB.id } })
+        expect(updated!.claimedAda).toBeNull()
+    })
+})
+
+describe('resolveAdaConflict', () => {
+    let cityId: string
+    let meetingId1: string
+    let meetingId2: string
+
+    beforeEach(async () => {
+        await resetDatabase(prisma as any)
+
+        const city = await createCity({ id: 'c1' })
+        cityId = city.id
+        const body = await createAdministrativeBody(cityId, {
+            notificationBehavior: 'NOTIFICATIONS_DISABLED',
+        })
+        const meeting1 = await createMeeting(cityId, { id: 'm1', administrativeBodyId: body.id })
+        const meeting2 = await createMeeting(cityId, { id: 'm2', administrativeBodyId: body.id })
+        meetingId1 = meeting1.id
+        meetingId2 = meeting2.id
+    })
+
+    test('dismiss — clears claimedAda without moving the decision', async () => {
+        const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
+        await prisma.decision.create({
+            data: { subjectId: subjectA.id, ada: 'ADA-X', pdfUrl: 'https://example.com/x.pdf', title: 'Original' },
+        })
+
+        const subjectB = await createSubject(meetingId2, cityId, { name: 'Subject B', agendaItemIndex: 1 })
+        await prisma.subject.update({ where: { id: subjectB.id }, data: { claimedAda: 'ADA-X' } })
+
+        await resolveAdaConflict(subjectB.id, 'dismiss')
+
+        // claimedAda cleared
+        const updatedB = await prisma.subject.findUnique({ where: { id: subjectB.id } })
+        expect(updatedB!.claimedAda).toBeNull()
+
+        // Original decision untouched
+        const decisionA = await prisma.decision.findUnique({ where: { subjectId: subjectA.id } })
+        expect(decisionA).not.toBeNull()
+        expect(decisionA!.ada).toBe('ADA-X')
+
+        // No decision on claiming subject
+        const decisionB = await prisma.decision.findUnique({ where: { subjectId: subjectB.id } })
+        expect(decisionB).toBeNull()
+    })
+
+    test('reassign — moves decision to the claiming subject', async () => {
+        const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
+        await prisma.decision.create({
+            data: {
+                subjectId: subjectA.id,
+                ada: 'ADA-X',
+                pdfUrl: 'https://example.com/x.pdf',
+                title: 'Original Title',
+                protocolNumber: '42/2025',
+            },
+        })
+
+        const subjectB = await createSubject(meetingId2, cityId, { name: 'Subject B', agendaItemIndex: 1 })
+        await prisma.subject.update({ where: { id: subjectB.id }, data: { claimedAda: 'ADA-X' } })
+
+        await resolveAdaConflict(subjectB.id, 'reassign')
+
+        // claimedAda cleared
+        const updatedB = await prisma.subject.findUnique({ where: { id: subjectB.id } })
+        expect(updatedB!.claimedAda).toBeNull()
+
+        // Decision moved to subjectB
+        const decisionB = await prisma.decision.findUnique({ where: { subjectId: subjectB.id } })
+        expect(decisionB).not.toBeNull()
+        expect(decisionB!.ada).toBe('ADA-X')
+        expect(decisionB!.pdfUrl).toBe('https://example.com/x.pdf')
+        expect(decisionB!.title).toBe('Original Title')
+        expect(decisionB!.protocolNumber).toBe('42/2025')
+
+        // No decision on original subject
+        const decisionA = await prisma.decision.findUnique({ where: { subjectId: subjectA.id } })
+        expect(decisionA).toBeNull()
+    })
+
+    test('reassign — when existing decision was deleted, just clears claim', async () => {
+        const subjectB = await createSubject(meetingId2, cityId, { name: 'Subject B', agendaItemIndex: 1 })
+        await prisma.subject.update({ where: { id: subjectB.id }, data: { claimedAda: 'ADA-X' } })
+
+        // No decision with ADA-X exists (it was deleted)
+        await resolveAdaConflict(subjectB.id, 'reassign')
+
+        // claimedAda cleared
+        const updatedB = await prisma.subject.findUnique({ where: { id: subjectB.id } })
+        expect(updatedB!.claimedAda).toBeNull()
+
+        // No decision created
+        const decisionB = await prisma.decision.findUnique({ where: { subjectId: subjectB.id } })
+        expect(decisionB).toBeNull()
+    })
+
+    test('reassign — when claiming subject already has a decision, dismisses instead', async () => {
+        const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
+        await prisma.decision.create({
+            data: { subjectId: subjectA.id, ada: 'ADA-X', pdfUrl: 'https://example.com/x.pdf' },
+        })
+
+        const subjectB = await createSubject(meetingId2, cityId, { name: 'Subject B', agendaItemIndex: 1 })
+        // SubjectB already has its own decision
+        await prisma.decision.create({
+            data: { subjectId: subjectB.id, ada: 'ADA-Y', pdfUrl: 'https://example.com/y.pdf' },
+        })
+        await prisma.subject.update({ where: { id: subjectB.id }, data: { claimedAda: 'ADA-X' } })
+
+        await resolveAdaConflict(subjectB.id, 'reassign')
+
+        // claimedAda cleared
+        const updatedB = await prisma.subject.findUnique({ where: { id: subjectB.id } })
+        expect(updatedB!.claimedAda).toBeNull()
+
+        // SubjectB keeps its original decision (ADA-Y)
+        const decisionB = await prisma.decision.findUnique({ where: { subjectId: subjectB.id } })
+        expect(decisionB!.ada).toBe('ADA-Y')
+
+        // SubjectA keeps its decision (ADA-X) — not moved
+        const decisionA = await prisma.decision.findUnique({ where: { subjectId: subjectA.id } })
+        expect(decisionA!.ada).toBe('ADA-X')
     })
 })


### PR DESCRIPTION
## Summary

- When polling for Diavgeia decisions, the same ADA can match subjects across different meetings. Previously this caused a P2002 unique constraint error, rolling back the entire transaction and losing all matches from that poll.
- Now, conflicting subjects record a `claimedAda` instead of failing. Non-conflicting matches in the same poll are still saved normally.
- Admin resolves each conflict via "Reassign" (move the decision) or "Dismiss" (discard the claim) in the Diavgeia admin page, with a confirmation dialog.
- Multiple subjects can independently claim the same ADA — the table groups them by ADA with rowSpan.

## Test plan

Run integration tests: `npm run test:integration -- tests/integration/task-handlers.test.ts`

Trigger polls for two meetings with overlapping subjects to verify conflicts are detected while non-conflicting matches are still saved. Visit `/admin/diavgeia` to verify the Conflicts section appears. Test both Reassign and Dismiss resolution flows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches decision polling and database writes around the `Decision.ada` unique constraint; incorrect conflict handling or resolution could misassign or drop decision links across subjects. Changes are guarded with transactions and integration tests but still affect production data integrity.
> 
> **Overview**
> Prevents `pollDecisions` runs from failing on `Decision.ada` uniqueness collisions by adding a nullable `Subject.claimedAda` and recording conflicts (skip decision upsert, set claim) while continuing to save non-conflicting matches in the same poll; also clears stale claims on successful upserts and logs conflict counts.
> 
> Adds an admin-facing **ADA Conflicts** section to the Diavgeia polling stats page to review grouped conflicts and resolve each via a confirmation dialog (*Reassign* moves the decision to the claiming subject; *Dismiss* clears the claim), backed by a new `resolveAdaConflict` server action with auth checks, transactional move, and cross-city guard.
> 
> Improves polling stats filters by expanding city/meeting dropdown sources (union of task history + still-polling meetings) and applying city/meeting filtering consistently across still-polling meetings, recent polls, and conflicts; adds integration test coverage for conflict detection, claim lifecycle, and resolution paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49ba069915e4d5a79ed9971035159032e2e42c31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents poll runs from failing entirely when the same ADA is matched to subjects across different meetings. Instead of letting the P2002 unique-constraint violation roll back the whole transaction, conflicts are recorded as `Subject.claimedAda` and an admin resolution UI is added to `/admin/diavgeia`.

**Key changes:**
- **Migration & schema** — minimal nullable `claimedAda` column addition
- **`handlePollDecisionsResult`** — conflict detection uses a pre-built in-memory map (updated after each successful upsert), and a P2002 catch provides a safety net for concurrent polls
- **`resolveAdaConflict`** — reassign is fully transactional with a fresh re-read, defensive cross-city check, and proper `taskId`/`createdById` preservation; dismiss is a single-update write
- **`PollingStats` / `ConflictsSection`** — adds ADA-grouped conflict table with confirmation dialog and error banner; uses ADA-level `resolvingAda` state to prevent concurrent UI actions within an ADA group
- **Tests** — comprehensive integration tests cover conflict detection, both resolution paths, concurrent-poll fallback, and edge cases

All previously-flagged critical issues have been addressed across multiple force-pushes: `taskId` preservation on reassign, error feedback in the UI, stale claim clearing after successful upsert, auth-before-data-read ordering, cross-city reassign guard, and concurrent-poll P2002 race. The code is well-tested and safe to merge.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — core logic is correct, well-tested, and all critical issues have been addressed.
- The PR implements robust conflict detection and resolution with proper transactional safety, auth checks, and guards. The reassign path is fully transactional with re-reads and cross-city validation; the concurrent-poll P2002 race has a fallback catch. Integration tests are comprehensive and cover both resolution flows, edge cases, and the concurrent-poll fallback. No critical logic issues remain.
- No files require special attention

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Poll returns matches] --> B[Build adaToExistingSubject map<br/>from current DB decisions]
    B --> C[For each match]
    C --> D{ADA already<br/>belongs to<br/>different subject?}
    D -- No --> E[decision.upsert]
    E --> F{P2002 concurrent<br/>race?}
    F -- No --> G[Clear stale claimedAda<br/>Update in-memory map]
    F -- Yes --> H[subject.claimedAda = ada<br/>conflictCount++]
    D -- Yes --> H
    H --> C
    G --> C

    subgraph Admin Resolution
        I[Admin visits /admin/diavgeia] --> J{conflicts.length > 0?}
        J -- Yes --> K[Show ADA Conflicts table<br/>grouped by ADA with rowSpan]
        K --> L{Admin chooses}
        L -- Dismiss --> M[subject.claimedAda = null]
        L -- Reassign --> N[Transaction: re-read claimedAda<br/>check existingOnClaiming<br/>cross-city guard<br/>delete old decision<br/>create on claiming subject<br/>clear claimedAda]
        N --> O[Page refreshes via updateParam]
        M --> O
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (5)</h3></summary>

1. General comment 

   **Intra-poll duplicate ADA still causes P2002 transaction rollback**

   The `adaToExistingSubject` map is built once from the database at the start of the loop (lines 829–833) and is never updated as new matches are processed. If two different subjects in the same poll both match the same brand-new ADA (one that doesn't yet exist in the DB), the second occurrence will pass the conflict check but fail the unique constraint at the upsert, rolling back the entire transaction — the same failure mode this PR aims to fix.

   **Example scenario:**
   1. Subject 1 matches ADA-NEW → no entry in `adaToExistingSubject` → upsert succeeds
   2. Subject 2 matches ADA-NEW → map still undefined (never updated) → conflict check passes → upsert violates unique constraint → P2002 → rollback

   **Suggested fix:** After each successful upsert, update the map so subsequent matches see the newly-claimed ADA:

   ```typescript
   processedCount++;
   // Track this ADA as now belonging to match.subjectId, so
   // later matches in the same poll see it as already taken.
   if (match.ada) {
       adaToExistingSubject.set(match.ada, match.subjectId);
   }
   ```

   Alternatively, pre-scan incoming matches for duplicate ADAs and record `claimedAda` for later occurrences before the loop starts.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/tasks/pollDecisions.ts
   Line: 827-893

   Comment:
   **Intra-poll duplicate ADA still causes P2002 transaction rollback**

   The `adaToExistingSubject` map is built once from the database at the start of the loop (lines 829–833) and is never updated as new matches are processed. If two different subjects in the same poll both match the same brand-new ADA (one that doesn't yet exist in the DB), the second occurrence will pass the conflict check but fail the unique constraint at the upsert, rolling back the entire transaction — the same failure mode this PR aims to fix.

   **Example scenario:**
   1. Subject 1 matches ADA-NEW → no entry in `adaToExistingSubject` → upsert succeeds
   2. Subject 2 matches ADA-NEW → map still undefined (never updated) → conflict check passes → upsert violates unique constraint → P2002 → rollback

   **Suggested fix:** After each successful upsert, update the map so subsequent matches see the newly-claimed ADA:

   ```typescript
   processedCount++;
   // Track this ADA as now belonging to match.subjectId, so
   // later matches in the same poll see it as already taken.
   if (match.ada) {
       adaToExistingSubject.set(match.ada, match.subjectId);
   }
   ```

   Alternatively, pre-scan incoming matches for duplicate ADAs and record `claimedAda` for later occurrences before the loop starts.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. General comment 

   **`discoveries` query ignores `cityId` / `councilMeetingId` filters**

   `getPollingStats` correctly applies the city/meeting filters to the `stillPollingMeetings`, `recentPollTasks`, and `claimingSubjects` queries, but the `discoveries` fetch starting here has no such filter:

   ```typescript
   const discoveries = await prisma.decision.findMany({
       where: { taskId: { not: null } },
       // ← no cityId / councilMeetingId filter
   ```

   As a result, when an admin selects a city (or meeting) filter in the admin UI, the **"Discoveries"** section and the `totalDiscoveries` summary card always reflect the global data set — inconsistent with every other section on the page.

   The `task` relation carries `cityId`/`councilMeetingId`, so the filter can be pushed into the query:

   ```typescript
   const discoveries = await prisma.decision.findMany({
       where: {
           taskId: { not: null },
           ...(cityId && { task: { cityId } }),
           ...(councilMeetingId && { task: { councilMeetingId } }),
       },
       ...
   });
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/tasks/pollDecisions.ts
   Line: 195-223

   Comment:
   **`discoveries` query ignores `cityId` / `councilMeetingId` filters**

   `getPollingStats` correctly applies the city/meeting filters to the `stillPollingMeetings`, `recentPollTasks`, and `claimingSubjects` queries, but the `discoveries` fetch starting here has no such filter:

   ```typescript
   const discoveries = await prisma.decision.findMany({
       where: { taskId: { not: null } },
       // ← no cityId / councilMeetingId filter
   ```

   As a result, when an admin selects a city (or meeting) filter in the admin UI, the **"Discoveries"** section and the `totalDiscoveries` summary card always reflect the global data set — inconsistent with every other section on the page.

   The `task` relation carries `cityId`/`councilMeetingId`, so the filter can be pushed into the query:

   ```typescript
   const discoveries = await prisma.decision.findMany({
       where: {
           taskId: { not: null },
           ...(cityId && { task: { cityId } }),
           ...(councilMeetingId && { task: { councilMeetingId } }),
       },
       ...
   });
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. General comment 

   **"Reassign" silently degrades to "dismiss" when claiming subject already has a decision**

   When `existingOnClaiming` is truthy the inner block is skipped entirely and the function just clears `claimedAda`. From the admin's perspective they clicked **Reassign** (dialog copy: *"This will move the decision from the current subject to the claiming subject"*), but what actually happened is a quiet dismiss — the original decision stays on its current subject and nothing moves.

   There is no exception thrown and no return value, so `handleResolve` in the UI will call `updateParam` to refresh the page. The conflict row disappears and the admin has no indication that the requested reassignment was not performed.

   Consider either:
   - Returning a discriminated result (e.g. `{ outcome: 'skipped' | 'reassigned' }`) and surfacing the skip reason in the UI, or
   - Throwing a descriptive error that the existing `catch` in `handleResolve` can display (`setError`) so the admin knows why the action was a no-op.

   The test is titled `'reassign — when claiming subject already has a decision, **dismisses instead**'` which confirms this is known behaviour — it just needs to be surfaced to the user.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/tasks/pollDecisions.ts
   Line: 688-714

   Comment:
   **"Reassign" silently degrades to "dismiss" when claiming subject already has a decision**

   When `existingOnClaiming` is truthy the inner block is skipped entirely and the function just clears `claimedAda`. From the admin's perspective they clicked **Reassign** (dialog copy: *"This will move the decision from the current subject to the claiming subject"*), but what actually happened is a quiet dismiss — the original decision stays on its current subject and nothing moves.

   There is no exception thrown and no return value, so `handleResolve` in the UI will call `updateParam` to refresh the page. The conflict row disappears and the admin has no indication that the requested reassignment was not performed.

   Consider either:
   - Returning a discriminated result (e.g. `{ outcome: 'skipped' | 'reassigned' }`) and surfacing the skip reason in the UI, or
   - Throwing a descriptive error that the existing `catch` in `handleResolve` can display (`setError`) so the admin knows why the action was a no-op.

   The test is titled `'reassign — when claiming subject already has a decision, **dismisses instead**'` which confirms this is known behaviour — it just needs to be surfaced to the user.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

4. General comment 

   **`claimedAda` is read outside the transaction and used as a closure value inside it**

   `subject.claimedAda` is read before the transaction begins. There is a window (auth check + any I/O latency) in which another concurrent request (e.g. a second admin resolving the same conflict, or a re-poll) could change or clear `claimedAda` on that subject. The transaction then operates on the stale ADA:

   1. `tx.decision.findUnique({ where: { ada: subject.claimedAda! } })` looks up the **old** ADA
   2. Deletes + recreates the decision for that old ADA
   3. `tx.subject.update({ data: { claimedAda: null } })` clears whatever value is now in the DB — possibly a *different* claimed ADA that was set by the concurrent poll

   In an admin panel this race is uncommon, but since the function is already inside a transaction, re-reading `claimedAda` inside the transaction (with appropriate serialisation) would be the correct fix:

   ```typescript
   await prisma.$transaction(async (tx) => {
       const freshSubject = await tx.subject.findUnique({
           where: { id: subjectId },
           select: { claimedAda: true },
       });
       if (!freshSubject?.claimedAda) return; // already resolved concurrently

       const existingOnClaiming = await tx.decision.findUnique({ where: { subjectId } });
       if (!existingOnClaiming) {
           const existingDecision = await tx.decision.findUnique({
               where: { ada: freshSubject.claimedAda },
           });
           // ... rest unchanged
       }
       await tx.subject.update({ where: { id: subjectId }, data: { claimedAda: null } });
   });
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/tasks/pollDecisions.ts
   Line: 667-696

   Comment:
   **`claimedAda` is read outside the transaction and used as a closure value inside it**

   `subject.claimedAda` is read before the transaction begins. There is a window (auth check + any I/O latency) in which another concurrent request (e.g. a second admin resolving the same conflict, or a re-poll) could change or clear `claimedAda` on that subject. The transaction then operates on the stale ADA:

   1. `tx.decision.findUnique({ where: { ada: subject.claimedAda! } })` looks up the **old** ADA
   2. Deletes + recreates the decision for that old ADA
   3. `tx.subject.update({ data: { claimedAda: null } })` clears whatever value is now in the DB — possibly a *different* claimed ADA that was set by the concurrent poll

   In an admin panel this race is uncommon, but since the function is already inside a transaction, re-reading `claimedAda` inside the transaction (with appropriate serialisation) would be the correct fix:

   ```typescript
   await prisma.$transaction(async (tx) => {
       const freshSubject = await tx.subject.findUnique({
           where: { id: subjectId },
           select: { claimedAda: true },
       });
       if (!freshSubject?.claimedAda) return; // already resolved concurrently

       const existingOnClaiming = await tx.decision.findUnique({ where: { subjectId } });
       if (!existingOnClaiming) {
           const existingDecision = await tx.decision.findUnique({
               where: { ada: freshSubject.claimedAda },
           });
           // ... rest unchanged
       }
       await tx.subject.update({ where: { id: subjectId }, data: { claimedAda: null } });
   });
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

5. `src/lib/tasks/pollDecisions.ts`, line 197-222 ([link](https://github.com/schemalabz/opencouncil/blob/b6381324c6ba6962c5a14df4ac988402da05bfd7/src/lib/tasks/pollDecisions.ts#L197-L222)) 

   **`discoveries` ignores city/meeting filter parameters**

   `getPollingStats` accepts `cityId` and `councilMeetingId` filter parameters and applies them to `stillPollingMeetings`, `recentPolls`, and the new `conflicts` query. However, the `discoveries` query has no filter at all:

   ```typescript
   const discoveries = await prisma.decision.findMany({
       where: { taskId: { not: null } },
       // ← no cityId / councilMeetingId filter
       ...
   });
   ```

   This means the **Discoveries** table in the admin UI always renders the full unfiltered history regardless of which city or meeting is selected in the filter dropdowns. Given that the PR explicitly "improves city/meeting filter dropdown sources", this inconsistency is likely unintentional.

   Consider applying the same filters used elsewhere:

   ```typescript
   const discoveries = await prisma.decision.findMany({
       where: {
           taskId: { not: null },
           ...(cityId && {
               subject: {
                   cityId,
                   ...(councilMeetingId && { councilMeetingId }),
               },
           }),
       },
       ...
   });
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/tasks/pollDecisions.ts
   Line: 197-222

   Comment:
   **`discoveries` ignores city/meeting filter parameters**

   `getPollingStats` accepts `cityId` and `councilMeetingId` filter parameters and applies them to `stillPollingMeetings`, `recentPolls`, and the new `conflicts` query. However, the `discoveries` query has no filter at all:

   ```typescript
   const discoveries = await prisma.decision.findMany({
       where: { taskId: { not: null } },
       // ← no cityId / councilMeetingId filter
       ...
   });
   ```

   This means the **Discoveries** table in the admin UI always renders the full unfiltered history regardless of which city or meeting is selected in the filter dropdowns. Given that the PR explicitly "improves city/meeting filter dropdown sources", this inconsistency is likely unintentional.

   Consider applying the same filters used elsewhere:

   ```typescript
   const discoveries = await prisma.decision.findMany({
       where: {
           taskId: { not: null },
           ...(cityId && {
               subject: {
                   cityId,
                   ...(councilMeetingId && { councilMeetingId }),
               },
           }),
       },
       ...
   });
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 49ba069</sub>

<!-- /greptile_comment -->