### PR TITLE
Replace meeting name display with administrative body + date

### DIFF
--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
@@ -12,6 +12,7 @@ import { el, enUS } from 'date-fns/locale';
 import EditButton from '@/components/meetings/EditButton';
 import ShareDropdown from '@/components/meetings/ShareDropdown';
 import { getMeetingDataCached } from '@/lib/getMeetingData';
+import { getMeetingDisplayTitle } from '@/lib/utils/meetingTitle';
 import { NavigationEvents } from '@/components/meetings/NavigationEvents';
 
 import { HighlightModeBar } from '@/components/meetings/HighlightModeBar';
@@ -32,19 +33,21 @@ export async function generateImageMetadata({
         return [];
     }
 
+    const displayTitle = getMeetingDisplayTitle(data.meeting);
+
     return [
         {
             contentType: 'image/png',
             size: { width: 1200, height: 630 },
             id: 'og',
-            alt: data.meeting.name,
+            alt: displayTitle,
             url: `/api/og?meetingId=${meetingId}&cityId=${cityId}`
         },
         {
             contentType: 'image/png',
             size: { width: 32, height: 32 },
             id: 'icon',
-            alt: data.meeting.name,
+            alt: displayTitle,
             url: `/api/icon?meetingId=${meetingId}&cityId=${cityId}`
         }
     ];
@@ -63,8 +66,10 @@ export async function generateMetadata({
         };
     }
 
+    const displayTitle = getMeetingDisplayTitle(data.meeting);
+
     // Create an optimized title between 30-60 characters
-    const optimizedTitle = `${data.city.name} - ${data.meeting.name} | OpenCouncil`;
+    const optimizedTitle = `${data.city.name} - ${displayTitle} | OpenCouncil`;
 
     // Use the hero text for description, which is already optimized for Greek audience
     const description = "To OpenCouncil χρησιμοποιεί τεχνητή νοημοσύνη για να παρακολουθεί τα δημοτικά συμβούλια και να τα κάνει απλά και κατανοητά";
@@ -81,7 +86,7 @@ export async function generateMetadata({
                 url: imageUrl,
                 width: 1200,
                 height: 630,
-                alt: `${data.meeting.name} - ${data.city.name} Δημοτικό Συμβούλιο`
+                alt: `${displayTitle} - ${data.city.name}`
             }]
         },
         twitter: {
@@ -119,6 +124,8 @@ export default async function CouncilMeetingPage({
         data.city.highlightCreationPermission === HighlightCreationPermission.EVERYONE
     );
 
+    const displayTitle = getMeetingDisplayTitle(data.meeting, locale, data.city.timezone);
+
     // Format meeting description to include more info
     const meetingDescription = [
         formatDate(new Date(data.meeting.dateTime), 'EEEE, d MMMM yyyy', { locale: locale === 'el' ? el : enUS }),
@@ -144,7 +151,7 @@ export default async function CouncilMeetingPage({
                                         city: data.city
                                     },
                                     {
-                                        name: data.meeting.name,
+                                        name: displayTitle,
                                         link: `/${cityId}/${meetingId}`,
                                         description: meetingDescription
                                     }

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/page.tsx
@@ -132,10 +132,14 @@ export default function MeetingPage() {
 function MeetingInfo() {
     const { meeting, subjects } = useCouncilMeetingData();
     const locale = useLocale();
+    const displayTitle = useMemo(
+        () => getMeetingDisplayTitle(meeting, locale),
+        [meeting, locale]
+    );
     return (
         <div className="absolute bottom-0 left-0 right-0 p-4 sm:p-6">
             <div className="max-w-4xl mx-auto space-y-3 sm:space-y-4">
-                <h1 className="text-xl sm:text-2xl font-bold">{meeting.name}</h1>
+                <h1 className="text-xl sm:text-2xl font-bold">{displayTitle}</h1>
                 <div className="flex flex-wrap items-center gap-4 sm:gap-6 text-xs sm:text-sm text-gray-600">
                     <div className="flex items-center">
                         <CalendarIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4 mr-2 sm:mr-2.5" />

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/opengraph-image.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/opengraph-image.tsx
@@ -5,6 +5,7 @@ import { formatDate } from "date-fns";
 import { el, enUS } from "date-fns/locale";
 import { PersonWithRelations } from '@/lib/db/people';
 import { ColorPercentageRingProps } from "@/components/ui/color-percentage-ring";
+import { getMeetingDisplayTitle } from "@/lib/utils/meetingTitle";
 
 // Image configuration
 export const size = {
@@ -212,6 +213,8 @@ export default async function SubjectOgImage({
         locale: params.locale === "el" ? el : enUS,
     });
 
+    const displayTitle = getMeetingDisplayTitle(data.meeting, params.locale);
+
     return new ImageResponse(
         (
             <Container>
@@ -238,7 +241,7 @@ export default async function SubjectOgImage({
                         logoImage: data.city.logoImage,
                     }}
                     meeting={{
-                        name: data.meeting.name,
+                        name: displayTitle,
                         dateFormatted: meetingDate,
                     }}
                 />

--- a/src/components/admin/meetings/ExpandableMeetingRow.tsx
+++ b/src/components/admin/meetings/ExpandableMeetingRow.tsx
@@ -27,6 +27,7 @@ import { MeetingStatusBadge } from "@/components/meetings/MeetingStatusBadge";
 import Link from "next/link";
 import { MeetingTimeline } from "@/components/meetings/MeetingTimeline";
 import { getPollingHistoryForMeeting } from "@/lib/tasks/pollDecisions";
+import { getMeetingDisplayTitle } from "@/lib/utils/meetingTitle";
 
 interface ExpandableMeetingRowProps {
     meeting: CouncilMeetingWithAdminBodyAndSubjects;
@@ -50,6 +51,7 @@ export function ExpandableMeetingRow({
     const [pollingFetched, setPollingFetched] = React.useState(false);
     const subjectCount = meeting.subjects.length;
     const meetingDate = format(new Date(meeting.dateTime), "MMM dd, yyyy");
+    const displayTitle = getMeetingDisplayTitle(meeting);
 
     const fetchCompleteMeetingData = async (): Promise<MeetingDataCore> => {
         const response = await fetch(`/api/cities/${selectedCityId}/meetings/${meeting.id}`);
@@ -240,13 +242,13 @@ export function ExpandableMeetingRow({
             onSelect={onSelect}
             expandedContent={expandedContent}
             onExpand={fetchPollingStatus}
-            ariaLabel={meeting.name}
+            ariaLabel={displayTitle}
         >
             {/* Meeting Info */}
             <TableCell className="min-w-0">
                 <div className="flex flex-col gap-1">
                     <div className="flex items-center gap-2 min-w-0">
-                        <span className="font-medium text-foreground truncate">{meeting.name}</span>
+                        <span className="font-medium text-foreground truncate">{displayTitle}</span>
                         {!meeting.released && (
                             <Badge variant="secondary" className="text-xs flex-shrink-0">
                                 Draft

--- a/src/components/meetings/MeetingCard.tsx
+++ b/src/components/meetings/MeetingCard.tsx
@@ -6,8 +6,9 @@ import { useLocale, useTranslations } from 'next-intl';
 import React, { useEffect, useState, useMemo } from 'react';
 import { format, formatDistanceToNow, isFuture } from 'date-fns';
 import { el, enUS } from 'date-fns/locale';
-import { CalendarIcon, Clock, Loader2, ChevronRight, Building } from 'lucide-react';
+import { CalendarIcon, Clock, Loader2, ChevronRight } from 'lucide-react';
 import { sortSubjectsByImportance, formatDateTime, formatDate, IS_DEV } from '@/lib/utils';
+import { getMeetingDisplayTitle } from '@/lib/utils/meetingTitle';
 import SubjectBadge from '../subject-badge';
 import { cn } from '@/lib/utils';
 import { Link } from '@/i18n/routing';
@@ -66,6 +67,10 @@ export default function MeetingCard({ item: meeting, editable, mostRecent, cityT
         setIsLoading(false);
     }, [pathname]);
 
+    const displayTitle = useMemo(() => {
+        return getMeetingDisplayTitle(meeting, locale, cityTimezone);
+    }, [meeting, locale, cityTimezone]);
+
     const sortedSubjects = useMemo(() => {
         const result = sortSubjectsByImportance(meeting.subjects, 'importance');
 
@@ -74,7 +79,7 @@ export default function MeetingCard({ item: meeting, editable, mostRecent, cityT
             const topThree = result.slice(0, Math.min(3, result.length));
             logDev('MeetingCard - Subject Sorting', {
                 meetingId: meeting.id,
-                meetingName: meeting.name,
+                displayTitle,
                 totalSubjects: result.length,
                 topSubjects: topThree.map(s => ({
                     id: s.id,
@@ -179,18 +184,12 @@ export default function MeetingCard({ item: meeting, editable, mostRecent, cityT
                                     isHovered ? "text-primary" : ""
                                 )}
                             >
-                                {meeting.name}
+                                {displayTitle}
                             </h3>
                         </div>
 
-                        {/* Meeting metadata - more compact */}
+                        {/* Meeting metadata -- date-only row (admin body is now part of the title) */}
                         <div className="mt-1 mb-1 flex flex-wrap gap-x-4 gap-y-1.5 text-xs text-muted-foreground">
-                            {meeting.administrativeBody && (
-                                <div className="flex items-center gap-1">
-                                    <Building className="w-3.5 h-3.5 text-muted-foreground/70" />
-                                    <span>{meeting.administrativeBody.name}</span>
-                                </div>
-                            )}
                             <div className="flex items-center gap-1">
                                 <CalendarIcon className="w-3.5 h-3.5 text-muted-foreground/70" />
                                 <span>{(isUpcoming || isToday)

--- a/src/components/meetings/Video.tsx
+++ b/src/components/meetings/Video.tsx
@@ -4,6 +4,7 @@ import { useVideo } from './VideoProvider';
 import { cn } from '@/lib/utils';
 import { ArrowDownLeft, ArrowUpRight, Minimize2, Move, ArrowDownLeftSquare, Scaling } from 'lucide-react';
 import { motion, useAnimation } from 'framer-motion';
+import { getMeetingDisplayTitle } from '@/lib/utils/meetingTitle';
 
 export const Video: React.FC<{ className?: string, expandable?: boolean, onExpandChange?: (expanded: boolean) => void }> = ({ className, expandable = false, onExpandChange }) => {
     const { playerRef, meeting, isPlaying, currentTime, setIsPlaying, seekTo } = useVideo();
@@ -15,6 +16,8 @@ export const Video: React.FC<{ className?: string, expandable?: boolean, onExpan
     const initialMousePos = useRef<{ x: number; y: number } | null>(null);
     const initialDimensions = useRef<{ width: number; height: number } | null>(null);
     const controls = useAnimation();
+
+    const displayTitle = useMemo(() => getMeetingDisplayTitle(meeting), [meeting]);
 
     const toggleExpand = () => {
         const prevState = {
@@ -83,7 +86,7 @@ export const Video: React.FC<{ className?: string, expandable?: boolean, onExpan
     };
 
     const renderVideoElement = () => {
-        return <VideoElement id={meeting.id} title={meeting.name} playbackId={meeting.muxPlaybackId!} isExpanded={isExpanded} />
+        return <VideoElement id={meeting.id} title={displayTitle} playbackId={meeting.muxPlaybackId!} isExpanded={isExpanded} />
     };
 
     if (isExpanded) {

--- a/src/components/meetings/docx/CouncilMeetingDocx.tsx
+++ b/src/components/meetings/docx/CouncilMeetingDocx.tsx
@@ -3,8 +3,11 @@ import { formatInTimeZone } from 'date-fns-tz';
 import { Document, Paragraph, TextRun, HeadingLevel, ExternalHyperlink, Packer, AlignmentType } from 'docx';
 import { getSpeakerDisplayInfo, formatTimestamp } from '@/lib/utils';
 import { MeetingDataForExport } from '@/lib/export/meetings';
+import { getMeetingDisplayTitle } from '@/lib/utils/meetingTitle';
 
 const createTitlePage = ({ meeting, city }: Pick<MeetingDataForExport, 'meeting' | 'city'>) => {
+    const displayTitle = getMeetingDisplayTitle(meeting, 'el', city.timezone);
+
     return [
         new Paragraph({ spacing: { before: 2880 } }),
 
@@ -14,7 +17,7 @@ const createTitlePage = ({ meeting, city }: Pick<MeetingDataForExport, 'meeting'
             spacing: { after: 400 },
             children: [
                 new TextRun({
-                    text: meeting.name,
+                    text: displayTitle,
                     size: 32, // 16pt
                     bold: true
                 })
@@ -135,7 +138,7 @@ export const renderDocx = async ({ meeting, transcript, people, city }: MeetingD
     const doc = new Document({
         creator: "OpenCouncil",
         description: "Council Meeting Transcript",
-        title: meeting.name,
+        title: getMeetingDisplayTitle(meeting, 'el', city.timezone),
         subject: "Council Meeting",
         keywords: ["council", "meeting", "transcript"].join(", "),
         lastModifiedBy: "OpenCouncil",

--- a/src/lib/email/highlightComplete.ts
+++ b/src/lib/email/highlightComplete.ts
@@ -4,6 +4,7 @@ import { HighlightCompleteEmail } from './templates/HighlightCompleteEmail';
 import prisma from '@/lib/db/prisma';
 import { formatDuration } from '@/lib/formatters/time';
 import { env } from '@/env.mjs';
+import { getMeetingDisplayTitle } from '@/lib/utils/meetingTitle';
 
 interface SendHighlightCompleteEmailParams {
     userId: string;
@@ -37,6 +38,7 @@ export async function sendHighlightCompleteEmail({
             include: {
                 meeting: {
                     include: {
+                        administrativeBody: true,
                         city: {
                             select: {
                                 name: true
@@ -79,7 +81,7 @@ export async function sendHighlightCompleteEmail({
         // Prepare email data
         const userName = user.name || user.email.split('@')[0];
         const highlightTitle = highlight.name || 'Χωρίς τίτλο';
-        const meetingName = highlight.meeting.name || `Συνεδρίαση ${new Date(highlight.meeting.dateTime).toLocaleDateString('el-GR')}`;
+        const meetingName = getMeetingDisplayTitle(highlight.meeting);
         const cityName = highlight.meeting.city.name;
 
         // Render the email template

--- a/src/lib/utils/meetingTitle.ts
+++ b/src/lib/utils/meetingTitle.ts
@@ -1,0 +1,42 @@
+import { formatDate } from '@/lib/formatters/time';
+
+/**
+ * Generates a display title for a meeting from its administrative body name and date.
+ *
+ * Per issue #209, council meetings don't need custom names — the administrative body
+ * they belong to plus the date is sufficient. This utility centralizes that logic so
+ * every surface (cards, breadcrumbs, OG images, exports, notifications, etc.) shows
+ * a consistent title.
+ *
+ * @example
+ * getMeetingDisplayTitle(meeting)           // "Δημοτικό Συμβούλιο — 15 Μαρτίου 2026"
+ * getMeetingDisplayTitle(meeting, 'en')     // "Municipal Council — March 15, 2026"
+ * getMeetingDisplayTitle(meeting, 'el', tz) // with timezone
+ */
+export function getMeetingDisplayTitle(
+  meeting: {
+    dateTime: Date | string;
+    administrativeBody?: {
+      name: string;
+      name_en: string;
+    } | null;
+  },
+  locale: string = 'el',
+  timezone?: string,
+): string {
+  const date = meeting.dateTime instanceof Date ? meeting.dateTime : new Date(meeting.dateTime);
+
+  // Format date using the existing el-GR formatter (e.g. "15 Μαρτίου 2026")
+  const formattedDate = formatDate(date, timezone);
+
+  const bodyName = meeting.administrativeBody
+    ? (locale === 'en' ? meeting.administrativeBody.name_en : meeting.administrativeBody.name)
+    : undefined;
+
+  if (bodyName) {
+    return `${bodyName} \u2014 ${formattedDate}`;
+  }
+
+  // Fallback: date only (should be rare once administrativeBody is required)
+  return formattedDate;
+}


### PR DESCRIPTION
## Summary

Fixes #209

Council meetings don't need custom names — the administrative body they belong to plus the date is sufficient identification. This PR introduces a centralized `getMeetingDisplayTitle()` utility and replaces `meeting.name` display across the codebase.

### Changes

**New utility** (`src/lib/utils/meetingTitle.ts`):
- `getMeetingDisplayTitle(meeting, locale?, timezone?)` generates titles like **"Δημοτικό Συμβούλιο — 15 Μαρτίου 2026"**
- Supports locale-aware body names (`name` for Greek, `name_en` for English)
- Falls back to date-only when no administrative body is set

**Updated display locations** (8 files):
| File | What changed |
|------|-------------|
| `MeetingCard.tsx` | Title now auto-generated; removed separate admin body metadata row (it's in the title) |
| `layout.tsx` (meeting) | Breadcrumb, SEO `<title>`, and OG image alt text use generated title |
| `page.tsx` (meeting) | Hero `<h1>` uses generated title |
| `ExpandableMeetingRow.tsx` | Admin table row and aria-label use generated title |
| `CouncilMeetingDocx.tsx` | DOCX title page heading and document metadata use generated title |
| `Video.tsx` | Mux player `video_title` metadata uses generated title |
| `opengraph-image.tsx` | Subject OG image header uses generated title |
| `highlightComplete.ts` | Highlight email meeting name uses generated title (+ includes `administrativeBody` in Prisma query) |

### What this PR deliberately does NOT change

- **Schema**: `name`/`name_en` columns remain as-is — making them optional or dropping them is a separate migration step
- **AddMeetingForm**: Name fields are kept for now; removing them requires the schema change first
- **Tags**: The meeting tag system mentioned in the issue (for cases like λογοδοσία) is a separate feature to be designed

### How it looks

```
Before:  "Τακτική Συνεδρίαση Δημοτικού Συμβουλίου 15/3/2026"  (custom name)
After:   "Δημοτικό Συμβούλιο — 15 Μαρτίου 2026"               (auto-generated)
```

This PR was authored by Claude Opus 4.6 (AI), operated by @MaxwellCalkin

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a well-structured `getMeetingDisplayTitle()` utility and consistently replaces raw `meeting.name` display across 8 files, cleanly centralizing the "administrative body + date" title format as described in issue #209. The implementation is clean and the Prisma query in `highlightComplete.ts` is correctly updated to include `administrativeBody`.

**Key observations:**
- `MeetingCard.tsx`, `page.tsx`, `opengraph-image.tsx`, and `CouncilMeetingPage` in `layout.tsx` all correctly pass `locale` (and timezone where relevant) to `getMeetingDisplayTitle`.
- `generateImageMetadata` and `generateMetadata` in `layout.tsx` do **not** destructure `locale` from their `params`, so SEO titles and OG image alt text always use the Greek administrative body name regardless of the visitor's locale. Since `locale` is available in the route params `[locale]/...`, it just needs to be added to the destructuring.
- `ExpandableMeetingRow.tsx` and `Video.tsx` also omit locale, causing the admin table and Mux video metadata to always show Greek body names.
- `CouncilMeetingDocx.tsx` intentionally hardcodes `'el'` for DOCX exports, which is appropriate.
- The underlying `formatDate` in `src/lib/formatters/time.ts` hardcodes `'el-GR'` — this pre-existing root-cause issue would complete the full locale story once the callers above are updated to pass locale.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — changes are purely cosmetic display replacements with no schema or data mutations; identified issues are style-level locale inconsistencies.
- The PR achieves its goal cleanly and introduces no regressions. The three identified issues represent style-level locale gaps (the app is primarily Greek so practical impact is low), not correctness bugs. The core utility and the majority of callsites are correct. After addressing the three locale-handling callsites, the implementation will be fully consistent.
- Three files need locale awareness added: `src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx` (`generateImageMetadata` and `generateMetadata`), `src/components/admin/meetings/ExpandableMeetingRow.tsx`, and `src/components/meetings/Video.tsx`.

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/lib/email/highlightComplete.ts`, line 42-46 ([link](https://github.com/schemalabz/opencouncil/blob/b71064823c3df9da19511ab38f41d84ae3c639d3/src/lib/email/highlightComplete.ts#L42-L46)) 

   City timezone not fetched — email meeting date may be off by one day

   The Prisma query only selects `name: true` from `city` (line 44), so `highlight.meeting.city.timezone` is `undefined`. When `getMeetingDisplayTitle(highlight.meeting)` is called on line 84 without a timezone, `formatDate` formats the date in UTC. For cities in positive-offset timezones (e.g., UTC+2), a meeting that locally occurs on the 14th could be stored as `2026-03-15T21:00:00Z` in UTC but then displayed as "March 15" in the email instead of "March 14".

   Add `timezone: true` to the city select and pass it through to `getMeetingDisplayTitle`:

   

   Then on line 84, pass the timezone:
   ```ts
   const meetingName = getMeetingDisplayTitle(highlight.meeting, 'el', highlight.meeting.city.timezone ?? undefined);
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/email/highlightComplete.ts
   Line: 42-46

   Comment:
   City timezone not fetched — email meeting date may be off by one day

   The Prisma query only selects `name: true` from `city` (line 44), so `highlight.meeting.city.timezone` is `undefined`. When `getMeetingDisplayTitle(highlight.meeting)` is called on line 84 without a timezone, `formatDate` formats the date in UTC. For cities in positive-offset timezones (e.g., UTC+2), a meeting that locally occurs on the 14th could be stored as `2026-03-15T21:00:00Z` in UTC but then displayed as "March 15" in the email instead of "March 14".

   Add `timezone: true` to the city select and pass it through to `getMeetingDisplayTitle`:

   

   Then on line 84, pass the timezone:
   ```ts
   const meetingName = getMeetingDisplayTitle(highlight.meeting, 'el', highlight.meeting.city.timezone ?? undefined);
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/components/meetings/MeetingCard.tsx`, line 95 ([link](https://github.com/schemalabz/opencouncil/blob/b71064823c3df9da19511ab38f41d84ae3c639d3/src/components/meetings/MeetingCard.tsx#L95)) 

   Stale `useMemo` dependency — `displayTitle` missing, `meeting.name` is leftover

   The `sortedSubjects` `useMemo` callback logs `displayTitle` on line 82, but `displayTitle` is not in the dependency array. Meanwhile, `meeting.name` — which was replaced with `displayTitle` in the log — is still listed as a dependency. The memoized result will not recompute when `displayTitle` changes due to a locale switch or `administrativeBody` change, potentially causing stale logs.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/meetings/MeetingCard.tsx
   Line: 95

   Comment:
   Stale `useMemo` dependency — `displayTitle` missing, `meeting.name` is leftover

   The `sortedSubjects` `useMemo` callback logs `displayTitle` on line 82, but `displayTitle` is not in the dependency array. Meanwhile, `meeting.name` — which was replaced with `displayTitle` in the log — is still listed as a dependency. The memoized result will not recompute when `displayTitle` changes due to a locale switch or `administrativeBody` change, potentially causing stale logs.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx`, line 25-69 ([link](https://github.com/schemalabz/opencouncil/blob/1bc4dcaea6b7d38d64f2a7341441a38ae2ef1300/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx#L25-L69)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`locale` missing from params in `generateImageMetadata` and `generateMetadata`**

   Both functions call `getMeetingDisplayTitle(data.meeting)` without the `locale` argument (lines 36 and 69), so the administrative body name always resolves to the Greek `name` field — even for English-locale visitors. This is inconsistent with the `CouncilMeetingPage` default export on line 127, which correctly passes `locale`.

   Next.js forwards all dynamic segment params to these functions, so `locale` is available — it just needs to be destructured from `params`:

   

   Apply the same change to `generateMetadata`:
   ```ts
   export async function generateMetadata({
       params: { meetingId, cityId, locale }
   }: {
       params: { meetingId: string; cityId: string; locale: string }
   }) {
       ...
       const displayTitle = getMeetingDisplayTitle(data.meeting, locale);
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
   Line: 25-69

   Comment:
   **`locale` missing from params in `generateImageMetadata` and `generateMetadata`**

   Both functions call `getMeetingDisplayTitle(data.meeting)` without the `locale` argument (lines 36 and 69), so the administrative body name always resolves to the Greek `name` field — even for English-locale visitors. This is inconsistent with the `CouncilMeetingPage` default export on line 127, which correctly passes `locale`.

   Next.js forwards all dynamic segment params to these functions, so `locale` is available — it just needs to be destructured from `params`:

   

   Apply the same change to `generateMetadata`:
   ```ts
   export async function generateMetadata({
       params: { meetingId, cityId, locale }
   }: {
       params: { meetingId: string; cityId: string; locale: string }
   }) {
       ...
       const displayTitle = getMeetingDisplayTitle(data.meeting, locale);
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
Line: 25-69

Comment:
**`locale` missing from params in `generateImageMetadata` and `generateMetadata`**

Both functions call `getMeetingDisplayTitle(data.meeting)` without the `locale` argument (lines 36 and 69), so the administrative body name always resolves to the Greek `name` field — even for English-locale visitors. This is inconsistent with the `CouncilMeetingPage` default export on line 127, which correctly passes `locale`.

Next.js forwards all dynamic segment params to these functions, so `locale` is available — it just needs to be destructured from `params`:

```suggestion
export async function generateImageMetadata({
    params: { meetingId, cityId, locale }
}: {
    params: { meetingId: string; cityId: string; locale: string }
}) {
    const data = await getMeetingDataCached(cityId, meetingId);

    if (!data || !data.city) {
        return [];
    }

    const displayTitle = getMeetingDisplayTitle(data.meeting, locale);
```

Apply the same change to `generateMetadata`:
```ts
export async function generateMetadata({
    params: { meetingId, cityId, locale }
}: {
    params: { meetingId: string; cityId: string; locale: string }
}) {
    ...
    const displayTitle = getMeetingDisplayTitle(data.meeting, locale);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/components/admin/meetings/ExpandableMeetingRow.tsx
Line: 54

Comment:
**No locale passed — always defaults to Greek**

`getMeetingDisplayTitle(meeting)` uses the default `'el'` locale, so the administrative body name will always render using the Greek `name` field even if the admin is browsing in English. This component is a client component using React hooks, so `useLocale()` is available:

```suggestion
    const locale = useLocale();
    const displayTitle = getMeetingDisplayTitle(meeting, locale);
```

You'll also need to add the import at the top:
```ts
import { useLocale } from 'next-intl';
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/components/meetings/Video.tsx
Line: 20

Comment:
**No locale passed to `getMeetingDisplayTitle`**

`getMeetingDisplayTitle(meeting)` defaults to `'el'`, so the Mux `video_title` metadata will always use the Greek administrative body name regardless of the viewer's locale. Since this is a client component using React hooks, you can use `useLocale()`:

```suggestion
    const locale = useLocale();
    const displayTitle = useMemo(() => getMeetingDisplayTitle(meeting, locale), [meeting, locale]);
```

And add the import:
```ts
import { useLocale } from 'next-intl';
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["Replace meeting name..."](https://github.com/schemalabz/opencouncil/commit/1bc4dcaea6b7d38d64f2a7341441a38ae2ef1300)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - .cursor/rules/general.mdc ([source](https://app.greptile.com/review/custom-context?memory=dc2172bf-e821-4a8e-b26f-cd165ffe6599))

<!-- /greptile_comment -->