### PR TITLE
feat: refactor notification onboarding flow

### DIFF
--- a/src/app/[locale]/(city)/[cityId]/(other)/notifications/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/notifications/page.tsx
@@ -17,7 +17,7 @@ interface PageProps {
 export default async function NotificationSignupPage({ params }: PageProps) {
     // Fetch city data with geometry at the server level
     const city = await getCity(params.cityId, { includeGeometry: true });
-    
+
     if (!city) {
         notFound();
     }
@@ -33,8 +33,8 @@ export default async function NotificationSignupPage({ params }: PageProps) {
                 <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
             </div>
         }>
-            <OnboardingPageContent 
-                initialStage={OnboardingStage.NOTIFICATION_INFO} 
+            <OnboardingPageContent
+                initialStage={OnboardingStage.NOTIFICATION_INFO}
                 cityId={params.cityId}
                 city={city}
             />

--- a/src/components/cities/CityHeader.tsx
+++ b/src/components/cities/CityHeader.tsx
@@ -21,6 +21,9 @@ import CityCreator from '@/components/cities/CityCreator';
 import { OfficialSupportBadge } from '@/components/cities/OfficialSupportBadge';
 import { IS_DEV } from '@/lib/utils';
 import { useToast } from '@/hooks/use-toast';
+import { FormContainer } from '@/components/onboarding/containers/FormContainer';
+import { OnboardingProvider } from '@/contexts/OnboardingContext';
+import { OnboardingStage } from '@/lib/types/onboarding';
 
 type CityHeaderProps = {
     city: City,
@@ -37,6 +40,12 @@ export function CityHeader({ city, councilMeetingsCount, cityMessage, hasNoData 
     const [canEdit, setCanEdit] = useState(false);
     const [hasNotifications, setHasNotifications] = useState(false);
     const [isResetting, setIsResetting] = useState(false);
+    const [currentStep, setCurrentStep] = useState(1);
+    const [formData, setFormData] = useState({
+        step1: '',
+        step2: '',
+        step3: ''
+    });
     const router = useRouter();
     const { data: session } = useSession();
     const { toast } = useToast();
@@ -88,6 +97,26 @@ export function CityHeader({ city, councilMeetingsCount, cityMessage, hasNoData 
         setIsCityCreatorOpen(false);
         // Refresh the page to show the updated city
         window.location.reload();
+    };
+
+    const handleNextStep = () => {
+        if (currentStep < 3) {
+            setCurrentStep(currentStep + 1);
+        }
+    };
+
+    const handlePreviousStep = () => {
+        if (currentStep > 1) {
+            setCurrentStep(currentStep - 1);
+        }
+    };
+
+    const handleFormSubmit = () => {
+        console.log('Form submitted:', formData);
+        toast({
+            title: "Form submitted successfully",
+            description: "Your 3-step form has been completed.",
+        });
     };
 
     const handleResetCity = async () => {
@@ -235,26 +264,24 @@ export function CityHeader({ city, councilMeetingsCount, cityMessage, hasNoData 
                             </Button>
                         )}
                     </div>
-                    {city.supportsNotifications && (
-                        <Button
-                            onClick={handleNotificationSignup}
-                            size="xl"
-                            className="group transition-all duration-300"
-                        >
-                            <div className="relative z-10 flex items-center gap-2">
-                                <Bell className="w-5 h-5" />
-                                <span className="font-medium">
-                                    {hasNotifications ? 'Διαχείριση ειδοποιήσεων' : 'Ενεργοποίηση ειδοποιήσεων'}
-                                </span>
-                            </div>
-                            <motion.div
-                                className="absolute inset-0 rounded-xl bg-[hsl(var(--orange))] opacity-0 group-hover:opacity-10 transition-opacity"
-                                whileHover={{
-                                    boxShadow: "0 0 30px rgba(var(--orange), 0.5)"
-                                }}
-                            />
-                        </Button>
-                    )}
+                    <Button
+                        onClick={handleNotificationSignup}
+                        size="xl"
+                        className="group transition-all duration-300"
+                    >
+                        <div className="relative z-10 flex items-center gap-2">
+                            <Bell className="w-5 h-5" />
+                            <span className="font-medium">
+                                {hasNotifications ? 'Διαχείριση ειδοποιήσεων' : 'Ενεργοποίηση ειδοποιήσεων'}
+                            </span>
+                        </div>
+                        <motion.div
+                            className="absolute inset-0 rounded-xl bg-[hsl(var(--orange))] opacity-0 group-hover:opacity-10 transition-opacity"
+                            whileHover={{
+                                boxShadow: "0 0 30px rgba(var(--orange), 0.5)"
+                            }}
+                        />
+                    </Button>
                     {city.status !== 'pending' && !city.officialSupport && (
                         <Button
                             onClick={() => router.push(`/${city.id}/petition`)}
@@ -303,8 +330,12 @@ export function CityHeader({ city, councilMeetingsCount, cityMessage, hasNoData 
                 </motion.div>
             )}
 
+            <OnboardingProvider city={city} initialStage={OnboardingStage.NOTIFICATION_TOPIC_SELECTION} >
+                <FormContainer />
+            </OnboardingProvider>
+
             {/* Search Section */}
-            <motion.form
+            {/* <motion.form
                 onSubmit={handleSearch}
                 className="relative mb-8 md:mb-12 max-w-2xl mx-auto"
                 initial={{ opacity: 0, y: 20 }}
@@ -318,7 +349,7 @@ export function CityHeader({ city, councilMeetingsCount, cityMessage, hasNoData 
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                 />
-            </motion.form>
+            </motion.form> */}
         </>
     );
 } 

--- a/src/components/onboarding/OnboardingFooter.tsx
+++ b/src/components/onboarding/OnboardingFooter.tsx
@@ -31,7 +31,7 @@ export function OnboardingFooter({
             onClick={onBack}
             className="text-muted-foreground hover:text-primary h-11 md:h-10 px-4 md:px-3 touch-manipulation"
           >
-            Πίσω
+            Προηγούμενο βήμα
           </Button>
         )}
       </div>
@@ -46,8 +46,8 @@ export function OnboardingFooter({
               idx === currentStep
                 ? 'bg-primary w-8 md:w-8 shadow-lg'
                 : idx < currentStep
-                ? 'bg-primary/50 w-6 md:w-6'
-                : 'bg-muted-foreground/30 w-4 md:w-4'
+                  ? 'bg-primary/50 w-6 md:w-6'
+                  : 'bg-muted-foreground/30 w-4 md:w-4'
             )}
           />
         ))}

--- a/src/components/onboarding/OnboardingStepTemplate.tsx
+++ b/src/components/onboarding/OnboardingStepTemplate.tsx
@@ -9,7 +9,7 @@ interface OnboardingStepTemplateProps {
 
 export function OnboardingStepTemplate({ title, description, children, footer }: OnboardingStepTemplateProps) {
   return (
-    <div className="flex flex-col h-full w-full max-w-md mx-auto bg-white pt-4 md:pt-6">
+    <div className="flex flex-col h-full w-full mx-auto pt-4 md:pt-6">
       {/* Header section */}
       <div className="flex-none px-4 md:px-6 lg:px-8 pb-2">
         <h2 className="text-lg md:text-xl font-bold mb-1 text-primary">{title}</h2>
@@ -17,7 +17,7 @@ export function OnboardingStepTemplate({ title, description, children, footer }:
       </div>
 
       {/* Scrollable content section */}
-      <div className="flex-1 overflow-y-auto overscroll-contain p-4 px-4 md:px-6 lg:px-8 pb-2">
+      <div className="flex-1 p-4 px-4 md:px-6 lg:px-8 p-2">
         {children}
       </div>
 

--- a/src/components/onboarding/containers/FormContainer.tsx
+++ b/src/components/onboarding/containers/FormContainer.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { useOnboarding } from '@/contexts/OnboardingContext';
 import { cn } from '@/lib/utils';
+import { CollapsibleCard } from '@/components/ui/collapsible-card';
 import { NotificationLocationStep } from '../steps/notification/NotificationLocationStep';
 import { NotificationTopicStep } from '../steps/notification/NotificationTopicStep';
 import { NotificationRegistrationStep } from '../steps/notification/NotificationRegistrationStep';
@@ -13,7 +14,6 @@ import { OnboardingStage, getCurrentFlow, getCurrentStep } from '@/lib/types/onb
 import { useRouter } from 'next/navigation';
 import { useMediaQuery } from '@/hooks/use-media-query';
 import { PetitionFormStep } from '../steps/petition/PetitionFormStep';
-import { NotificationInfoStep } from '../steps/notification/NotificationInfoStep';
 
 export function FormContainer() {
     const {
@@ -53,15 +53,6 @@ export function FormContainer() {
 
     const renderNotificationStep = () => {
         switch (stage) {
-            case OnboardingStage.NOTIFICATION_INFO:
-                return (
-                    <NotificationInfoStep
-                        currentStep={currentFlow.getProgressStepIndex(stage)}
-                        totalSteps={currentFlow.getProgressStepCount()}
-                        onBack={handleBack}
-                        onContinue={handleNext}
-                    />
-                );
             case OnboardingStage.NOTIFICATION_LOCATION_SELECTION:
                 return (
                     <NotificationLocationStep
@@ -149,28 +140,18 @@ export function FormContainer() {
     if (!isFormVisible) return null;
 
     return (
-        <div
-            className={cn(
-                "absolute z-10 transition-all duration-300 ease-in-out",
-                "fixed top-20 md:top-24 bottom-4 md:bottom-8 mx-auto w-[95%] md:w-[90%] max-w-md rounded-xl shadow-2xl overflow-hidden bg-white/95 backdrop-blur-sm",
-                isDesktop ? "left-4" : "left-1/2 -translate-x-1/2",
-                "safe-area-inset-top safe-area-inset-bottom"
-            )}
-        >
-            <div className={cn(
-                "w-full h-full",
-                !isDesktop && "space-y-6"
-            )}>
+        <CollapsibleCard title="Ειδοποιήσεις" defaultOpen>
+            <div className={cn("w-full", !isDesktop && "space-y-6")}>
                 {isLoading ? (
                     <div className="w-full h-40 flex items-center justify-center">
                         <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-primary"></div>
                     </div>
                 ) : (
-                    <div className="w-full h-full">
+                    <div className="w-full">
                         {renderStep()}
                     </div>
                 )}
             </div>
-        </div>
+        </CollapsibleCard>
     );
 } 

--- a/src/components/onboarding/selectors/LocationSelector.tsx
+++ b/src/components/onboarding/selectors/LocationSelector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { X, MapPin, AlertCircle, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -9,6 +9,7 @@ import { getPlaceSuggestions, getPlaceDetails, PlaceSuggestion, PlaceSuggestions
 import { useDebounce } from '@/hooks/use-debounce';
 import { cn, calculateGeometryBounds } from '@/lib/utils';
 import { CityWithGeometry } from '@/lib/db/cities';
+import Map, { MapFeature } from '@/components/map/map';
 
 interface LocationSelectorProps {
     selectedLocations: Location[];
@@ -16,6 +17,7 @@ interface LocationSelectorProps {
     onRemove: (index: number) => void;
     city: CityWithGeometry;
     onLocationClick?: (location: Location) => void;
+    quickSuggestions?: string[];
 }
 
 export function LocationSelector({
@@ -23,7 +25,8 @@ export function LocationSelector({
     onSelect,
     onRemove,
     city,
-    onLocationClick
+    onLocationClick,
+    quickSuggestions = ['Κουκάκι', 'Παγκράτι'],
 }: LocationSelectorProps) {
     const [inputValue, setInputValue] = useState('');
     const [suggestions, setSuggestions] = useState<PlaceSuggestion[]>([]);
@@ -31,6 +34,7 @@ export function LocationSelector({
     const [isSelectingLocation, setIsSelectingLocation] = useState(false);
     const [isWaitingForDebounce, setIsWaitingForDebounce] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [zoomToGeometry, setZoomToGeometry] = useState<GeoJSON.Geometry | null>(null);
     const inputRef = useRef<HTMLInputElement>(null);
 
     // Debounce the input value to avoid making too many API calls
@@ -107,6 +111,38 @@ export function LocationSelector({
         fetchSuggestions();
     }, [debouncedInputValue, city.name, city.geometry, getErrorMessage]);
 
+    const mapFeatures = useMemo(() => {
+        const cityFeature: MapFeature = {
+            id: city.id,
+            geometry: city.geometry,
+            style: { fillColor: '#627BBC', fillOpacity: 0.2, strokeColor: '#4263EB', strokeWidth: 2 }
+        };
+        const locationFeatures = selectedLocations
+            .map((loc, i) => {
+                const lng = parseFloat(String(loc.coordinates[0]));
+                const lat = parseFloat(String(loc.coordinates[1]));
+                if (isNaN(lng) || isNaN(lat) || !isFinite(lng) || !isFinite(lat)) return null;
+                return {
+                    id: `location-${i}`,
+                    geometry: { type: 'Point' as const, coordinates: [lng, lat] as [number, number] },
+                    style: { fillColor: '#EF4444', fillOpacity: 0.8, strokeColor: '#B91C1C', strokeWidth: 6 }
+                } satisfies MapFeature;
+            })
+            .filter(Boolean) as MapFeature[];
+        return [cityFeature, ...locationFeatures];
+    }, [city, selectedLocations]);
+
+    const { center: mapCenter, zoom: mapZoom } = useMemo(() => {
+        if (!city.geometry) return { center: [23.7275, 37.9838] as [number, number], zoom: 6 };
+        const { bounds, center } = calculateGeometryBounds(city.geometry);
+        let zoom = 10;
+        if (bounds) {
+            const maxDiff = Math.max(bounds.maxLng - bounds.minLng, bounds.maxLat - bounds.minLat);
+            zoom = Math.max(8, Math.min(13, 11 - Math.log2(maxDiff * 111)));
+        }
+        return { center, zoom };
+    }, [city.geometry]);
+
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const newValue = e.target.value;
         setInputValue(newValue);
@@ -137,6 +173,10 @@ export function LocationSelector({
                 };
 
                 onSelect(location);
+                setZoomToGeometry({
+                    type: 'Point',
+                    coordinates: [placeDetails.coordinates[0], placeDetails.coordinates[1]]
+                });
                 setInputValue('');
                 setSuggestions([]);
                 setIsWaitingForDebounce(false);
@@ -152,117 +192,146 @@ export function LocationSelector({
     };
 
     return (
-        <div className="space-y-5">
-            <div className="relative">
-                <div className="flex items-center gap-2">
-                    <div className="relative flex-1">
-                        <MapPin className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-500" />
-                        <Input
-                            ref={inputRef}
-                            type="text"
-                            inputMode="search"
-                            autoComplete="off"
-                            data-1p-ignore
-                            data-lpignore="true"
-                            data-form-type="other"
-                            placeholder={`Αναζητήστε διεύθυνση στον δήμο ${city.name}...`}
-                            className={`pl-10 py-5 text-base md:text-sm ${(isLoadingSuggestions || isSelectingLocation || isWaitingForDebounce) ? 'pr-10' : ''}`}
-                            value={inputValue}
-                            onChange={handleInputChange}
-                            disabled={isSelectingLocation}
-                        />
-                        {(isLoadingSuggestions || isSelectingLocation || isWaitingForDebounce) && (
-                            <div className="absolute right-3 top-1/2 transform -translate-y-1/2 pointer-events-none z-10">
-                                <Loader2 className="h-5 w-5 md:h-4 md:w-4 animate-spin text-primary" />
-                            </div>
-                        )}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 items-start">
+            {/* Column 1: search + selected locations */}
+            <div className="space-y-4">
+                <div className="relative">
+                    <div className="flex items-center gap-2">
+                        <div className="relative flex-1">
+                            <MapPin className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-500" />
+                            <Input
+                                ref={inputRef}
+                                type="text"
+                                inputMode="search"
+                                autoComplete="off"
+                                data-1p-ignore
+                                data-lpignore="true"
+                                data-form-type="other"
+                                placeholder={`Αναζητήστε διεύθυνση στον δήμο ${city.name}...`}
+                                className={`pl-10 py-5 text-base md:text-sm ${(isLoadingSuggestions || isSelectingLocation || isWaitingForDebounce) ? 'pr-10' : ''}`}
+                                value={inputValue}
+                                onChange={handleInputChange}
+                                disabled={isSelectingLocation}
+                            />
+                            {(isLoadingSuggestions || isSelectingLocation || isWaitingForDebounce) && (
+                                <div className="absolute right-3 top-1/2 transform -translate-y-1/2 pointer-events-none z-10">
+                                    <Loader2 className="h-5 w-5 md:h-4 md:w-4 animate-spin text-primary" />
+                                </div>
+                            )}
+                        </div>
+                        <Button
+                            variant="outline"
+                            size="icon"
+                            onClick={() => {
+                                setInputValue('');
+                                setError(null);
+                                setIsWaitingForDebounce(false);
+                                setSuggestions([]);
+                            }}
+                            className={cn(
+                                "transition-opacity h-11 w-11 md:h-10 md:w-10 touch-manipulation",
+                                inputValue ? "opacity-100" : "opacity-0"
+                            )}
+                            disabled={!inputValue}
+                        >
+                            <X className="h-5 w-5 md:h-4 md:w-4" />
+                        </Button>
                     </div>
-                    <Button
-                        variant="outline"
-                        size="icon"
-                        onClick={() => {
-                            setInputValue('');
-                            setError(null);
-                            setIsWaitingForDebounce(false);
-                            setSuggestions([]);
-                        }}
-                        className={cn(
-                            "transition-opacity h-11 w-11 md:h-10 md:w-10 touch-manipulation",
-                            inputValue ? "opacity-100" : "opacity-0"
-                        )}
-                        disabled={!inputValue}
-                    >
-                        <X className="h-5 w-5 md:h-4 md:w-4" />
-                    </Button>
+
+                    {!inputValue && quickSuggestions.length > 0 && (
+                        <div className="flex gap-2 mt-2 flex-wrap">
+                            {quickSuggestions.map((s) => (
+                                <button
+                                    key={s}
+                                    type="button"
+                                    onClick={() => setInputValue(s)}
+                                    className="text-xs px-3 py-1.5 rounded-full border border-gray-300 bg-white hover:border-primary hover:text-primary transition-colors text-muted-foreground"
+                                >
+                                    {s}
+                                </button>
+                            ))}
+                        </div>
+                    )}
+
+                    {error && (
+                        <div className="mt-2 p-2 bg-red-50 border border-red-200 rounded-md text-sm flex items-center gap-2 text-red-600">
+                            <AlertCircle className="h-4 w-4 flex-shrink-0" />
+                            <p>{error}</p>
+                        </div>
+                    )}
+
+                    {suggestions.length > 0 && (
+                        <div className="absolute z-10 mt-2 w-full bg-white rounded-md shadow-lg max-h-60 overflow-auto border border-gray-200">
+                            <ul className="py-1">
+                                {suggestions.map((suggestion) => (
+                                    <li
+                                        key={suggestion.id}
+                                        className={cn(
+                                            "px-4 py-4 md:py-3 hover:bg-gray-50 active:bg-gray-100 flex items-center gap-3 border-b last:border-b-0 border-gray-100 touch-manipulation min-h-[48px] md:min-h-0",
+                                            isSelectingLocation ? "cursor-not-allowed opacity-50" : "cursor-pointer"
+                                        )}
+                                        onClick={() => !isSelectingLocation && handleSelectLocation(suggestion)}
+                                    >
+                                        <MapPin className="h-5 w-5 md:h-4 md:w-4 text-primary flex-shrink-0" />
+                                        <span className="line-clamp-2 text-base md:text-sm">{suggestion.text}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
                 </div>
 
-                {error && (
-                    <div className="mt-2 p-2 bg-red-50 border border-red-200 rounded-md text-sm flex items-center gap-2 text-red-600">
-                        <AlertCircle className="h-4 w-4 flex-shrink-0" />
-                        <p>{error}</p>
-                    </div>
-                )}
-
-                {suggestions.length > 0 && (
-                    <div className="absolute z-10 mt-2 w-full bg-white rounded-md shadow-lg max-h-60 overflow-auto border border-gray-200">
-                        <ul className="py-1">
-                            {suggestions.map((suggestion) => (
-                                <li
-                                    key={suggestion.id}
-                                    className={cn(
-                                        "px-4 py-4 md:py-3 hover:bg-gray-50 active:bg-gray-100 flex items-center gap-3 border-b last:border-b-0 border-gray-100 touch-manipulation min-h-[48px] md:min-h-0",
-                                        isSelectingLocation ? "cursor-not-allowed opacity-50" : "cursor-pointer"
-                                    )}
-                                    onClick={() => !isSelectingLocation && handleSelectLocation(suggestion)}
+                {selectedLocations.length > 0 ? (
+                    <div>
+                        <div className="text-sm font-medium text-gray-700 mb-2">Επιλεγμένες τοποθεσίες ({selectedLocations.length})</div>
+                        <div className="grid grid-cols-1 gap-2">
+                            {selectedLocations.map((location, index) => (
+                                <div
+                                    key={`loc-${index}`}
+                                    className={`flex items-center justify-between p-3 bg-white rounded-lg border border-gray-200 hover:border-primary/40 hover:bg-primary/5 transition-colors group ${onLocationClick ? 'cursor-pointer' : ''}`}
+                                    onClick={() => onLocationClick?.(location)}
                                 >
-                                    <MapPin className="h-5 w-5 md:h-4 md:w-4 text-primary flex-shrink-0" />
-                                    <span className="line-clamp-2 text-base md:text-sm">{suggestion.text}</span>
-                                </li>
+                                    <div className="flex items-center gap-2 min-w-0">
+                                        <MapPin className="h-4 w-4 text-primary flex-shrink-0" />
+                                        <div className="truncate text-sm font-medium">{location.text}</div>
+                                    </div>
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        className="h-11 md:h-7 px-3 md:px-2 text-xs text-red-600 hover:text-red-700 hover:bg-red-50 rounded-full flex-shrink-0 opacity-80 group-hover:opacity-100 touch-manipulation min-w-[88px] md:min-w-0"
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            onRemove(index);
+                                        }}
+                                    >
+                                        <X className="h-4 w-4 md:h-3 md:w-3 mr-1" />
+                                        <span className="hidden sm:inline">Αφαίρεση</span>
+                                        <span className="sm:hidden">Αφαίρ.</span>
+                                    </Button>
+                                </div>
                             ))}
-                        </ul>
+                        </div>
+                    </div>
+                ) : (
+                    <div className="text-center p-6 border border-dashed border-gray-300 rounded-lg bg-gray-50">
+                        <MapPin className="h-8 w-8 mx-auto text-gray-400 mb-2" />
+                        <p className="text-gray-500 text-sm">Δεν έχετε επιλέξει τοποθεσίες ακόμα.</p>
+                        <p className="text-gray-500 text-xs mt-1">Χρησιμοποιήστε την αναζήτηση για να προσθέσετε τοποθεσίες ενδιαφέροντος.</p>
                     </div>
                 )}
             </div>
 
-            {selectedLocations.length > 0 ? (
-                <div className="mt-4">
-                    <div className="text-sm font-medium text-gray-700 mb-2">Επιλεγμένες τοποθεσίες ({selectedLocations.length})</div>
-                    <div className="grid grid-cols-1 gap-2">
-                        {selectedLocations.map((location, index) => (
-                            <div
-                                key={`loc-${index}`}
-                                className={`flex items-center justify-between p-3 bg-white rounded-lg border border-gray-200 hover:border-primary/40 hover:bg-primary/5 transition-colors group ${onLocationClick ? 'cursor-pointer' : ''
-                                    }`}
-                                onClick={() => onLocationClick?.(location)}
-                            >
-                                <div className="flex items-center gap-2 min-w-0">
-                                    <MapPin className="h-4 w-4 text-primary flex-shrink-0" />
-                                    <div className="truncate text-sm font-medium">{location.text}</div>
-                                </div>
-                                <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    className="h-11 md:h-7 px-3 md:px-2 text-xs text-red-600 hover:text-red-700 hover:bg-red-50 rounded-full flex-shrink-0 opacity-80 group-hover:opacity-100 touch-manipulation min-w-[88px] md:min-w-0"
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        onRemove(index);
-                                    }}
-                                >
-                                    <X className="h-4 w-4 md:h-3 md:w-3 mr-1" />
-                                    <span className="hidden sm:inline">Αφαίρεση</span>
-                                    <span className="sm:hidden">Αφαίρ.</span>
-                                </Button>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            ) : (
-                <div className="mt-6 text-center p-6 border border-dashed border-gray-300 rounded-lg bg-gray-50">
-                    <MapPin className="h-8 w-8 mx-auto text-gray-400 mb-2" />
-                    <p className="text-gray-500 text-sm">Δεν έχετε επιλέξει τοποθεσίες ακόμα.</p>
-                    <p className="text-gray-500 text-xs mt-1">Χρησιμοποιήστε την αναζήτηση για να προσθέσετε τοποθεσίες ενδιαφέροντος.</p>
-                </div>
-            )}
+            {/* Column 2: map */}
+            <div className="col-span-1 rounded-lg overflow-hidden border border-gray-200 h-full min-h-48">
+                <Map
+                    features={mapFeatures}
+                    center={mapCenter}
+                    zoom={mapZoom}
+                    animateRotation={false}
+                    zoomToGeometry={zoomToGeometry}
+                    className="w-full h-full"
+                />
+            </div>
         </div>
     );
 } 

--- a/src/components/onboarding/selectors/TopicSelector.tsx
+++ b/src/components/onboarding/selectors/TopicSelector.tsx
@@ -149,7 +149,7 @@ export function TopicSelector({
                                 </Button>
                             )}
                         </div>
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                        <div className="grid md:grid-cols-3 sm:grid-cols-2 grid-cols-1 gap-4">
                             {topics.map(topic => {
                                 const isSelected = isTopicSelected(topic);
                                 return (
@@ -183,9 +183,6 @@ export function TopicSelector({
                                             </div>
                                             <div className="flex flex-col items-start overflow-hidden flex-1">
                                                 <span className="font-medium truncate w-full">{topic.name}</span>
-                                                {topic.name_en && (
-                                                    <span className="text-xs text-gray-500 truncate w-full">{topic.name_en}</span>
-                                                )}
                                             </div>
                                             {isSelected && (
                                                 <motion.div

--- a/src/components/onboarding/steps/notification/NotificationLocationStep.tsx
+++ b/src/components/onboarding/steps/notification/NotificationLocationStep.tsx
@@ -1,9 +1,13 @@
-import React from 'react';
+'use client';
+
+import React, { useEffect, useState } from 'react';
 import { useOnboarding } from '@/contexts/OnboardingContext';
 import { LocationSelector } from '@/components/onboarding/selectors/LocationSelector';
 import { Location } from '@/lib/types/onboarding';
 import { OnboardingStepTemplate } from '@/components/onboarding/OnboardingStepTemplate';
 import { OnboardingFooter } from '@/components/onboarding/OnboardingFooter';
+import { getSubjectsNearLocations, NearbySubject } from '@/lib/actions';
+import { Loader2 } from 'lucide-react';
 
 interface NotificationLocationStepProps {
   currentStep: number;
@@ -19,6 +23,21 @@ export function NotificationLocationStep({ currentStep, totalSteps, onBack, onCo
     setSelectedLocations,
   } = useOnboarding();
 
+  const [nearbySubjects, setNearbySubjects] = useState<NearbySubject[]>([]);
+  const [isLoadingSubjects, setIsLoadingSubjects] = useState(false);
+
+  useEffect(() => {
+    if (selectedLocations.length === 0) {
+      setNearbySubjects([]);
+      return;
+    }
+
+    setIsLoadingSubjects(true);
+    getSubjectsNearLocations(selectedLocations.map(l => l.coordinates))
+      .then(setNearbySubjects)
+      .finally(() => setIsLoadingSubjects(false));
+  }, [selectedLocations]);
+
   if (!city) return null;
 
   const handleLocationSelect = (location: Location) => {
@@ -31,7 +50,7 @@ export function NotificationLocationStep({ currentStep, totalSteps, onBack, onCo
 
   return (
     <OnboardingStepTemplate
-      title="Τοποθεσίες ενδιαφέροντος"
+      title="Σε ενδιαφέρει κάποια τοποθεσία;"
       description={`Επιλέξτε τοποθεσίες στον δήμο για τις οποίες θέλετε να λαμβάνετε ενημερώσεις`}
       footer={
         <OnboardingFooter
@@ -39,18 +58,57 @@ export function NotificationLocationStep({ currentStep, totalSteps, onBack, onCo
           totalSteps={totalSteps}
           onBack={onBack}
           onAction={onContinue}
-          actionLabel="Συνέχεια"
+          actionLabel="Επόμενο βήμα"
         />
       }
     >
-      <div className="flex flex-col gap-6 w-full max-w-md">
+      <div className="flex flex-col gap-6 w-full">
         <LocationSelector
           selectedLocations={selectedLocations}
           onSelect={handleLocationSelect}
           onRemove={handleLocationRemove}
           city={city}
         />
+
+        {selectedLocations.length > 0 && (
+          <div className="space-y-2">
+            <div className="text-sm font-medium text-gray-700">
+              Θέματα που συζητήθηκαν κοντά στις τοποθεσίες σας
+            </div>
+            {isLoadingSubjects ? (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="h-5 w-5 animate-spin text-primary" />
+              </div>
+            ) : nearbySubjects.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-2">
+                Δεν βρέθηκαν θέματα κοντά στις επιλεγμένες τοποθεσίες.
+              </p>
+            ) : (
+              <ul className="space-y-1.5">
+                {nearbySubjects.map(subject => (
+                  <li
+                    key={subject.id}
+                    className="flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm"
+                  >
+                    {subject.topic && (
+                      <span
+                        className="h-2.5 w-2.5 flex-shrink-0 rounded-full"
+                        style={{ backgroundColor: subject.topic.colorHex }}
+                      />
+                    )}
+                    <span className="flex-1 truncate">{subject.name}</span>
+                    {subject.meetingDate && (
+                      <span className="flex-shrink-0 text-xs text-muted-foreground">
+                        {new Date(subject.meetingDate).toLocaleDateString('el-GR', { month: 'short', year: 'numeric' })}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
       </div>
     </OnboardingStepTemplate>
   );
-} 
+}

--- a/src/components/onboarding/steps/notification/NotificationTopicStep.tsx
+++ b/src/components/onboarding/steps/notification/NotificationTopicStep.tsx
@@ -1,8 +1,12 @@
+'use client';
+
 import React from 'react';
 import { useOnboarding } from '@/contexts/OnboardingContext';
 import { TopicSelector } from '@/components/onboarding/selectors/TopicSelector';
 import { OnboardingStepTemplate } from '@/components/onboarding/OnboardingStepTemplate';
 import { OnboardingFooter } from '@/components/onboarding/OnboardingFooter';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Info } from 'lucide-react';
 import { Topic } from '@prisma/client';
 
 interface NotificationTopicStepProps {
@@ -32,19 +36,34 @@ export function NotificationTopicStep({ currentStep, totalSteps, onBack, onConti
 
   return (
     <OnboardingStepTemplate
-      title="Θέματα ενδιαφέροντος"
-      description="Επιλέξτε θέματα για τα οποία θέλετε να λαμβάνετε ενημερώσεις"
+      title="Μείνετε συντονισμένοι!"
+      description={
+        <span className="flex items-center gap-1.5">
+          Επιλέξτε τις κατηγορίες για θέματα που σας ενδιαφέρουν για να λαμβάνετε προσωποποιημένες ειδοποιήσεις.
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Info className="h-4 w-4 flex-shrink-0 text-muted-foreground cursor-help" />
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs text-sm">
+                <p>Με βάση αυτές τις επιλογές και τις επιλογές που σε ενδιαφέρουν, θα λαμβάνεις ενημερώσεις στο email ή το κινητό σου, με όσα πραγματικά έχουν σημασία για εσένα.</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </span>
+      }
       footer={
         <OnboardingFooter
           currentStep={currentStep}
           totalSteps={totalSteps}
           onBack={onBack}
           onAction={onContinue}
-          actionLabel="Συνέχεια"
+          actionLabel="Επόμενο βήμα"
+          hideBack
         />
       }
     >
-      <div className="flex flex-col gap-6 w-full max-w-md">
+      <div className="flex flex-col gap-6 w-full">
         <TopicSelector
           selectedTopics={selectedTopics}
           onSelect={handleTopicSelect}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -3,6 +3,55 @@
 import axios from 'axios';
 import { env } from '@/env.mjs';
 import { Result, createSuccess, createError } from '@/lib/result';
+import { findNearbyLocations } from '@/lib/db/location';
+import prisma from '@/lib/db/prisma';
+
+const NEARBY_SUBJECTS_RADIUS_METERS = 1000;
+
+export type NearbySubject = {
+    id: string;
+    name: string;
+    cityId: string;
+    councilMeetingId: string;
+    topic: { name: string; colorHex: string } | null;
+    meetingDate: Date | null;
+};
+
+export async function getSubjectsNearLocations(
+    coordinates: [number, number][]
+): Promise<NearbySubject[]> {
+    const locationArrays = await Promise.all(
+        coordinates.map(coords =>
+            findNearbyLocations({ coordinates: coords, distanceInMeters: NEARBY_SUBJECTS_RADIUS_METERS })
+        )
+    );
+
+    const locationIds = [...new Set(locationArrays.flat().map(l => l.id))];
+    if (locationIds.length === 0) return [];
+
+    const subjects = await prisma.subject.findMany({
+        where: { locationId: { in: locationIds } },
+        select: {
+            id: true,
+            name: true,
+            cityId: true,
+            councilMeetingId: true,
+            topic: { select: { name: true, colorHex: true } },
+            councilMeeting: { select: { date: true } },
+        },
+        orderBy: { councilMeeting: { date: 'desc' } },
+        take: 20,
+    });
+
+    return subjects.map(s => ({
+        id: s.id,
+        name: s.name,
+        cityId: s.cityId,
+        councilMeetingId: s.councilMeetingId,
+        topic: s.topic,
+        meetingDate: s.councilMeeting?.date ?? null,
+    }));
+}
 
 // The radius to use for location-based search, in meters (40km)
 const SEARCH_RADIUS = 40000;

--- a/src/lib/types/onboarding.ts
+++ b/src/lib/types/onboarding.ts
@@ -44,9 +44,8 @@ export interface Flow {
 export const notificationFlow: Flow = {
     type: 'notification',
     steps: [
-        { id: OnboardingStage.NOTIFICATION_INFO, showInProgress: false },
-        { id: OnboardingStage.NOTIFICATION_LOCATION_SELECTION, showInProgress: true },
         { id: OnboardingStage.NOTIFICATION_TOPIC_SELECTION, showInProgress: true },
+        { id: OnboardingStage.NOTIFICATION_LOCATION_SELECTION, showInProgress: true },
         { id: OnboardingStage.NOTIFICATION_REGISTRATION, showInProgress: true },
         { id: OnboardingStage.NOTIFICATION_COMPLETE, showInProgress: false }
     ],
@@ -58,7 +57,7 @@ export const notificationFlow: Flow = {
         const currentIndex = notificationFlow.steps.findIndex(s => s.id === currentStep);
         return currentIndex > 0 ? notificationFlow.steps[currentIndex - 1].id : undefined;
     },
-    isFirstStep: (step) => step === OnboardingStage.NOTIFICATION_INFO,
+    isFirstStep: (step) => step === OnboardingStage.NOTIFICATION_TOPIC_SELECTION,
     isLastStep: (step) => step === OnboardingStage.NOTIFICATION_COMPLETE,
     getProgressStepCount: () => notificationFlow.steps.filter(step => step.showInProgress).length,
     getProgressStepIndex: (step) => {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the notification onboarding flow: it removes the introductory `NOTIFICATION_INFO` step, reorders the remaining steps so topic selection comes before location selection, embeds the `FormContainer` directly inside `CityHeader` via a `CollapsibleCard`, and enriches the location step with an inline map preview, quick-suggestion chips, and a nearby-subjects panel.

The structural refactor is solid, but several issues were introduced that need attention before merging:

- **Blank notifications page** — `notifications/page.tsx` still passes `initialStage={OnboardingStage.NOTIFICATION_INFO}`, which is no longer in the flow. `FormContainer` resolves it to `undefined` and renders nothing.
- **Notification button shown for all cities** — The `city.supportsNotifications` guard was removed from `CityHeader`, so the bell button now appears for every city, including those that redirect away from the notifications flow.
- **Subjects not scoped to current city** — `getSubjectsNearLocations` in `actions.ts` fetches subjects by proximity without filtering by `cityId`, which can surface agenda items from neighbouring municipalities.
- **Hardcoded Athens-specific quick suggestions** — The `LocationSelector` default for `quickSuggestions` is `['Κουκάκι', 'Παγκράτι']`, which is meaningless for any city other than Athens.
- **Dead code in `CityHeader`** — `currentStep`, `formData`, `handleNextStep`, `handlePreviousStep`, and `handleFormSubmit` (including a `console.log`) were added but are never used.
- **Conflicting Tailwind classes** — `OnboardingStepTemplate` has both `p-4` and `p-2` on the same element, and the `overflow-y-auto` scroll behaviour was removed from the content pane.

<h3>Confidence Score: 1/5</h3>

- Not safe to merge — the notifications page renders blank due to the stale `initialStage`, and the notification button is shown for all cities unconditionally.
- Two logic regressions block the primary user-facing feature: the notifications page is broken for all users (blank render), and the bell button appears on cities that don't support notifications. Additional issues include a missing city-scoping filter in the new server action and hardcoded Athens-specific defaults.
- `src/app/[locale]/(city)/[cityId]/(other)/notifications/page.tsx` (stale initialStage) and `src/components/cities/CityHeader.tsx` (missing supportsNotifications guard, dead code) require the most attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/(city)/[cityId]/(other)/notifications/page.tsx | Still passes `NOTIFICATION_INFO` as `initialStage`, which was removed from the flow — causes the entire notifications page to render blank. |
| src/components/cities/CityHeader.tsx | Removes the `supportsNotifications` guard (button shown for all cities), adds unused state/handlers including a `console.log`, and leaves the search form commented out. |
| src/components/onboarding/OnboardingStepTemplate.tsx | Removes `max-w-md` constraint and scroll behaviour; introduces conflicting `p-4`/`p-2` padding classes on the content div. |
| src/components/onboarding/containers/FormContainer.tsx | Removes `NOTIFICATION_INFO` step rendering and switches from a fixed-position overlay to a `CollapsibleCard`; clean refactor but breaks when `initialStage` is still `NOTIFICATION_INFO`. |
| src/components/onboarding/selectors/LocationSelector.tsx | Adds map preview and quick-suggestion chips; hardcoded Athens-specific neighbourhood defaults will show incorrect suggestions for all other cities. |
| src/lib/actions.ts | New `getSubjectsNearLocations` server action correctly queries nearby subjects, but lacks a `cityId` filter — subjects from adjacent municipalities can leak in. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CityHeader
    participant NotificationsPage
    participant OnboardingProvider
    participant FormContainer
    participant TopicStep
    participant LocationStep
    participant RegistrationStep

    User->>CityHeader: Click bell button (all cities, no guard)
    CityHeader->>NotificationsPage: router.push(/{cityId}/notifications)
    NotificationsPage->>OnboardingProvider: initialStage=NOTIFICATION_INFO ⚠️
    OnboardingProvider->>FormContainer: stage=NOTIFICATION_INFO
    FormContainer->>FormContainer: getCurrentStep(NOTIFICATION_INFO) → undefined
    FormContainer-->>User: Renders blank (null)

    Note over NotificationsPage,FormContainer: Intended happy path (after fix)
    NotificationsPage->>OnboardingProvider: initialStage=NOTIFICATION_TOPIC_SELECTION
    OnboardingProvider->>FormContainer: stage=NOTIFICATION_TOPIC_SELECTION
    FormContainer->>TopicStep: render step 1
    TopicStep-->>User: Select topics → onContinue
    FormContainer->>LocationStep: render step 2
    LocationStep->>LocationStep: getSubjectsNearLocations(coords) [no cityId filter ⚠️]
    LocationStep-->>User: Select locations → onContinue
    FormContainer->>RegistrationStep: render step 3
    RegistrationStep-->>User: Enter email/phone → submit
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/cities/CityHeader.tsx`, line 133-143 ([link](https://github.com/schemalabz/opencouncil/blob/9310fe796d1043a80adf4aff3daaf23067bfbb90/src/components/cities/CityHeader.tsx#L133-L143)) 

   **Commented-out search form**

   The entire `<motion.form>` search block has been commented out rather than deleted. If this feature is intentionally disabled, the dead markup should be removed. If it is temporarily disabled, a TODO comment explaining the intention would be more appropriate.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/cities/CityHeader.tsx
   Line: 133-143

   Comment:
   **Commented-out search form**

   The entire `<motion.form>` search block has been commented out rather than deleted. If this feature is intentionally disabled, the dead markup should be removed. If it is temporarily disabled, a TODO comment explaining the intention would be more appropriate.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 9310fe7</sub>

> Greptile also left **6 inline comments** on this PR.

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->