### PR TITLE
feat: batch Discord alerts for pollDecisions cron

### DIFF
--- a/docs/admin-alerts.md
+++ b/docs/admin-alerts.md
@@ -4,6 +4,7 @@ OpenCouncil sends real-time admin alerts to Discord for key events:
 
 - 🆕 **New meeting added** - With link to view meeting
 - ▶️ **Task started/completed/failed** - With links to admin panel
+- 📋 **pollDecisions batch** - Batch started + aggregated completion summary (replaces per-task alerts)
 - ✅ **Human review completed** - With review statistics (edits, time, efficiency)
 - ✨ **User onboarded** - Via notification preferences, petition, magic link, or admin invite
 - 📝 **New petition** - When submitted for a municipality
@@ -98,6 +99,46 @@ Municipality: Athens | Meeting: City Council - January 2025
 - Secondary reviewer sessions are marked with ↳ symbol
 - Efficiency is calculated using total time from all reviewers
 - "Total Time (All)" field only appears when there are multiple reviewers
+
+**pollDecisions Alerts:**
+
+Unlike other task types, `pollDecisions` uses `discordAlertMode: 'none'` — generic per-task started/completed/failed alerts are suppressed entirely. Instead, two batch-level alerts replace them:
+
+*Batch Started (cron dispatch only):*
+```
+▶️ pollDecisions cron: 5 tasks dispatched
+Batch dispatched successfully
+Dispatched: 5 | Skipped (backoff): 2
+Meetings:
+  `athens/jan15_2025`
+  `thessaloniki/feb10_2025`
+  ...
+```
+
+*Batch Completed (when all sibling tasks finish):*
+```
+📋 pollDecisions: 3 decision(s) found
+5 task(s) completed
+Succeeded: 5 | Failed: 0 | Decisions Found: 3
+Details:
+  `athens/jan15_2025` — 2 match(es)
+  `thessaloniki/feb10_2025` — 1 match(es), 1 reassignment(s)
+Admin Panel: athens/jan15_2025 | thessaloniki/feb10_2025
+```
+
+Color coding: green (all succeeded), orange (conflicts found), red (failures).
+
+No-op runs (no new decisions):
+```
+📋 pollDecisions batch completed (no new decisions)
+5 task(s) completed
+Succeeded: 5 | Failed: 0 | Decisions Found: 0
+```
+
+**Notes:**
+- Cron batches produce **2 messages** instead of up to 20 (1 started + 1 completed).
+- Manual triggers from the admin panel get a completion summary when the task finishes (batch of 1). No separate started alert.
+- Sibling tasks are grouped by a ±2 minute window (`BATCH_WINDOW_MS`). The cron interval must be >4 minutes to avoid batch overlap.
 
 **User Onboarded:**
 ```

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -8,6 +8,7 @@
 import { env } from '@/env.mjs';
 import { formatDurationMs } from '@/lib/formatters/time';
 import type { ReviewerInfo } from '@/lib/db/reviews';
+import type { PollDecisionsMeetingResult } from '@/lib/tasks/pollDecisions';
 
 interface DiscordEmbed {
     title?: string;
@@ -601,6 +602,154 @@ export async function sendTranscriptSentAdminAlert(data: {
                 inline: false,
             },
         ],
+    });
+}
+
+/** Discord embed field value limit. Truncates with an indicator when exceeded. */
+const DISCORD_FIELD_LIMIT = 1024;
+function truncateField(s: string, limit = DISCORD_FIELD_LIMIT): string {
+    if (s.length <= limit) return s;
+    const suffix = '\n… (truncated)';
+    return s.substring(0, limit - suffix.length) + suffix;
+}
+
+/**
+ * Send batch started alert when the pollDecisions cron dispatches tasks.
+ * Replaces individual "started" alerts for cron-triggered polls.
+ */
+export async function sendPollDecisionsBatchStartedAlert(data: {
+    dispatchedCount: number;
+    skippedCount: number;
+    meetings: Array<{ cityId: string; meetingId: string }>;
+    errors: Array<{ cityId: string; meetingId: string; error: string }>;
+}): Promise<void> {
+    if (data.dispatchedCount === 0 && data.errors.length === 0) return;
+
+    const meetingList = data.meetings
+        .map(m => `\`${m.cityId}/${m.meetingId}\``)
+        .join('\n');
+
+    const fields: Array<{ name: string; value: string; inline?: boolean }> = [
+        { name: 'Dispatched', value: data.dispatchedCount.toString(), inline: true },
+        { name: 'Skipped (backoff)', value: data.skippedCount.toString(), inline: true },
+    ];
+
+    if (meetingList) {
+        fields.push({
+            name: 'Meetings',
+            value: truncateField(meetingList),
+            inline: false,
+        });
+    }
+
+    if (data.errors.length > 0) {
+        const errorText = data.errors
+            .map(e => `\`${e.cityId}/${e.meetingId}\`: ${e.error}`)
+            .join('\n');
+        fields.push({
+            name: 'Dispatch Errors',
+            value: truncateField(errorText),
+            inline: false,
+        });
+    }
+
+    await sendAdminAlert({
+        title: `▶️ pollDecisions cron: ${data.dispatchedCount} tasks dispatched`,
+        description: data.errors.length > 0
+            ? `${data.errors.length} dispatch error(s)`
+            : 'Batch dispatched successfully',
+        color: 0x3498db, // Blue
+        fields,
+    });
+}
+
+/**
+ * Send batch completed alert when all pollDecisions tasks in a cron batch finish.
+ * Aggregates results from all sibling tasks into a single summary.
+ */
+export async function sendPollDecisionsBatchCompletedAlert(data: {
+    succeededCount: number;
+    failedCount: number;
+    totalMatches: number;
+    totalReassignments: number;
+    totalConflicts: number;
+    meetingBreakdown: PollDecisionsMeetingResult[];
+}): Promise<void> {
+    const hasDecisions = data.totalMatches > 0;
+    const hasFailures = data.failedCount > 0;
+    // Check per-meeting breakdown for any conflicts
+    const hasConflicts = data.meetingBreakdown.some(m => m.conflicts > 0);
+
+    const color = hasFailures ? 0xff0000 : hasConflicts ? 0xf39c12 : 0x00ff00;
+
+    const title = hasDecisions
+        ? hasFailures
+            ? `📋 pollDecisions: ${data.totalMatches} decision(s) found, ${data.failedCount} failure(s)`
+            : `📋 pollDecisions: ${data.totalMatches} decision(s) found`
+        : hasFailures
+          ? `📋 pollDecisions batch: ${data.failedCount} failure(s), no decisions found`
+          : '📋 pollDecisions batch completed (no new decisions)';
+
+    const fields: Array<{ name: string; value: string; inline?: boolean }> = [
+        { name: 'Succeeded', value: data.succeededCount.toString(), inline: true },
+        { name: 'Failed', value: data.failedCount.toString(), inline: true },
+        { name: 'Decisions Found', value: data.totalMatches.toString(), inline: true },
+    ];
+
+    if (data.totalReassignments > 0) {
+        fields.push({ name: 'Reassignments', value: data.totalReassignments.toString(), inline: true });
+    }
+
+    if (data.totalConflicts > 0) {
+        fields.push({ name: 'Conflicts', value: data.totalConflicts.toString(), inline: true });
+    }
+
+    // Per-meeting breakdown for meetings with results or failures
+    const notable = data.meetingBreakdown.filter(
+        m => m.matches > 0 || m.reassignments > 0 || m.conflicts > 0 || m.status === 'failed'
+    );
+
+    if (notable.length > 0) {
+        const breakdown = notable
+            .map(m => {
+                const parts: string[] = [`\`${m.cityId}/${m.meetingId}\``];
+                if (m.status === 'failed') {
+                    parts.push(`**FAILED**: ${m.error?.substring(0, 200) ?? 'unknown error'}`);
+                } else {
+                    const details: string[] = [];
+                    if (m.matches > 0) details.push(`${m.matches} match(es)`);
+                    if (m.reassignments > 0) details.push(`${m.reassignments} reassignment(s)`);
+                    if (m.conflicts > 0) details.push(`${m.conflicts} conflict(s)`);
+                    parts.push(details.join(', '));
+                }
+                return parts.join(' — ');
+            })
+            .join('\n');
+        fields.push({
+            name: 'Details',
+            value: truncateField(breakdown),
+            inline: false,
+        });
+    }
+
+    // Admin panel links for meetings with decisions, conflicts, or failures
+    const actionable = data.meetingBreakdown.filter(m => m.matches > 0 || m.conflicts > 0 || m.status === 'failed');
+    if (actionable.length > 0) {
+        const links = actionable
+            .map(m => `[${m.cityId}/${m.meetingId}](${meetingAdminUrl(m.cityId, m.meetingId)})`)
+            .join(' | ');
+        fields.push({
+            name: 'Admin Panel',
+            value: truncateField(links),
+            inline: false,
+        });
+    }
+
+    await sendAdminAlert({
+        title,
+        description: `${data.succeededCount + data.failedCount} task(s) completed`,
+        color,
+        fields,
     });
 }
 

