### PR TITLE
fix: match unlinked speaker contributions by name fallback

### DIFF
--- a/src/components/meetings/subject/ContributionCard.tsx
+++ b/src/components/meetings/subject/ContributionCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { FileText, Clock } from "lucide-react";
 import { PersonBadge } from "@/components/persons/PersonBadge";
@@ -12,6 +12,7 @@ import { useTranslations } from "next-intl";
 import { SpeakerContribution } from "@/lib/apiTypes";
 import { PlayPauseButton } from "@/components/meetings/PlayPauseButton";
 import { formatTimestamp } from "@/lib/formatters/time";
+import { matchSpeakerNameToPerson } from "@/lib/utils/speakerMatch";
 import useSWR from "swr";
 
 interface UtteranceTimeRange {
@@ -30,18 +31,33 @@ export const ContributionCard = memo(function ContributionCard({
     contribution,
     subjectId,
 }: ContributionCardProps) {
-    const { getPerson, meeting } = useCouncilMeetingData();
+    const { getPerson, meeting, people } = useCouncilMeetingData();
     const t = useTranslations("Subject");
 
-    const speaker = contribution.speakerId
-        ? getPerson(contribution.speakerId)
-        : null;
+    const speaker = useMemo(() => {
+        // Direct lookup by ID
+        if (contribution.speakerId) {
+            return getPerson(contribution.speakerId) ?? null;
+        }
+        // Fallback: try to match speakerName against known people by shared
+        // name tokens (handles role-prefixed names like "Αντιδήμαρχος Ευαγγελίδου")
+        if (contribution.speakerName) {
+            const matchedId = matchSpeakerNameToPerson(contribution.speakerName, people);
+            if (matchedId) {
+                return getPerson(matchedId) ?? null;
+            }
+        }
+        return null;
+    }, [contribution.speakerId, contribution.speakerName, getPerson, people]);
+
+    // Use the resolved speaker's ID (from direct match or name fallback)
+    const resolvedSpeakerId = speaker?.id ?? null;
 
     // Fetch the time range for this speaker's discussion of this subject
     // Uses the discussionSubjectId index for efficient lookup
     const { data: utteranceInfo } = useSWR<UtteranceTimeRange>(
-        contribution.speakerId
-            ? `/api/subject/${subjectId}/first-utterance/${contribution.speakerId}`
+        resolvedSpeakerId
+            ? `/api/subject/${subjectId}/first-utterance/${resolvedSpeakerId}`
             : null,
         fetcher
     );

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -12,6 +12,7 @@ import { getSubjectsForMeeting, extractUtteranceIdsFromContributions } from "./s
 import { Subject as DbSubject } from "@prisma/client";
 import { getPartyFromRoles, getRoleNameForPerson } from "../utils";
 import { categorizeSubjectsForUpsert } from "./subject-helpers";
+import { matchSpeakerNameToPerson } from "../utils/speakerMatch";
 
 // Type for the Prisma interactive transaction client
 type PrismaTxClient = Omit<typeof prisma, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>;
@@ -168,7 +169,15 @@ async function validateSubjectPersons(subjects: Subject[], cityId: string) {
 
     const existingIntroducerIds = new Set(existingIntroducers.map(p => p.id));
 
-    return { topicsByName, validSpeakerIds, existingIntroducerIds };
+    // Fetch all people with names for fallback speaker-name matching.
+    // This is a lightweight query (id + name only) used when the AI backend
+    // returns a speakerName but no speakerId.
+    const cityPeople = await prisma.person.findMany({
+        where: { cityId },
+        select: { id: true, name: true }
+    });
+
+    return { topicsByName, validSpeakerIds, existingIntroducerIds, cityPeople };
 }
 
 async function createLocationInTx(
@@ -270,8 +279,26 @@ export async function saveSubjectsForMeeting(
     cityId: string,
     councilMeetingId: string,
 ): Promise<Map<string, string>> {
-    const { topicsByName, validSpeakerIds, existingIntroducerIds } = await validateSubjectPersons(subjects, cityId);
+    const { topicsByName, validSpeakerIds, existingIntroducerIds, cityPeople } = await validateSubjectPersons(subjects, cityId);
     const subjectIdMap = new Map<string, string>();
+
+    // Resolve speakerId for a contribution: validate the existing speakerId,
+    // or fall back to name-matching when the AI backend returned a speakerName
+    // but no speakerId (e.g. "Αντιδήμαρχος Ευαγγελίδου" instead of a person ID).
+    const resolveSpeakerId = (contrib: { speakerId: string | null; speakerName: string | null }): string | null => {
+        if (contrib.speakerId && validSpeakerIds.has(contrib.speakerId)) {
+            return contrib.speakerId;
+        }
+        // Fallback: try to match by name when speakerId is missing or invalid
+        if (contrib.speakerName) {
+            const matched = matchSpeakerNameToPerson(contrib.speakerName, cityPeople);
+            if (matched) {
+                console.log(`Matched speakerName "${contrib.speakerName}" to person ${matched} by name`);
+            }
+            return matched;
+        }
+        return null;
+    };
 
     // Fetch existing subjects for matching
     const existingSubjects = await prisma.subject.findMany({
@@ -361,9 +388,7 @@ export async function saveSubjectsForMeeting(
                 await tx.speakerContribution.createMany({
                     data: incoming.speakerContributions.map(contrib => ({
                         subjectId: existingId,
-                        speakerId: contrib.speakerId && validSpeakerIds.has(contrib.speakerId)
-                            ? contrib.speakerId
-                            : null,
+                        speakerId: resolveSpeakerId(contrib),
                         speakerName: contrib.speakerName,
                         text: contrib.text
                     }))
@@ -425,9 +450,7 @@ export async function saveSubjectsForMeeting(
                     proximityImportance: subject.proximityImportance,
                     contributions: {
                         create: subject.speakerContributions.map(contrib => ({
-                            speakerId: contrib.speakerId && validSpeakerIds.has(contrib.speakerId)
-                                ? contrib.speakerId
-                                : null,
+                            speakerId: resolveSpeakerId(contrib),
                             speakerName: contrib.speakerName,
                             text: contrib.text
                         }))

--- a/src/lib/utils/__tests__/speakerMatch.test.ts
+++ b/src/lib/utils/__tests__/speakerMatch.test.ts
@@ -1,0 +1,64 @@
+import { matchSpeakerNameToPerson } from '../speakerMatch';
+
+describe('matchSpeakerNameToPerson', () => {
+    const people = [
+        { id: 'p1', name: 'Μαρία Ευαγγελίδου' },
+        { id: 'p2', name: 'Νίκος Τουσιάς' },
+        { id: 'p3', name: 'Γιώργος Παπαδόπουλος' },
+    ];
+
+    it('matches role-prefixed last name to correct person', () => {
+        expect(matchSpeakerNameToPerson('Αντιδήμαρχος Ευαγγελίδου', people)).toBe('p1');
+    });
+
+    it('matches full name', () => {
+        expect(matchSpeakerNameToPerson('Νίκος Τουσιάς', people)).toBe('p2');
+    });
+
+    it('matches last name only', () => {
+        expect(matchSpeakerNameToPerson('Παπαδόπουλος', people)).toBe('p3');
+    });
+
+    it('returns null for empty string', () => {
+        expect(matchSpeakerNameToPerson('', people)).toBeNull();
+    });
+
+    it('returns null for short tokens only', () => {
+        // All tokens < 3 chars
+        expect(matchSpeakerNameToPerson('Α Β', people)).toBeNull();
+    });
+
+    it('returns null when no match found', () => {
+        expect(matchSpeakerNameToPerson('Δήμαρχος Αγγελόπουλος', people)).toBeNull();
+    });
+
+    it('returns null for ambiguous match (multiple people share a token)', () => {
+        const peopleWithSharedToken = [
+            { id: 'p1', name: 'Νίκος Ευαγγελίδης' },
+            { id: 'p2', name: 'Μαρία Ευαγγελίδου' },
+        ];
+        // "Ευαγγελίδου" does not match "Ευαγγελίδης" (exact token match)
+        // so this should match only p2
+        expect(matchSpeakerNameToPerson('Αντιδήμαρχος Ευαγγελίδου', peopleWithSharedToken)).toBe('p2');
+    });
+
+    it('returns null when multiple people match the same token', () => {
+        const peopleWithDuplicate = [
+            { id: 'p1', name: 'Νίκος Παπαδόπουλος' },
+            { id: 'p2', name: 'Μαρία Παπαδόπουλος' },
+        ];
+        // Both share "Παπαδόπουλος" token — ambiguous
+        expect(matchSpeakerNameToPerson('Αντιδήμαρχος Παπαδόπουλος', peopleWithDuplicate)).toBeNull();
+    });
+
+    it('returns null with empty people list', () => {
+        expect(matchSpeakerNameToPerson('Αντιδήμαρχος Ευαγγελίδου', [])).toBeNull();
+    });
+
+    it('is case-insensitive', () => {
+        const upperPeople = [
+            { id: 'p1', name: 'ΜΑΡΊΑ ΕΥΑΓΓΕΛΊΔΟΥ' },
+        ];
+        expect(matchSpeakerNameToPerson('αντιδήμαρχος ευαγγελίδου', upperPeople)).toBe('p1');
+    });
+});

--- a/src/lib/utils/speakerMatch.ts
+++ b/src/lib/utils/speakerMatch.ts
@@ -1,0 +1,32 @@
+/**
+ * Try to match a speakerName (which may include a role prefix, e.g.
+ * "Αντιδήμαρχος Ευαγγελίδου") to one of the known people.
+ *
+ * Strategy: tokenize both the speakerName and each person's name, then check
+ * if any person has at least one name-token that appears inside the
+ * speakerName tokens. To avoid false positives on very short tokens (e.g.
+ * single-letter initials) we require the matching token to be at least 3
+ * characters. If exactly one person matches, return their id; otherwise
+ * return null to avoid ambiguous matches.
+ */
+export function matchSpeakerNameToPerson(
+    speakerName: string,
+    people: { id: string; name: string }[]
+): string | null {
+    const speakerTokens = speakerName.toLowerCase().split(/\s+/).filter(t => t.length >= 3);
+    if (speakerTokens.length === 0) return null;
+
+    const matches: string[] = [];
+
+    for (const person of people) {
+        const personTokens = person.name.toLowerCase().split(/\s+/).filter(t => t.length >= 3);
+        // Check if any person name-token is present in the speaker tokens
+        const hasMatch = personTokens.some(pt => speakerTokens.includes(pt));
+        if (hasMatch) {
+            matches.push(person.id);
+        }
+    }
+
+    // Only return a match if exactly one person matched (unambiguous)
+    return matches.length === 1 ? matches[0] : null;
+}


### PR DESCRIPTION
## Summary

Fixes #252 (speaker matching bug portion).

When the AI summarization backend returns a speaker contribution with `speakerName` but no `speakerId` (e.g. "Αντιδήμαρχος Ευαγγελίδου"), the speaker is currently displayed as plain text without their avatar, party color, or profile link. This PR adds token-based name matching as a fallback to resolve these speakers against the city's known people.

**Changes:**
- **`src/lib/utils/speakerMatch.ts`** — New shared utility: `matchSpeakerNameToPerson()` tokenizes both the speaker name and each person's name, returning a match only when exactly one person matches unambiguously (tokens >= 3 chars to avoid false positives on initials/short words).
- **`src/lib/db/utils.ts`** — Server-side fix: during `saveSubjectsForMeeting`, contributions without a `speakerId` are now matched by name before persisting. This means new summarization runs will link speakers correctly in the database.
- **`src/components/meetings/subject/ContributionCard.tsx`** — Client-side fallback: for existing data already saved with `null` speakerId, the component attempts to resolve the speaker at render time using the same matching logic against the meeting's people list. This also enables the utterance time range lookup and transcript link for name-matched speakers.
- **`src/lib/utils/__tests__/speakerMatch.test.ts`** — 10 tests covering: role-prefixed names, full names, last-name-only, empty inputs, short tokens, no-match, ambiguous matches (multiple people sharing a token), and case insensitivity.

**Note:** The typo portion of issue #252 (incorrect speaker name "Τουσίας" in transcript data) is a data correction that requires re-processing the specific meeting transcript and is not addressed by this code change.

## Test plan

- [x] All 10 unit tests for `matchSpeakerNameToPerson` pass
- [ ] Verify on the subject page that "Αντιδήμαρχος Ευαγγελίδου" now shows with proper PersonBadge (avatar + party color + link)
- [ ] Verify that re-summarizing a meeting correctly links previously unlinked speakers in the database
- [ ] Verify that ambiguous names (matching multiple people) still show as plain text rather than incorrectly linking

---

> **Disclosure:** This PR was authored by an AI (Claude Opus 4.6, operating as [github.com/MaxwellCalkin](https://github.com/MaxwellCalkin)) with full transparency — not impersonating a human contributor.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a token-based name-matching fallback so that speaker contributions carrying only a `speakerName` (e.g. `"Αντιδήμαρχος Ευαγγελίδου"`) are linked to the correct `Person` record both at write-time (in `saveSubjectsForMeeting`) and at read-time (in `ContributionCard`). The new `matchSpeakerNameToPerson` utility is well-contained, the dual-layer fix (DB + component) correctly handles both new and already-persisted data, and the 10-test suite provides solid coverage.

**Key changes:**
- `src/lib/utils/speakerMatch.ts` — new shared utility; tokenizes both names, requires ≥ 3-char tokens, returns a match only when unambiguous
- `src/lib/db/utils.ts` — `resolveSpeakerId` helper added to `saveSubjectsForMeeting`; replaces two inline ternaries, but leaves a `console.log` in the hot path that leaks internal IDs
- `src/components/meetings/subject/ContributionCard.tsx` — `useMemo`-based fallback; wires `resolvedSpeakerId` through to SWR and the transcript link
- `src/lib/utils/__tests__/speakerMatch.test.ts` — good coverage, but one test description contradicts its actual assertion (says "ambiguous" but asserts success)

<h3>Confidence Score: 4/5</h3>

- Safe to merge — core logic is correct and well-tested; minor style issues only (debug log and test description mismatch).
- The matching logic and dual-layer integration (DB + component) are sound with no correctness errors. The two remaining findings are minor style issues: a misleading test description that doesn't affect test behavior, and a debug `console.log` in production that should be removed. Neither impacts functionality or safety. The code can be merged confidently after these cosmetic fixes.
- src/lib/db/utils.ts — remove debug console.log at line 296; src/lib/utils/__tests__/speakerMatch.test.ts — fix misleading test description at line 35.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SpeakerContribution received] --> B{speakerId present?}
    B -- Yes --> C{speakerId in validSpeakerIds?}
    C -- Yes --> D[Use speakerId directly]
    C -- No --> E{speakerName present?}
    B -- No --> E
    E -- No --> F[Store null speakerId]
    E -- Yes --> G[matchSpeakerNameToPerson]
    G --> H[Tokenize speakerName\nfilter tokens ≥ 3 chars]
    H --> I{Any tokens left?}
    I -- No --> F
    I -- Yes --> J[For each person:\ntokenize name, check overlap]
    J --> K{Exactly 1 person matches?}
    K -- Yes --> L[Use matched person's ID]
    K -- No / 0 --> F
    D --> M[Persist speakerId to DB]
    L --> M
    F --> M
```

<sub>Last reviewed commit: f630ea9</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->