### PR TITLE
Make nix optional in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Development Environment
 
-This project uses [Nix](https://nixos.org/) to manage development dependencies. All shell commands (`npm`, `npx`, `node`, etc.) must be run inside the Nix development shell.
-
-**Prefix all commands with `nix develop --command`**, for example:
-```bash
-nix develop --command npm run build
-nix develop --command npx tsc --noEmit
-```
-
-If you open an interactive shell session first (`nix develop`), subsequent commands in that session don't need the prefix.
+Run commands (`npm`, `npx`, etc.) directly. Optionally, use `nix develop` for a reproducible shell with all dependencies pinned.
 
 ## Build Commands
 


### PR DESCRIPTION
Nix is no longer required for running commands — just recommended for reproducibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates developer instructions; no runtime or build logic is modified.
> 
> **Overview**
> Updates `CLAUDE.md` to **stop requiring Nix for running commands**, instead recommending `nix develop` only as an optional reproducible dev shell.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c67d5ee9a393c4c4a43d046c5edd8d9d69de900. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies the Development Environment section of `CLAUDE.md` by removing the requirement that all shell commands be run inside a Nix development shell. The previous multi-paragraph instruction (with code examples for `nix develop --command` prefixing) is replaced by a single line stating commands can be run directly, with Nix offered as an optional tool for reproducibility.

- Reduces the `CLAUDE.md` Development Environment section from 9 lines to 1 concise line
- Note: `.claude/commands/pre-pr.md` (not changed in this PR) still instructs Claude to use `nix develop --command` as a mandatory prefix for build, lint, and test commands (lines 100, 103, 107, 117). This may cause confusion — consider updating it in a follow-up to align with the new guidance.

<h3>Confidence Score: 4/5</h3>

- This is a low-risk documentation-only change that simplifies developer setup instructions.
- The change is a straightforward documentation edit with no code impact. Score is 4 instead of 5 because `.claude/commands/pre-pr.md` still mandates the old `nix develop --command` pattern, creating an inconsistency that could confuse tooling or contributors.
- No files require special attention, though `.claude/commands/pre-pr.md` should be updated in a follow-up to stay consistent.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | Replaces mandatory Nix shell instructions with a single line making Nix optional. The change itself is correct, but creates an inconsistency with `.claude/commands/pre-pr.md` which still mandates `nix develop --command`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer runs command] --> B{Nix available?}
    B -->|Yes| C[nix develop for reproducible shell]
    C --> D[Run npm/npx commands inside shell]
    B -->|No| E[Run npm/npx commands directly]
    D --> F[Build / Test / Dev]
    E --> F
```

<sub>Last reviewed commit: 1c67d5e</sub>

<!-- /greptile_comment -->