--- a/src/lib/tasks/__tests__/checkTaskIdempotency.test.ts
+++ b/src/lib/tasks/__tests__/checkTaskIdempotency.test.ts
@@ -1,6 +1,7 @@
 /** @jest-environment node */
 
 const mockFindFirst = jest.fn();
+const mockFindUnique = jest.fn();
 const mockCreate = jest.fn();
 const mockUpdate = jest.fn();
 
@@ -10,8 +11,10 @@ jest.mock('../../db/prisma', () => ({
   default: {
     taskStatus: {
       findFirst: (...args: unknown[]) => mockFindFirst(...args),
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
       create: (...args: unknown[]) => mockCreate(...args),
       update: (...args: unknown[]) => mockUpdate(...args),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
     },
   },
 }));
@@ -21,9 +24,14 @@ jest.mock('../../auth', () => ({ withUserAuthorizedToEdit: jest.fn() }));
 jest.mock('../../discord', () => ({
   sendTaskAdminAlert: jest.fn(),
 }));
-jest.mock('../registry', () => ({ taskHandlers: {} }));
+const mockTerminalHook = jest.fn().mockResolvedValue(undefined);
+jest.mock('../registry', () => ({
+  taskHandlers: {},
+  taskTerminalHooks: { pollDecisions: (...args: unknown[]) => mockTerminalHook(...args) },
+}));
 
-import { checkTaskIdempotency, startTask } from '../tasks';
+import { checkTaskIdempotency, startTask, handleTaskUpdate } from '../tasks';
+import { sendTaskAdminAlert } from '../../discord';
 
 const CITY_ID = 'city-1';
 const MEETING_ID = 'meeting-1';
