### PR TITLE
feat: add subject numbers to meeting sidebar

### DIFF
--- a/src/components/meetings/sidebar.tsx
+++ b/src/components/meetings/sidebar.tsx
@@ -161,7 +161,7 @@ export default function MeetingSidebar() {
 
                             {subjectsExpanded && (
                                 <>
-                                    {chronologicalSubjects?.map((subject) => (
+                                    {chronologicalSubjects?.map((subject, index) => (
                                         <SidebarMenuItem key={subject.id} className="pl-8">
                                             <SidebarMenuButton
                                                 asChild
@@ -174,7 +174,7 @@ export default function MeetingSidebar() {
                                                         activeItem === `/${city.id}/${meeting.id}/subjects/${subject.id}` && "text-primary font-medium"
                                                     )}
                                                 >
-                                                    <span className="text-sm">{subject.name}</span>
+                                                    <span className="text-sm"><span className="text-muted-foreground tabular-nums">{index + 1}.</span>{' '}{subject.name}</span>
                                                 </Link>
                                             </SidebarMenuButton>
                                         </SidebarMenuItem>


### PR DESCRIPTION
## Summary

Adds sequential numbers (1., 2., 3., ...) in front of each subject name in the meeting sidebar, making it easy to find a specific subject by number.

Fixes #172

**Before:** Subject names listed without numbers — users must manually count to find "subject 7"
**After:** Each subject is prefixed with its position number in muted color with `tabular-nums` for consistent alignment

## Changes

- `src/components/meetings/sidebar.tsx`: Added `index` parameter to `chronologicalSubjects.map()` and rendered `{index + 1}.` before each subject name

## Disclosure

This PR was authored by Claude Opus 4.6 (an AI), operated by [Maxwell Calkin](https://github.com/MaxwellCalkin).

## Test plan

- [ ] Open any meeting page with multiple subjects
- [ ] Verify numbers appear in the sidebar next to each subject name
- [ ] Verify numbers are muted/subtle and don't interfere with readability
- [ ] Verify the correct subject number matches when expanding/collapsing
- [ ] `npm run build` succeeds

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes a small, focused UI enhancement to `src/components/meetings/sidebar.tsx`: it adds a 1-based sequential number (e.g. `1.`, `2.`, …) in front of each subject entry in the meeting sidebar, styled with `text-muted-foreground tabular-nums` so the numbers are visually subtle and consistently aligned.

**Key observations:**
- The numbering is derived from the index of `chronologicalSubjects` (subjects sorted by appearance order via `sortSubjectsByImportance(subjects, 'appearance')`). The numbers therefore reflect agenda appearance order, not any separately stored official numbering field — this is intentional per the PR description.
- When a subject is active, the `Link` receives `text-primary font-medium`. Because the number `<span>` has an explicit `text-muted-foreground` class, it correctly remains muted even for the active item, while the subject name inherits `text-primary` — exactly as the author intended.
- The `{' '}` space literal between the number span and the subject name is a standard React pattern and renders correctly.
- The `?.map` optional chaining already handled the `undefined` case before this change and continues to do so.
- No logic, accessibility, or performance issues were identified.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the change is a minimal, well-scoped UI addition with no logic, data, or security implications.
- Only one file is changed; the modification is two lines that add a display index to an existing `.map()` call. No state, data fetching, routing, or business logic is affected.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/meetings/sidebar.tsx | Adds `index` to `chronologicalSubjects.map()` and renders a muted, tabular-nums number prefix before each subject name; change is minimal and correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MeetingSidebar renders] --> B{subjectsExpanded?}
    B -- No --> C[Subjects list hidden]
    B -- Yes --> D[chronologicalSubjects.map subject, index]
    D --> E[SidebarMenuItem per subject]
    E --> F{activeItem matches subject path?}
    F -- Yes --> G["Link: text-primary font-medium"]
    F -- No --> H["Link: default style"]
    G --> I["&lt;span text-sm&gt;\n  &lt;span text-muted-foreground tabular-nums&gt;index+1.&lt;/span&gt;\n  subject.name\n&lt;/span&gt;"]
    H --> I
    I --> J[Number stays muted, name inherits active color]
```

<sub>Last reviewed commit: 8a365a3</sub>

<!-- /greptile_comment -->