### PR TITLE
Fix re-summarize leaving stale topic labels and utterance statuses

### DIFF
--- a/src/lib/tasks/summarize.ts
+++ b/src/lib/tasks/summarize.ts
@@ -87,6 +87,26 @@ export async function handleSummarizeResult(taskId: string, response: SummarizeR
     });
     const topicByName = new Map(topics.map(t => [t.name, t]));
 
+    // Clean up stale data from previous summarize runs before processing new results.
+    // This ensures re-summarize produces the same result as a first-time summarize.
+    // 1. Delete old topic labels for this meeting's speaker segments
+    await prisma.topicLabel.deleteMany({
+        where: {
+            speakerSegmentId: { in: availableSpeakerSegmentIds }
+        }
+    });
+
+    // 2. Reset utterance discussion statuses for this meeting's speaker segments
+    await prisma.utterance.updateMany({
+        where: {
+            speakerSegmentId: { in: availableSpeakerSegmentIds }
+        },
+        data: {
+            discussionStatus: null,
+            discussionSubjectId: null
+        }
+    });
+
     // Prepare all operations for batch execution
     const operations: any[] = [];
 


### PR DESCRIPTION
Fixes #248

## Problem

When `handleSummarizeResult` runs a second time on the same meeting, summaries and subjects are properly replaced (upsert/update semantics), but **topic labels** and **utterance discussion statuses** accumulate stale data from previous runs:

- **Topic labels**: Old `TopicLabel` records are never deleted before creating new ones, so labels from a previous run that are no longer in the new response persist.
- **Utterance discussion statuses**: Only utterances mentioned in the new response are updated. Utterances from the previous run that are absent from the new response keep their old `discussionStatus` and `discussionSubjectId`.

## Fix

Before processing the new summarize results, clean up data from previous runs — scoped to the meeting's speaker segments (`availableSpeakerSegmentIds`):

1. **`prisma.topicLabel.deleteMany`** — removes all topic labels for the meeting's speaker segments before upserting new ones.
2. **`prisma.utterance.updateMany`** — resets `discussionStatus` and `discussionSubjectId` to `null` for all utterances in the meeting's speaker segments before applying new statuses.

Both cleanups run before any new data is written, so re-summarize now produces the same result as a first-time summarize.

## Why this is safe

- The cleanup is scoped by `speakerSegmentId: { in: availableSpeakerSegmentIds }`, which is already filtered to the specific meeting + city.
- Topic labels are immediately re-created in the same function via upserts.
- Utterance statuses are immediately re-applied in the same function via individual updates.
- Summaries and subjects already handled re-runs correctly and are not affected.

---

This PR was authored by Claude Opus 4.6 (AI), operated by @MaxwellCalkin

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes stale `TopicLabel` records and `discussionStatus`/`discussionSubjectId` values that accumulated across multiple summarize runs by adding two cleanup operations (`deleteMany` + `updateMany`) at the start of `handleSummarizeResult`, before any new data is written.

Key changes and observations:
- **Fix is correct in intent**: placing cleanup in `handleSummarizeResult` ensures it runs unconditionally for every run (not just `force=true`), and the cleanup happens right before the new data is written, minimising the empty-data window.
- **Conflict with existing force-path cleanup**: `requestSummarize` already contains an identical cleanup block under `if (force)` (lines 32–46). Now that `handleSummarizeResult` handles this unconditionally, the early cleanup in `requestSummarize` is redundant and actively harmful — it wipes data as soon as the force request is submitted and leaves the meeting in an empty state for the entire duration of the summarize task (which can take minutes).
- **Atomicity gap**: The cleanup operations are not inside the same transaction as the subsequent `prisma.$transaction(operations)` call. A failure between cleanup and the writes would leave the meeting with no topic labels and nulled statuses (previously flagged in review thread, not re-addressed in this PR).
- The scoping of both cleanup operations via `availableSpeakerSegmentIds` (fetched via `getAvailableSpeakerSegmentIds`) is equivalent to the existing filter (`speakerSegment: { meetingId, cityId }`), so there is no unintended scope creep.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness of non-force re-summarizes, but introduces a UX regression for force summarizes due to a redundant early cleanup in `requestSummarize`.
- The core fix (cleanup in `handleSummarizeResult`) correctly solves the described bug and is properly scoped. However, it was not paired with removal of the now-redundant force-time cleanup in `requestSummarize`, which means force summarize runs will leave the meeting in an empty/nulled state for the full duration of the task execution — a worse UX outcome than before. The atomicity gap (cleanup outside the write transaction) remains unaddressed but was already noted in a prior review.
- Pay close attention to `src/lib/tasks/summarize.ts` lines 32–46 (`requestSummarize` force cleanup) and lines 93–108 (new `handleSummarizeResult` cleanup) — both perform identical operations and only one should exist.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/tasks/summarize.ts | Adds unconditional stale-data cleanup before writing new summarize results; correctly fixes the re-summarize accumulation bug, but creates a conflicting double-cleanup with the existing force-path in `requestSummarize`, which exposes an empty-data window during task execution. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client
    participant RS as requestSummarize
    participant DB as Database
    participant T as Remote Task
    participant HR as handleSummarizeResult

    C->>RS: requestSummarize(force=true)
    RS->>DB: ❌ topicLabel.deleteMany (early wipe)
    RS->>DB: ❌ utterance.updateMany reset (early wipe)
    Note over DB: Data is now EMPTY<br/>visible to users during task execution
    RS->>T: startTask('summarize', body)
    RS-->>C: taskId

    Note over T: Task runs remotely<br/>(may take minutes — DB is empty)

    T->>HR: handleSummarizeResult(taskId, response)
    HR->>DB: topicLabel.deleteMany (redundant no-op)
    HR->>DB: utterance.updateMany reset (redundant no-op)
    HR->>DB: $transaction([summary upserts, topicLabel upserts])
    HR->>DB: saveSubjectsForMeeting
    HR->>DB: utterance.update × N (discussion statuses)
    Note over DB: Data is now RESTORED
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/tasks/summarize.ts
Line: 93-108

Comment:
**Duplicate cleanup makes `requestSummarize` force-cleanup harmful**

The new unconditional cleanup in `handleSummarizeResult` (lines 93–108) is correct on its own, but it now conflicts with the pre-existing cleanup in `requestSummarize` (lines 32–46) that runs at force-request time.

For a `force=true` summarize the execution order becomes:

1. `requestSummarize` → **clears** topic labels + discussion statuses immediately
2. Task runs remotely (may take **minutes**) — data is now **empty/null** for any user viewing the meeting during this window
3. `handleSummarizeResult` → **clears again** (no-op, already empty) → writes fresh data

The early wipe in `requestSummarize` is now redundant because `handleSummarizeResult` handles the cleanup right before writing new data. Keeping both means users see a completely empty state for the whole duration of the summarize task (step 2), which is a regression in perceived data quality.

The fix is to remove the force-time cleanup from `requestSummarize`, since `handleSummarizeResult` now provides the correct idempotent behavior at result time.

```ts
// In requestSummarize — remove the duplicate cleanup block:
if (force) {
    console.log(`Force summarize: deleting stale summarize data for meeting ${councilMeetingId}`);
    // ❌ Remove these — handleSummarizeResult now handles cleanup unconditionally
    await prisma.topicLabel.deleteMany({ ... });
    await prisma.utterance.updateMany({ ... });
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: delete stale to..."](https://github.com/schemalabz/opencouncil/commit/40a535a207c2b7d7d544c3e40322e16b4d0f742e)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->