### PR TITLE
fix: enable dev login tools in preview deployments

### DIFF
--- a/src/app/api/dev/mobile-preview/route.ts
+++ b/src/app/api/dev/mobile-preview/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { IS_DEV } from '@/lib/utils'
+import { IS_DEV_OR_PREVIEW } from '@/lib/utils'
 
 interface ConnectedDevice {
   id: string
@@ -55,7 +55,7 @@ function cleanStaleDevices() {
 }
 
 export async function POST(request: NextRequest) {
-  if (!IS_DEV) {
+  if (!IS_DEV_OR_PREVIEW) {
     return NextResponse.json({ error: 'Not allowed in production' }, { status: 403 })
   }
 
@@ -89,7 +89,7 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET() {
-  if (!IS_DEV) {
+  if (!IS_DEV_OR_PREVIEW) {
     return NextResponse.json({ error: 'Not allowed in production' }, { status: 403 })
   }
 
@@ -105,7 +105,7 @@ export async function GET() {
 }
 
 export async function DELETE(request: NextRequest) {
-  if (!IS_DEV) {
+  if (!IS_DEV_OR_PREVIEW) {
     return NextResponse.json({ error: 'Not allowed in production' }, { status: 403 })
   }
 

--- a/src/app/api/dev/quick-login/route.ts
+++ b/src/app/api/dev/quick-login/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db/prisma'
 import { PrismaAdapter } from "@auth/prisma-adapter"
-import { IS_DEV } from '@/lib/utils'
+import { IS_DEV, IS_DEV_OR_PREVIEW } from '@/lib/utils'
 
 export async function POST(request: NextRequest) {
   // Only allow in development environment
-  if (!IS_DEV) {
+  if (!IS_DEV_OR_PREVIEW) {
     return NextResponse.json({ error: 'Not allowed in production' }, { status: 403 })
   }
 

--- a/src/app/api/dev/seed-test-users/route.ts
+++ b/src/app/api/dev/seed-test-users/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@/lib/db/prisma'
 import { TEST_USERS } from '@/lib/dev/test-users'
-import { IS_DEV } from '@/lib/utils'
+import { IS_DEV_OR_PREVIEW } from '@/lib/utils'
 import { env } from '@/env.mjs'
 import { createUser } from '@/lib/db/users'
 
@@ -9,7 +9,7 @@ const DEV_TEST_CITY_ID = env.DEV_TEST_CITY_ID
 
 export async function POST(request: NextRequest) {
   // Only allow in development environment
-  if (!IS_DEV) {
+  if (!IS_DEV_OR_PREVIEW) {
     return NextResponse.json({ error: 'Not allowed in production' }, { status: 403 })
   }
 
@@ -130,7 +130,7 @@ export async function POST(request: NextRequest) {
 // Add a GET endpoint to check if test users exist
 export async function GET(request: NextRequest) {
   // Only allow in development environment
-  if (!IS_DEV) {
+  if (!IS_DEV_OR_PREVIEW) {
     return NextResponse.json({ error: 'Not allowed in production' }, { status: 403 })
   }
 

--- a/src/components/dev/MobilePreviewReporter.tsx
+++ b/src/components/dev/MobilePreviewReporter.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react'
 import { usePathname } from 'next/navigation'
-import { IS_DEV } from '@/lib/utils'
+import { IS_DEV_OR_PREVIEW } from '@/lib/utils'
 
 function generateId(): string {
   // crypto.randomUUID() requires a secure context (HTTPS).
@@ -49,7 +49,7 @@ export default function MobilePreviewReporter() {
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   useEffect(() => {
-    if (!IS_DEV || !isLanAccess()) return
+    if (!IS_DEV_OR_PREVIEW || !isLanAccess()) return
 
     const sendHeartbeat = () => {
       fetch('/api/dev/mobile-preview', {

--- a/src/components/dev/QuickLogin.tsx
+++ b/src/components/dev/QuickLogin.tsx
@@ -18,7 +18,7 @@ import { Badge } from "@/components/ui/badge"
 import { LogOut, Settings, User, Crown, EyeOff } from 'lucide-react'
 import { getTestUsersForDisplay } from '@/lib/dev/test-users'
 import { useQuickLoginVisibility } from '@/hooks/useQuickLoginVisibility'
-import { IS_DEV } from '@/lib/utils'
+import { IS_DEV_OR_PREVIEW } from '@/lib/utils'
 import MobilePreviewButton from '@/components/dev/MobilePreviewButton'
 
 // Get predefined test users from shared definition
@@ -154,7 +154,7 @@ export default function QuickLogin() {
   }
 
   // Only show in development
-  if (!IS_DEV) {
+  if (!IS_DEV_OR_PREVIEW) {
     return null
   }
 

--- a/src/components/profile/DevelopmentSection.tsx
+++ b/src/components/profile/DevelopmentSection.tsx
@@ -12,7 +12,7 @@ export function DevelopmentSection() {
   const { isVisible, isLoaded, toggle } = useQuickLoginVisibility()
 
   // Only show in development
-  if (!IS_DEV) {
+  if (!IS_DEV_OR_PREVIEW) {
     return null
   }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -37,6 +37,8 @@ export {
 } from './utils/roles';
 
 export const IS_DEV = process.env.NODE_ENV === 'development';
+export const IS_PREVIEW = process.env.NEXTAUTH_URL?.includes('.preview.') ?? false;
+export const IS_DEV_OR_PREVIEW = IS_DEV || IS_PREVIEW;
 
 export const SUBJECT_POINT_COLOR = '#E57373'; // A nice red color that contrasts with the blue city polygons
 


### PR DESCRIPTION
Fixes #250

## Summary

The Quick Login component and related dev tools are gated on `IS_DEV` (`NODE_ENV === 'development'`), but preview deployments run with `NODE_ENV=production`. This makes it impossible to log in as Admin/City Admin on preview URLs for role-based testing.

This PR:
- Adds `IS_PREVIEW` (detects `*.preview.*` in `NEXTAUTH_URL`) and `IS_DEV_OR_PREVIEW` constants to `src/lib/utils.ts`
- Updates all dev tool access gates to use `IS_DEV_OR_PREVIEW`:
  - `QuickLogin` component
  - `DevelopmentSection` profile component
  - `MobilePreviewReporter` component
  - `/api/dev/quick-login` route
  - `/api/dev/seed-test-users` route
  - `/api/dev/mobile-preview` route
- Preserves `IS_DEV` for cookie configuration in the quick-login route (preview deployments correctly use `__Secure-` prefixed cookies over HTTPS)

## Why this is safe

Per the [issue discussion](https://github.com/schemalabz/opencouncil/issues/250#issuecomment-2694785655):
- Preview databases use PII-free staging data
- Task server integration is disabled by default in previews
- The detection is scoped to `NEXTAUTH_URL` containing `.preview.`, which is only set by the NixOS preview module — production deployments are unaffected

## Files changed

| File | Change |
|------|--------|
| `src/lib/utils.ts` | Add `IS_PREVIEW`, `IS_DEV_OR_PREVIEW` |
| `src/components/dev/QuickLogin.tsx` | `IS_DEV` → `IS_DEV_OR_PREVIEW` |
| `src/components/dev/MobilePreviewReporter.tsx` | `IS_DEV` → `IS_DEV_OR_PREVIEW` |
| `src/components/profile/DevelopmentSection.tsx` | `IS_DEV` → `IS_DEV_OR_PREVIEW` |
| `src/app/api/dev/quick-login/route.ts` | `IS_DEV` → `IS_DEV_OR_PREVIEW` (access), keep `IS_DEV` (cookies) |
| `src/app/api/dev/seed-test-users/route.ts` | `IS_DEV` → `IS_DEV_OR_PREVIEW` |
| `src/app/api/dev/mobile-preview/route.ts` | `IS_DEV` → `IS_DEV_OR_PREVIEW` |

## Test plan

- [ ] Deploy as a preview and verify the Quick Login floating button appears
- [ ] Verify quick login as Admin/City Admin works on preview URL
- [ ] Verify seed test users endpoint works on preview
- [ ] Verify production deployments are unaffected (no `NEXTAUTH_URL` with `.preview.`)
- [ ] Verify local development still works as before

---

This PR was authored by Claude Opus 4.6 (AI), operated by @MaxwellCalkin

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aims to enable dev/preview login tools in preview deployments by introducing `IS_PREVIEW` and `IS_DEV_OR_PREVIEW` flags. The server-side API routes are correctly gated, but there are two blocking issues that prevent the client-side UI from working as intended:

1. **ReferenceError in `DevelopmentSection.tsx`**: The import statement on line 9 imports only `IS_DEV`, but the code uses `IS_DEV_OR_PREVIEW` on line 15. This causes an immediate runtime crash.

2. **Hydration mismatch for client components**: `IS_PREVIEW` derives from `process.env.NEXTAUTH_URL`, which is a server-only environment variable (not `NEXT_PUBLIC_` prefixed). Next.js replaces it with `undefined` in the client bundle. On the server, components render with `IS_DEV_OR_PREVIEW=true`, but after client hydration, `IS_DEV_OR_PREVIEW=false`, causing `QuickLogin` and `DevelopmentSection` to disappear. The API routes work correctly since they are server-only.

**Cookie handling** in the quick-login route correctly retains `IS_DEV` for the `__Secure-` prefix and `secure` flag, which is appropriate for HTTPS preview URLs.

<h3>Confidence Score: 1/5</h3>

- Not safe to merge — contains a ReferenceError crash and a hydration mismatch that breaks all client-side UI components on preview deployments.
- Two blocking bugs prevent this PR from achieving its stated goal: (1) `DevelopmentSection.tsx` will crash at runtime due to the missing `IS_DEV_OR_PREVIEW` import, and (2) all three client components (`QuickLogin`, `DevelopmentSection`, `MobilePreviewReporter`) will disappear after hydration because `NEXTAUTH_URL` is not available in the browser bundle, causing `IS_PREVIEW` to always be false on the client. The API-route changes are correct, but they are insufficient without the UI working.
- src/components/profile/DevelopmentSection.tsx (ReferenceError), src/lib/utils.ts (server-only env var used in client components)

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request / Render] --> B{IS_DEV_OR_PREVIEW?}
    B -->|false| C[Block / Return null]
    B -->|true| D[Allow access]

    subgraph "IS_DEV_OR_PREVIEW evaluation"
        E[IS_DEV\nNODE_ENV === 'development'] --> G[IS_DEV_OR_PREVIEW\nIS_DEV OR IS_PREVIEW]
        F[IS_PREVIEW\nNEXTAUTH_URL includes '.preview.'] --> G
    end

    subgraph "Server context ✅"
        F -->|NEXTAUTH_URL available| H["IS_PREVIEW = true\n(preview env)"]
    end

    subgraph "Browser context ❌"
        F -->|NEXTAUTH_URL = undefined\nnot NEXT_PUBLIC_| I["IS_PREVIEW = false\n(hydration mismatch)"]
    end

    D --> J{Server or Client component?}
    J -->|API route\nserver-only| K["✅ Works correctly\n/api/dev/*"]
    J -->|Client component\n'use client'| L["⚠️ Disappears after hydration\nQuickLogin, DevelopmentSection\n❌ ReferenceError in DevelopmentSection"]

    style I fill:#ffcccc,stroke:#cc0000
    style L fill:#ffcccc,stroke:#cc0000
    style K fill:#ccffcc,stroke:#00cc00
    style H fill:#ccffcc,stroke:#00cc00
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/profile/DevelopmentSection.tsx`, line 9 ([link](https://github.com/schemalabz/opencouncil/blob/ceef4640f1c2ecfc725b7113ce5ede447baf61cc/src/components/profile/DevelopmentSection.tsx#L9)) 

   Missing import: `IS_DEV_OR_PREVIEW` is not imported but is used on line 15. This will cause a `ReferenceError: IS_DEV_OR_PREVIEW is not defined` at runtime.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/profile/DevelopmentSection.tsx
   Line: 9

   Comment:
   Missing import: `IS_DEV_OR_PREVIEW` is not imported but is used on line 15. This will cause a `ReferenceError: IS_DEV_OR_PREVIEW is not defined` at runtime.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: ceef464</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->