@@ -222,5 +230,258 @@ describe('startTask — idempotency scoping', () => {
 
     // force skips the DB check entirely
     expect(mockFindFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe('startTask — silent option', () => {
+  const createdTask = {
+    id: 'new-task',
+    type: 'summarize',
+    status: 'pending',
+    councilMeeting: { city: { name_en: 'Test City' }, name_en: 'Test Meeting' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindFirst.mockResolvedValue(null);
+    mockCreate.mockResolvedValue(createdTask);
+    mockUpdate.mockResolvedValue(createdTask);
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, text: async () => '{}' });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('sends Discord alert by default', async () => {
+    await startTask('generateHighlight', {}, MEETING_ID, CITY_ID);
+
+    expect(sendTaskAdminAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'started', taskType: 'generateHighlight' })
+    );
+  });
+
+  it('suppresses Discord alert when silent: true', async () => {
+    await startTask('generateHighlight', {}, MEETING_ID, CITY_ID, { silent: true });
+
+    expect(sendTaskAdminAlert).not.toHaveBeenCalled();
+  });
+
+  it('suppresses Discord alert for pollDecisions (discordAlertMode: none)', async () => {
+    const pollTask = { ...createdTask, type: 'pollDecisions' };
+    mockCreate.mockResolvedValue(pollTask);
+    mockUpdate.mockResolvedValue(pollTask);
+
+    await startTask('pollDecisions', {}, MEETING_ID, CITY_ID);
+
+    expect(sendTaskAdminAlert).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleTaskUpdate — discordAlertMode gating', () => {
+  const mockProcessResult = jest.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockProcessResult.mockResolvedValue(undefined);
+  });
+
+  it('sends Discord alert for summarize (default alertMode)', async () => {
+    const task = {
+      id: 'task-1',
+      type: 'summarize',
+      cityId: CITY_ID,
+      councilMeetingId: MEETING_ID,
+      councilMeeting: { city: { name_en: 'City' }, name_en: 'Meeting' },
+    };
+    mockFindUnique.mockResolvedValue(task);
+    mockUpdate.mockResolvedValue({ ...task, status: 'succeeded' });
+
+    await handleTaskUpdate(
+      'task-1',
+      { status: 'success', result: { data: 'test' }, stage: '', progressPercent: 100, version: 1 },
+      mockProcessResult,
+    );
+
+    expect(sendTaskAdminAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'completed', taskType: 'summarize' })
+    );
+  });
+
+  it('suppresses Discord alert for pollDecisions success (discordAlertMode: none)', async () => {
+    const task = {
+      id: 'task-1',
+      type: 'pollDecisions',
+      cityId: CITY_ID,
+      councilMeetingId: MEETING_ID,
+      councilMeeting: { city: { name_en: 'City' }, name_en: 'Meeting' },
+    };
+    mockFindUnique.mockResolvedValue(task);
+    mockUpdate.mockResolvedValue({ ...task, status: 'succeeded' });
+
+    await handleTaskUpdate(
+      'task-1',
+      { status: 'success', result: { matches: [] }, stage: '', progressPercent: 100, version: 1 },
+      mockProcessResult,
+    );
+
+    expect(sendTaskAdminAlert).not.toHaveBeenCalled();
+  });
+
+  it('suppresses Discord alert for pollDecisions failure (discordAlertMode: none)', async () => {
+    const task = {
+      id: 'task-1',
+      type: 'pollDecisions',
+      cityId: CITY_ID,
+      councilMeetingId: MEETING_ID,
+      councilMeeting: { city: { name_en: 'City' }, name_en: 'Meeting' },
+    };
+    mockFindUnique.mockResolvedValue(task);
+    mockUpdate.mockResolvedValue({ ...task, status: 'failed' });
+
+    await handleTaskUpdate(
+      'task-1',
+      { status: 'error', error: 'some error', stage: '', progressPercent: 0, version: 1 },
+      mockProcessResult,
+    );
+
+    expect(sendTaskAdminAlert).not.toHaveBeenCalled();
+  });
+
+  it('sends Discord alert for summarize failure (default alertMode)', async () => {
+    const task = {
+      id: 'task-1',
+      type: 'summarize',
+      cityId: CITY_ID,
+      councilMeetingId: MEETING_ID,
+      councilMeeting: { city: { name_en: 'City' }, name_en: 'Meeting' },
+    };
+    mockFindUnique.mockResolvedValue(task);
+    mockUpdate.mockResolvedValue({ ...task, status: 'failed' });
+
+    await handleTaskUpdate(
+      'task-1',
+      { status: 'error', error: 'some error', stage: '', progressPercent: 0, version: 1 },
+      mockProcessResult,
+    );
+
+    expect(sendTaskAdminAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed', taskType: 'summarize' })
+    );
+  });
+});
+
+describe('handleTaskUpdate — terminal hooks', () => {
+  const mockProcessResult = jest.fn().mockResolvedValue(undefined);
+
+  const pollDecisionsTask = {
+    id: 'task-1',
+    type: 'pollDecisions',
+    cityId: CITY_ID,
+    councilMeetingId: MEETING_ID,
+    createdAt: new Date('2026-03-06T10:00:00Z'),
+    councilMeeting: { city: { name_en: 'City' }, name_en: 'Meeting' },
+  };
+
+  const summarizeTask = {
+    id: 'task-2',
+    type: 'summarize',
+    cityId: CITY_ID,
+    councilMeetingId: MEETING_ID,
+    createdAt: new Date('2026-03-06T10:00:00Z'),
+    councilMeeting: { city: { name_en: 'City' }, name_en: 'Meeting' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockProcessResult.mockResolvedValue(undefined);
+  });
+
+  it('calls terminal hook after successful processing', async () => {
+    mockFindUnique.mockResolvedValue(pollDecisionsTask);
+    mockUpdate.mockResolvedValue({ ...pollDecisionsTask, status: 'succeeded' });
+
+    await handleTaskUpdate(
+      'task-1',
+      { status: 'success', result: { matches: [] }, stage: '', progressPercent: 100, version: 1 },
+      mockProcessResult,
+    );
+
+    expect(mockTerminalHook).toHaveBeenCalledTimes(1);
+    expect(mockTerminalHook).toHaveBeenCalledWith('task-1', pollDecisionsTask.createdAt);
+  });
+
+  it('calls terminal hook after processing failure', async () => {
+    mockFindUnique.mockResolvedValue(pollDecisionsTask);
+    // First update sets status to 'succeeded' (before processResult runs),
+    // second update sets status to 'failed' (in the catch block after processResult throws).
+    mockUpdate
+      .mockResolvedValueOnce({ ...pollDecisionsTask, status: 'succeeded' })
+      .mockResolvedValueOnce({ ...pollDecisionsTask, status: 'failed' });
+    mockProcessResult.mockRejectedValue(new Error('DB transaction failed'));
+
+    await handleTaskUpdate(
+      'task-1',
+      { status: 'success', result: { matches: [] }, stage: '', progressPercent: 100, version: 1 },
+      mockProcessResult,
+    );
+
+    // Hook still runs — after catch block settles the status to 'failed'
+    expect(mockTerminalHook).toHaveBeenCalledTimes(1);
+    expect(mockTerminalHook).toHaveBeenCalledWith('task-1', pollDecisionsTask.createdAt);
+  });
+
+  it('calls terminal hook after server error', async () => {
+    mockFindUnique.mockResolvedValue(pollDecisionsTask);
+    mockUpdate.mockResolvedValue({ ...pollDecisionsTask, status: 'failed' });
+
+    await handleTaskUpdate(
+      'task-1',
+      { status: 'error', error: 'worker timeout', stage: '', progressPercent: 0, version: 1 },
+      mockProcessResult,
+    );
+
+    expect(mockTerminalHook).toHaveBeenCalledTimes(1);
+    expect(mockTerminalHook).toHaveBeenCalledWith('task-1', pollDecisionsTask.createdAt);
+  });
+
+  it('does not call terminal hook for processing status', async () => {
+    mockFindUnique.mockResolvedValue(pollDecisionsTask);
+
+    await handleTaskUpdate(
+      'task-1',
+      { status: 'processing', stage: 'matching', progressPercent: 50, version: 1 },
+      mockProcessResult,
+    );
+
+    expect(mockTerminalHook).not.toHaveBeenCalled();
+  });
+
+  it('does not call terminal hook for task types without one', async () => {
+    mockFindUnique.mockResolvedValue(summarizeTask);
+    mockUpdate.mockResolvedValue({ ...summarizeTask, status: 'succeeded' });
+
+    await handleTaskUpdate(
+      'task-2',
+      { status: 'success', result: { data: 'test' }, stage: '', progressPercent: 100, version: 1 },
+      mockProcessResult,
+    );
+
+    expect(mockTerminalHook).not.toHaveBeenCalled();
+  });
+
+  it('does not break handleTaskUpdate if terminal hook throws', async () => {
+    mockFindUnique.mockResolvedValue(pollDecisionsTask);
+    mockUpdate.mockResolvedValue({ ...pollDecisionsTask, status: 'succeeded' });
+    mockTerminalHook.mockRejectedValue(new Error('hook crashed'));
+
+    // Should not throw — hook error is caught and logged
+    await handleTaskUpdate(
+      'task-1',
+      { status: 'success', result: { matches: [] }, stage: '', progressPercent: 100, version: 1 },
+      mockProcessResult,
+    );
+
+    expect(mockTerminalHook).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/tasks/__tests__/pollDecisionsBatchAlerts.test.ts
+++ b/src/lib/tasks/__tests__/pollDecisionsBatchAlerts.test.ts
@@ -1,0 +1,365 @@
+/** @jest-environment node */
+
+const mockFindUnique = jest.fn();
+const mockTaskStatusFindMany = jest.fn();
+const mockSendBatchStarted = jest.fn().mockResolvedValue(undefined);
+const mockSendBatchCompleted = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../db/prisma', () => ({
+  __esModule: true,
+  default: {
+    taskStatus: {
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
+      findMany: (...args: unknown[]) => mockTaskStatusFindMany(...args),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    subject: {
+      findMany: jest.fn().mockResolvedValue([]),
+      update: jest.fn(),
+      updateMany: jest.fn(),
+    },
+    decision: {
+      findMany: jest.fn().mockResolvedValue([]),
+      upsert: jest.fn(),
+    },
+    $transaction: jest.fn().mockImplementation((fn: (tx: unknown) => Promise<void>) => fn({
+      decision: {
+        findMany: jest.fn().mockResolvedValue([]),
+        upsert: jest.fn(),
+        deleteMany: jest.fn(),
+      },
+      subject: {
+        findMany: jest.fn().mockResolvedValue([]),
+        update: jest.fn(),
+        updateMany: jest.fn(),
+      },
+    })),
+  },
+}));
+jest.mock('@/env.mjs', () => ({ env: { NEXTAUTH_URL: 'http://test', TASK_API_URL: 'http://test', TASK_API_KEY: 'key' } }));
+jest.mock('next/cache', () => ({ revalidateTag: jest.fn() }));
+jest.mock('../../auth', () => ({ withUserAuthorizedToEdit: jest.fn() }));
+jest.mock('../../discord', () => ({
+  sendTaskAdminAlert: jest.fn(),
+  sendPollDecisionsBatchStartedAlert: (...args: unknown[]) => mockSendBatchStarted(...args),
+  sendPollDecisionsBatchCompletedAlert: (...args: unknown[]) => mockSendBatchCompleted(...args),
+}));
+jest.mock('../registry', () => ({ taskHandlers: {}, taskTerminalHooks: {} }));
+
+import { checkBatchCompletionAndAlert } from '../pollDecisions';
+
+const CITY_ID = 'city-1';
+const MEETING_ID = 'meeting-1';
+const TASK_CREATED_AT = new Date('2026-03-06T10:00:00Z');
+
+/** Helper to build a responseBody with _processedCounts */
+function enrichedResponseBody(raw: Record<string, unknown>, counts: { matches: number; reassignments: number; conflicts: number }) {
+  return JSON.stringify({ ...raw, _processedCounts: counts });
+}
+
+describe('checkBatchCompletionAndAlert', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends batch alert when all sibling tasks are terminal', async () => {
+    mockTaskStatusFindMany.mockResolvedValue([
+      {
+        id: 'task-1',
+        status: 'succeeded',
+        cityId: CITY_ID,
+        councilMeetingId: MEETING_ID,
+        responseBody: enrichedResponseBody(
+          { matches: [{ subjectId: 's1', ada: 'ADA1', pdfUrl: 'http://pdf' }], reassignments: [], unmatchedSubjects: [], ambiguousSubjects: [] },
+          { matches: 1, reassignments: 0, conflicts: 0 },
+        ),
+      },
+      {
+        id: 'task-2',
+        status: 'succeeded',
+        cityId: 'city-2',
+        councilMeetingId: 'meeting-2',
+        responseBody: enrichedResponseBody(
+          { matches: [{ subjectId: 's2' }, { subjectId: 's3' }], reassignments: [], unmatchedSubjects: [], ambiguousSubjects: [] },
+          { matches: 2, reassignments: 0, conflicts: 0 },
+        ),
+      },
+    ]);
+
+    await checkBatchCompletionAndAlert('task-1', TASK_CREATED_AT);
+
+    expect(mockSendBatchCompleted).toHaveBeenCalledTimes(1);
+    expect(mockSendBatchCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        succeededCount: 2,
+        failedCount: 0,
+        totalMatches: 3,
+        totalReassignments: 0,
+        totalConflicts: 0,
+      })
+    );
+  });
+
+  it('does not send alert when some sibling tasks are still pending', async () => {
+    mockTaskStatusFindMany.mockResolvedValue([
+      {
+        id: 'task-1',
+        status: 'succeeded',
+        cityId: CITY_ID,
+        councilMeetingId: MEETING_ID,
+        responseBody: '{}',
+      },
+      {
+        id: 'task-2',
+        status: 'pending',
+        cityId: 'city-2',
+        councilMeetingId: 'meeting-2',
+        responseBody: null,
+      },
+    ]);
+
+    await checkBatchCompletionAndAlert('task-1', TASK_CREATED_AT);
+
+    expect(mockSendBatchCompleted).not.toHaveBeenCalled();
+  });
+
+  it('sends alert immediately for single task (manual trigger)', async () => {
+    mockTaskStatusFindMany.mockResolvedValue([
+      {
+        id: 'task-1',
+        status: 'succeeded',
+        cityId: CITY_ID,
+        councilMeetingId: MEETING_ID,
+        responseBody: enrichedResponseBody(
+          { matches: [{ subjectId: 's1' }], reassignments: [], unmatchedSubjects: [], ambiguousSubjects: [] },
+          { matches: 1, reassignments: 0, conflicts: 0 },
+        ),
+      },
+    ]);
+
+    await checkBatchCompletionAndAlert('task-1', TASK_CREATED_AT);
+
+    expect(mockSendBatchCompleted).toHaveBeenCalledTimes(1);
+    expect(mockSendBatchCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        succeededCount: 1,
+        failedCount: 0,
+        totalMatches: 1,
+      })
+    );
+  });
+
+  it('includes failure info in batch alert for mixed results', async () => {
+    mockTaskStatusFindMany.mockResolvedValue([
+      {
+        id: 'task-1',
+        status: 'succeeded',
+        cityId: CITY_ID,
+        councilMeetingId: MEETING_ID,
+        responseBody: enrichedResponseBody(
+          { matches: [{ subjectId: 's1' }], reassignments: [], unmatchedSubjects: [], ambiguousSubjects: [] },
+          { matches: 1, reassignments: 0, conflicts: 0 },
+        ),
+      },
+      {
+        id: 'task-2',
+        status: 'failed',
+        cityId: 'city-2',
+        councilMeetingId: 'meeting-2',
+        responseBody: 'Connection timeout to Diavgeia',
+      },
+    ]);
+
+    await checkBatchCompletionAndAlert('task-1', TASK_CREATED_AT);
+
+    expect(mockSendBatchCompleted).toHaveBeenCalledTimes(1);
+    const callArg = mockSendBatchCompleted.mock.calls[0][0];
+    expect(callArg.succeededCount).toBe(1);
+    expect(callArg.failedCount).toBe(1);
+    expect(callArg.meetingBreakdown).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          cityId: 'city-2',
+          meetingId: 'meeting-2',
+          status: 'failed',
+          error: 'Connection timeout to Diavgeia',
+        }),
+      ])
+    );
+  });
+
+  it('aggregates conflicts across all tasks from _processedCounts', async () => {
+    mockTaskStatusFindMany.mockResolvedValue([
+      {
+        id: 'task-1',
+        status: 'succeeded',
+        cityId: CITY_ID,
+        councilMeetingId: MEETING_ID,
+        responseBody: enrichedResponseBody(
+          { matches: [{ subjectId: 's1' }], reassignments: [{ ada: 'ADA1' }], unmatchedSubjects: [], ambiguousSubjects: [] },
+          { matches: 1, reassignments: 1, conflicts: 2 },
+        ),
+      },
+      {
+        id: 'task-2',
+        status: 'succeeded',
+        cityId: 'city-2',
+        councilMeetingId: 'meeting-2',
+        responseBody: enrichedResponseBody(
+          { matches: [{ subjectId: 's2' }], reassignments: [], unmatchedSubjects: [], ambiguousSubjects: [] },
+          { matches: 1, reassignments: 0, conflicts: 1 },
+        ),
+      },
+    ]);
+
+    await checkBatchCompletionAndAlert('task-1', TASK_CREATED_AT);
+
+    expect(mockSendBatchCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        totalMatches: 2,
+        totalReassignments: 1,
+        totalConflicts: 3, // 2 from task-1 + 1 from task-2
+      })
+    );
+  });
+
+  it('falls back to raw response counts when _processedCounts is absent', async () => {
+    mockTaskStatusFindMany.mockResolvedValue([
+      {
+        id: 'task-1',
+        status: 'succeeded',
+        cityId: CITY_ID,
+        councilMeetingId: MEETING_ID,
+        responseBody: JSON.stringify({
+          matches: [{ subjectId: 's1' }, { subjectId: 's2' }],
+          reassignments: [{ ada: 'ADA1' }],
+          unmatchedSubjects: [],
+          ambiguousSubjects: [],
+        }),
+      },
+    ]);
+
+    await checkBatchCompletionAndAlert('task-1', TASK_CREATED_AT);
+
+    expect(mockSendBatchCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        totalMatches: 2,
+        totalReassignments: 1,
+        totalConflicts: 0, // not available without _processedCounts
+      })
+    );
+  });
+
+  it('handles malformed responseBody gracefully', async () => {
+    mockTaskStatusFindMany.mockResolvedValue([
+      {
+        id: 'task-1',
+        status: 'succeeded',
+        cityId: CITY_ID,
+        councilMeetingId: MEETING_ID,
+        responseBody: 'not json',
+      },
+      {
+        id: 'task-2',
+        status: 'succeeded',
+        cityId: 'city-2',
+        councilMeetingId: 'meeting-2',
+        responseBody: null,
+      },
+    ]);
+
+    await checkBatchCompletionAndAlert('task-1', TASK_CREATED_AT);
+
+    expect(mockSendBatchCompleted).toHaveBeenCalledTimes(1);
+    expect(mockSendBatchCompleted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        succeededCount: 2,
+        totalMatches: 0,
+      })
+    );
+  });
+
+  it('reports correct counts for server-level error (last task in batch)', async () => {
+    mockTaskStatusFindMany.mockResolvedValue([
+      {
+        id: 'task-1',
+        status: 'succeeded',
+        cityId: CITY_ID,
+        councilMeetingId: MEETING_ID,
+        responseBody: enrichedResponseBody(
+          { matches: [{ subjectId: 's1' }], reassignments: [], unmatchedSubjects: [], ambiguousSubjects: [] },
+          { matches: 1, reassignments: 0, conflicts: 0 },
+        ),
+      },
+      {
+        id: 'task-2',
+        status: 'failed',
+        cityId: 'city-2',
+        councilMeetingId: 'meeting-2',
+        responseBody: 'Server error: worker timeout',
+      },
+    ]);
+
+    await checkBatchCompletionAndAlert('task-2', TASK_CREATED_AT);
+
+    expect(mockSendBatchCompleted).toHaveBeenCalledTimes(1);
+    const callArg = mockSendBatchCompleted.mock.calls[0][0];
+    expect(callArg.succeededCount).toBe(1);
+    expect(callArg.failedCount).toBe(1);
+    expect(callArg.totalMatches).toBe(1);
+    expect(callArg.meetingBreakdown).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ status: 'failed', error: 'Server error: worker timeout' }),
+      ])
+    );
+  });
+
+  it('reports all failed when entire batch fails', async () => {
+    mockTaskStatusFindMany.mockResolvedValue([
+      {
+        id: 'task-1',
+        status: 'failed',
+        cityId: CITY_ID,
+        councilMeetingId: MEETING_ID,
+        responseBody: 'Processing error: DB timeout',
+      },
+      {
+        id: 'task-2',
+        status: 'failed',
+        cityId: 'city-2',
+        councilMeetingId: 'meeting-2',
+        responseBody: 'Server error: OOM',
+      },
+    ]);
+
+    await checkBatchCompletionAndAlert('task-1', TASK_CREATED_AT);
+
+    expect(mockSendBatchCompleted).toHaveBeenCalledTimes(1);
+    const callArg = mockSendBatchCompleted.mock.calls[0][0];
+    expect(callArg.succeededCount).toBe(0);
+    expect(callArg.failedCount).toBe(2);
+    expect(callArg.totalMatches).toBe(0);
+    expect(callArg.meetingBreakdown).toHaveLength(2);
+    expect(callArg.meetingBreakdown.every((m: { status: string }) => m.status === 'failed')).toBe(true);
+  });
+
+  it('truncates long error messages in breakdown', async () => {
+    const longError = 'x'.repeat(500);
+    mockTaskStatusFindMany.mockResolvedValue([
+      {
+        id: 'task-1',
+        status: 'failed',
+        cityId: CITY_ID,
+        councilMeetingId: MEETING_ID,
+        responseBody: longError,
+      },
+    ]);
+
+    await checkBatchCompletionAndAlert('task-1', TASK_CREATED_AT);
+
+    const callArg = mockSendBatchCompleted.mock.calls[0][0];
+    const failedMeeting = callArg.meetingBreakdown.find((m: { status: string }) => m.status === 'failed');
+    expect(failedMeeting.error.length).toBe(200); // ERROR_PREVIEW_LENGTH
+  });
+});

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -7,6 +7,7 @@ import { upsertDecision, deleteDecision, getDecisionForSubject } from "../db/dec
 export { getDecisionForSubject };
 import { withUserAuthorizedToEdit } from "../auth";
 import { shouldSkipPolling, getBackoffState, BACKOFF_SCHEDULE, MAX_POLLING_DAYS } from "./pollDecisionsBackoff";
