### PR TITLE
test: add unit tests for references, youtube, and selection-utils

### DIFF
--- a/src/lib/__tests__/selection-utils.test.ts
+++ b/src/lib/__tests__/selection-utils.test.ts
@@ -1,0 +1,97 @@
+import { calculateUtteranceRange } from '../selection-utils';
+
+describe('calculateUtteranceRange', () => {
+  const utterances = [
+    { id: 'u1' },
+    { id: 'u2' },
+    { id: 'u3' },
+    { id: 'u4' },
+    { id: 'u5' },
+  ];
+
+  it('returns IDs between start and end (inclusive)', () => {
+    expect(calculateUtteranceRange(utterances, 'u2', 'u4')).toEqual([
+      'u2',
+      'u3',
+      'u4',
+    ]);
+  });
+
+  it('returns a single ID when start equals end', () => {
+    expect(calculateUtteranceRange(utterances, 'u3', 'u3')).toEqual(['u3']);
+  });
+
+  it('returns all IDs when selecting first to last', () => {
+    expect(calculateUtteranceRange(utterances, 'u1', 'u5')).toEqual([
+      'u1',
+      'u2',
+      'u3',
+      'u4',
+      'u5',
+    ]);
+  });
+
+  it('handles reversed order (end before start)', () => {
+    expect(calculateUtteranceRange(utterances, 'u4', 'u2')).toEqual([
+      'u2',
+      'u3',
+      'u4',
+    ]);
+  });
+
+  it('returns empty array when startId is not found', () => {
+    expect(calculateUtteranceRange(utterances, 'nonexistent', 'u3')).toEqual(
+      []
+    );
+  });
+
+  it('returns empty array when endId is not found', () => {
+    expect(calculateUtteranceRange(utterances, 'u1', 'nonexistent')).toEqual(
+      []
+    );
+  });
+
+  it('returns empty array when both IDs are not found', () => {
+    expect(
+      calculateUtteranceRange(utterances, 'nonexistent1', 'nonexistent2')
+    ).toEqual([]);
+  });
+
+  it('returns empty array for empty utterances list', () => {
+    expect(calculateUtteranceRange([], 'u1', 'u2')).toEqual([]);
+  });
+
+  it('works with a single-element array', () => {
+    const single = [{ id: 'only' }];
+    expect(calculateUtteranceRange(single, 'only', 'only')).toEqual(['only']);
+  });
+
+  it('returns first two elements correctly', () => {
+    expect(calculateUtteranceRange(utterances, 'u1', 'u2')).toEqual([
+      'u1',
+      'u2',
+    ]);
+  });
+
+  it('returns last two elements correctly', () => {
+    expect(calculateUtteranceRange(utterances, 'u4', 'u5')).toEqual([
+      'u4',
+      'u5',
+    ]);
+  });
+
+  it('handles UUID-style IDs', () => {
+    const uuidUtterances = [
+      { id: 'a1b2c3d4-0001' },
+      { id: 'a1b2c3d4-0002' },
+      { id: 'a1b2c3d4-0003' },
+    ];
+    expect(
+      calculateUtteranceRange(
+        uuidUtterances,
+        'a1b2c3d4-0001',
+        'a1b2c3d4-0003'
+      )
+    ).toEqual(['a1b2c3d4-0001', 'a1b2c3d4-0002', 'a1b2c3d4-0003']);
+  });
+});

