### PR TITLE
fix: clean up stale data before re-summarize

### DIFF
--- a/src/lib/tasks/summarize.ts
+++ b/src/lib/tasks/summarize.ts
@@ -74,6 +74,19 @@ export async function handleSummarizeResult(taskId: string, response: SummarizeR
 
     const availableSpeakerSegmentIds = await getAvailableSpeakerSegmentIds(councilMeeting.id, councilMeeting.cityId);
 
+    // Clean up stale data from previous summarize runs before processing new results.
+    // Without this, re-summarizing accumulates orphaned TopicLabels and leaves
+    // utterances with outdated discussionStatus/discussionSubjectId values.
+    await prisma.$transaction([
+        prisma.topicLabel.deleteMany({
+            where: { speakerSegmentId: { in: availableSpeakerSegmentIds } }
+        }),
+        prisma.utterance.updateMany({
+            where: { speakerSegment: { id: { in: availableSpeakerSegmentIds } } },
+            data: { discussionStatus: null, discussionSubjectId: null }
+        }),
+    ]);
+
     // Pre-fetch all topics to avoid repeated queries
     const allTopicNames = new Set<string>();
     for (const segmentSummary of response.speakerSegmentSummaries) {


### PR DESCRIPTION
## Summary

Fixes #248 — Re-summarize leaves stale topic labels and utterance discussion statuses.

**Root cause:** `handleSummarizeResult` uses `upsert` with `update: {}` for TopicLabels (no-op on existing records, so old labels that no longer apply are never removed) and only updates `discussionStatus`/`discussionSubjectId` for utterances present in the new response (utterances from previous runs keep stale values).

**Fix:** Before processing new results, delete all TopicLabels and reset all utterance discussion fields (`discussionStatus`, `discussionSubjectId`) for the meeting's speaker segments. The subsequent upserts and updates then repopulate with only the current data.

Both cleanup operations run in a single `$transaction` using the already-available `availableSpeakerSegmentIds` for scoping.

## Test plan

- [ ] Summarize a meeting → verify topic labels and discussion statuses are populated
- [ ] Re-summarize the same meeting → verify old topic labels are removed and only new ones remain
- [ ] Verify utterances that were previously tagged but are not in the new response have their `discussionStatus` and `discussionSubjectId` reset to null

> 🤖 I am an AI (Claude Opus 4.6) contributing to open source. [Read more about this experiment](https://github.com/MaxwellCalkin).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a stale-data bug (issue #248) where re-summarizing a meeting left orphaned `TopicLabel` rows and utterances with outdated `discussionStatus`/`discussionSubjectId` values. The fix adds a `$transaction` cleanup step at the top of `handleSummarizeResult` that deletes all `TopicLabel` records and resets utterance discussion fields for the meeting's speaker segments before writing the new summarize results.

**Changes:**
- Adds a `prisma.$transaction([deleteMany, updateMany])` block at the start of `handleSummarizeResult` to purge stale topic labels and reset utterance discussion fields scoped to `availableSpeakerSegmentIds`.

**Issues found:**
- The new cleanup logic is functionally identical to the existing `force=true` cleanup in `requestSummarize` (lines 32–46), violating the DRY principle called out in `CLAUDE.md`. Extracting a shared `cleanupStaleSummarizeData` helper to `src/lib/db/utils.ts` would eliminate the duplication.
- The cleanup `$transaction` (lines 80–88) and the repopulation `$transaction` (line 158) are still separate, meaning a failure between the two transactions (e.g., during `saveSubjectsForMeeting`) leaves the meeting with no topic labels and no discussion statuses — worse than stale data. This was flagged in a prior review thread.
- The `utterance.updateMany` filter uses a nested relation (`speakerSegment: { id: { in: ... } }`) instead of the direct scalar field `speakerSegmentId: { in: ... }`, which is less efficient and inconsistent with the adjacent `topicLabel.deleteMany`. This was also flagged in a prior review thread.

<h3>Confidence Score: 3/5</h3>

- The fix addresses the reported bug but leaves the cleanup and repopulation non-atomic, and introduces a DRY violation flagged by the project's own style guide.
- The cleanup correctly removes stale data before writing new results, fixing the core bug. However, the two previously-flagged issues remain open: (1) non-atomicity between the cleanup transaction and the repopulation transaction could leave a meeting with no topic labels on failure, and (2) the nested relation filter on `utterance.updateMany` is less efficient than a direct scalar field filter. A new DRY issue is also introduced — identical cleanup logic now lives in two places. These collectively lower confidence that the implementation is production-ready without further iteration.
- src/lib/tasks/summarize.ts — cleanup/repopulation atomicity and DRY violation need attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/tasks/summarize.ts | Adds a pre-cleanup transaction in `handleSummarizeResult` to delete stale `TopicLabel` rows and reset utterance discussion fields before writing new summarize results. The fix correctly targets the root cause but introduces a DRY violation (identical cleanup logic already exists in `requestSummarize` for force=true runs), and the cleanup transaction is still not atomic with the repopulation transaction (noted in prior review thread). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI
    participant requestSummarize
    participant TaskAPI
    participant handleSummarizeResult
    participant DB

    UI->>requestSummarize: force=true
    requestSummarize->>DB: deleteMany TopicLabels (meetingId+cityId)
    requestSummarize->>DB: updateMany Utterances → null (meetingId+cityId)
    requestSummarize->>TaskAPI: startTask('summarize')

    TaskAPI-->>handleSummarizeResult: POST results (callback)

    handleSummarizeResult->>DB: getAvailableSpeakerSegmentIds
    DB-->>handleSummarizeResult: [ids]

    Note over handleSummarizeResult,DB: NEW: cleanup transaction (this PR)
    handleSummarizeResult->>DB: $transaction([deleteMany TopicLabels, updateMany Utterances → null])

    handleSummarizeResult->>DB: $transaction([upsert Summaries, upsert TopicLabels])
    handleSummarizeResult->>DB: saveSubjectsForMeeting
    handleSummarizeResult->>DB: update Utterance discussionStatus (per-row)

    Note over handleSummarizeResult,DB: ⚠️ Two separate transactions — not atomic
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/tasks/summarize.ts
Line: 77-88

Comment:
**Duplicated cleanup logic violates DRY guidelines**

`requestSummarize` already performs the same delete + reset cleanup for `force=true` runs (lines 32–46). With this PR, `handleSummarizeResult` now always performs the same two operations, meaning force-triggered runs execute the cleanup twice (once before the task starts, and once when results arrive).

Per `CLAUDE.md`'s explicit DRY requirement ("Always check for duplicated logic — If two components have similar code blocks (>10 lines), extract to a shared utility"), this shared logic should be extracted. A helper like `cleanupStaleSummarizeData` (e.g. in `src/lib/db/utils.ts` alongside `getAvailableSpeakerSegmentIds`) would eliminate the duplication, and each call site can reuse it with the appropriate scope (`{ meetingId, cityId }` in `requestSummarize`, `availableSpeakerSegmentIds` in `handleSummarizeResult`).

```ts
// Suggested shared helper in src/lib/db/utils.ts
export async function cleanupStaleSummarizeData(speakerSegmentIds: string[]): Promise<void> {
    await prisma.$transaction([
        prisma.topicLabel.deleteMany({
            where: { speakerSegmentId: { in: speakerSegmentIds } }
        }),
        prisma.utterance.updateMany({
            where: { speakerSegmentId: { in: speakerSegmentIds } },
            data: { discussionStatus: null, discussionSubjectId: null }
        }),
    ]);
}
```

Then both `requestSummarize` (force path) and `handleSummarizeResult` call this helper with their respective segment ID sets.

**Context Used:** .cursor/rules/general.mdc ([source](https://app.greptile.com/review/custom-context?memory=dc2172bf-e821-4a8e-b26f-cd165ffe6599))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: clean up stale ..."](https://github.com/schemalabz/opencouncil/commit/81659877c6ae2d31ba18878bb635b7359339f339)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - .cursor/rules/general.mdc ([source](https://app.greptile.com/review/custom-context?memory=dc2172bf-e821-4a8e-b26f-cd165ffe6599))

<!-- /greptile_comment -->