+import { sendPollDecisionsBatchStartedAlert, sendPollDecisionsBatchCompletedAlert } from "../discord";
 
 export async function requestPollDecisions(
     cityId: string,
@@ -20,10 +21,13 @@ export async function requestPollDecisions(
 /**
  * Core function to poll decisions for a meeting. Used by both the admin action and the cron job.
  * Does NOT check authorization — callers are responsible for auth.
+ *
+ * @param options.silent - When true, suppresses the per-task "started" Discord alert (used by cron batch)
  */
 export async function pollDecisionsForMeeting(
     cityId: string,
     councilMeetingId: string,
+    options?: { silent?: boolean },
 ) {
     const councilMeeting = await prisma.councilMeeting.findUnique({
         where: {
@@ -84,7 +88,7 @@ export async function pollDecisionsForMeeting(
         })),
     };
 
-    return startTask('pollDecisions', body, councilMeetingId, cityId);
+    return startTask('pollDecisions', body, councilMeetingId, cityId, { silent: options?.silent });
 }
 
 /**
@@ -153,6 +157,9 @@ export async function pollDecisionsForRecentMeetings() {
 
     const results: Array<{ cityId: string; meetingId: string; status: string }> = [];
     let dispatched = 0;
+    let skipped = 0;
+    const dispatchedMeetings: Array<{ cityId: string; meetingId: string }> = [];
+    const dispatchErrors: Array<{ cityId: string; meetingId: string; error: string }> = [];
 
     for (const meeting of meetings) {
         if (dispatched >= 10) break;
@@ -166,6 +173,7 @@ export async function pollDecisionsForRecentMeetings() {
         );
         if (skipReason) {
             results.push({ cityId: meeting.cityId, meetingId: meeting.id, status: `skipped: ${skipReason}` });
+            skipped++;
             continue;
         }
 
@@ -173,14 +181,30 @@ export async function pollDecisionsForRecentMeetings() {
             await pollDecisionsForMeeting(
                 meeting.cityId,
                 meeting.id,
+                { silent: true },
             );
 
             dispatched++;
+            dispatchedMeetings.push({ cityId: meeting.cityId, meetingId: meeting.id });
             results.push({ cityId: meeting.cityId, meetingId: meeting.id, status: 'started' });
         } catch (error) {
             console.error(`Failed to poll decisions for meeting ${meeting.cityId}/${meeting.id}:`, error);
-            results.push({ cityId: meeting.cityId, meetingId: meeting.id, status: `error: ${(error as Error).message}` });
+            const errorMsg = (error as Error).message;
+            dispatchErrors.push({ cityId: meeting.cityId, meetingId: meeting.id, error: errorMsg });
+            results.push({ cityId: meeting.cityId, meetingId: meeting.id, status: `error: ${errorMsg}` });
         }
+    }
+
+    // Send a single batch started alert instead of per-task alerts.
+    // .catch() ensures failures are logged — this is the sole observability path
+    // for pollDecisions (discordAlertMode: 'none' suppresses all generic alerts).
+    if (dispatched > 0 || dispatchErrors.length > 0) {
+        sendPollDecisionsBatchStartedAlert({
+            dispatchedCount: dispatched,
+            skippedCount: skipped,
+            meetings: dispatchedMeetings,
+            errors: dispatchErrors,
+        }).catch(err => console.error('Failed to send pollDecisions batch started alert:', err));
     }
 
     return { meetingsProcessed: dispatched, results };
@@ -806,6 +830,145 @@ export async function resolveAdaConflict(
     });
 }
 
+/** Per-meeting entry in the batch completion summary. */
+export interface PollDecisionsMeetingResult {
+    cityId: string;
+    meetingId: string;
+    matches: number;
+    reassignments: number;
+    conflicts: number;
+    status: 'succeeded' | 'failed';
+    error?: string;
+}
+
+/** Max characters for an individual error line in batch Discord summaries. */
+const ERROR_PREVIEW_LENGTH = 200;
+
+/**
+ * Radius (ms) for grouping pollDecisions tasks into a batch.
+ * Tasks created within ±BATCH_WINDOW_MS of each other are considered siblings.
+ *
+ * Must be less than half the cron interval to avoid grouping tasks from
+ * consecutive runs into the same batch. Current cron interval: 10 minutes.
+ */
+const BATCH_WINDOW_MS = 2 * 60 * 1000;
+
+/**
+ * After a pollDecisions task reaches a terminal state, check whether all sibling
+ * tasks in the same batch window have also finished. If so, aggregate results
+ * and send a single batch completion alert.
+ *
+ * Called via taskTerminalHooks in handleTaskUpdate — runs AFTER the task's DB
+ * status is settled, so all statuses read from DB are correct.
+ *
+ * NOTE: Tasks that fail during startTask() (backend API errors) are set to
+ * 'failed' directly without a callback, so handleTaskUpdate and this hook are
+ * never invoked for them. Partial dispatch failures self-heal (surviving tasks
+ * trigger this hook and find failed siblings via the time-window query). A
+ * complete dispatch failure produces only a batch started alert — no completed
+ * alert fires, since the started alert already shows the dispatch errors.
+ */
+export async function checkBatchCompletionAndAlert(
+    _taskId: string,
+    taskCreatedAt: Date,
+) {
+    const windowStart = new Date(taskCreatedAt.getTime() - BATCH_WINDOW_MS);
+    const windowEnd = new Date(taskCreatedAt.getTime() + BATCH_WINDOW_MS);
+
+    // Find all pollDecisions tasks in the time window
+    const siblingTasks = await prisma.taskStatus.findMany({
+        where: {
+            type: 'pollDecisions',
+            createdAt: { gte: windowStart, lte: windowEnd },
+        },
+        select: {
+            id: true,
+            status: true,
+            cityId: true,
+            councilMeetingId: true,
+            responseBody: true,
+        },
+    });
+
+    // Check if all siblings are in terminal state.
+    // Note: if two tasks complete nearly simultaneously, both may see allTerminal=true
+    // and send a duplicate alert. This is a benign race — Discord duplicates are
+    // preferable to missing alerts, and the window is very small in practice.
+    const allTerminal = siblingTasks.every(t => t.status === 'succeeded' || t.status === 'failed');
+    if (!allTerminal) {
+        return; // Not all done yet — a later completion will trigger the summary
+    }
+
+    // Aggregate results — all tasks read uniformly from DB.
+    let totalMatches = 0;
+    let totalReassignments = 0;
+    let totalConflicts = 0;
+    let succeededCount = 0;
+    let failedCount = 0;
+    const meetingBreakdown: PollDecisionsMeetingResult[] = [];
+
+    for (const sibling of siblingTasks) {
+        const cityId = sibling.cityId;
+        const meetingId = sibling.councilMeetingId ?? 'unknown';
+
+        if (sibling.status === 'failed') {
+            failedCount++;
+            meetingBreakdown.push({
+                cityId,
+                meetingId,
+                matches: 0,
+                reassignments: 0,
+                conflicts: 0,
+                status: 'failed',
+                error: sibling.responseBody?.substring(0, ERROR_PREVIEW_LENGTH) ?? undefined,
+            });
+            continue;
+        }
+
+        succeededCount++;
+
+        // Parse responseBody for result counts. Prefer _processedCounts (enriched
+        // after processing) for accurate post-processing numbers; fall back to raw
+        // server response counts for older tasks or edge cases.
+        let matches = 0;
+        let reassignments = 0;
+        let conflicts = 0;
+        if (sibling.responseBody) {
+            try {
+                const parsed = JSON.parse(sibling.responseBody);
+                if (parsed._processedCounts) {
+                    matches = parsed._processedCounts.matches ?? 0;
+                    reassignments = parsed._processedCounts.reassignments ?? 0;
+                    conflicts = parsed._processedCounts.conflicts ?? 0;
+                } else {
+                    matches = Array.isArray(parsed.matches) ? parsed.matches.length : 0;
+                    reassignments = Array.isArray(parsed.reassignments) ? parsed.reassignments.length : 0;
+                }
+            } catch { /* ignore parse errors */ }
+        }
+        totalMatches += matches;
+        totalReassignments += reassignments;
+        totalConflicts += conflicts;
+        meetingBreakdown.push({
+            cityId,
+            meetingId,
+            matches,
+            reassignments,
+            conflicts,
+            status: 'succeeded',
+        });
+    }
+
+    sendPollDecisionsBatchCompletedAlert({
+        succeededCount,
+        failedCount,
+        totalMatches,
+        totalReassignments,
+        totalConflicts,
+        meetingBreakdown,
+    }).catch(err => console.error('Failed to send pollDecisions batch completed alert:', err));
+}
+
 export async function handlePollDecisionsResult(taskId: string, result: PollDecisionsResult) {
     const task = await prisma.taskStatus.findUnique({
         where: { id: taskId },
@@ -814,6 +977,10 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
     if (!task) {
         throw new Error("Task not found");
     }
+
+    let reassignmentCount = 0;
+    let processedCount = 0;
+    let conflictCount = 0;
 
     // Collect all subjectIds from matches and reassignments for validation
     const allSubjectIds = [
@@ -844,10 +1011,6 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
     // Reassignments delete old decisions to free ADA unique constraints before
     // upserting new ones — without a transaction, a failed upsert after a
     // successful delete would permanently lose decision data.
-    let reassignmentCount = 0;
-    let processedCount = 0;
-    let conflictCount = 0;
-
     await prisma.$transaction(async (tx) => {
         // Step 1: Detect ADA conflicts — find ADAs that already exist on other subjects
         const matchAdas = result.matches.map(m => m.ada).filter((ada): ada is string => ada != null);
@@ -944,6 +1107,24 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
             }
         }
     });
+
+    // Enrich responseBody with post-processing counts so the batch completion
+    // hook (checkBatchCompletionAndAlert) can read accurate totals from DB.
+    // Wrapped in try/catch because this runs after the main transaction committed —
+    // a failure here should not mark the task as failed when decisions were already persisted.
+    try {
+        await prisma.taskStatus.update({
+            where: { id: taskId },
+            data: {
+                responseBody: JSON.stringify({
+                    ...result,
+                    _processedCounts: { matches: processedCount, reassignments: reassignmentCount, conflicts: conflictCount },
+                }),
+            },
+        });
+    } catch (enrichError) {
+        console.error(`Failed to enrich responseBody for task ${taskId} (decisions already persisted):`, enrichError);
+    }
 
     console.log(`Poll decisions completed: ${processedCount} processed, ${reassignmentCount} reassigned, ${conflictCount} conflicts, ${result.unmatchedSubjects.length} unmatched, ${result.ambiguousSubjects.length} ambiguous`);
 }

--- a/src/lib/tasks/registry.ts
+++ b/src/lib/tasks/registry.ts
@@ -6,7 +6,7 @@ import { handleFixTranscriptResult } from './fixTranscript';
 import { handleProcessAgendaResult } from './processAgenda';
 import { handleGenerateVoiceprintResult } from './generateVoiceprint';
 import { handleGenerateHighlightResult } from './generateHighlight';
-import { handlePollDecisionsResult } from './pollDecisions';
+import { handlePollDecisionsResult, checkBatchCompletionAndAlert } from './pollDecisions';
 
 // Task handler registry - maps task types to their result handlers
 export type TaskResultHandler = (taskId: string, result: any, options?: { force?: boolean }) => Promise<void>;
@@ -21,5 +21,15 @@ export const taskHandlers: Record<string, TaskResultHandler> = {
     generateVoiceprint: handleGenerateVoiceprintResult,
     generateHighlight: handleGenerateHighlightResult,
     pollDecisions: handlePollDecisionsResult,
+};
+
+// Hooks called after a task reaches a terminal state (succeeded or failed).
+// Runs after handleTaskUpdate has settled the DB status, so the hook always
+// sees the correct final state. Used by task types that need post-terminal
+// coordination (e.g., batch completion detection for pollDecisions).
+export type TaskTerminalHook = (taskId: string, taskCreatedAt: Date) => Promise<void>;
+
+export const taskTerminalHooks: Partial<Record<string, TaskTerminalHook>> = {
+    pollDecisions: checkBatchCompletionAndAlert,
 };
 

--- a/src/lib/tasks/tasks.ts
+++ b/src/lib/tasks/tasks.ts
@@ -2,13 +2,13 @@
 
 import { TaskUpdate } from '../apiTypes';
 import prisma from '@/lib/db/prisma';
-import { MeetingTaskType, TASK_CONFIG } from '@/lib/tasks/types';
+import { MeetingTaskType, TASK_CONFIG, getDiscordAlertMode } from '@/lib/tasks/types';
 import { withUserAuthorizedToEdit } from '../auth';
 import { env } from '@/env.mjs';
 import { sendTaskAdminAlert } from '@/lib/discord';
 import { Prisma, TaskStatus } from '@prisma/client';
 import { revalidateTag } from 'next/cache';
-import { taskHandlers } from './registry';
+import { taskHandlers, taskTerminalHooks } from './registry';
 
 export interface TaskIdempotencyResult {
     proceed: boolean;
@@ -80,7 +80,7 @@ const taskStatusWithMeetingInclude = {
     }
 } satisfies Prisma.TaskStatusInclude;
 
-export const startTask = async (taskType: MeetingTaskType, requestBody: any, councilMeetingId: string, cityId: string, options: { force?: boolean } = {}) => {
+export const startTask = async (taskType: MeetingTaskType, requestBody: any, councilMeetingId: string, cityId: string, options: { force?: boolean; silent?: boolean } = {}) => {
     // Only enforce idempotency for core pipeline tasks — non-pipeline tasks
     // (generateHighlight, splitMediaFile, etc.) can legitimately run multiple times
     if (TASK_CONFIG[taskType].requiredForPipeline) {
@@ -163,16 +163,18 @@ export const startTask = async (taskType: MeetingTaskType, requestBody: any, cou
         data: { requestBody: JSON.stringify(fullRequestBody) }
     });
 
-    // Send Discord admin alert
-    sendTaskAdminAlert({
-        status: 'started',
-        taskType: taskType,
-        cityName: newTask.councilMeeting.city.name_en,
-        meetingName: newTask.councilMeeting.name_en,
-        taskId: newTask.id,
-        cityId: cityId,
-        meetingId: councilMeetingId,
-    });
+    // Send Discord admin alert unless silent or alert mode is 'none'
+    if (!options.silent && getDiscordAlertMode(taskType) !== 'none') {
+        sendTaskAdminAlert({
+            status: 'started',
+            taskType: taskType,
+            cityName: newTask.councilMeeting.city.name_en,
+            meetingName: newTask.councilMeeting.name_en,
+            taskId: newTask.id,
+            cityId: cityId,
+            meetingId: councilMeetingId,
+        });
+    }
 
     return newTask;
 }
@@ -189,6 +191,9 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
         return;
     }
 
+    // Check if generic Discord alerts should be sent for this task type
+    const sendGenericAlerts = getDiscordAlertMode(task.type) !== 'none';
+
     if (update.status === 'success') {
         const updatedTask = await prisma.taskStatus.update({
             where: { id: taskId },
@@ -200,16 +205,18 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
                 await processResult(taskId, update.result, options);
 
                 // Send Discord admin alert for successful completion AFTER processing succeeds
-                sendTaskAdminAlert({
-                    status: 'completed',
-                    taskType: task.type,
-                    cityName: task.councilMeeting.city.name_en,
-                    meetingName: task.councilMeeting.name_en,
-                    taskId: task.id,
-                    cityId: task.cityId,
-                    meetingId: task.councilMeetingId,
-                });
-                
+                if (sendGenericAlerts) {
+                    sendTaskAdminAlert({
+                        status: 'completed',
+                        taskType: task.type,
+                        cityName: task.councilMeeting.city.name_en,
+                        meetingName: task.councilMeeting.name_en,
+                        taskId: task.id,
+                        cityId: task.cityId,
+                        meetingId: task.councilMeetingId,
+                    });
+                }
+
                 // Revalidate cache only for successful tasks that affect meeting data
                 if (updatedTask.cityId && shouldRevalidateForTaskType(updatedTask.type as MeetingTaskType)) {
                     try {
@@ -228,30 +235,34 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
                 });
 
                 // Send Discord admin alert for processing failure
+                if (sendGenericAlerts) {
+                    sendTaskAdminAlert({
+                        status: 'failed',
+                        taskType: task.type,
+                        cityName: task.councilMeeting.city.name_en,
+                        meetingName: task.councilMeeting.name_en,
+                        taskId: task.id,
+                        cityId: task.cityId,
+                        meetingId: task.councilMeetingId,
+                        error: (error as Error).message,
+                    });
+                }
+            }
+        } else {
+            console.log(`No result for task ${taskId}`);
+
+            // Task succeeded but has no result to process - still send completion admin alert
+            if (sendGenericAlerts) {
                 sendTaskAdminAlert({
-                    status: 'failed',
+                    status: 'completed',
                     taskType: task.type,
                     cityName: task.councilMeeting.city.name_en,
                     meetingName: task.councilMeeting.name_en,
                     taskId: task.id,
                     cityId: task.cityId,
                     meetingId: task.councilMeetingId,
-                    error: (error as Error).message,
                 });
             }
-        } else {
-            console.log(`No result for task ${taskId}`);
-
-            // Task succeeded but has no result to process - still send completion admin alert
-            sendTaskAdminAlert({
-                status: 'completed',
-                taskType: task.type,
-                cityName: task.councilMeeting.city.name_en,
-                meetingName: task.councilMeeting.name_en,
-                taskId: task.id,
-                cityId: task.cityId,
-                meetingId: task.councilMeetingId,
-            });
         }
     } else if (update.status === 'error') {
         await prisma.taskStatus.update({
@@ -260,25 +271,40 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
         });
 
         // Send Discord admin alert for task failure
-        sendTaskAdminAlert({
-            status: 'failed',
-            taskType: task.type,
-            cityName: task.councilMeeting.city.name_en,
-            meetingName: task.councilMeeting.name_en,
-            taskId: task.id,
-            cityId: task.cityId,
-            meetingId: task.councilMeetingId,
-            error: update.error,
-        });
+        if (sendGenericAlerts) {
+            sendTaskAdminAlert({
+                status: 'failed',
+                taskType: task.type,
+                cityName: task.councilMeeting.city.name_en,
+                meetingName: task.councilMeeting.name_en,
+                taskId: task.id,
+                cityId: task.cityId,
+                meetingId: task.councilMeetingId,
+                error: update.error,
+            });
+        }
     } else if (update.status === 'processing') {
         // Use updateMany with WHERE clause to atomically prevent overwriting terminal states
         await prisma.taskStatus.updateMany({
-            where: { 
+            where: {
                 id: taskId,
                 status: { notIn: ['succeeded', 'failed'] }
             },
             data: { status: 'pending', stage: update.stage, percentComplete: update.progressPercent, version: update.version }
         });
+    }
+
+    // After the task reaches a terminal state, call registered hooks.
+    // Runs after all DB status updates are settled, so hooks always see correct state.
+    if (update.status === 'success' || update.status === 'error') {
+        const terminalHook = taskTerminalHooks[task.type];
+        if (terminalHook) {
+            try {
+                await terminalHook(taskId, task.createdAt);
+            } catch (hookError) {
+                console.error(`Error in terminal hook for task ${taskId}:`, hookError);
+            }
+        }
     }
 }
 

--- a/src/lib/tasks/types.ts
+++ b/src/lib/tasks/types.ts
@@ -1,4 +1,20 @@
 // Centralized task configuration and types
+
+/**
+ * Controls whether generic Discord alerts (started/completed/failed) are sent
+ * via sendTaskAdminAlert for a given task type.
+ *
+ * - 'all'  — send all lifecycle alerts (default when omitted)
+ * - 'none' — suppress all generic alerts; the task's result handler
+ *            is responsible for sending its own alerts
+ */
+export type DiscordAlertMode = 'all' | 'none';
+
+interface TaskConfig {
+  requiredForPipeline: boolean;
+  discordAlertMode?: DiscordAlertMode;
+}
+
 export const TASK_CONFIG = {
   processAgenda: {
     requiredForPipeline: false,
@@ -32,11 +48,22 @@ export const TASK_CONFIG = {
   },
   pollDecisions: {
     requiredForPipeline: false,
+    discordAlertMode: 'none',
   },
-} as const;
+} satisfies Record<string, TaskConfig>;
 
 // Derive MeetingTaskType from the configuration
 export type MeetingTaskType = keyof typeof TASK_CONFIG;
+
+/**
+ * Returns the DiscordAlertMode for a task type.
+ * Unknown task types (e.g. from DB records with stale type values) default to 'all'
+ * so that generic alerts are never accidentally suppressed.
+ */
+export function getDiscordAlertMode(taskType: string): DiscordAlertMode {
+  const config = TASK_CONFIG[taskType as MeetingTaskType] as TaskConfig | undefined;
+  return config?.discordAlertMode ?? 'all';
+}
 
 // Derive core processing tasks from configuration
 export const CORE_PROCESSING_TASKS = Object.entries(TASK_CONFIG)


### PR DESCRIPTION
## Overview
The `pollDecisions` cron job dispatches up to 10 tasks per run. Each task was sending individual "started" and "completed" Discord alerts — producing up to 20 messages per invocation, most of which reported no new decisions.

This PR replaces per-task alerts with batch summaries:
- **1 batch started alert** when the cron dispatches tasks (counts, meeting list, any dispatch errors)
- **1 batch completed alert** when the last task in the batch finishes (aggregated results, per-meeting breakdown, admin links)

Net effect: **20 messages → 2 messages** per cron run. Manual triggers from the admin panel or subject page still get individual started alerts plus an immediate completion summary.

## How it works

- **`DiscordAlertMode`** (`types.ts`): New config on `TASK_CONFIG` — `'none'` suppresses all generic Discord alerts for a task type. Only `pollDecisions` uses it; all others default to `'all'`.
- **`silent` option** (`tasks.ts`): `startTask()` accepts `silent: true` to skip the "started" alert. The cron batch uses this while manual triggers don't.
- **Batch completion detection** (`pollDecisions.ts`): After processing a result, `checkBatchCompletionAndNotify()` queries sibling `pollDecisions` tasks created within a ±2 minute window. When all are in a terminal state, it aggregates results and sends a single summary. Runs in a `finally` block so failures aren't silently lost.

## Test plan

- Trigger cron endpoint and verify Discord channel gets 2 messages instead of 20
- Trigger manual poll from admin panel and verify individual started alert + immediate completion summary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes task lifecycle alerting/observability and adds new terminal-hook execution after task updates, which could impact when/if Discord notifications fire and how `TaskStatus.responseBody` is written.
> 
> **Overview**
> Reduces Discord noise from `pollDecisions` by **suppressing generic per-task started/completed/failed alerts** and replacing them with **batch-level cron alerts** (one dispatch summary + one aggregated completion summary).
> 
> Adds `DiscordAlertMode` to `TASK_CONFIG` (with `pollDecisions` set to `none`), a `silent` option on `startTask`, and a new `taskTerminalHooks` mechanism so `pollDecisions` can detect when all sibling tasks in a ±2 minute window are terminal and then send a single completion embed with counts, per-meeting details, admin links, and safe field truncation.
> 
> Updates `pollDecisions` processing to enrich stored `responseBody` with post-processing counts for accurate aggregation, expands test coverage around alert gating and batching, and documents the new alert behavior in `docs/admin-alerts.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f52a38b9c41bee569c6736ee5415003658ff7f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces Discord alert noise for the `pollDecisions` cron job from up to 20 per-task messages down to 2 batch-level messages — one started summary at dispatch time and one aggregated completion summary when all sibling tasks finish. It introduces `DiscordAlertMode` configuration in `TASK_CONFIG`, a `silent` option on `startTask`, and a `taskTerminalHooks` mechanism that fires after `handleTaskUpdate` has fully settled a task's DB status, eliminating the previously noted stale-status race condition.

Key changes:
- **`types.ts`**: New `DiscordAlertMode` type (`'all' | 'none'`), explicit `TaskConfig` interface, and `getDiscordAlertMode()` helper. `pollDecisions` is the only task type set to `'none'`.
- **`tasks.ts`**: `startTask` gains a `silent` flag; `handleTaskUpdate` gates all `sendTaskAdminAlert` calls behind `sendGenericAlerts`; a `taskTerminalHooks` dispatch runs at the very end of `handleTaskUpdate` after all DB writes are committed.
- **`pollDecisions.ts`**: Cron dispatch tracks `skipped`/`dispatchedMeetings`/`dispatchErrors` and fires a single `sendPollDecisionsBatchStartedAlert`. `checkBatchCompletionAndAlert` (the terminal hook) queries all `pollDecisions` sibling tasks in a ±2-minute window; when all are terminal it aggregates results (using `_processedCounts` enriched into `responseBody` by `handlePollDecisionsResult`) and fires `sendPollDecisionsBatchCompletedAlert`.
- **`discord.ts`**: Two new embed functions with field truncation via `truncateField()`, failure-aware title logic for the completed alert, and `.catch()` wrappers on both fire-and-forget calls.
- Two new test suites provide thorough coverage of the `silent` flag, `discordAlertMode` gating, terminal hook lifecycle, and batch aggregation logic.

<h3>Confidence Score: 4/5</h3>

- PR is safe to merge; two minor style improvements are worth addressing but neither causes data loss or silent failures.
- The core logic is well-engineered: the terminal hook correctly fires after DB status is settled (fixing the previously noted race), the `_processedCounts` enrichment uses a try/catch so failure can't mark a succeeded task as failed, and field truncation is applied consistently. Two residual issues keep the score below 5: (1) the started alert uses a fixed blue color even when all tasks fail at dispatch — since that's the only alert fired in a complete-dispatch-failure scenario, the color matters; (2) `cityId` lacks the null-safety fallback (`?? 'unknown'`) that `councilMeetingId` already has. Test coverage is comprehensive and directly validates the new mechanisms.
- `src/lib/discord.ts` (started alert color), `src/lib/tasks/pollDecisions.ts` (cityId null guard in `checkBatchCompletionAndAlert`)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/tasks/tasks.ts | Adds `silent` option to `startTask`, introduces `getDiscordAlertMode` gating throughout `handleTaskUpdate`, and appends the `taskTerminalHooks` dispatch at the end. Terminal hook correctly fires after all DB writes are settled (both `success` and `error` paths). Logic is sound. |
| src/lib/tasks/pollDecisions.ts | Adds batch dispatch tracking and `checkBatchCompletionAndAlert`. Minor: `cityId` lacks a null-safety fallback (unlike `councilMeetingId`). Counter variables correctly moved outside the transaction so enrichment can access post-processing totals. Documented race conditions (duplicate alerts, manual-trigger grouping) are acceptable trade-offs. |
| src/lib/discord.ts | Adds `sendPollDecisionsBatchStartedAlert` and `sendPollDecisionsBatchCompletedAlert` with proper field truncation via `truncateField`. The started alert uses a fixed blue color even when dispatch errors are present — important because when all tasks fail at dispatch, only this alert fires. Completed alert title correctly differentiates all four state combinations. |
| src/lib/tasks/registry.ts | Cleanly introduces `taskTerminalHooks` as a `Partial<Record<string, TaskTerminalHook>>`, wires `checkBatchCompletionAndAlert` for `pollDecisions`. Type and structure look correct. |
| src/lib/tasks/types.ts | Adds `DiscordAlertMode` type, explicit `TaskConfig` interface, and `getDiscordAlertMode` helper. Correctly defaults unknown task types to `'all'` to prevent accidental alert suppression. Switches from `as const` to `satisfies` for better type checking. |
| src/lib/tasks/__tests__/checkTaskIdempotency.test.ts | Adds comprehensive coverage for the `silent` option and `taskTerminalHooks` mechanism. The two-phase mock (`mockResolvedValueOnce` for succeeded then failed) correctly models the actual flow in `handleTaskUpdate`. Edge cases (hook throws, processing status, non-hooked task types) are all covered. |
| src/lib/tasks/__tests__/pollDecisionsBatchAlerts.test.ts | New test file with thorough coverage of `checkBatchCompletionAndAlert`: all-terminal, partial, single-task, failure mixing, conflict aggregation, `_processedCounts` fallback, malformed responseBody, and error truncation. Well-structured and complete. |
| docs/admin-alerts.md | Documentation is accurate and complete. Correctly documents the 2-message-per-cron-run behaviour, alert format examples, and the BATCH_WINDOW_MS coupling constraint with the cron interval. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Cron as pollDecisionsForRecentMeetings
    participant ST as startTask
    participant Discord as Discord
    participant CB as Callback Endpoint
    participant HTU as handleTaskUpdate
    participant HPR as handlePollDecisionsResult
    participant Hook as checkBatchCompletionAndAlert

    Cron->>ST: pollDecisionsForMeeting(silent:true) ×N
    ST->>ST: DB create task (status=pending)
    ST->>ST: Call backend API
    ST-->>Cron: task created (no started alert)
    Cron->>Discord: sendPollDecisionsBatchStartedAlert(N tasks)

    note over CB,Hook: Each task completes asynchronously

    CB->>HTU: handleTaskUpdate(taskId, status=success)
    HTU->>HTU: DB update → succeeded (raw responseBody)
    HTU->>HPR: processResult (handlePollDecisionsResult)
    HPR->>HPR: $transaction (process decisions)
    HPR->>HPR: DB update responseBody += _processedCounts
    HPR-->>HTU: returns
    HTU->>Hook: taskTerminalHooks[pollDecisions](taskId, createdAt)
    Hook->>Hook: DB query: all siblings in ±2min window
    alt not all terminal
        Hook-->>HTU: return (wait for siblings)
    else all terminal
        Hook->>Hook: aggregate counts from _processedCounts
        Hook->>Discord: sendPollDecisionsBatchCompletedAlert
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/lib/discord.ts`, line 773-774 ([link](https://github.com/schemalabz/opencouncil/blob/7009a9c805c8fd02402a1d104ba3d2613b835d8d/src/lib/discord.ts#L773-L774)) 

   **`truncateField` not applied to pre-existing `sendTranscriptSendFailedAdminAlert`**

   This PR introduces `truncateField()` as the canonical way to handle Discord's 1024-character field limit (with a visible `… (truncated)` indicator). The `Error` field in `sendTranscriptSendFailedAdminAlert` still uses a raw `.substring(0, 1024)` with a comment instead:

   ```ts
   value: data.error.substring(0, 1024), // Discord field value limit
   ```

   Since the helper is now available, this is an easy clean-up to make the truncation behaviour consistent across all alert functions:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/discord.ts
   Line: 773-774

   Comment:
   **`truncateField` not applied to pre-existing `sendTranscriptSendFailedAdminAlert`**

   This PR introduces `truncateField()` as the canonical way to handle Discord's 1024-character field limit (with a visible `… (truncated)` indicator). The `Error` field in `sendTranscriptSendFailedAdminAlert` still uses a raw `.substring(0, 1024)` with a comment instead:

   ```ts
   value: data.error.substring(0, 1024), // Discord field value limit
   ```

   Since the helper is now available, this is an easy clean-up to make the truncation behaviour consistent across all alert functions:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

2. `src/lib/discord.ts`, line 129-131 ([link](https://github.com/schemalabz/opencouncil/blob/3f52a38b9c41bee569c6736ee5415003658ff7f0/src/lib/discord.ts#L129-L131)) 

   **Started alert stays blue when dispatch errors occur**

   `sendPollDecisionsBatchStartedAlert` uses a fixed blue color (`0x3498db`) even when `data.errors.length > 0`. The `sendPollDecisionsBatchCompletedAlert` function correctly adjusts color based on failure state, but the started alert does not.

   This is particularly important for the documented edge case where all tasks fail at dispatch time — only the started alert fires in that scenario, so its color is the sole visual signal that something went wrong. An operator glancing at the Discord channel would see a blue embed (indicating normal operation) rather than the expected red.


3. `src/lib/tasks/pollDecisions.ts`, line 1063-1066 ([link](https://github.com/schemalabz/opencouncil/blob/3f52a38b9c41bee569c6736ee5415003658ff7f0/src/lib/tasks/pollDecisions.ts#L1063-L1066)) 

   **`cityId` lacks a null-safety fallback unlike `councilMeetingId`**

   `councilMeetingId` is defensively handled with `?? 'unknown'`, but `cityId` is used directly without a fallback. If the Prisma schema permits `TaskStatus.cityId` to be null (or if it ever becomes nullable in a future migration), this would propagate a `null` into `PollDecisionsMeetingResult.cityId` — which is typed as `string` — causing a type error and potentially malformed `meetingAdminUrl` calls in `discord.ts` (producing links like `null/meeting-id`).

   Consider adding a consistent fallback:

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 3f52a38</sub>

<!-- /greptile_comment -->