--- a/src/lib/utils/__tests__/references.test.ts
+++ b/src/lib/utils/__tests__/references.test.ts
@@ -1,0 +1,131 @@
+import { parseReferences, extractUtteranceIds, ParsedReference } from '../references';
+
+describe('parseReferences', () => {
+  it('returns empty array for text with no references', () => {
+    expect(parseReferences('Hello world, no references here.')).toEqual([]);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(parseReferences('')).toEqual([]);
+  });
+
+  it('parses a single utterance reference', () => {
+    const text = 'As stated in [this statement](REF:UTTERANCE:utt-123)';
+    const result = parseReferences(text);
+    expect(result).toEqual<ParsedReference[]>([
+      { type: 'utterance', id: 'utt-123', displayText: 'this statement' },
+    ]);
+  });
+
+  it('parses a single person reference', () => {
+    const text = 'According to [Γιώργος Παπαδόπουλος](REF:PERSON:person-456)';
+    const result = parseReferences(text);
+    expect(result).toEqual<ParsedReference[]>([
+      { type: 'person', id: 'person-456', displayText: 'Γιώργος Παπαδόπουλος' },
+    ]);
+  });
+
+  it('parses a party reference', () => {
+    const text = 'The [ΝΔ](REF:PARTY:party-789) voted in favor.';
+    const result = parseReferences(text);
+    expect(result).toEqual<ParsedReference[]>([
+      { type: 'party', id: 'party-789', displayText: 'ΝΔ' },
+    ]);
+  });
+
+  it('parses a subject reference', () => {
+    const text = 'Regarding [urban planning](REF:SUBJECT:subj-001)';
+    const result = parseReferences(text);
+    expect(result).toEqual<ParsedReference[]>([
+      { type: 'subject', id: 'subj-001', displayText: 'urban planning' },
+    ]);
+  });
+
+  it('parses multiple references of different types', () => {
+    const text =
+      '[Speaker A](REF:PERSON:p1) discussed [topic X](REF:SUBJECT:s1) ' +
+      'and cited [a previous remark](REF:UTTERANCE:u1). ' +
+      'The [party](REF:PARTY:pt1) agreed.';
+    const result = parseReferences(text);
+    expect(result).toHaveLength(4);
+    expect(result).toEqual<ParsedReference[]>([
+      { type: 'person', id: 'p1', displayText: 'Speaker A' },
+      { type: 'subject', id: 's1', displayText: 'topic X' },
+      { type: 'utterance', id: 'u1', displayText: 'a previous remark' },
+      { type: 'party', id: 'pt1', displayText: 'party' },
+    ]);
+  });
+
+  it('handles reference IDs with UUIDs', () => {
+    const uuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    const text = `[item](REF:UTTERANCE:${uuid})`;
+    const result = parseReferences(text);
+    expect(result).toEqual<ParsedReference[]>([
+      { type: 'utterance', id: uuid, displayText: 'item' },
+    ]);
+  });
+
+  it('handles display text with special characters', () => {
+    const text = '[Σύνδεσμος & Εταίροι](REF:PARTY:p-special)';
+    const result = parseReferences(text);
+    expect(result).toEqual<ParsedReference[]>([
+      { type: 'party', id: 'p-special', displayText: 'Σύνδεσμος & Εταίροι' },
+    ]);
+  });
+
+  it('ignores malformed references with unknown type', () => {
+    const text = '[bad](REF:UNKNOWN:id-1)';
+    expect(parseReferences(text)).toEqual([]);
+  });
+
+  it('ignores standard markdown links (no REF: prefix)', () => {
+    const text = '[OpenCouncil](https://opencouncil.gr)';
+    expect(parseReferences(text)).toEqual([]);
+  });
+
+  it('ignores references with missing display text brackets', () => {
+    const text = 'missing brackets (REF:UTTERANCE:id-1)';
+    expect(parseReferences(text)).toEqual([]);
+  });
+
+  it('handles multiple references on the same line', () => {
+    const text =
+      '[A](REF:PERSON:p1) and [B](REF:PERSON:p2) debated [topic](REF:SUBJECT:s1)';
+    const result = parseReferences(text);
+    expect(result).toHaveLength(3);
+    expect(result.map(r => r.id)).toEqual(['p1', 'p2', 's1']);
+  });
+});
+
+describe('extractUtteranceIds', () => {
+  it('returns empty array when no references exist', () => {
+    expect(extractUtteranceIds('Plain text with no references')).toEqual([]);
+  });
+
+  it('returns empty array when references exist but none are utterances', () => {
+    const text = '[person](REF:PERSON:p1) discussed [topic](REF:SUBJECT:s1)';
+    expect(extractUtteranceIds(text)).toEqual([]);
+  });
+
+  it('extracts a single utterance ID', () => {
+    const text = 'Referenced [this](REF:UTTERANCE:utt-42)';
+    expect(extractUtteranceIds(text)).toEqual(['utt-42']);
+  });
+
+  it('extracts multiple utterance IDs', () => {
+    const text =
+      '[first](REF:UTTERANCE:u1) and [second](REF:UTTERANCE:u2) and [third](REF:UTTERANCE:u3)';
+    expect(extractUtteranceIds(text)).toEqual(['u1', 'u2', 'u3']);
+  });
+
+  it('filters out non-utterance references and returns only utterance IDs', () => {
+    const text =
+      '[speaker](REF:PERSON:p1) said [this](REF:UTTERANCE:u1) about [topic](REF:SUBJECT:s1) ' +
+      'and also [that](REF:UTTERANCE:u2)';
+    expect(extractUtteranceIds(text)).toEqual(['u1', 'u2']);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(extractUtteranceIds('')).toEqual([]);
+  });
+});

