### PR TITLE
Add embeddable meetings widget for municipality websites

### DIFF
--- a/messages/el.json
+++ b/messages/el.json
@@ -160,7 +160,39 @@
         "noItems": "Δεν υπάρχουν πόλεις στο OpenCouncil.",
         "allAdministrativeBodies": "Όλα τα όργανα",
         "filterByAdminBody": "Φιλτράρισμα ανά Διοικητικό Όργανο",
-        "citySections": "Ενότητες δήμου"
+        "citySections": "Ενότητες δήμου",
+        "widget": "Widget"
+    },
+    "EmbedConfigurator": {
+        "title": "Widget για την ιστοσελίδα σας",
+        "description": "Ενσωματώστε τις συνεδριάσεις του δήμου στο site σας. Ρυθμίστε την εμφάνιση, αντιγράψτε τον κώδικα iframe και επικολλήστε τον στο CMS σας (WordPress, Joomla κλπ).",
+        "accentColor": "Χρώμα",
+        "accentColorHint": "Το κύριο χρώμα του widget — χρησιμοποιείται σε τίτλους, links και badges. Βάλτε το χρώμα του δήμου σας για να ταιριάζει με το site.",
+        "darkMode": "Σκούρο φόντο",
+        "numberOfMeetings": "Πόσες συνεδριάσεις να εμφανίζονται",
+        "showSubjects": "Εμφάνιση θεμάτων συνεδρίασης",
+        "borderRadius": "Γωνίες καρτών",
+        "radiusSharp": "Ορθές",
+        "radiusRounded": "Στρογγυλές",
+        "radiusPill": "Πολύ στρογγυλές",
+        "administrativeBodies": "Όργανα",
+        "embedCode": "Κώδικας iframe",
+        "embedCodeHint": "Αντιγράψτε και επικολλήστε σε HTML block στο site σας.",
+        "copy": "Αντιγραφή",
+        "copied": "Αντιγράφηκε!",
+        "preview": "Προεπισκόπηση",
+        "previewTitle": "Προεπισκόπηση widget",
+        "troubleshootingTitle": "Σημειώσεις εγκατάστασης",
+        "troubleshootingCSP": "Αν το widget δεν εμφανίζεται, ελέγξτε ότι το Content Security Policy (CSP) του site σας επιτρέπει frame-src από opencouncil.gr.",
+        "troubleshootingWordPress": "Σε WordPress, χρησιμοποιήστε Custom HTML block. Σε Joomla, χρησιμοποιήστε module τύπου \"Custom / mod_custom\" με editor σε code view.",
+        "troubleshootingHeight": "Ρυθμίστε το height στον κώδικα ανάλογα με τον αριθμό συνεδριάσεων. Για 5 συνεδριάσεις, 600px είναι καλή αρχή."
+    },
+    "EmbedWidget": {
+        "subjects": "Θέματα",
+        "more": "ακόμη",
+        "noMeetings": "Δεν υπάρχουν διαθέσιμες συνεδριάσεις.",
+        "upcoming": "Επερχόμενες Συνεδριάσεις",
+        "recent": "Πρόσφατες Συνεδριάσεις"
     },
     "AddMeetingForm": {
         "meetingName": "Όνομα Συνεδρίασης",

--- a/messages/en.json
+++ b/messages/en.json
@@ -143,7 +143,39 @@
         "searchInCity": "Search in city council meetings",
         "allAdministrativeBodies": "All Bodies",
         "filterByAdminBody": "Filter by Administrative Body",
-        "citySections": "City sections"
+        "citySections": "City sections",
+        "widget": "Widget"
+    },
+    "EmbedConfigurator": {
+        "title": "Widget for your website",
+        "description": "Embed council meetings on your municipality website. Customize the appearance, copy the iframe code and paste it into your CMS (WordPress, Joomla, etc.).",
+        "accentColor": "Color",
+        "accentColorHint": "The main widget color — used for titles, links and badges. Match it to your site's brand color.",
+        "darkMode": "Dark background",
+        "numberOfMeetings": "Meetings to show",
+        "showSubjects": "Show meeting subjects",
+        "borderRadius": "Card corners",
+        "radiusSharp": "Square",
+        "radiusRounded": "Rounded",
+        "radiusPill": "Extra rounded",
+        "administrativeBodies": "Bodies",
+        "embedCode": "Iframe code",
+        "embedCodeHint": "Copy and paste into an HTML block on your site.",
+        "copy": "Copy",
+        "copied": "Copied!",
+        "preview": "Preview",
+        "previewTitle": "Widget preview",
+        "troubleshootingTitle": "Installation notes",
+        "troubleshootingCSP": "If the widget doesn't load, check that your site's Content Security Policy (CSP) allows frame-src from opencouncil.gr.",
+        "troubleshootingWordPress": "In WordPress, use a Custom HTML block. In Joomla, use a \"Custom / mod_custom\" module with the editor in code view.",
+        "troubleshootingHeight": "Adjust the height value in the code based on the number of meetings. For 5 meetings, 600px is a good starting point."
+    },
+    "EmbedWidget": {
+        "subjects": "Subjects",
+        "more": "more",
+        "noMeetings": "No meetings available.",
+        "upcoming": "Upcoming Meetings",
+        "recent": "Recent Meetings"
     },
     "AddMeetingForm": {
         "meetingName": "Meeting Name",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,6 +30,18 @@ const nextConfig = {
     swcMinify: true,
     // Enable custom domains - we'll handle this entirely in middleware
     // Removing the invalid rewrite configuration
+    async headers() {
+        return [
+            {
+                // Allow embed pages to be loaded in iframes on any domain
+                source: '/:locale/embed/:path*',
+                headers: [
+                    { key: 'Content-Security-Policy', value: 'frame-ancestors *' },
+                    { key: 'Cache-Control', value: 'public, s-maxage=300, stale-while-revalidate=3600' },
+                ],
+            },
+        ];
+    },
     async redirects() {
         return [
             {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -26,6 +26,18 @@ const nextConfig = {
     swcMinify: true,
     // Enable custom domains - we'll handle this entirely in middleware
     // Removing the invalid rewrite configuration
+    async headers() {
+        return [
+            {
+                // Allow embed pages to be loaded in iframes on any domain
+                source: '/:locale/embed/:path*',
+                headers: [
+                    { key: 'Content-Security-Policy', value: 'frame-ancestors *' },
+                    { key: 'Cache-Control', value: 'public, s-maxage=300, stale-while-revalidate=3600' },
+                ],
+            },
+        ];
+    },
     async redirects() {
         return [
             {

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/widget/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/widget/page.tsx
@@ -1,0 +1,27 @@
+import { notFound } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
+import { isUserAuthorizedToEdit } from '@/lib/auth';
+import { getAdministrativeBodiesForCityCached } from '@/lib/cache/queries';
+import { AdministrativeBodyType } from '@prisma/client';
+import { EmbedConfigurator } from '@/components/embed/EmbedConfigurator';
+
+const ADMIN_BODY_TYPE_ORDER: AdministrativeBodyType[] = ['council', 'committee', 'community'];
+
+export default async function WidgetPage({
+    params: { cityId },
+}: {
+    params: { cityId: string };
+}) {
+    const canEdit = await isUserAuthorizedToEdit({ cityId });
+    if (!canEdit) notFound();
+
+    const tCommon = await getTranslations('Common');
+
+    const bodies = await getAdministrativeBodiesForCityCached(cityId);
+    const typesPresent = new Set(bodies.map(b => b.type));
+    const bodyTypeOptions = ADMIN_BODY_TYPE_ORDER
+        .filter(type => typesPresent.has(type))
+        .map(type => ({ value: type, label: tCommon(`adminBodyType_${type}`) }));
+
+    return <EmbedConfigurator cityId={cityId} bodyTypeOptions={bodyTypeOptions} />;
+}

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/widget/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/widget/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
+import { isUserAuthorizedToEdit } from '@/lib/auth';
+import prisma from '@/lib/db/prisma';
+import { AdministrativeBodyType } from '@prisma/client';
+import { EmbedConfigurator } from '@/components/embed/EmbedConfigurator';
+
+const ADMIN_BODY_TYPE_ORDER: AdministrativeBodyType[] = ['council', 'committee', 'community'];
+
+export default async function WidgetPage({
+    params: { cityId },
+}: {
+    params: { cityId: string };
+}) {
+    const canEdit = await isUserAuthorizedToEdit({ cityId });
+    if (!canEdit) notFound();
+
+    const tCommon = await getTranslations('Common');
+
+    // Get distinct body types for this city (lightweight — no meeting data)
+    const bodies = await prisma.administrativeBody.findMany({
+        where: { cityId },
+        select: { type: true },
+        distinct: ['type'],
+    });
+    const typesPresent = new Set(bodies.map(b => b.type));
+    const bodyTypeOptions = ADMIN_BODY_TYPE_ORDER
+        .filter(type => typesPresent.has(type))
+        .map(type => ({ value: type, label: tCommon(`adminBodyType_${type}`) }));
+
+    return <EmbedConfigurator cityId={cityId} bodyTypeOptions={bodyTypeOptions} />;
+}

--- a/src/app/[locale]/(embed)/embed/meetings/embed.css
+++ b/src/app/[locale]/(embed)/embed/meetings/embed.css
@@ -1,0 +1,159 @@
+.embed-widget {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--embed-bg);
+    color: var(--embed-text);
+    padding: 12px;
+    min-height: 100px;
+}
+
+.embed-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+/* ── Section labels ── */
+.embed-section-label {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--embed-accent);
+    padding: 4px 0 0;
+}
+
+/* ── Card ── */
+.embed-card,
+.embed-card:hover,
+.embed-card:visited {
+    text-decoration: none;
+    color: inherit;
+}
+.embed-card {
+    display: block;
+    padding: 16px;
+    border: 1px solid var(--embed-border);
+    background: var(--embed-card-bg);
+    transition: background 0.15s, box-shadow 0.15s, border-color 0.15s;
+}
+.embed-card:hover {
+    background: var(--embed-card-hover);
+    border-color: var(--embed-accent);
+    box-shadow: 0 2px 12px rgba(0,0,0,0.06);
+}
+
+/* ── Card title ── */
+.embed-card-title {
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 1.4;
+    color: var(--embed-text);
+    transition: color 0.15s;
+}
+.embed-card:hover .embed-card-title {
+    color: var(--embed-accent);
+}
+
+/* ── Metadata row ── */
+.embed-card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--embed-text-muted);
+}
+.embed-card-meta-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+/* ── Subjects section ── */
+.embed-card-subjects {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid var(--embed-border);
+}
+
+.embed-subjects-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--embed-text-muted);
+    margin-bottom: 6px;
+}
+
+.embed-subjects-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.embed-subject-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    line-height: 1.4;
+    color: var(--embed-text);
+}
+
+.embed-subject-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.embed-card-more {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--embed-text-muted);
+}
+
+/* ── Empty state ── */
+.embed-empty {
+    text-align: center;
+    padding: 32px 16px;
+    color: var(--embed-text-muted);
+    font-size: 14px;
+}
+
+/* ── Footer ── */
+.embed-footer {
+    display: flex;
+    justify-content: center;
+    padding-top: 14px;
+    margin-top: 6px;
+}
+.embed-footer-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--embed-text-muted);
+    text-decoration: none;
+    opacity: 0.7;
+    transition: opacity 0.15s;
+}
+.embed-footer-link:hover {
+    opacity: 1;
+    color: var(--embed-accent);
+}
+.embed-footer-logo {
+    opacity: 0.5;
+    width: 16px;
+    height: 16px;
+    object-fit: contain;
+}

