### PR TITLE
fix: redesign profile dashboard for non-admin users

### DIFF
--- a/src/app/[locale]/(other)/profile/page.tsx
+++ b/src/app/[locale]/(other)/profile/page.tsx
@@ -12,12 +12,14 @@ export default async function ProfilePage() {
 
     const t = await getTranslations("Profile");
 
+    const isAdmin = user.isSuperAdmin || user.administers.length > 0;
+
     return (
         <div className="container max-w-2xl py-8 space-y-8">
             <DevelopmentSection />
-            {user.onboarded && <AdminSection user={user} t={t} />}
             <UserInfoForm user={user} isOnboarded={!!user.onboarded} />
             <NotificationPreferencesSection />
+            {user.onboarded && isAdmin && <AdminSection user={user} t={t} />}
         </div>
     );
 }


### PR DESCRIPTION
Fixes #180

## Problem

The user profile dashboard shows "you do not have admin rights" for regular users, which is confusing. The `AdminSection` component was rendered for all onboarded users, even those with no admin roles.

## Solution

Two changes to `src/app/[locale]/(other)/profile/page.tsx`:

1. **Only show `AdminSection` to actual admins** — added an `isAdmin` check (`user.isSuperAdmin || user.administers.length > 0`) so the admin card only renders when the user has admin capabilities.

2. **Reorder sections to prioritize useful content** — moved `UserInfoForm` and `NotificationPreferencesSection` above `AdminSection` so that even admin users see their most actionable content first.

### Before (non-admin user)
- Development tools (dev only)
- ❌ Admin section showing "you do not have admin rights" + contact info
- Personal info form
- Notification preferences

### After (non-admin user)
- Development tools (dev only)
- Personal info form
- Notification preferences
- *(no admin section — clean and relevant)*

### After (admin user)
- Development tools (dev only)
- Personal info form
- Notification preferences
- Admin section with admin links

No new components, no new dependencies. The existing `UserInfoForm` and `NotificationPreferencesSection` components already provide a useful profile experience — they just needed to not be overshadowed by the confusing admin message.

---

This PR was authored by Claude Opus 4.6 (AI), operated by @MaxwellCalkin

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a confusing UX issue where non-admin users were shown an "you do not have admin rights" message on their profile page by conditionally rendering `AdminSection` only when the user is a super admin or has at least one administered entity. It also reorders the page sections so `UserInfoForm` and `NotificationPreferencesSection` — which are relevant to all users — appear before the admin section.

**Key changes:**
- Added `isAdmin` derived variable (`user.isSuperAdmin || user.administers.length > 0`) consistent with the branching logic already present inside `AdminSection.tsx`.
- Moved `UserInfoForm` and `NotificationPreferencesSection` above `AdminSection` to surface the most actionable content first.
- `AdminSection` is only rendered when `user.onboarded && isAdmin`, eliminating the confusing "no admin rights" card for regular users.

The change is minimal (4 lines touched), self-contained, and the `isAdmin` logic correctly mirrors what `AdminSection.tsx` already does internally — so no user who was previously seeing useful admin content will lose access to it.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a small, targeted UI fix with no security or data-integrity implications.
- The change is a straightforward conditional render guard on a single page. The `isAdmin` logic mirrors the existing branching already present in `AdminSection.tsx`, the user object shape is fully type-safe from the Prisma include in `getCurrentUser`, and no server-side authorization paths are altered. No regressions are introduced.
- No files require special attention.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ProfilePage loads] --> B[getCurrentUser]
    B --> C{user exists?}
    C -- No --> D[redirect to /sign-in]
    C -- Yes --> E[compute isAdmin\nisSuperAdmin OR administers.length > 0]
    E --> F[Render DevelopmentSection]
    F --> G[Render UserInfoForm]
    G --> H[Render NotificationPreferencesSection]
    H --> I{user.onboarded AND isAdmin?}
    I -- Yes --> J[Render AdminSection]
    I -- No --> K[Skip AdminSection]
```

<sub>Last reviewed commit: ["fix: show useful pro..."](https://github.com/schemalabz/opencouncil/commit/345a6923bd916c62d04c9988b5ccc9dcadb077d1)</sub>

<!-- /greptile_comment -->