--- a/src/lib/utils/__tests__/youtube.test.ts
+++ b/src/lib/utils/__tests__/youtube.test.ts
@@ -1,0 +1,94 @@
+import { isValidYouTubeUrl, YOUTUBE_URL_REGEX } from '../youtube';
+
+describe('YOUTUBE_URL_REGEX', () => {
+  it('is a RegExp', () => {
+    expect(YOUTUBE_URL_REGEX).toBeInstanceOf(RegExp);
+  });
+});
+
+describe('isValidYouTubeUrl', () => {
+  describe('valid youtube.com/watch URLs', () => {
+    it.each([
+      ['https://www.youtube.com/watch?v=dQw4w9WgXcQ'],
+      ['http://www.youtube.com/watch?v=dQw4w9WgXcQ'],
+      ['https://youtube.com/watch?v=dQw4w9WgXcQ'],
+      ['https://m.youtube.com/watch?v=dQw4w9WgXcQ'],
+      ['https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=120'],
+      ['https://www.youtube.com/watch?v=abc123&list=PLtest'],
+    ])('accepts %s', (url) => {
+      expect(isValidYouTubeUrl(url)).toBe(true);
+    });
+  });
+
+  describe('valid youtube.com/live URLs', () => {
+    it.each([
+      ['https://www.youtube.com/live/dQw4w9WgXcQ'],
+      ['https://youtube.com/live/abc123'],
+      ['https://m.youtube.com/live/xyz789'],
+    ])('accepts %s', (url) => {
+      expect(isValidYouTubeUrl(url)).toBe(true);
+    });
+  });
+
+  describe('valid youtube.com/shorts URLs', () => {
+    it.each([
+      ['https://www.youtube.com/shorts/dQw4w9WgXcQ'],
+      ['https://youtube.com/shorts/abc123'],
+      ['https://m.youtube.com/shorts/xyz789'],
+    ])('accepts %s', (url) => {
+      expect(isValidYouTubeUrl(url)).toBe(true);
+    });
+  });
+
+  describe('valid youtu.be short URLs', () => {
+    it.each([
+      ['https://youtu.be/dQw4w9WgXcQ'],
+      ['http://youtu.be/dQw4w9WgXcQ'],
+      ['https://youtu.be/dQw4w9WgXcQ?t=30'],
+    ])('accepts %s', (url) => {
+      expect(isValidYouTubeUrl(url)).toBe(true);
+    });
+  });
+
+  describe('invalid URLs', () => {
+    it.each([
+      ['https://vimeo.com/123456789'],
+      ['https://dailymotion.com/video/x7tgad0'],
+      ['https://www.google.com'],
+      ['https://youtube.com/channel/UCtest'],
+      ['https://youtube.com/playlist?list=PLtest'],
+      ['not a url at all'],
+      [''],
+      ['https://notyoutube.com/watch?v=abc'],
+      ['ftp://youtube.com/watch?v=abc'],
+    ])('rejects %s', (url) => {
+      expect(isValidYouTubeUrl(url)).toBe(false);
+    });
+  });
+
+  describe('captures video ID', () => {
+    it('captures ID from watch URL', () => {
+      const match = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'.match(YOUTUBE_URL_REGEX);
+      expect(match).not.toBeNull();
+      expect(match![1]).toBe('dQw4w9WgXcQ');
+    });
+
+    it('captures ID from short URL', () => {
+      const match = 'https://youtu.be/dQw4w9WgXcQ'.match(YOUTUBE_URL_REGEX);
+      expect(match).not.toBeNull();
+      expect(match![1]).toBe('dQw4w9WgXcQ');
+    });
+
+    it('captures ID from live URL', () => {
+      const match = 'https://www.youtube.com/live/abc123xyz'.match(YOUTUBE_URL_REGEX);
+      expect(match).not.toBeNull();
+      expect(match![1]).toBe('abc123xyz');
+    });
+
+    it('captures ID from shorts URL', () => {
+      const match = 'https://www.youtube.com/shorts/ShortId99'.match(YOUTUBE_URL_REGEX);
+      expect(match).not.toBeNull();
+      expect(match![1]).toBe('ShortId99');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for three untested utility modules, continuing the test coverage effort from #258.

### Files covered

| Module | Function(s) | Tests | Edge cases |
|---|---|---|---|
| `src/lib/utils/references.ts` | `parseReferences` | 12 cases | All 4 reference types, UUIDs, Greek text, special chars, malformed input, unknown types, standard markdown links |
| `src/lib/utils/references.ts` | `extractUtteranceIds` | 6 cases | Filtering non-utterance refs, empty input |
| `src/lib/utils/youtube.ts` | `isValidYouTubeUrl`, `YOUTUBE_URL_REGEX` | 30+ cases | watch/live/shorts/youtu.be URLs, mobile URLs, query params, video ID capture groups, invalid URLs (Vimeo, empty, FTP, non-YouTube domains) |
| `src/lib/selection-utils.ts` | `calculateUtteranceRange` | 12 cases | Normal range, reversed start/end, single element, missing IDs, empty array, UUID-style IDs |

All functions tested are pure (no external dependencies, no mocks needed), following the `it.each` and direct-assertion patterns used in the existing test suite.

Contributes to #197

## Disclosure

This PR was authored by Claude Opus 4.6 (an AI), operated by [Maxwell Calkin](https://github.com/MaxwellCalkin).

## Test plan

- [ ] Run `npm test -- src/lib/utils/__tests__/references.test.ts`
- [ ] Run `npm test -- src/lib/utils/__tests__/youtube.test.ts`
- [ ] Run `npm test -- src/lib/__tests__/selection-utils.test.ts`
- [ ] All tests pass
- [ ] No existing tests broken

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds unit tests for three pure utility modules — `references.ts`, `youtube.ts`, and `selection-utils.ts` — with no changes to production code. The tests are well-structured, use idiomatic Jest patterns (`it.each`, direct assertions), and correctly reflect the behaviour of the underlying implementations.

**Key observations:**
- All import paths are correct relative to each `__tests__` directory.
- `parseReferences` and `extractUtteranceIds` tests correctly exercise all four reference types, UUID-style IDs, Greek text, and malformed/unknown-type inputs.
- `calculateUtteranceRange` tests cover normal ranges, reversed start/end, single-element arrays, empty arrays, and missing IDs — all matching the `Math.min`/`Math.max` branch logic in the source.
- The `YOUTUBE_URL_REGEX` capture-group assertions are accurate; `match![1]` is safe because each assertion is preceded by `expect(match).not.toBeNull()`.
- **Test coverage gap:** `YOUTUBE_URL_REGEX` uses `([^#&?]*)` (zero-or-more), so URLs with empty video IDs (e.g., `https://www.youtube.com/watch?v=`, `https://youtu.be/`) incorrectly pass `isValidYouTubeUrl` and would fail downstream when sent to YouTube's oEmbed API. Adding test cases for these URLs would ensure proper validation.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it only adds new test files with no changes to production code. The one flagged issue is a test coverage gap, not a correctness problem.
- The PR is purely additive with well-structured tests for pure functions. All three test files are correct and follow existing patterns. However, the YouTube validator tests have a coverage gap: empty video ID URLs (e.g., `watch?v=`) would pass validation and only fail downstream at YouTube's oEmbed API. Adding these edge cases to the invalid URLs suite would improve test quality and prevent silent failures. Score reduced from 5 to 4 due to this identified gap worth addressing.
- src/lib/utils/__tests__/youtube.test.ts — add test cases for empty video ID URLs to prevent accepting invalid inputs.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/utils/__tests__/youtube.test.ts
Line: 53-67

Comment:
Missing edge case: empty video ID URLs

The test suite covers valid and invalid URLs thoroughly, but one important edge case is missing: URLs with empty video IDs (e.g., `https://www.youtube.com/watch?v=`, `https://youtu.be/`).

Because `YOUTUBE_URL_REGEX` uses `([^#&?]*)` (zero-or-more quantifier), these URLs **will pass** `isValidYouTubeUrl` and return `true`, even though they don't point to a real video. In the current code flow, such URLs would then be passed to YouTube's oEmbed API (line 18 in route.ts), which would fail, resulting in a "Could not load preview" error instead of being rejected upfront by the validator.

Adding these cases to the invalid URLs block would ensure the validator properly rejects malformed YouTube URLs:

```suggestion
    it.each([
      ['https://vimeo.com/123456789'],
      ['https://dailymotion.com/video/x7tgad0'],
      ['https://www.google.com'],
      ['https://youtube.com/channel/UCtest'],
      ['https://youtube.com/playlist?list=PLtest'],
      ['not a url at all'],
      [''],
      ['https://notyoutube.com/watch?v=abc'],
      ['ftp://youtube.com/watch?v=abc'],
      ['https://www.youtube.com/watch?v='],
      ['https://www.youtube.com/live/'],
      ['https://youtu.be/'],
    ])('rejects %s', (url) => {
      expect(isValidYouTubeUrl(url)).toBe(false);
    });
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["test: add unit tests..."](https://github.com/schemalabz/opencouncil/commit/394753866403070b7f615b1925eacb161f23b95c)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->