--- a/src/app/[locale]/(embed)/embed/meetings/page.tsx
+++ b/src/app/[locale]/(embed)/embed/meetings/page.tsx
@@ -1,0 +1,112 @@
+import { notFound } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
+import { getCityCached, getCouncilMeetingsForCityPublicCached } from '@/lib/cache';
+import { EmbedMeetingCard } from '@/components/embed/EmbedMeetingCard';
+import { EmbedFooter } from '@/components/embed/EmbedFooter';
+import {
+    generateThemeVars,
+    parseAccentColor,
+    type EmbedMode,
+    type EmbedRadius,
+} from '@/lib/utils/embedTheme';
+import { AdministrativeBodyType } from '@prisma/client';
+import { env } from '@/env.mjs';
+import './embed.css';
+
+// Cache the page for 5 minutes at the CDN, serve stale for up to 1 hour while revalidating
+export const revalidate = 300;
+
+const VALID_BODY_TYPES = new Set<string>(['council', 'committee', 'community']);
+
+interface EmbedMeetingsPageProps {
+    params: { locale: string };
+    searchParams: {
+        cityId?: string;
+        accent?: string;
+        mode?: string;
+        limit?: string;
+        showSubjects?: string;
+        radius?: string;
+        bodies?: string;
+    };
+}
+
+export default async function EmbedMeetingsPage({ params, searchParams }: EmbedMeetingsPageProps) {
+    const { locale } = params;
+    const { cityId } = searchParams;
+
+    if (!cityId) notFound();
+
+    const city = await getCityCached(cityId);
+    if (!city) notFound();
+
+    const accent = parseAccentColor(searchParams.accent);
+    const mode: EmbedMode = searchParams.mode === 'dark' ? 'dark' : 'light';
+    const limit = Math.min(Math.max(parseInt(searchParams.limit || '5', 10) || 5, 1), 10);
+    const showSubjects = searchParams.showSubjects !== 'false';
+    const radius: EmbedRadius =
+        searchParams.radius === 'sharp' || searchParams.radius === 'pill'
+            ? searchParams.radius
+            : 'rounded';
+    const bodyTypeFilter = (searchParams.bodies?.split(',').filter(Boolean) || [])
+        .filter((v): v is AdministrativeBodyType => VALID_BODY_TYPES.has(v));
+    const administrativeBodyTypes = bodyTypeFilter.length > 0 ? bodyTypeFilter : undefined;
+
+    // Fetch upcoming (ASC, nearest first) and past (DESC, most recent first) in parallel.
+    // Two queries are correct: a single DESC query would cut off the nearest upcoming
+    // meetings when there are more upcoming than `limit`.
+    const [upcomingAll, pastAll] = await Promise.all([
+        getCouncilMeetingsForCityPublicCached(cityId, { limit, administrativeBodyTypes, timeFilter: 'upcoming' }),
+        getCouncilMeetingsForCityPublicCached(cityId, { limit, administrativeBodyTypes, timeFilter: 'past' }),
+    ]);
+
+    // Prioritize upcoming; fill remaining slots with past meetings.
+    const upcoming = upcomingAll.slice(0, limit);
+    const past = pastAll.slice(0, Math.max(0, limit - upcoming.length));
+    const hasAnyMeetings = upcoming.length + past.length > 0;
+
+    const t = await getTranslations('EmbedWidget');
+    const themeVars = generateThemeVars(accent, mode, radius);
+    const baseUrl = env.NEXTAUTH_URL.replace(/\/$/, '');
+    const cardTranslations = { subjects: t('subjects'), more: t('more') };
+
+    const renderCards = (items: typeof upcoming) =>
+        items.map((meeting) => (
+            <EmbedMeetingCard
+                key={meeting.id}
+                meeting={meeting}
+                locale={locale}
+                showSubjects={showSubjects}
+                baseUrl={baseUrl}
+                cityTimezone={city.timezone}
+                translations={cardTranslations}
+            />
+        ));
+
+    return (
+        <div className="embed-widget" style={themeVars as React.CSSProperties}>
+            {!hasAnyMeetings ? (
+                <div className="embed-empty">{t('noMeetings')}</div>
+            ) : (
+                <div className="embed-list">
+                    {upcoming.length > 0 && (
+                        <>
+                            <div className="embed-section-label">{t('upcoming')}</div>
+                            {renderCards(upcoming)}
+                        </>
+                    )}
+                    {past.length > 0 && (
+                        <>
+                            {upcoming.length > 0 && (
+                                <div className="embed-section-label">{t('recent')}</div>
+                            )}
+                            {renderCards(past)}
+                        </>
+                    )}
+                </div>
+            )}
+
+            <EmbedFooter baseUrl={baseUrl} cityId={cityId} />
+        </div>
+    );
+}

--- a/src/app/[locale]/(embed)/layout.tsx
+++ b/src/app/[locale]/(embed)/layout.tsx
@@ -1,0 +1,8 @@
+/**
+ * Minimal layout for embed routes.
+ * No navigation, no footer, no session provider overhead.
+ * The locale layout above provides NextIntlClientProvider.
+ */
+export default function EmbedLayout({ children }: { children: React.ReactNode }) {
+    return <>{children}</>;
+}

--- a/src/components/cities/CityHeader.tsx
+++ b/src/components/cities/CityHeader.tsx
@@ -4,9 +4,10 @@ import { useTranslations } from 'next-intl';
 import { useState, useEffect } from 'react';
 import FormSheet from '@/components/FormSheet';
 import CityForm from '@/components/cities/CityForm';
-import { Building2, Bell, Database, BadgeCheck } from 'lucide-react';
+import { Building2, Bell, Database, BadgeCheck, Code } from 'lucide-react';
 import { Search } from "lucide-react";
 import { useRouter } from 'next/navigation';
+import { Link } from '@/i18n/routing';
 import Image from 'next/image';
 import { Input } from '@/components/ui/input';
 import { isUserAuthorizedToEdit } from '@/lib/auth';
@@ -171,12 +172,20 @@ export function CityHeader({ city, councilMeetingsCount, cityMessage, hasNoData 
                 >
                     <div className="flex gap-2">
                         {canEdit && (
-                            <FormSheet
-                                FormComponent={CityForm}
-                                formProps={{ city, cityMessage, onSuccess: () => setIsSheetOpen(false) }}
-                                title={t('editCity')}
-                                type="edit"
-                            />
+                            <>
+                                <FormSheet
+                                    FormComponent={CityForm}
+                                    formProps={{ city, cityMessage, onSuccess: () => setIsSheetOpen(false) }}
+                                    title={t('editCity')}
+                                    type="edit"
+                                />
+                                <Button asChild variant="outline" size="sm">
+                                    <Link href={`/${city.id}/widget`}>
+                                        <Code className="w-4 h-4 mr-2" />
+                                        {t('widget')}
+                                    </Link>
+                                </Button>
+                            </>
                         )}
                         {isSuperAdmin && (city.status === 'pending' || hasNoData) && (
                             <Sheet open={isCityCreatorOpen} onOpenChange={setIsCityCreatorOpen}>

--- a/src/components/embed/EmbedConfigurator.tsx
+++ b/src/components/embed/EmbedConfigurator.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import { useState, useMemo, useEffect } from 'react';
+import { useTranslations, useLocale } from 'next-intl';
+import { AdministrativeBodyType } from '@prisma/client';
+// @ts-ignore
+import { HexColorPicker, HexColorInput } from 'react-colorful';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Slider } from '@/components/ui/slider';
+import { Label } from '@/components/ui/label';
+import { BadgePicker, type BadgePickerOption } from '@/components/ui/badge-picker';
+import { Check, Copy, Code, Sun, Moon } from 'lucide-react';
+import { type EmbedRadius } from '@/lib/utils/embedTheme';
+
+interface EmbedConfiguratorProps {
+    cityId: string;
+    bodyTypeOptions: BadgePickerOption<AdministrativeBodyType>[];
+}
+
+export function EmbedConfigurator({ cityId, bodyTypeOptions }: EmbedConfiguratorProps) {
+    const t = useTranslations('EmbedConfigurator');
+    const tCommon = useTranslations('Common');
+    const locale = useLocale();
+
+    // Configuration state
+    const [accent, setAccent] = useState('#3b82f6');
+    const [mode, setMode] = useState<'light' | 'dark'>('light');
+    const [limit, setLimit] = useState(5);
+    const [showSubjects, setShowSubjects] = useState(true);
+    const [radius, setRadius] = useState<EmbedRadius>('rounded');
+    const [selectedBodyTypes, setSelectedBodyTypes] = useState<AdministrativeBodyType[]>([]);
+    const [copied, setCopied] = useState(false);
+    const [origin, setOrigin] = useState('');
+
+    useEffect(() => {
+        setOrigin(window.location.origin);
+    }, []);
+
+    useEffect(() => {
+        if (!copied) return;
+        const timer = setTimeout(() => setCopied(false), 2000);
+        return () => clearTimeout(timer);
+    }, [copied]);
+
+    // Build the embed URL
+    const embedUrl = useMemo(() => {
+        if (!origin) return '';
+        const params = new URLSearchParams();
+        params.set('cityId', cityId);
+        if (accent !== '#3b82f6') params.set('accent', accent.replace('#', ''));
+        if (mode !== 'light') params.set('mode', mode);
+        if (limit !== 5) params.set('limit', String(limit));
+        if (!showSubjects) params.set('showSubjects', 'false');
+        if (radius !== 'rounded') params.set('radius', radius);
+        if (selectedBodyTypes.length > 0) params.set('bodies', selectedBodyTypes.join(','));
+        return `${origin}/${locale}/embed/meetings?${params.toString()}`;
+    }, [origin, locale, cityId, accent, mode, limit, showSubjects, radius, selectedBodyTypes]);
+
+    const embedCode = `<iframe\n  src="${embedUrl}"\n  width="100%"\n  height="600"\n  frameborder="0"\n  style="border-radius: 8px; border: 1px solid #e5e7eb;"\n  title="OpenCouncil"\n></iframe>`;
+
+    const handleCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(embedCode);
+            setCopied(true);
+        } catch {
+            // Clipboard API unavailable — user can manually select the code
+        }
+    };
+
+    const radiusOptions: { value: EmbedRadius; label: string }[] = [
+        { value: 'sharp', label: t('radiusSharp') },
+        { value: 'rounded', label: t('radiusRounded') },
+        { value: 'pill', label: t('radiusPill') },
+    ];
+
+    return (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            {/* Controls */}
+            <div className="space-y-6">
+                <div>
+                    <h2 className="text-xl font-semibold mb-1">{t('title')}</h2>
+                    <p className="text-sm text-muted-foreground">{t('description')}</p>
+                </div>
+
+                {/* Accent color */}
+                <div className="space-y-3">
+                    <Label>{t('accentColor')}</Label>
+                    <p className="text-xs text-muted-foreground">{t('accentColorHint')}</p>
+                    <div className="flex gap-4 items-start">
+                        <HexColorPicker color={accent} onChange={setAccent} style={{ width: 160, height: 120 }} />
+                        <div className="space-y-2">
+                            <div className="flex items-center gap-2">
+                                <span className="text-sm text-muted-foreground">#</span>
+                                <HexColorInput
+                                    color={accent}
+                                    onChange={setAccent}
+                                    className="w-24 px-2 py-1 text-sm border rounded bg-background"
+                                />
+                            </div>
+                            <div
+                                className="w-full h-8 rounded border"
+                                style={{ backgroundColor: accent }}
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {/* Mode */}
+                <div className="flex items-center justify-between">
+                    <Label htmlFor="mode-switch" className="flex items-center gap-2">
+                        {mode === 'light' ? <Sun size={16} /> : <Moon size={16} />}
+                        {t('darkMode')}
+                    </Label>
+                    <Switch
+                        id="mode-switch"
+                        checked={mode === 'dark'}
+                        onCheckedChange={(checked) => setMode(checked ? 'dark' : 'light')}
+                    />
+                </div>
+
+                {/* Number of meetings */}
+                <div className="space-y-3">
+                    <div className="flex items-center justify-between">
+                        <Label>{t('numberOfMeetings')}</Label>
+                        <span className="text-sm font-medium tabular-nums">{limit}</span>
+                    </div>
+                    <Slider
+                        value={[limit]}
+                        onValueChange={([v]) => setLimit(v)}
+                        min={1}
+                        max={10}
+                        step={1}
+                    />
+                </div>
+
+                {/* Show subjects */}
+                <div className="flex items-center justify-between">
+                    <Label htmlFor="subjects-switch">{t('showSubjects')}</Label>
+                    <Switch
+                        id="subjects-switch"
+                        checked={showSubjects}
+                        onCheckedChange={setShowSubjects}
+                    />
+                </div>
+
+                {/* Border radius */}
+                <div className="space-y-2">
+                    <Label>{t('borderRadius')}</Label>
+                    <div className="flex gap-2">
+                        {radiusOptions.map((opt) => (
+                            <button
+                                key={opt.value}
+                                onClick={() => setRadius(opt.value)}
+                                className={`px-3 py-1.5 text-sm border rounded-md transition-colors ${
+                                    radius === opt.value
+                                        ? 'bg-primary text-primary-foreground border-primary'
+                                        : 'bg-background text-foreground border-border hover:bg-muted'
+                                }`}
+                            >
+                                {opt.label}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Administrative body type filter — reuses BadgePicker from meetings list */}
+                {bodyTypeOptions.length > 1 && (
+                    <div className="space-y-2">
+                        <Label>{t('administrativeBodies')}</Label>
+                        <BadgePicker
+                            options={bodyTypeOptions}
+                            selectedValues={selectedBodyTypes}
+                            onSelectionChange={setSelectedBodyTypes}
+                            allLabel={tCommon('allMeetings')}
+                            collapsible={false}
+                            inline
+                        />
+                    </div>
+                )}
+
+                {/* Embed code */}
+                <div className="space-y-2">
+                    <Label className="flex items-center gap-2">
+                        <Code size={16} />
+                        {t('embedCode')}
+                    </Label>
+                    <p className="text-xs text-muted-foreground">{t('embedCodeHint')}</p>
+                    <div className="relative">
+                        <pre className="p-3 text-xs bg-muted rounded-md overflow-x-auto whitespace-pre-wrap break-all font-mono border">
+                            {embedCode}
+                        </pre>
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={handleCopy}
+                            className="absolute top-2 right-2"
+                        >
+                            {copied ? (
+                                <>
+                                    <Check size={14} className="mr-1" />
+                                    {t('copied')}
+                                </>
+                            ) : (
+                                <>
+                                    <Copy size={14} className="mr-1" />
+                                    {t('copy')}
+                                </>
+                            )}
+                        </Button>
+                    </div>
+                </div>
+
+                {/* Troubleshooting */}
+                <div className="space-y-2 rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+                    <p className="font-medium text-foreground">{t('troubleshootingTitle')}</p>
+                    <ul className="list-disc pl-4 space-y-1 text-xs">
+                        <li>{t('troubleshootingCSP')}</li>
+                        <li>{t('troubleshootingWordPress')}</li>
+                        <li>{t('troubleshootingHeight')}</li>
+                    </ul>
+                </div>
+            </div>
+
+            {/* Live preview */}
+            <div className="space-y-3">
+                <Label>{t('preview')}</Label>
+                <div className="border rounded-lg overflow-hidden bg-muted/30 sticky top-8">
+                    {embedUrl ? (
+                        <iframe
+                            src={embedUrl}
+                            width="100%"
+                            height={500}
+                            className="border-0"
+                            title={t('previewTitle')}
+                        />
+                    ) : (
+                        <div className="flex items-center justify-center h-[500px] text-muted-foreground text-sm">
+                            {t('preview')}...
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/embed/EmbedFooter.tsx
+++ b/src/components/embed/EmbedFooter.tsx
@@ -1,0 +1,27 @@
+interface EmbedFooterProps {
+    baseUrl: string;
+    cityId: string;
+}
+
+export function EmbedFooter({ baseUrl, cityId }: EmbedFooterProps) {
+    return (
+        <div className="embed-footer">
+            <a
+                href={`${baseUrl}/${cityId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="embed-footer-link"
+            >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                    src={`${baseUrl}/logo.png`}
+                    alt="OpenCouncil"
+                    width={16}
+                    height={16}
+                    className="embed-footer-logo"
+                />
+                <span>OpenCouncil</span>
+            </a>
+        </div>
+    );
+}

--- a/src/components/embed/EmbedMeetingCard.tsx
+++ b/src/components/embed/EmbedMeetingCard.tsx
@@ -1,0 +1,95 @@
+import { CouncilMeeting, Subject, Topic, AdministrativeBody } from '@prisma/client';
+import { sortSubjectsByImportance } from '@/lib/utils';
+import { formatDate } from '@/lib/formatters/time';
+import Icon from '@/components/icon';
+import { CalendarIcon, Building, ChevronRight } from 'lucide-react';
+
+type MeetingWithRelations = CouncilMeeting & {
+    subjects: (Subject & { topic?: Topic | null })[];
+    administrativeBody?: AdministrativeBody | null;
+};
+
+interface EmbedMeetingCardProps {
+    meeting: MeetingWithRelations;
+    locale: string;
+    showSubjects: boolean;
+    baseUrl: string;
+    cityTimezone?: string;
+    translations: EmbedTranslations;
+}
+
+export interface EmbedTranslations {
+    subjects: string;
+    more: string;
+}
+
+function localize<T extends { name: string; name_en: string }>(obj: T, locale: string): string {
+    return locale === 'en' ? obj.name_en : obj.name;
+}
+
+export function EmbedMeetingCard({ meeting, locale, showSubjects, baseUrl, cityTimezone, translations: t }: EmbedMeetingCardProps) {
+    const meetingUrl = `${baseUrl}/${meeting.cityId}/${meeting.id}`;
+    const sortedSubjects = sortSubjectsByImportance(meeting.subjects, 'importance');
+    const topSubjects = sortedSubjects.slice(0, 3);
+    const remainingCount = Math.max(0, meeting.subjects.length - 3);
+
+    return (
+        <a
+            href={meetingUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ borderRadius: 'var(--embed-radius)' }}
+            className="embed-card"
+        >
+            <div className="embed-card-title">
+                {localize(meeting, locale)}
+            </div>
+
+            <div className="embed-card-meta">
+                {meeting.administrativeBody && (
+                    <span className="embed-card-meta-item">
+                        <Building size={13} />
+                        {localize(meeting.administrativeBody, locale)}
+                    </span>
+                )}
+                <span className="embed-card-meta-item">
+                    <CalendarIcon size={13} />
+                    {formatDate(meeting.dateTime, cityTimezone, locale)}
+                </span>
+            </div>
+
+            {showSubjects && topSubjects.length > 0 && (
+                <div className="embed-card-subjects">
+                    <div className="embed-subjects-label">{t.subjects}</div>
+                    <ol className="embed-subjects-list">
+                        {topSubjects.map((subject) => (
+                            <li key={subject.id} className="embed-subject-item">
+                                <div
+                                    className="embed-subject-icon"
+                                    style={{
+                                        backgroundColor: subject.topic?.colorHex
+                                            ? `${subject.topic.colorHex}20`
+                                            : '#e5e7eb',
+                                    }}
+                                >
+                                    <Icon
+                                        name={subject.topic?.icon || 'Hash'}
+                                        color={subject.topic?.colorHex || '#9ca3af'}
+                                        size={14}
+                                    />
+                                </div>
+                                <span>{subject.name}</span>
+                            </li>
+                        ))}
+                    </ol>
+                    {remainingCount > 0 && (
+                        <span className="embed-card-more">
+                            +{remainingCount} {t.more}
+                            <ChevronRight size={12} />
+                        </span>
+                    )}
+                </div>
+            )}
+        </a>
+    );
+}

--- a/src/components/embed/EmbedMeetingCard.tsx
+++ b/src/components/embed/EmbedMeetingCard.tsx
@@ -5,7 +5,7 @@ import Icon from '@/components/icon';
 import { CalendarIcon, Building, ChevronRight } from 'lucide-react';
 
 type MeetingWithRelations = CouncilMeeting & {
-    subjects: (Subject & { topic?: Topic | null })[];
+    subjects: (Subject & { topic?: Topic | null; _count?: { contributions: number } })[];
     administrativeBody?: AdministrativeBody | null;
 };
 

--- a/src/components/embed/EmbedMeetingCard.tsx
+++ b/src/components/embed/EmbedMeetingCard.tsx
@@ -1,16 +1,11 @@
-import { CouncilMeeting, Subject, Topic, AdministrativeBody } from '@prisma/client';
 import { sortSubjectsByImportance } from '@/lib/utils';
 import { formatDate } from '@/lib/formatters/time';
 import Icon from '@/components/icon';
 import { CalendarIcon, Building, ChevronRight } from 'lucide-react';
-
-type MeetingWithRelations = CouncilMeeting & {
-    subjects: (Subject & { topic?: Topic | null; _count?: { contributions: number } })[];
-    administrativeBody?: AdministrativeBody | null;
-};
+import { CouncilMeetingWithAdminBodyAndSubjects } from '@/lib/db/meetings';
 
 interface EmbedMeetingCardProps {
-    meeting: MeetingWithRelations;
+    meeting: CouncilMeetingWithAdminBodyAndSubjects;
     locale: string;
     showSubjects: boolean;
     baseUrl: string;

--- a/src/components/meetings/MeetingCard.tsx
+++ b/src/components/meetings/MeetingCard.tsx
@@ -1,5 +1,4 @@
 'use client'
-import { CouncilMeeting, Subject, Topic, AdministrativeBody } from '@prisma/client';
 import { useRouter, usePathname } from '../../i18n/routing';
 import { Card, CardContent } from "../ui/card";
 import { useLocale, useTranslations } from 'next-intl';
@@ -13,6 +12,7 @@ import { cn } from '@/lib/utils';
 import { Link } from '@/i18n/routing';
 import { Badge } from '../ui/badge';
 import { motion } from 'framer-motion';
+import { CouncilMeetingWithAdminBodyAndSubjects } from '@/lib/db/meetings';
 
 // Helper function for development-only logs
 const logDev = (message: string, data?: any) => {
@@ -22,14 +22,7 @@ const logDev = (message: string, data?: any) => {
 };
 
 interface MeetingCardProps {
-    item: CouncilMeeting & {
-        subjects: (Subject & {
-            topic?: Topic | null,
-            speakerSegments?: unknown[],
-            _count?: { contributions: number }
-        })[],
-        administrativeBody?: AdministrativeBody | null
-    };
+    item: CouncilMeetingWithAdminBodyAndSubjects;
     editable: boolean;
     mostRecent?: boolean;
     cityTimezone?: string;

--- a/src/components/meetings/MeetingCard.tsx
+++ b/src/components/meetings/MeetingCard.tsx
@@ -25,7 +25,8 @@ interface MeetingCardProps {
     item: CouncilMeeting & {
         subjects: (Subject & {
             topic?: Topic | null,
-            speakerSegments?: any[] // Using any for flexibility with the structure
+            speakerSegments?: unknown[],
+            _count?: { contributions: number }
         })[],
         administrativeBody?: AdministrativeBody | null
     };

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -315,10 +315,10 @@ describe('subjectToMapFeature', () => {
 });
 
 describe('sortSubjectsByImportance', () => {
-  it('should sort by speaking time', () => {
+  it('should sort by contributions count (descending)', () => {
     const subjects = [
-      { name: 'Subject 1', statistics: { speakingSeconds: 100 } },
-      { name: 'Subject 2', statistics: { speakingSeconds: 200 } }
+      { name: 'Subject 1', _count: { contributions: 2 } },
+      { name: 'Subject 2', _count: { contributions: 5 } }
     ];
 
     const sorted = sortSubjectsByImportance(subjects as any);
@@ -326,14 +326,105 @@ describe('sortSubjectsByImportance', () => {
     expect(sorted[1].name).toBe('Subject 1');
   });
 
-  it('should handle subjects without statistics', () => {
+  it('should sort beforeAgenda subjects last', () => {
     const subjects = [
-      { name: 'Subject 1' },
-      { name: 'Subject 2', statistics: { speakingSeconds: 200 } }
+      { name: 'Before', nonAgendaReason: 'beforeAgenda', _count: { contributions: 10 } },
+      { name: 'Agenda', agendaItemIndex: 1, _count: { contributions: 1 } },
+      { name: 'OutOfAgenda', nonAgendaReason: 'outOfAgenda', _count: { contributions: 3 } }
     ];
 
-    // Should not throw error
-    expect(() => sortSubjectsByImportance(subjects as any)).not.toThrow();
+    const sorted = sortSubjectsByImportance(subjects as any);
+    expect(sorted[0].name).toBe('OutOfAgenda');
+    expect(sorted[1].name).toBe('Agenda');
+    expect(sorted[2].name).toBe('Before');
+  });
+
+  it('should use agenda item index as tie-breaker', () => {
+    const subjects = [
+      { name: 'Item 3', agendaItemIndex: 3, _count: { contributions: 2 } },
+      { name: 'Item 1', agendaItemIndex: 1, _count: { contributions: 2 } }
+    ];
+
+    const sorted = sortSubjectsByImportance(subjects as any);
+    expect(sorted[0].name).toBe('Item 1');
+    expect(sorted[1].name).toBe('Item 3');
+  });
+
+  it('should fall back to alphabetical when no sorting fields are present', () => {
+    const subjects = [
+      { name: 'Zebra' },
+      { name: 'Alpha' },
+      { name: 'Middle' }
+    ];
+
+    const sorted = sortSubjectsByImportance(subjects as any);
+    expect(sorted.map(s => s.name)).toEqual(['Alpha', 'Middle', 'Zebra']);
+  });
+});
+
+describe('sortSubjectsByImportance (appearance)', () => {
+  it('should sort by earliest speaker segment timestamp', () => {
+    const subjects = [
+      { name: 'Later', speakerSegments: [{ startTimestamp: 300 }, { startTimestamp: 500 }] },
+      { name: 'First', speakerSegments: [{ startTimestamp: 100 }] },
+      { name: 'Middle', speakerSegments: [{ startTimestamp: 200 }] },
+    ];
+
+    const sorted = sortSubjectsByImportance(subjects as any, 'appearance');
+    expect(sorted.map(s => s.name)).toEqual(['First', 'Middle', 'Later']);
+  });
+
+  it('should handle nested speakerSegment.startTimestamp structure', () => {
+    const subjects = [
+      { name: 'B', speakerSegments: [{ speakerSegment: { startTimestamp: 200 } }] },
+      { name: 'A', speakerSegments: [{ speakerSegment: { startTimestamp: 100 } }] },
+    ];
+
+    const sorted = sortSubjectsByImportance(subjects as any, 'appearance');
+    expect(sorted.map(s => s.name)).toEqual(['A', 'B']);
+  });
+
+  it('should fall back to agendaItemIndex when no timestamps', () => {
+    const subjects = [
+      { name: 'Third', agendaItemIndex: 3 },
+      { name: 'First', agendaItemIndex: 1 },
+      { name: 'Second', agendaItemIndex: 2 },
+    ];
+
+    const sorted = sortSubjectsByImportance(subjects as any, 'appearance');
+    expect(sorted.map(s => s.name)).toEqual(['First', 'Second', 'Third']);
+  });
+
+  it('should sort subjects with agendaItemIndex before those without', () => {
+    const subjects = [
+      { name: 'No index' },
+      { name: 'Has index', agendaItemIndex: 5 },
+    ];
+
+    const sorted = sortSubjectsByImportance(subjects as any, 'appearance');
+    expect(sorted[0].name).toBe('Has index');
+    expect(sorted[1].name).toBe('No index');
+  });
+
+  it('should fall back to alphabetical when timestamps are equal', () => {
+    const subjects = [
+      { name: 'Zebra', speakerSegments: [{ startTimestamp: 100 }] },
+      { name: 'Alpha', speakerSegments: [{ startTimestamp: 100 }] },
+    ];
+
+    const sorted = sortSubjectsByImportance(subjects as any, 'appearance');
+    expect(sorted.map(s => s.name)).toEqual(['Alpha', 'Zebra']);
+  });
+
+  it('should fall back to agendaItemIndex when only one subject has segments', () => {
+    const subjects = [
+      { name: 'No segments', agendaItemIndex: 1 },
+      { name: 'Has segments', speakerSegments: [{ startTimestamp: 100 }], agendaItemIndex: 2 },
+    ];
+
+    const sorted = sortSubjectsByImportance(subjects as any, 'appearance');
+    expect(sorted[0].name).toBe('No segments');
+    expect(sorted[1].name).toBe('Has segments');
   });
 });
 

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -315,10 +315,10 @@ describe('subjectToMapFeature', () => {
 });
 
 describe('sortSubjectsByImportance', () => {
-  it('should sort by speaking time', () => {
+  it('should sort by contributions count (descending)', () => {
     const subjects = [
-      { name: 'Subject 1', statistics: { speakingSeconds: 100 } },
-      { name: 'Subject 2', statistics: { speakingSeconds: 200 } }
+      { name: 'Subject 1', _count: { contributions: 2 } },
+      { name: 'Subject 2', _count: { contributions: 5 } }
     ];
 
     const sorted = sortSubjectsByImportance(subjects as any);
@@ -326,10 +326,34 @@ describe('sortSubjectsByImportance', () => {
     expect(sorted[1].name).toBe('Subject 1');
   });
 
-  it('should handle subjects without statistics', () => {
+  it('should sort beforeAgenda subjects last', () => {
+    const subjects = [
+      { name: 'Before', nonAgendaReason: 'beforeAgenda', _count: { contributions: 10 } },
+      { name: 'Agenda', agendaItemIndex: 1, _count: { contributions: 1 } },
+      { name: 'OutOfAgenda', nonAgendaReason: 'outOfAgenda', _count: { contributions: 3 } }
+    ];
+
+    const sorted = sortSubjectsByImportance(subjects as any);
+    expect(sorted[0].name).toBe('OutOfAgenda');
+    expect(sorted[1].name).toBe('Agenda');
+    expect(sorted[2].name).toBe('Before');
+  });
+
+  it('should use agenda item index as tie-breaker', () => {
+    const subjects = [
+      { name: 'Item 3', agendaItemIndex: 3, _count: { contributions: 2 } },
+      { name: 'Item 1', agendaItemIndex: 1, _count: { contributions: 2 } }
+    ];
+
+    const sorted = sortSubjectsByImportance(subjects as any);
+    expect(sorted[0].name).toBe('Item 1');
+    expect(sorted[1].name).toBe('Item 3');
+  });
+
+  it('should handle subjects without _count gracefully', () => {
     const subjects = [
       { name: 'Subject 1' },
-      { name: 'Subject 2', statistics: { speakingSeconds: 200 } }
+      { name: 'Subject 2' }
     ];
 
     // Should not throw error

--- a/src/lib/cache/queries.ts
+++ b/src/lib/cache/queries.ts
@@ -1,3 +1,4 @@
+import { AdministrativeBodyType } from "@prisma/client";
 import { isUserAuthorizedToEdit } from "@/lib/auth";
 import { getCity, getAllCitiesMinimal, getSupportedCitiesWithLogos, getAboutPageStats } from "@/lib/db/cities";
 import { getGitHubStats } from "@/lib/github";
@@ -42,10 +43,17 @@ export async function getCouncilMeetingsForCityCached(cityId: string, { limit, p
  * Public (no-auth) version of getCouncilMeetingsForCityCached.
  * Only returns released meetings. Safe for static pages (no headers() call).
  */
-export async function getCouncilMeetingsForCityPublicCached(cityId: string, { limit }: { limit?: number } = {}) {
+export async function getCouncilMeetingsForCityPublicCached(
+  cityId: string,
+  { limit, administrativeBodyTypes, timeFilter }: { limit?: number; administrativeBodyTypes?: AdministrativeBodyType[]; timeFilter?: 'upcoming' | 'past' } = {}
+) {
+  const typeKey = administrativeBodyTypes && administrativeBodyTypes.length > 0
+    ? `types:${[...administrativeBodyTypes].sort().join(',')}`
+    : 'types:all';
+  const timeKey = timeFilter ?? 'all';
   return createCache(
-    () => getCouncilMeetingsForCity(cityId, { includeUnreleased: false, limit }),
-    ['city', cityId, 'meetings', 'onlyReleased', limit ? `limit:${limit}` : 'all'],
+    () => getCouncilMeetingsForCity(cityId, { includeUnreleased: false, limit, administrativeBodyTypes, timeFilter }),
+    ['city', cityId, 'meetings', 'onlyReleased', limit ? `limit:${limit}` : 'all', typeKey, timeKey],
     { tags: ['city', `city:${cityId}`, `city:${cityId}:meetings`] }
   )();
 }

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -1,18 +1,37 @@
 "use server";
-import { CouncilMeeting, Subject, AdministrativeBody, AdministrativeBodyType } from '@prisma/client';
+import { CouncilMeeting, AdministrativeBodyType, Prisma } from '@prisma/client';
 import { revalidateTag, revalidatePath } from 'next/cache';
 import prisma from "./prisma";
 import { withUserAuthorizedToEdit, isUserAuthorizedToEdit } from '../auth';
 import { buildDateFilter } from './reviews/dateFilters';
 import { formatDateAsMeetingId } from '../utils/meetingId';
 
-export type CouncilMeetingWithAdminBody = CouncilMeeting & {
-    administrativeBody: AdministrativeBody | null
-}
+const meetingWithAdminBodyInclude = {
+    administrativeBody: true,
+} satisfies Prisma.CouncilMeetingInclude;
 
-export type CouncilMeetingWithAdminBodyAndSubjects = CouncilMeetingWithAdminBody & {
-    subjects: (Subject & { _count?: { contributions: number } })[]
-}
+export type CouncilMeetingWithAdminBody = Prisma.CouncilMeetingGetPayload<{
+    include: typeof meetingWithAdminBodyInclude
+}>;
+
+const meetingWithSubjectsInclude = {
+    subjects: {
+        orderBy: [
+            { agendaItemIndex: 'asc' as const },
+            { name: 'asc' as const },
+        ],
+        include: {
+            topic: true,
+            speakerSegments: true,
+            _count: { select: { contributions: true } },
+        },
+    },
+    administrativeBody: true,
+} satisfies Prisma.CouncilMeetingInclude;
+
+export type CouncilMeetingWithAdminBodyAndSubjects = Prisma.CouncilMeetingGetPayload<{
+    include: typeof meetingWithSubjectsInclude
+}>;
 
 export async function deleteCouncilMeeting(cityId: string, id: string): Promise<void> {
     await withUserAuthorizedToEdit({ councilMeetingId: id, cityId: cityId });
@@ -39,9 +58,7 @@ export async function createCouncilMeeting(meetingData: Omit<CouncilMeeting, 'cr
 export async function createCouncilMeetingDirect(meetingData: Omit<CouncilMeeting, 'createdAt' | 'updatedAt' | 'audioUrl' | 'videoUrl'> & { audioUrl?: string, videoUrl?: string }): Promise<CouncilMeetingWithAdminBody> {
     return prisma.councilMeeting.create({
         data: meetingData,
-        include: {
-            administrativeBody: true
-        }
+        include: meetingWithAdminBodyInclude,
     });
 }
 
@@ -83,9 +100,7 @@ export async function editCouncilMeeting(cityId: string, id: string, meetingData
         const updatedMeeting = await prisma.councilMeeting.update({
             where: { cityId_id: { cityId, id } },
             data: meetingData,
-            include: {
-                administrativeBody: true
-            }
+            include: meetingWithAdminBodyInclude,
         });
         return updatedMeeting;
     } catch (error) {
@@ -99,9 +114,7 @@ export async function getCouncilMeeting(cityId: string, id: string): Promise<Cou
     try {
         const meeting = await prisma.councilMeeting.findUnique({
             where: { cityId_id: { cityId, id } },
-            include: {
-                administrativeBody: true
-            }
+            include: meetingWithAdminBodyInclude,
         });
         const endTime = performance.now();
 
@@ -151,21 +164,7 @@ export async function getCouncilMeetingsForCity(cityId: string, { includeUnrelea
                 : [{ dateTime: 'desc' }, { createdAt: 'desc' }],
             ...(skip !== undefined && { skip }),
             ...(take && { take }),
-            include: {
-                subjects: {
-                    orderBy: [
-                        { agendaItemIndex: 'asc' },
-                        { name: 'asc' }
-                    ],
-                    include: {
-                        topic: true,
-                        // Include speaker segments through the junction table
-                        speakerSegments: true, // This gets all SubjectSpeakerSegment records
-                        _count: { select: { contributions: true } }
-                    }
-                },
-                administrativeBody: true
-            }
+            include: meetingWithSubjectsInclude,
         });
 
         return meetings;
@@ -181,9 +180,7 @@ export async function toggleMeetingRelease(cityId: string, id: string, released:
         const updatedMeeting = await prisma.councilMeeting.update({
             where: { cityId_id: { cityId, id } },
             data: { released },
-            include: {
-                administrativeBody: true
-            }
+            include: meetingWithAdminBodyInclude,
         });
         // TODO: utilize api/cities/[cityId]/meetings/[meetingId] to edit the meeting
         revalidateTag(`city:${cityId}:meetings`);

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -1,5 +1,5 @@
 "use server";
-import { CouncilMeeting, Subject, AdministrativeBody } from '@prisma/client';
+import { CouncilMeeting, Subject, AdministrativeBody, AdministrativeBodyType } from '@prisma/client';
 import { revalidateTag, revalidatePath } from 'next/cache';
 import prisma from "./prisma";
 import { withUserAuthorizedToEdit, isUserAuthorizedToEdit } from '../auth';
@@ -115,7 +115,7 @@ export async function getCouncilMeeting(cityId: string, id: string): Promise<Cou
     }
 }
 
-export async function getCouncilMeetingsForCity(cityId: string, { includeUnreleased, limit, page, pageSize = 12, from, to }: { includeUnreleased?: boolean; limit?: number; page?: number; pageSize?: number; from?: Date; to?: Date } = {}): Promise<CouncilMeetingWithAdminBodyAndSubjects[]> {
+export async function getCouncilMeetingsForCity(cityId: string, { includeUnreleased, limit, page, pageSize = 12, from, to, administrativeBodyTypes, timeFilter }: { includeUnreleased?: boolean; limit?: number; page?: number; pageSize?: number; from?: Date; to?: Date; administrativeBodyTypes?: AdministrativeBodyType[]; timeFilter?: 'upcoming' | 'past' } = {}): Promise<CouncilMeetingWithAdminBodyAndSubjects[]> {
 
     try {
         // Calculate pagination
@@ -123,10 +123,18 @@ export async function getCouncilMeetingsForCity(cityId: string, { includeUnrelea
         const take = page ? pageSize : limit;
 
         // Build dateTime filter
-        const dateTimeFilter = (from || to) ? {
-            ...(from && { gte: from }),
-            ...(to && { lte: to }),
-        } : undefined;
+        const now = new Date();
+        const timeFilterValue = timeFilter === 'upcoming'
+            ? { gt: now }
+            : timeFilter === 'past'
+                ? { lte: now }
+                : undefined;
+        const dateTimeFilter = (from || to)
+            ? {
+                ...(from && { gte: from }),
+                ...(to && { lte: to }),
+            }
+            : timeFilterValue;
 
         // First, get meetings with subjects and basic relationships
         const meetings = await prisma.councilMeeting.findMany({
@@ -134,11 +142,13 @@ export async function getCouncilMeetingsForCity(cityId: string, { includeUnrelea
                 cityId,
                 released: includeUnreleased ? undefined : true,
                 ...(dateTimeFilter && { dateTime: dateTimeFilter }),
+                ...(administrativeBodyTypes && administrativeBodyTypes.length > 0 && {
+                    administrativeBody: { type: { in: administrativeBodyTypes } }
+                }),
             },
-            orderBy: [
-                { dateTime: 'desc' },
-                { createdAt: 'desc' }
-            ],
+            orderBy: timeFilter === 'upcoming'
+                ? [{ dateTime: 'asc' }, { createdAt: 'asc' }]
+                : [{ dateTime: 'desc' }, { createdAt: 'desc' }],
             ...(skip !== undefined && { skip }),
             ...(take && { take }),
             include: {

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -10,7 +10,7 @@ export type CouncilMeetingWithAdminBody = CouncilMeeting & {
 }
 
 export type CouncilMeetingWithAdminBodyAndSubjects = CouncilMeetingWithAdminBody & {
-    subjects: Subject[]
+    subjects: (Subject & { _count?: { contributions: number } })[]
 }
 
 export async function deleteCouncilMeeting(cityId: string, id: string): Promise<void> {
@@ -117,7 +117,8 @@ export async function getCouncilMeetingsForCity(cityId: string, { includeUnrelea
                     include: {
                         topic: true,
                         // Include speaker segments through the junction table
-                        speakerSegments: true // This gets all SubjectSpeakerSegment records
+                        speakerSegments: true, // This gets all SubjectSpeakerSegment records
+                        _count: { select: { contributions: true } }
                     }
                 },
                 administrativeBody: true

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -11,7 +11,7 @@ export type CouncilMeetingWithAdminBody = CouncilMeeting & {
 }
 
 export type CouncilMeetingWithAdminBodyAndSubjects = CouncilMeetingWithAdminBody & {
-    subjects: Subject[]
+    subjects: (Subject & { _count?: { contributions: number } })[]
 }
 
 export async function deleteCouncilMeeting(cityId: string, id: string): Promise<void> {
@@ -160,7 +160,8 @@ export async function getCouncilMeetingsForCity(cityId: string, { includeUnrelea
                     include: {
                         topic: true,
                         // Include speaker segments through the junction table
-                        speakerSegments: true // This gets all SubjectSpeakerSegment records
+                        speakerSegments: true, // This gets all SubjectSpeakerSegment records
+                        _count: { select: { contributions: true } }
                     }
                 },
                 administrativeBody: true

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -1,5 +1,5 @@
 "use server";
-import { CouncilMeeting, Subject, AdministrativeBody } from '@prisma/client';
+import { CouncilMeeting, Subject, AdministrativeBody, AdministrativeBodyType } from '@prisma/client';
 import { revalidateTag, revalidatePath } from 'next/cache';
 import prisma from "./prisma";
 import { withUserAuthorizedToEdit, isUserAuthorizedToEdit } from '../auth';
@@ -79,20 +79,33 @@ export async function getCouncilMeeting(cityId: string, id: string): Promise<Cou
     }
 }
 
-export async function getCouncilMeetingsForCity(cityId: string, { includeUnreleased, limit, page, pageSize = 12 }: { includeUnreleased?: boolean; limit?: number; page?: number; pageSize?: number } = {}): Promise<CouncilMeetingWithAdminBodyAndSubjects[]> {
+export async function getCouncilMeetingsForCity(cityId: string, { includeUnreleased, limit, page, pageSize = 12, administrativeBodyTypes, timeFilter }: { includeUnreleased?: boolean; limit?: number; page?: number; pageSize?: number; administrativeBodyTypes?: AdministrativeBodyType[]; timeFilter?: 'upcoming' | 'past' } = {}): Promise<CouncilMeetingWithAdminBodyAndSubjects[]> {
 
     try {
         // Calculate pagination
         const skip = page ? (page - 1) * pageSize : undefined;
         const take = page ? pageSize : limit;
 
+        const now = new Date();
+        const dateFilter = timeFilter === 'upcoming'
+            ? { gt: now }
+            : timeFilter === 'past'
+                ? { lte: now }
+                : undefined;
+
         // First, get meetings with subjects and basic relationships
         const meetings = await prisma.councilMeeting.findMany({
-            where: { cityId, released: includeUnreleased ? undefined : true },
-            orderBy: [
-                { dateTime: 'desc' },
-                { createdAt: 'desc' }
-            ],
+            where: {
+                cityId,
+                released: includeUnreleased ? undefined : true,
+                ...(administrativeBodyTypes && administrativeBodyTypes.length > 0 && {
+                    administrativeBody: { type: { in: administrativeBodyTypes } }
+                }),
+                ...(dateFilter && { dateTime: dateFilter })
+            },
+            orderBy: timeFilter === 'upcoming'
+                ? [{ dateTime: 'asc' }, { createdAt: 'asc' }]
+                : [{ dateTime: 'desc' }, { createdAt: 'desc' }],
             ...(skip !== undefined && { skip }),
             ...(take && { take }),
             include: {

--- a/src/lib/formatters/time.ts
+++ b/src/lib/formatters/time.ts
@@ -92,17 +92,18 @@ export function formatRelativeTime(date: Date, locale: string = 'el'): string {
  * @param timezone - Optional timezone
  * @returns Formatted date string
  */
-export function formatDate(date: Date, timezone?: string): string {
+export function formatDate(date: Date, timezone?: string, locale: string = 'el'): string {
   const options: Intl.DateTimeFormatOptions = { dateStyle: 'long' };
 
   if (timezone) {
     options.timeZone = timezone;
   }
 
+  const intlLocale = locale === 'en' ? 'en-US' : 'el-GR';
   if (date instanceof Date) {
-    return new Intl.DateTimeFormat('el-GR', options).format(date);
+    return new Intl.DateTimeFormat(intlLocale, options).format(date);
   } else if (typeof date === 'string') {
-    return new Intl.DateTimeFormat('el-GR', options).format(new Date(date));
+    return new Intl.DateTimeFormat(intlLocale, options).format(new Date(date));
   } else {
     throw new Error(`Invalid date: ${date}`);
   }

--- a/src/lib/formatters/time.ts
+++ b/src/lib/formatters/time.ts
@@ -100,17 +100,18 @@ export function formatRelativeTime(date: Date, locale: string = 'el'): string {
  * @param timezone - Optional timezone
  * @returns Formatted date string
  */
-export function formatDate(date: Date, timezone?: string): string {
+export function formatDate(date: Date, timezone?: string, locale: string = 'el'): string {
   const options: Intl.DateTimeFormatOptions = { dateStyle: 'long' };
 
   if (timezone) {
     options.timeZone = timezone;
   }
 
+  const intlLocale = locale === 'en' ? 'en-US' : 'el-GR';
   if (date instanceof Date) {
-    return new Intl.DateTimeFormat('el-GR', options).format(date);
+    return new Intl.DateTimeFormat(intlLocale, options).format(date);
   } else if (typeof date === 'string') {
-    return new Intl.DateTimeFormat('el-GR', options).format(new Date(date));
+    return new Intl.DateTimeFormat(intlLocale, options).format(new Date(date));
   } else {
     throw new Error(`Invalid date: ${date}`);
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -135,8 +135,10 @@ interface SortableSubject {
   name: string;
   // Optional fields used for advanced sorting
   statistics?: Statistics;
-  speakerSegments?: any[];
+  speakerSegments?: unknown[];
   agendaItemIndex?: number | null;
+  nonAgendaReason?: string | null;
+  _count?: { contributions?: number };
 }
 
 export function sortSubjectsByImportance<T extends SortableSubject>(
@@ -145,95 +147,47 @@ export function sortSubjectsByImportance<T extends SortableSubject>(
 ) {
   return [...subjects].sort((a, b) => {
     if (orderBy === 'importance') {
-      // First priority: speaking time from statistics
-      if (a.statistics && b.statistics) {
-        const timeComparison = b.statistics.speakingSeconds - a.statistics.speakingSeconds;
-        // Add tie breaker for equal statistics
-        if (timeComparison === 0) {
-          // If agenda items exist, use them as first tie breaker
-          if (a.agendaItemIndex !== null && b.agendaItemIndex !== null) {
-            return (a.agendaItemIndex ?? Infinity) - (b.agendaItemIndex ?? Infinity);
-          }
-          // If names exist, use alphabetical order as second tie breaker
-          return a.name.localeCompare(b.name);
-        }
-        return timeComparison;
-      }
+      // 1. Agenda status: beforeAgenda sorts last;
+      //    outOfAgenda and regular agenda items are treated equally
+      const aIsBeforeAgenda = a.nonAgendaReason === 'beforeAgenda' ? 1 : 0;
+      const bIsBeforeAgenda = b.nonAgendaReason === 'beforeAgenda' ? 1 : 0;
+      if (aIsBeforeAgenda !== bIsBeforeAgenda) return aIsBeforeAgenda - bIsBeforeAgenda;
 
-      // Alternative for importance: number of speaker segments
-      if (a.speakerSegments && b.speakerSegments) {
-        const segmentComparison = b.speakerSegments.length - a.speakerSegments.length;
-        // Add tie breaker for equal segment counts
-        if (segmentComparison === 0) {
-          // If agenda items exist, use them as first tie breaker
-          if (a.agendaItemIndex !== null && b.agendaItemIndex !== null) {
-            return (a.agendaItemIndex ?? Infinity) - (b.agendaItemIndex ?? Infinity);
-          }
-          // If names exist, use alphabetical order as second tie breaker
-          return a.name.localeCompare(b.name);
-        }
-        return segmentComparison;
-      }
+      // 2. Number of speaker contributions (descending)
+      const aContributions = a._count?.contributions ?? 0;
+      const bContributions = b._count?.contributions ?? 0;
+      if (aContributions !== bContributions) return bContributions - aContributions;
 
-      // If no statistics or segments, use agenda item index
-      if (a.agendaItemIndex !== null && b.agendaItemIndex !== null) {
-        return (a.agendaItemIndex ?? Infinity) - (b.agendaItemIndex ?? Infinity);
-      }
+      // 3. Agenda item index (ascending), non-agenda items sort after agenda items
+      const aIndex = a.agendaItemIndex ?? Infinity;
+      const bIndex = b.agendaItemIndex ?? Infinity;
+      if (aIndex !== bIndex) return aIndex - bIndex;
 
-      // Last resort: alphabetical sort by name
+      // Final tie-breaker: alphabetical by name
       return a.name.localeCompare(b.name);
     } else if (orderBy === 'appearance') {
-      // For appearance order, we need a different approach based on data available
+      // For appearance order, use speaker segment timestamps
 
-      // If we have full speaker segments with timestamps
       if (a.speakerSegments?.length && b.speakerSegments?.length) {
-        // Try to extract timestamps if the structure has them
-        const aHasTimestamps = a.speakerSegments.some(s =>
-          s.startTimestamp || (s.speakerSegment && s.speakerSegment.startTimestamp));
+        const getTimestamp = (s: Record<string, unknown>) =>
+          (s.startTimestamp as number) || ((s.speakerSegment as Record<string, unknown>)?.startTimestamp as number) || 0;
+        const aHasTimestamps = a.speakerSegments.some(s => getTimestamp(s as Record<string, unknown>));
 
         if (aHasTimestamps) {
-          try {
-            // Try to extract timestamps from various possible structures
-            const aTimestamps = a.speakerSegments.map(s =>
-              s.startTimestamp || (s.speakerSegment && s.speakerSegment.startTimestamp) || 0);
-            const bTimestamps = b.speakerSegments.map(s =>
-              s.startTimestamp || (s.speakerSegment && s.speakerSegment.startTimestamp) || 0);
-
-            if (aTimestamps.length && bTimestamps.length) {
-              const timestampComparison = Math.min(...aTimestamps) - Math.min(...bTimestamps);
-              // If timestamps are equal, fall back to agenda item
-              if (timestampComparison === 0) {
-                // If agenda items exist, use them as tie breaker
-                if (a.agendaItemIndex !== null && b.agendaItemIndex !== null) {
-                  return (a.agendaItemIndex ?? Infinity) - (b.agendaItemIndex ?? Infinity);
-                }
-                // Last resort: alphabetical sort by name
-                return a.name.localeCompare(b.name);
-              }
-              return timestampComparison;
-            }
-          } catch (error) {
-            // Fallback silently if timestamp extraction fails
-            console.error("Error extracting timestamps:", error);
-          }
+          const aMin = Math.min(...a.speakerSegments.map(s => getTimestamp(s as Record<string, unknown>)));
+          const bMin = Math.min(...b.speakerSegments.map(s => getTimestamp(s as Record<string, unknown>)));
+          if (aMin !== bMin) return aMin - bMin;
         }
       }
 
-      // Fallback to agenda item index for appearance order
-      if (a.agendaItemIndex !== null && b.agendaItemIndex !== null) {
-        const indexComparison = (a.agendaItemIndex ?? Infinity) - (b.agendaItemIndex ?? Infinity);
-        // If agenda items are equal, sort alphabetically by name
-        if (indexComparison === 0) {
-          return a.name.localeCompare(b.name);
-        }
-        return indexComparison;
-      }
+      // Fallback to agenda item index
+      const aIndex = a.agendaItemIndex ?? Infinity;
+      const bIndex = b.agendaItemIndex ?? Infinity;
+      if (aIndex !== bIndex) return aIndex - bIndex;
 
-      // Last resort: alphabetical sort by name
       return a.name.localeCompare(b.name);
     }
 
-    // Default fallback - alphabetical order
     return a.name.localeCompare(b.name);
   });
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -138,8 +138,10 @@ interface SortableSubject {
   name: string;
   // Optional fields used for advanced sorting
   statistics?: Statistics;
-  speakerSegments?: any[];
+  speakerSegments?: unknown[];
   agendaItemIndex?: number | null;
+  nonAgendaReason?: string | null;
+  _count?: { contributions?: number };
 }
 
 export function sortSubjectsByImportance<T extends SortableSubject>(
@@ -148,95 +150,47 @@ export function sortSubjectsByImportance<T extends SortableSubject>(
 ) {
   return [...subjects].sort((a, b) => {
     if (orderBy === 'importance') {
-      // First priority: speaking time from statistics
-      if (a.statistics && b.statistics) {
-        const timeComparison = b.statistics.speakingSeconds - a.statistics.speakingSeconds;
-        // Add tie breaker for equal statistics
-        if (timeComparison === 0) {
-          // If agenda items exist, use them as first tie breaker
-          if (a.agendaItemIndex !== null && b.agendaItemIndex !== null) {
-            return (a.agendaItemIndex ?? Infinity) - (b.agendaItemIndex ?? Infinity);
-          }
-          // If names exist, use alphabetical order as second tie breaker
-          return a.name.localeCompare(b.name);
-        }
-        return timeComparison;
-      }
+      // 1. Agenda status: beforeAgenda sorts last;
+      //    outOfAgenda and regular agenda items are treated equally
+      const aIsBeforeAgenda = a.nonAgendaReason === 'beforeAgenda' ? 1 : 0;
+      const bIsBeforeAgenda = b.nonAgendaReason === 'beforeAgenda' ? 1 : 0;
+      if (aIsBeforeAgenda !== bIsBeforeAgenda) return aIsBeforeAgenda - bIsBeforeAgenda;
 
-      // Alternative for importance: number of speaker segments
-      if (a.speakerSegments && b.speakerSegments) {
-        const segmentComparison = b.speakerSegments.length - a.speakerSegments.length;
-        // Add tie breaker for equal segment counts
-        if (segmentComparison === 0) {
-          // If agenda items exist, use them as first tie breaker
-          if (a.agendaItemIndex !== null && b.agendaItemIndex !== null) {
-            return (a.agendaItemIndex ?? Infinity) - (b.agendaItemIndex ?? Infinity);
-          }
-          // If names exist, use alphabetical order as second tie breaker
-          return a.name.localeCompare(b.name);
-        }
-        return segmentComparison;
-      }
+      // 2. Number of speaker contributions (descending)
+      const aContributions = a._count?.contributions ?? 0;
+      const bContributions = b._count?.contributions ?? 0;
+      if (aContributions !== bContributions) return bContributions - aContributions;
 
-      // If no statistics or segments, use agenda item index
-      if (a.agendaItemIndex !== null && b.agendaItemIndex !== null) {
-        return (a.agendaItemIndex ?? Infinity) - (b.agendaItemIndex ?? Infinity);
-      }
+      // 3. Agenda item index (ascending), non-agenda items sort after agenda items
+      const aIndex = a.agendaItemIndex ?? Infinity;
+      const bIndex = b.agendaItemIndex ?? Infinity;
+      if (aIndex !== bIndex) return aIndex - bIndex;
 
-      // Last resort: alphabetical sort by name
+      // Final tie-breaker: alphabetical by name
       return a.name.localeCompare(b.name);
     } else if (orderBy === 'appearance') {
-      // For appearance order, we need a different approach based on data available
+      // For appearance order, use speaker segment timestamps
 
-      // If we have full speaker segments with timestamps
       if (a.speakerSegments?.length && b.speakerSegments?.length) {
-        // Try to extract timestamps if the structure has them
-        const aHasTimestamps = a.speakerSegments.some(s =>
-          s.startTimestamp || (s.speakerSegment && s.speakerSegment.startTimestamp));
+        const getTimestamp = (s: Record<string, unknown>) =>
+          (s.startTimestamp as number) || ((s.speakerSegment as Record<string, unknown>)?.startTimestamp as number) || 0;
+        const aHasTimestamps = a.speakerSegments.some(s => getTimestamp(s as Record<string, unknown>));
 
         if (aHasTimestamps) {
-          try {
-            // Try to extract timestamps from various possible structures
-            const aTimestamps = a.speakerSegments.map(s =>
-              s.startTimestamp || (s.speakerSegment && s.speakerSegment.startTimestamp) || 0);
-            const bTimestamps = b.speakerSegments.map(s =>
-              s.startTimestamp || (s.speakerSegment && s.speakerSegment.startTimestamp) || 0);
-
-            if (aTimestamps.length && bTimestamps.length) {
-              const timestampComparison = Math.min(...aTimestamps) - Math.min(...bTimestamps);
-              // If timestamps are equal, fall back to agenda item
-              if (timestampComparison === 0) {
-                // If agenda items exist, use them as tie breaker
-                if (a.agendaItemIndex !== null && b.agendaItemIndex !== null) {
-                  return (a.agendaItemIndex ?? Infinity) - (b.agendaItemIndex ?? Infinity);
-                }
-                // Last resort: alphabetical sort by name
-                return a.name.localeCompare(b.name);
-              }
-              return timestampComparison;
-            }
-          } catch (error) {
-            // Fallback silently if timestamp extraction fails
-            console.error("Error extracting timestamps:", error);
-          }
+          const aMin = Math.min(...a.speakerSegments.map(s => getTimestamp(s as Record<string, unknown>)));
+          const bMin = Math.min(...b.speakerSegments.map(s => getTimestamp(s as Record<string, unknown>)));
+          if (aMin !== bMin) return aMin - bMin;
         }
       }
 
-      // Fallback to agenda item index for appearance order
-      if (a.agendaItemIndex !== null && b.agendaItemIndex !== null) {
-        const indexComparison = (a.agendaItemIndex ?? Infinity) - (b.agendaItemIndex ?? Infinity);
-        // If agenda items are equal, sort alphabetically by name
-        if (indexComparison === 0) {
-          return a.name.localeCompare(b.name);
-        }
-        return indexComparison;
-      }
+      // Fallback to agenda item index
+      const aIndex = a.agendaItemIndex ?? Infinity;
+      const bIndex = b.agendaItemIndex ?? Infinity;
+      if (aIndex !== bIndex) return aIndex - bIndex;
 
-      // Last resort: alphabetical sort by name
       return a.name.localeCompare(b.name);
     }
 
-    // Default fallback - alphabetical order
     return a.name.localeCompare(b.name);
   });
 }

--- a/src/lib/utils/embedTheme.ts
+++ b/src/lib/utils/embedTheme.ts
@@ -1,0 +1,123 @@
+/**
+ * Embed widget theme utilities.
+ *
+ * Derives a full color palette from a single accent hex color + light/dark mode.
+ */
+
+const DEFAULT_ACCENT = '#3b82f6'; // A sensible blue
+
+function hexToRgb(hex: string): [number, number, number] {
+    hex = hex.replace('#', '');
+    if (hex.length === 3) {
+        hex = hex.split('').map(c => c + c).join('');
+    }
+    const n = parseInt(hex, 16);
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
+    r /= 255; g /= 255; b /= 255;
+    const max = Math.max(r, g, b), min = Math.min(r, g, b);
+    const l = (max + min) / 2;
+    if (max === min) return [0, 0, l];
+    const d = max - min;
+    const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    let h = 0;
+    if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+    else if (max === g) h = ((b - r) / d + 2) / 6;
+    else h = ((r - g) / d + 4) / 6;
+    return [h, s, l];
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+    const hue2rgb = (p: number, q: number, t: number) => {
+        if (t < 0) t += 1;
+        if (t > 1) t -= 1;
+        if (t < 1 / 6) return p + (q - p) * 6 * t;
+        if (t < 1 / 2) return q;
+        if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+        return p;
+    };
+    let r: number, g: number, b: number;
+    if (s === 0) {
+        r = g = b = l;
+    } else {
+        const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+        const p = 2 * l - q;
+        r = hue2rgb(p, q, h + 1 / 3);
+        g = hue2rgb(p, q, h);
+        b = hue2rgb(p, q, h - 1 / 3);
+    }
+    const toHex = (n: number) => Math.round(n * 255).toString(16).padStart(2, '0');
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+export interface EmbedThemeVars {
+    '--embed-accent': string;
+    '--embed-accent-light': string;
+    '--embed-accent-dark': string;
+    '--embed-bg': string;
+    '--embed-card-bg': string;
+    '--embed-card-hover': string;
+    '--embed-text': string;
+    '--embed-text-muted': string;
+    '--embed-border': string;
+    '--embed-radius': string;
+}
+
+export type EmbedMode = 'light' | 'dark';
+export type EmbedRadius = 'sharp' | 'rounded' | 'pill';
+
+const RADIUS_MAP: Record<EmbedRadius, string> = {
+    sharp: '0px',
+    rounded: '8px',
+    pill: '16px',
+};
+
+export function parseAccentColor(raw: string | null | undefined): string {
+    if (!raw) return DEFAULT_ACCENT;
+    const cleaned = raw.startsWith('#') ? raw : `#${raw}`;
+    // Validate hex
+    if (/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(cleaned)) return cleaned;
+    return DEFAULT_ACCENT;
+}
+
+export function generateThemeVars(
+    accent: string,
+    mode: EmbedMode = 'light',
+    radius: EmbedRadius = 'rounded',
+): EmbedThemeVars {
+    const [r, g, b] = hexToRgb(accent);
+    const [h, s, l] = rgbToHsl(r, g, b);
+
+    const accentLight = hslToHex(h, s, Math.min(l + 0.15, 0.9));
+    const accentDark = hslToHex(h, s, Math.max(l - 0.15, 0.15));
+
+    if (mode === 'dark') {
+        return {
+            '--embed-accent': accent,
+            '--embed-accent-light': accentLight,
+            '--embed-accent-dark': accentDark,
+            '--embed-bg': '#1a1a1a',
+            '--embed-card-bg': '#262626',
+            '--embed-card-hover': '#333333',
+            '--embed-text': '#e5e5e5',
+            '--embed-text-muted': '#a3a3a3',
+            '--embed-border': '#404040',
+            '--embed-radius': RADIUS_MAP[radius],
+        };
+    }
+
+    return {
+        '--embed-accent': accent,
+        '--embed-accent-light': accentLight,
+        '--embed-accent-dark': accentDark,
+        '--embed-bg': '#ffffff',
+        '--embed-card-bg': '#ffffff',
+        '--embed-card-hover': '#f5f5f5',
+        '--embed-text': '#1a1a1a',
+        '--embed-text-muted': '#737373',
+        '--embed-border': '#e5e5e5',
+        '--embed-radius': RADIUS_MAP[radius],
+    };
+}


### PR DESCRIPTION
## Summary

Municipalities can now embed a meetings widget on their websites (e.g. chania.gr). An admin configures the widget's appearance via a visual configurator, copies an iframe snippet, and pastes it into their CMS.

**Widget** (`/[locale]/embed/meetings?cityId=...`)
- Lists recent and upcoming council meetings with topic icons, dates, admin body names
- Upcoming meetings shown under "Επερχόμενες Συνεδριάσεις" section header
- Customizable: accent color, light/dark mode, card radius, number of meetings, subject visibility, admin body type filter
- "OpenCouncil" footer with logo linking back to the city page
- Cached via `unstable_cache` + CDN headers (`s-maxage=300, stale-while-revalidate=3600`)

**Configurator** (`/[cityId]/widget`, admin-only)
- Live iframe preview, color picker, switches, sliders
- Reuses `BadgePicker` for body type filter (same as meetings list)
- Generates copy-to-clipboard iframe code
- Installation notes section (CSP, WordPress/Joomla tips)
- Accessible via button next to "Επεξεργασία πόλης"

**Subject sorting** (shared by MeetingCard + widget)
- New ordering: beforeAgenda last → contributions count desc → agenda index asc
- Adds `_count.contributions` to meeting query
- `formatDate` now accepts locale parameter

## Test plan

- [ ] Visit `/el/embed/meetings?cityId=chania` — verify widget renders with meetings, subjects, topic icons, footer
- [ ] Visit `/el/embed/meetings?cityId=chania&mode=dark&accent=2B6181` — verify dark mode and custom accent
- [ ] As admin, visit city page → click Widget button → verify configurator loads with live preview
- [ ] Change accent color, toggle dark mode, adjust slider — verify preview updates
- [ ] Copy embed code, paste in an HTML file, open in browser — verify iframe loads
- [ ] Verify no hydration errors in browser console
- [ ] Run `npm test` — all tests pass



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public embeddable surface (iframe/CSP headers) and changes meeting queries/sorting logic, which could affect what meetings/subjects appear and how they’re cached.
> 
> **Overview**
> Adds a new public embed route `/:locale/embed/meetings` that renders a themed, CDN-cached list of upcoming/recent meetings (optional subjects) designed for iframe embedding, plus minimal embed layout/CSS and footer branding.
> 
> Introduces an admin-only `/:cityId/widget` configurator (linked from the city header) that live-previews the iframe, lets admins tune accent color/light-dark/radius/limits/body-type filters, and copy-paste the generated embed code.
> 
> Extends meeting fetching/caching to support administrative-body filtering and upcoming vs past time slicing, updates subject “importance” sorting to use agenda status + contributions counts (with DB `_count.contributions` included), and makes `formatDate` locale-aware; adds corresponding `en`/`el` translations and Next.js headers to allow framing embed pages (`frame-ancestors *`) with cache headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d4e7411fbf10b3e7a6ed41f0664d9215a2bad97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an embeddable meetings widget (`/[locale]/embed/meetings`) with an admin-only configurator (`/[cityId]/widget`), updates `getCouncilMeetingsForCity` with `timeFilter`/`administrativeBodyTypes` support and a two-query fetch strategy for the embed page, and refactors `sortSubjectsByImportance` to use `_count.contributions` and `nonAgendaReason` instead of speaking-time statistics. Auth, input sanitization, and cache-key correctness all look solid.

<h3>Confidence Score: 5/5</h3>

Safe to merge; only P2 findings present.

No P0 or P1 issues found. Auth is correctly awaited on the admin page, public embed inputs are sanitized, cache keys are collision-free, and the two-query approach for upcoming/past meetings is sound. The two P2 findings (asymmetric timestamp guard in appearance sort, window.location.origin in the configurator) are minor and do not affect production correctness.

src/lib/utils.ts (appearance sort guard) and src/components/embed/EmbedConfigurator.tsx (embed URL origin)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/(embed)/embed/meetings/page.tsx | New public embed page: validates inputs, fetches upcoming/past meetings with two parallel cached queries, renders themed widget with section labels and footer. Input sanitization and auth model look correct. |
| src/components/embed/EmbedConfigurator.tsx | Admin configurator for embed widget; uses window.location.origin to build embed URL, which can produce non-canonical URLs in staging/preview environments instead of the production NEXTAUTH_URL. |
| src/lib/utils.ts | sortSubjectsByImportance refactored: importance mode now uses _count.contributions + nonAgendaReason; appearance mode has asymmetric aHasTimestamps guard that can misorder subjects when only one side has real timestamps. |
| src/lib/db/meetings.ts | Adds timeFilter and administrativeBodyTypes to getCouncilMeetingsForCity; introduces shared meetingWithSubjectsInclude (now including _count.contributions) and typed Prisma payload types. Logic is correct. |
| src/lib/cache/queries.ts | Public cached query extended with timeFilter and administrativeBodyTypes; cache key correctly incorporates sorted type list and time filter to avoid stale cross-parameter hits. |
| src/app/[locale]/(city)/[cityId]/(other)/(tabs)/widget/page.tsx | Admin-only widget configurator page; correctly awaits isUserAuthorizedToEdit before rendering, returns notFound() for unauthorized access. |
| src/lib/formatters/time.ts | formatDate now accepts an optional locale parameter (defaulting to 'el'), mapping 'en' to 'en-US' for Intl.DateTimeFormat. Backward-compatible change. |
| next.config.mjs | Adds headers for embed routes: frame-ancestors * (CSP) and CDN cache-control. X-Frame-Options was removed in a prior fix; remaining headers are correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Admin as Admin Browser
    participant WidgetPage as /[cityId]/widget
    participant EmbedPage as /[locale]/embed/meetings
    participant Cache as unstable_cache
    participant DB as Prisma / DB

    Admin->>WidgetPage: GET (isUserAuthorizedToEdit)
    WidgetPage-->>Admin: EmbedConfigurator (iframe preview)

    Admin->>EmbedPage: iframe src (cityId, accent, mode, …)
    EmbedPage->>Cache: getCouncilMeetingsForCityPublicCached (timeFilter: upcoming)
    EmbedPage->>Cache: getCouncilMeetingsForCityPublicCached (timeFilter: past)
    Cache->>DB: findMany (dateTime > now, ASC)
    Cache->>DB: findMany (dateTime ≤ now, DESC)
    DB-->>Cache: upcoming meetings
    DB-->>Cache: past meetings
    Cache-->>EmbedPage: [upcomingAll, pastAll]
    EmbedPage-->>Admin: Rendered widget (CDN-cached, frame-ancestors *)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/lib/utils.ts:177-183
**Asymmetric timestamp guard in `appearance` sort**

Only `aHasTimestamps` is checked before performing the `Math.min` comparison on both subjects. If `a`'s segments all have `startTimestamp = 0` (or no timestamp field), `aHasTimestamps` is `false` and the entire block is skipped — even when `b` has valid timestamps. Conversely, if `a` has real timestamps but `b`'s segments return `0` from `getTimestamp`, `bMin` becomes `0` and `b` sorts to the very front of the list, ahead of `a`, which is incorrect.

Consider checking both sides before entering the timestamp path:

```typescript
const aHasTimestamps = a.speakerSegments.some(s => getTimestamp(s as Record<string, unknown>));
const bHasTimestamps = b.speakerSegments.some(s => getTimestamp(s as Record<string, unknown>));
if (aHasTimestamps && bHasTimestamps) {
```

### Issue 2 of 2
src/components/embed/EmbedConfigurator.tsx:527-530
**Embed URL uses browser origin, not canonical app URL**

`embedUrl` is built from `window.location.origin`, so if an admin accesses the configurator from a staging domain, preview environment, or a custom proxy, the copied iframe `src` will point to that non-canonical origin rather than the production URL. The embed page itself already uses `env.NEXTAUTH_URL` as the authoritative base — the configurator could expose the same value via a server component prop or an env var prefixed with `NEXT_PUBLIC_` to guarantee the generated code always references the production endpoint.

`````

</details>

<sub>Reviews (8): Last reviewed commit: ["refactor(db): derive meeting types from ..."](https://github.com/schemalabz/opencouncil/commit/a84460c554e68c4332dcdc9b476b9dd32189dd17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28019302)</sub>

<!-- /greptile_comment -->