### PR TITLE
Add topic descriptions and admin CRUD UI

### DIFF
--- a/prisma/migrations/20260411120000_add_topic_description/migration.sql
+++ b/prisma/migrations/20260411120000_add_topic_description/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Topic" ADD COLUMN "description" TEXT NOT NULL DEFAULT '';
+ALTER TABLE "Topic" ADD COLUMN "deprecated" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -376,11 +376,13 @@ model TopicLabel {
 }
 
 model Topic {
-  id        String   @id  @default(cuid())
-  name      String
-  name_en   String
-  colorHex  String
-  icon      String?
+  id          String   @id  @default(cuid())
+  name        String
+  name_en     String
+  colorHex    String
+  icon        String?
+  description String   @default("")
+  deprecated  Boolean  @default(false)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/app/[locale]/(other)/admin/cache/page.tsx
+++ b/src/app/[locale]/(other)/admin/cache/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { CacheRevalidationForm } from '@/components/admin/cache/CacheRevalidationForm';
-import { ErrorMessage } from '@/components/onboarding/ErrorMessage';
+import { CacheStats } from '@/components/admin/cache/CacheStats';
 import { Info } from 'lucide-react';
 
 export const metadata: Metadata = {
@@ -45,6 +45,8 @@ export default function CacheRevalidationPage() {
                     </div>
                 </div>
             </div>
+
+            <CacheStats />
 
             <div className="bg-white rounded-lg shadow p-6">
                 <CacheRevalidationForm />

--- a/src/app/[locale]/(other)/admin/topics/page.tsx
+++ b/src/app/[locale]/(other)/admin/topics/page.tsx
@@ -1,0 +1,7 @@
+import { getAllTopicsWithSubjectCount } from "@/lib/db/topics";
+import { TopicsTable } from "@/components/admin/topics/topics-table";
+
+export default async function TopicsAdminPage() {
+    const topics = await getAllTopicsWithSubjectCount();
+    return <TopicsTable initialTopics={topics} />;
+}

--- a/src/app/api/admin/topics/[topicId]/route.ts
+++ b/src/app/api/admin/topics/[topicId]/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { getCurrentUser } from "@/lib/auth";
+import { deleteTopic, updateTopic } from "@/lib/db/topics";
+import { handleApiError } from "@/lib/api/errors";
+
+export async function PUT(
+    request: Request,
+    { params }: { params: { topicId: string } }
+) {
+    const user = await getCurrentUser();
+    if (!user?.isSuperAdmin) {
+        return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    try {
+        const data = await request.json();
+        const { name, name_en, colorHex, icon, description, deprecated } = data;
+
+        const topic = await updateTopic(params.topicId, {
+            name,
+            name_en,
+            colorHex,
+            icon: icon === undefined ? undefined : (icon || null),
+            description,
+            deprecated: deprecated === undefined ? undefined : Boolean(deprecated),
+        });
+
+        revalidatePath("/admin/topics");
+        revalidatePath("/api/topics");
+
+        return NextResponse.json(topic);
+    } catch (error) {
+        return handleApiError(error, "Failed to update topic");
+    }
+}
+
+export async function DELETE(
+    _request: Request,
+    { params }: { params: { topicId: string } }
+) {
+    const user = await getCurrentUser();
+    if (!user?.isSuperAdmin) {
+        return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    try {
+        await deleteTopic(params.topicId);
+
+        revalidatePath("/admin/topics");
+        revalidatePath("/api/topics");
+
+        return NextResponse.json({ message: "Topic deleted successfully" });
+    } catch (error) {
+        return handleApiError(error, "Failed to delete topic");
+    }
+}

--- a/src/app/api/admin/topics/route.ts
+++ b/src/app/api/admin/topics/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { getCurrentUser } from "@/lib/auth";
+import { createTopic, getAllTopicsWithSubjectCount } from "@/lib/db/topics";
+import { handleApiError } from "@/lib/api/errors";
+
+export async function GET() {
+    const user = await getCurrentUser();
+    if (!user?.isSuperAdmin) {
+        return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    try {
+        const topics = await getAllTopicsWithSubjectCount();
+        return NextResponse.json(topics);
+    } catch (error) {
+        return handleApiError(error, "Failed to fetch topics");
+    }
+}
+
+export async function POST(request: Request) {
+    const user = await getCurrentUser();
+    if (!user?.isSuperAdmin) {
+        return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    try {
+        const data = await request.json();
+        const { name, name_en, colorHex, icon, description, deprecated } = data;
+
+        if (!name || !name_en || !colorHex || typeof description !== "string") {
+            return new NextResponse("Missing required fields", { status: 400 });
+        }
+
+        const topic = await createTopic({
+            name,
+            name_en,
+            colorHex,
+            icon: icon || null,
+            description,
+            deprecated: Boolean(deprecated),
+        });
+
+        revalidatePath("/admin/topics");
+        revalidatePath("/api/topics");
+
+        return NextResponse.json(topic);
+    } catch (error) {
+        return handleApiError(error, "Failed to create topic");
+    }
+}

--- a/src/components/admin/cache/CacheStats.tsx
+++ b/src/components/admin/cache/CacheStats.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { RefreshCw, Database, Server, HardDrive, CheckCircle2, XCircle } from 'lucide-react';
+
+interface CacheStatsData {
+  connected: boolean;
+  backend: string;
+  keyCount?: number;
+  memoryUsed?: string;
+  instance: string;
+  error?: string;
+}
+
+export function CacheStats() {
+  const [stats, setStats] = useState<CacheStatsData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStats = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/admin/cache/stats');
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      setStats(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to fetch cache stats');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchStats();
+  }, []);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+        <CardTitle>Cache Backend</CardTitle>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={fetchStats}
+          disabled={isLoading}
+        >
+          <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {error ? (
+          <p className="text-sm text-red-600">{error}</p>
+        ) : !stats ? (
+          <p className="text-sm text-muted-foreground">Loading...</p>
+        ) : (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <StatItem
+              icon={stats.connected
+                ? <CheckCircle2 className="h-4 w-4 text-green-600" />
+                : <XCircle className="h-4 w-4 text-red-500" />
+              }
+              label="Status"
+              value={stats.connected ? 'Connected' : 'Disconnected'}
+              detail={stats.error}
+            />
+            <StatItem
+              icon={<Database className="h-4 w-4 text-muted-foreground" />}
+              label="Backend"
+              value={stats.connected ? 'Valkey' : 'In-memory'}
+            />
+            {stats.connected && (
+              <>
+                <StatItem
+                  icon={<HardDrive className="h-4 w-4 text-muted-foreground" />}
+                  label="Keys"
+                  value={stats.keyCount?.toLocaleString() ?? '—'}
+                  detail={stats.memoryUsed ? `${stats.memoryUsed} used` : undefined}
+                />
+                <StatItem
+                  icon={<Server className="h-4 w-4 text-muted-foreground" />}
+                  label="Instance"
+                  value={stats.instance}
+                />
+              </>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatItem({ icon, label, value, detail }: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  detail?: string;
+}) {
+  return (
+    <div className="flex items-start gap-2">
+      <div className="mt-0.5">{icon}</div>
+      <div className="min-w-0">
+        <p className="text-xs text-muted-foreground">{label}</p>
+        <p className="text-sm font-medium truncate">{value}</p>
+        {detail && <p className="text-xs text-muted-foreground truncate">{detail}</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/sidebar.tsx
+++ b/src/components/admin/sidebar.tsx
@@ -1,4 +1,4 @@
-import { LayoutDashboard, Users, FileText, Settings, Files, FileOutput, Rocket, UserRound, List, RefreshCw, Search, Bell, QrCode, ClipboardCheck, MessageSquareText, Landmark } from "lucide-react";
+import { LayoutDashboard, Users, FileText, Settings, Files, FileOutput, Rocket, UserRound, List, RefreshCw, Search, Bell, QrCode, ClipboardCheck, MessageSquareText, Landmark, Tag } from "lucide-react";
 import Link from "next/link";
 import {
     Sidebar,
@@ -43,6 +43,11 @@ const menuItems = [
         title: "Notifications",
         icon: Bell,
         url: "/admin/notifications",
+    },
+    {
+        title: "Topics",
+        icon: Tag,
+        url: "/admin/topics",
     },
     {
         title: "Offers",

--- a/src/components/admin/topics/topic-dialog.tsx
+++ b/src/components/admin/topics/topic-dialog.tsx
@@ -182,7 +182,7 @@ export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved
                                     variant="outline"
                                     size="icon"
                                     className="h-9 w-9 shrink-0"
-                                    onClick={() => setColorHex(suggestDistinctColor(existingColors))}
+                                    onClick={() => setColorHex(suggestDistinctColor([...existingColors, colorHex]))}
                                     title="Suggest a distinct color"
                                     aria-label="Suggest a distinct color"
                                 >

--- a/src/components/admin/topics/topic-dialog.tsx
+++ b/src/components/admin/topics/topic-dialog.tsx
@@ -49,6 +49,7 @@ export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved
     const [icon, setIcon] = useState<string>(NONE_ICON);
     const [description, setDescription] = useState("");
     const [deprecated, setDeprecated] = useState(false);
+    const [suggestedHistory, setSuggestedHistory] = useState<string[]>([]);
 
     useEffect(() => {
         if (open) {
@@ -58,8 +59,20 @@ export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved
             setIcon(topic?.icon ?? NONE_ICON);
             setDescription(topic?.description ?? "");
             setDeprecated(topic?.deprecated ?? false);
+            setSuggestedHistory([]);
         }
     }, [open, topic]);
+
+    function onManualColorChange(value: string) {
+        setColorHex(value);
+        setSuggestedHistory([]);
+    }
+
+    function onSuggestColor() {
+        const suggestion = suggestDistinctColor([...existingColors, ...suggestedHistory, colorHex]);
+        setColorHex(suggestion);
+        setSuggestedHistory((prev) => [...prev, suggestion]);
+    }
 
     async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
         e.preventDefault();
@@ -166,14 +179,14 @@ export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved
                                     id="colorHex"
                                     type="text"
                                     value={colorHex}
-                                    onChange={(e) => setColorHex(e.target.value)}
+                                    onChange={(e) => onManualColorChange(e.target.value)}
                                     placeholder="#4f46e5"
                                     required
                                 />
                                 <input
                                     type="color"
                                     value={HEX_REGEX.test(colorHex) ? colorHex : "#4f46e5"}
-                                    onChange={(e) => setColorHex(e.target.value)}
+                                    onChange={(e) => onManualColorChange(e.target.value)}
                                     className="h-9 w-9 cursor-pointer rounded border border-input"
                                     aria-label="Color picker"
                                 />
@@ -182,7 +195,7 @@ export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved
                                     variant="outline"
                                     size="icon"
                                     className="h-9 w-9 shrink-0"
-                                    onClick={() => setColorHex(suggestDistinctColor([...existingColors, colorHex]))}
+                                    onClick={onSuggestColor}
                                     title="Suggest a distinct color"
                                     aria-label="Suggest a distinct color"
                                 >

--- a/src/components/admin/topics/topic-dialog.tsx
+++ b/src/components/admin/topics/topic-dialog.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { useEffect, useState } from "react";
+import { Topic } from "@prisma/client";
+import { toast } from "@/hooks/use-toast";
+import { iconMap } from "@/components/icon";
+import { Sparkles } from "lucide-react";
+import { suggestDistinctColor } from "@/lib/utils/colorSuggestion";
+
+interface TopicDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    topic?: Topic;
+    existingColors: string[];
+    onSaved: () => void;
+}
+
+const HEX_REGEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+const NONE_ICON = "__none__";
+const ICON_NAMES = Object.keys(iconMap).sort();
+
+export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved }: TopicDialogProps) {
+    const isEditing = !!topic;
+    const [loading, setLoading] = useState(false);
+
+    const [name, setName] = useState("");
+    const [nameEn, setNameEn] = useState("");
+    const [colorHex, setColorHex] = useState("#4f46e5");
+    const [icon, setIcon] = useState<string>(NONE_ICON);
+    const [description, setDescription] = useState("");
+    const [deprecated, setDeprecated] = useState(false);
+
+    useEffect(() => {
+        if (open) {
+            setName(topic?.name ?? "");
+            setNameEn(topic?.name_en ?? "");
+            setColorHex(topic?.colorHex ?? "#4f46e5");
+            setIcon(topic?.icon ?? NONE_ICON);
+            setDescription(topic?.description ?? "");
+            setDeprecated(topic?.deprecated ?? false);
+        }
+    }, [open, topic]);
+
+    async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+
+        if (!name.trim() || !nameEn.trim()) {
+            toast({
+                title: "Validation error",
+                description: "Name (Greek) and name (English) are required.",
+                variant: "destructive",
+            });
+            return;
+        }
+
+        if (!HEX_REGEX.test(colorHex)) {
+            toast({
+                title: "Validation error",
+                description: "Color must be a valid hex code, e.g. #4f46e5.",
+                variant: "destructive",
+            });
+            return;
+        }
+
+        setLoading(true);
+
+        const payload = {
+            name: name.trim(),
+            name_en: nameEn.trim(),
+            colorHex,
+            icon: icon === NONE_ICON ? null : icon,
+            description: description.trim(),
+            deprecated,
+        };
+
+        try {
+            const url = isEditing ? `/api/admin/topics/${topic!.id}` : "/api/admin/topics";
+            const response = await fetch(url, {
+                method: isEditing ? "PUT" : "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload),
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => null);
+                throw new Error(errorData?.error || "Failed to save topic");
+            }
+
+            toast({
+                title: "Success",
+                description: isEditing ? "Topic updated." : "Topic created.",
+            });
+
+            onSaved();
+            onOpenChange(false);
+        } catch (error) {
+            toast({
+                title: "Error",
+                description: error instanceof Error ? error.message : "Failed to save topic",
+                variant: "destructive",
+            });
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    const SelectedIcon = icon !== NONE_ICON ? iconMap[icon] : null;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-[560px]">
+                <DialogHeader>
+                    <DialogTitle>{isEditing ? "Edit topic" : "Create topic"}</DialogTitle>
+                    <DialogDescription>
+                        Topics are categories assigned to subjects. The description is passed to the LLM
+                        during summarization to help it classify subjects correctly.
+                    </DialogDescription>
+                </DialogHeader>
+                <form onSubmit={onSubmit} className="space-y-4">
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="name">Name (Greek)</Label>
+                            <Input
+                                id="name"
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                                required
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="name_en">Name (English)</Label>
+                            <Input
+                                id="name_en"
+                                value={nameEn}
+                                onChange={(e) => setNameEn(e.target.value)}
+                                required
+                            />
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="colorHex">Color</Label>
+                            <div className="flex items-center gap-2">
+                                <Input
+                                    id="colorHex"
+                                    type="text"
+                                    value={colorHex}
+                                    onChange={(e) => setColorHex(e.target.value)}
+                                    placeholder="#4f46e5"
+                                    required
+                                />
+                                <input
+                                    type="color"
+                                    value={HEX_REGEX.test(colorHex) ? colorHex : "#4f46e5"}
+                                    onChange={(e) => setColorHex(e.target.value)}
+                                    className="h-9 w-9 cursor-pointer rounded border border-input"
+                                    aria-label="Color picker"
+                                />
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="icon"
+                                    className="h-9 w-9 shrink-0"
+                                    onClick={() => setColorHex(suggestDistinctColor(existingColors))}
+                                    title="Suggest a distinct color"
+                                    aria-label="Suggest a distinct color"
+                                >
+                                    <Sparkles className="h-4 w-4" />
+                                </Button>
+                            </div>
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="icon">Icon</Label>
+                            <Select value={icon} onValueChange={setIcon}>
+                                <SelectTrigger id="icon">
+                                    <SelectValue placeholder="Select an icon">
+                                        <div className="flex items-center gap-2">
+                                            {SelectedIcon ? (
+                                                <>
+                                                    <SelectedIcon className="h-4 w-4" style={{ color: colorHex }} />
+                                                    <span>{icon}</span>
+                                                </>
+                                            ) : (
+                                                <span className="text-muted-foreground">None</span>
+                                            )}
+                                        </div>
+                                    </SelectValue>
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value={NONE_ICON}>
+                                        <span className="text-muted-foreground">None</span>
+                                    </SelectItem>
+                                    {ICON_NAMES.map((iconName) => {
+                                        const IconComponent = iconMap[iconName];
+                                        return (
+                                            <SelectItem key={iconName} value={iconName}>
+                                                <div className="flex items-center gap-2">
+                                                    <IconComponent
+                                                        className="h-4 w-4"
+                                                        style={{ color: colorHex }}
+                                                    />
+                                                    <span>{iconName}</span>
+                                                </div>
+                                            </SelectItem>
+                                        );
+                                    })}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="description">Description</Label>
+                        <Textarea
+                            id="description"
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            rows={5}
+                            placeholder="Describe which subjects the LLM should classify under this topic."
+                        />
+                        <p className="text-xs text-muted-foreground">
+                            Used as guidance for the LLM when classifying subjects into this topic.
+                        </p>
+                    </div>
+
+                    <div className="flex items-start justify-between gap-4 rounded-lg border p-3">
+                        <div className="space-y-1">
+                            <Label htmlFor="deprecated">Deprecated</Label>
+                            <p className="text-xs text-muted-foreground">
+                                Deprecated topics are never passed to the task API. Existing subjects keep
+                                their topic assignment, but the LLM will no longer classify new subjects
+                                into this topic.
+                            </p>
+                        </div>
+                        <Switch
+                            id="deprecated"
+                            checked={deprecated}
+                            onCheckedChange={setDeprecated}
+                        />
+                    </div>
+
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => onOpenChange(false)}
+                            disabled={loading}
+                        >
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={loading}>
+                            {loading ? "Saving..." : isEditing ? "Save changes" : "Create topic"}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/admin/topics/topics-table.tsx
+++ b/src/components/admin/topics/topics-table.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { PlusIcon, PencilIcon, Trash2Icon } from "lucide-react";
+import { toast } from "@/hooks/use-toast";
+import { TopicDialog } from "./topic-dialog";
+import { TopicWithSubjectCount } from "@/lib/db/topics";
+import Icon from "@/components/icon";
+import { Badge } from "@/components/ui/badge";
+
+interface TopicsTableProps {
+    initialTopics: TopicWithSubjectCount[];
+}
+
+export function TopicsTable({ initialTopics: topics }: TopicsTableProps) {
+    const router = useRouter();
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [selectedTopic, setSelectedTopic] = useState<TopicWithSubjectCount | undefined>();
+    const [topicToDelete, setTopicToDelete] = useState<TopicWithSubjectCount | null>(null);
+    const [deleting, setDeleting] = useState(false);
+
+    function onCreate() {
+        setSelectedTopic(undefined);
+        setDialogOpen(true);
+    }
+
+    function onEdit(topic: TopicWithSubjectCount) {
+        setSelectedTopic(topic);
+        setDialogOpen(true);
+    }
+
+    async function handleConfirmDelete() {
+        if (!topicToDelete) return;
+        setDeleting(true);
+        try {
+            const response = await fetch(`/api/admin/topics/${topicToDelete.id}`, {
+                method: "DELETE",
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => null);
+                throw new Error(errorData?.error || "Failed to delete topic");
+            }
+
+            toast({
+                title: "Success",
+                description: `Topic "${topicToDelete.name}" has been deleted.`,
+            });
+            setTopicToDelete(null);
+            router.refresh();
+        } catch (error) {
+            toast({
+                title: "Error",
+                description: error instanceof Error ? error.message : "Failed to delete topic",
+                variant: "destructive",
+            });
+        } finally {
+            setDeleting(false);
+        }
+    }
+
+    return (
+        <TooltipProvider>
+            <div className="p-6 space-y-6">
+                <div className="flex justify-between items-center">
+                    <div>
+                        <h1 className="text-2xl font-bold">Topics</h1>
+                        <p className="text-sm text-muted-foreground">
+                            Topic categories used to classify subjects. Descriptions are passed to the LLM during
+                            agenda processing and summarization.
+                        </p>
+                    </div>
+                    <Button onClick={onCreate}>
+                        <PlusIcon className="mr-2 h-4 w-4" />
+                        Create topic
+                    </Button>
+                </div>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>All topics ({topics.length})</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead className="w-20">Symbol</TableHead>
+                                    <TableHead>Name</TableHead>
+                                    <TableHead>Name (EN)</TableHead>
+                                    <TableHead className="w-24 text-right">Subjects</TableHead>
+                                    <TableHead>Description</TableHead>
+                                    <TableHead className="w-32 text-right">Actions</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {topics.length === 0 ? (
+                                    <TableRow>
+                                        <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                                            No topics yet. Create one to get started.
+                                        </TableCell>
+                                    </TableRow>
+                                ) : (
+                                    topics.map((topic) => {
+                                        const subjectCount = topic._count.subjects;
+                                        const canDelete = subjectCount === 0;
+                                        return (
+                                            <TableRow
+                                                key={topic.id}
+                                                className={topic.deprecated ? "bg-amber-50 dark:bg-amber-950/30" : undefined}
+                                            >
+                                                <TableCell>
+                                                    <div
+                                                        className="flex h-9 w-9 items-center justify-center rounded-full border border-border"
+                                                        style={{ backgroundColor: topic.colorHex }}
+                                                        title={topic.colorHex}
+                                                    >
+                                                        {topic.icon && (
+                                                            <Icon name={topic.icon} color="#ffffff" size={18} />
+                                                        )}
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell className="font-medium">
+                                                    <div className="flex items-center gap-2">
+                                                        <span className={topic.deprecated ? "line-through text-muted-foreground" : undefined}>
+                                                            {topic.name}
+                                                        </span>
+                                                        {topic.deprecated && (
+                                                            <Badge variant="destructive" className="uppercase tracking-wide">
+                                                                Deprecated
+                                                            </Badge>
+                                                        )}
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell>{topic.name_en}</TableCell>
+                                                <TableCell className="text-right tabular-nums">
+                                                    {subjectCount}
+                                                </TableCell>
+                                                <TableCell className="max-w-[400px]">
+                                                    <span
+                                                        className="line-clamp-2 text-sm text-muted-foreground"
+                                                        title={topic.description}
+                                                    >
+                                                        {topic.description || (
+                                                            <span className="italic">No description</span>
+                                                        )}
+                                                    </span>
+                                                </TableCell>
+                                                <TableCell className="text-right">
+                                                    <div className="flex justify-end gap-1">
+                                                        <Button
+                                                            variant="ghost"
+                                                            size="sm"
+                                                            onClick={() => onEdit(topic)}
+                                                            aria-label="Edit topic"
+                                                        >
+                                                            <PencilIcon className="h-4 w-4" />
+                                                        </Button>
+                                                        {canDelete ? (
+                                                            <Button
+                                                                variant="ghost"
+                                                                size="sm"
+                                                                onClick={() => setTopicToDelete(topic)}
+                                                                aria-label="Delete topic"
+                                                            >
+                                                                <Trash2Icon className="h-4 w-4" />
+                                                            </Button>
+                                                        ) : (
+                                                            <Tooltip>
+                                                                <TooltipTrigger asChild>
+                                                                    <span>
+                                                                        <Button
+                                                                            variant="ghost"
+                                                                            size="sm"
+                                                                            disabled
+                                                                            aria-label="Delete topic (disabled)"
+                                                                        >
+                                                                            <Trash2Icon className="h-4 w-4" />
+                                                                        </Button>
+                                                                    </span>
+                                                                </TooltipTrigger>
+                                                                <TooltipContent>
+                                                                    Cannot delete: {subjectCount} subject
+                                                                    {subjectCount === 1 ? "" : "s"} still
+                                                                    assigned to this topic.
+                                                                </TooltipContent>
+                                                            </Tooltip>
+                                                        )}
+                                                    </div>
+                                                </TableCell>
+                                            </TableRow>
+                                        );
+                                    })
+                                )}
+                            </TableBody>
+                        </Table>
+                    </CardContent>
+                </Card>
+
+                <TopicDialog
+                    open={dialogOpen}
+                    onOpenChange={setDialogOpen}
+                    topic={selectedTopic}
+                    existingColors={topics
+                        .filter((t) => t.id !== selectedTopic?.id)
+                        .map((t) => t.colorHex)}
+                    onSaved={() => router.refresh()}
+                />
+
+                <Dialog open={!!topicToDelete} onOpenChange={(open) => !open && setTopicToDelete(null)}>
+                    <DialogContent>
+                        <DialogHeader>
+                            <DialogTitle>Delete topic</DialogTitle>
+                            <DialogDescription>
+                                This will permanently delete the topic{" "}
+                                <span className="font-semibold">{topicToDelete?.name}</span>. This cannot be
+                                undone.
+                            </DialogDescription>
+                        </DialogHeader>
+                        <DialogFooter>
+                            <DialogClose asChild>
+                                <Button variant="outline" disabled={deleting}>
+                                    Cancel
+                                </Button>
+                            </DialogClose>
+                            <Button variant="destructive" onClick={handleConfirmDelete} disabled={deleting}>
+                                {deleting ? "Deleting..." : "Delete topic"}
+                            </Button>
+                        </DialogFooter>
+                    </DialogContent>
+                </Dialog>
+            </div>
+        </TooltipProvider>
+    );
+}

--- a/src/lib/__tests__/db-utils.test.ts
+++ b/src/lib/__tests__/db-utils.test.ts
@@ -10,7 +10,10 @@ jest.mock('../db/prisma', () => ({
 jest.mock('../db/transcript', () => ({ getTranscript: jest.fn() }));
 jest.mock('../db/people', () => ({ getPeopleForMeeting: jest.fn() }));
 jest.mock('../db/parties', () => ({ getPartiesForCity: jest.fn() }));
-jest.mock('../db/topics', () => ({ getAllTopics: jest.fn() }));
+jest.mock('../db/topics', () => ({
+    getAllTopics: jest.fn(),
+    getActiveTopicsForTasks: jest.fn(),
+}));
 jest.mock('../db/cities', () => ({ getCity: jest.fn() }));
 jest.mock('../db/meetings', () => ({ getCouncilMeeting: jest.fn() }));
 
@@ -18,7 +21,7 @@ import prisma from '../db/prisma';
 import { getTranscript } from '../db/transcript';
 import { getPeopleForMeeting } from '../db/people';
 import { getPartiesForCity } from '../db/parties';
-import { getAllTopics } from '../db/topics';
+import { getAllTopics, getActiveTopicsForTasks } from '../db/topics';
 import { getCity } from '../db/cities';
 import { getCouncilMeeting } from '../db/meetings';
 import { getRequestOnTranscriptRequestBody } from '../db/utils';
@@ -29,6 +32,7 @@ const mockGetCouncilMeeting = getCouncilMeeting as jest.MockedFunction<typeof ge
 const mockGetPeopleForMeeting = getPeopleForMeeting as jest.MockedFunction<typeof getPeopleForMeeting>;
 const mockGetPartiesForCity = getPartiesForCity as jest.MockedFunction<typeof getPartiesForCity>;
 const mockGetAllTopics = getAllTopics as jest.MockedFunction<typeof getAllTopics>;
+const mockGetActiveTopicsForTasks = getActiveTopicsForTasks as jest.MockedFunction<typeof getActiveTopicsForTasks>;
 const mockGetCity = getCity as jest.MockedFunction<typeof getCity>;
 const mockPrismaPersonFindMany = (prisma.person.findMany as jest.Mock);
 
@@ -53,6 +57,10 @@ function setupCommonMocks() {
 
     mockGetAllTopics.mockResolvedValue([
         { id: 'topic-1', name: 'Environment' },
+    ] as any);
+
+    mockGetActiveTopicsForTasks.mockResolvedValue([
+        { id: 'topic-1', name: 'Environment', description: '' },
     ] as any);
 
     mockGetCity.mockResolvedValue({

--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -105,6 +105,11 @@ export type Voiceprint = {
  * Task: Process Agenda
  */
 
+export interface TopicLabelInfo {
+    name: string;
+    description: string;
+}
+
 export interface ProcessAgendaRequest extends TaskRequest {
     agendaUrl: string;
     people: {
@@ -113,7 +118,7 @@ export interface ProcessAgendaRequest extends TaskRequest {
         role: string;
         party: string;
     }[];
-    topicLabels: string[];
+    topicLabels: TopicLabelInfo[];
     cityName: string;
     date: string;
 }
@@ -237,7 +242,7 @@ export interface RequestOnTranscript extends TaskRequest {
             endTimestamp: number;
         }[];
     }[];
-    topicLabels: string[];
+    topicLabels: TopicLabelInfo[];
     cityName: string;
     administrativeBodyName: string | null;
     partiesWithPeople: {

--- a/src/lib/db/topics.ts
+++ b/src/lib/db/topics.ts
@@ -1,13 +1,113 @@
 "use server";
 import { Topic } from '@prisma/client';
 import prisma from "./prisma";
+import { withUserAuthorizedToEdit } from "../auth";
+import { ConflictError } from "../api/errors";
+
+export type TopicWithSubjectCount = Topic & {
+    _count: {
+        subjects: number;
+    };
+};
 
 export async function getAllTopics(): Promise<Topic[]> {
     try {
-        const topics = await prisma.topic.findMany();
+        const topics = await prisma.topic.findMany({
+            orderBy: { name: 'asc' }
+        });
         return topics;
     } catch (error) {
         console.error('Error fetching topics:', error);
         throw new Error('Failed to fetch topics');
     }
+}
+
+export async function getAllTopicsWithSubjectCount(): Promise<TopicWithSubjectCount[]> {
+    try {
+        const topics = await prisma.topic.findMany({
+            orderBy: { name: 'asc' },
+            include: {
+                _count: {
+                    select: { subjects: true },
+                },
+            },
+        });
+        return topics;
+    } catch (error) {
+        console.error('Error fetching topics with counts:', error);
+        throw new Error('Failed to fetch topics');
+    }
+}
+
+export type TopicInput = {
+    name: string;
+    name_en: string;
+    colorHex: string;
+    icon?: string | null;
+    description: string;
+    deprecated?: boolean;
+};
+
+export async function getActiveTopicsForTasks(): Promise<Topic[]> {
+    try {
+        const topics = await prisma.topic.findMany({
+            where: { deprecated: false },
+            orderBy: { name: 'asc' },
+        });
+        return topics;
+    } catch (error) {
+        console.error('Error fetching active topics:', error);
+        throw new Error('Failed to fetch active topics');
+    }
+}
+
+export async function createTopic(data: TopicInput): Promise<Topic> {
+    await withUserAuthorizedToEdit({});
+    return prisma.topic.create({
+        data: {
+            name: data.name,
+            name_en: data.name_en,
+            colorHex: data.colorHex,
+            icon: data.icon ?? null,
+            description: data.description,
+            deprecated: data.deprecated ?? false,
+        },
+    });
+}
+
+export async function updateTopic(id: string, data: Partial<TopicInput>): Promise<Topic> {
+    await withUserAuthorizedToEdit({});
+    return prisma.topic.update({
+        where: { id },
+        data: {
+            ...(data.name !== undefined && { name: data.name }),
+            ...(data.name_en !== undefined && { name_en: data.name_en }),
+            ...(data.colorHex !== undefined && { colorHex: data.colorHex }),
+            ...(data.icon !== undefined && { icon: data.icon }),
+            ...(data.description !== undefined && { description: data.description }),
+            ...(data.deprecated !== undefined && { deprecated: data.deprecated }),
+        },
+    });
+}
+
+export async function deleteTopic(id: string): Promise<void> {
+    await withUserAuthorizedToEdit({});
+
+    const [subjectCount, labelCount, notificationCount] = await Promise.all([
+        prisma.subject.count({ where: { topicId: id } }),
+        prisma.topicLabel.count({ where: { topicId: id } }),
+        prisma.notificationPreference.count({ where: { interests: { some: { id } } } }),
+    ]);
+
+    if (subjectCount > 0 || labelCount > 0 || notificationCount > 0) {
+        const parts: string[] = [];
+        if (subjectCount > 0) parts.push(`${subjectCount} subject(s)`);
+        if (labelCount > 0) parts.push(`${labelCount} topic label(s)`);
+        if (notificationCount > 0) parts.push(`${notificationCount} notification preference(s)`);
+        throw new ConflictError(
+            `Cannot delete topic: it is still referenced by ${parts.join(', ')}.`
+        );
+    }
+
+    await prisma.topic.delete({ where: { id } });
 }

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -3,7 +3,7 @@
 import { getTranscript } from "./transcript";
 import { getPeopleForMeeting } from "./people";
 import { getPartiesForCity } from "./parties";
-import { getAllTopics } from "./topics";
+import { getActiveTopicsForTasks } from "./topics";
 import { getCity } from "./cities";
 import { getCouncilMeeting } from "./meetings";
 import { RequestOnTranscript, SummarizeRequest, TranscribeRequest, Subject } from "../apiTypes";
@@ -41,7 +41,7 @@ export async function getRequestOnTranscriptRequestBody(councilMeetingId: string
     // People filtered by meeting's administrative body (for LLM context)
     const meetingPeople = await getPeopleForMeeting(cityId, councilMeeting.administrativeBodyId);
     const parties = await getPartiesForCity(cityId);
-    const topics = await getAllTopics();
+    const topics = await getActiveTopicsForTasks();
     const city = await getCity(cityId);
 
     if (!city) {
@@ -69,7 +69,7 @@ export async function getRequestOnTranscriptRequestBody(councilMeetingId: string
                 }))
             };
         }),
-        topicLabels: topics.map(t => t.name),
+        topicLabels: topics.map(t => ({ name: t.name, description: t.description })),
         cityName: city.name,
         administrativeBodyName: councilMeeting.administrativeBody?.name || null,
         partiesWithPeople: parties.map(p => ({

--- a/src/lib/tasks/processAgenda.ts
+++ b/src/lib/tasks/processAgenda.ts
@@ -5,7 +5,7 @@ import { startTask } from "./tasks";
 import prisma from "../db/prisma";
 import { saveSubjectsForMeeting } from "../db/utils";
 import { withUserAuthorizedToEdit } from "../auth";
-import { getAllTopics } from "../db/topics";
+import { getActiveTopicsForTasks } from "../db/topics";
 import { getPartyFromRoles, getRoleNameForPerson } from "../utils";
 import { getPeopleForMeeting } from "../db/people";
 
@@ -65,7 +65,7 @@ export async function requestProcessAgenda(agendaUrl: string, councilMeetingId: 
 
     // Get relevant people for the meeting (filtered by administrative body)
     const people = await getPeopleForMeeting(cityId, councilMeeting.administrativeBodyId);
-    const topicLabels = await getAllTopics();
+    const topicLabels = await getActiveTopicsForTasks();
 
     // Build people array with deduplication by ID (keep last entry)
     const peopleMap = new Map();
@@ -87,7 +87,7 @@ export async function requestProcessAgenda(agendaUrl: string, councilMeetingId: 
         agendaUrl,
         date: councilMeeting.dateTime.toISOString(),
         people: Array.from(peopleMap.values()),
-        topicLabels: topicLabels.map(t => t.name),
+        topicLabels: topicLabels.map(t => ({ name: t.name, description: t.description })),
         cityName: councilMeeting.city.name
     }
 

--- a/src/lib/utils/colorSuggestion.ts
+++ b/src/lib/utils/colorSuggestion.ts
@@ -1,0 +1,88 @@
+/**
+ * Color utilities for suggesting a hex color that is visually distinct
+ * from a set of existing colors.
+ */
+
+type Rgb = [number, number, number];
+
+function hexToRgb(hex: string): Rgb | null {
+    const match = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.exec(hex);
+    if (!match) return null;
+    const raw = match[1];
+    const full = raw.length === 3 ? raw.split("").map((c) => c + c).join("") : raw;
+    return [
+        parseInt(full.slice(0, 2), 16),
+        parseInt(full.slice(2, 4), 16),
+        parseInt(full.slice(4, 6), 16),
+    ];
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+    const sn = s / 100;
+    const ln = l / 100;
+    const c = (1 - Math.abs(2 * ln - 1)) * sn;
+    const hPrime = h / 60;
+    const x = c * (1 - Math.abs((hPrime % 2) - 1));
+    let r = 0;
+    let g = 0;
+    let b = 0;
+    if (hPrime < 1) [r, g, b] = [c, x, 0];
+    else if (hPrime < 2) [r, g, b] = [x, c, 0];
+    else if (hPrime < 3) [r, g, b] = [0, c, x];
+    else if (hPrime < 4) [r, g, b] = [0, x, c];
+    else if (hPrime < 5) [r, g, b] = [x, 0, c];
+    else [r, g, b] = [c, 0, x];
+    const m = ln - c / 2;
+    const toHex = (v: number) =>
+        Math.round((v + m) * 255)
+            .toString(16)
+            .padStart(2, "0");
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+/**
+ * Returns a hex color that maximizes the minimum RGB distance to every
+ * color in `existing`. Candidates are sampled along the hue circle at a
+ * fixed saturation and lightness so the result always looks reasonable.
+ * If `existing` is empty, returns a random saturated color.
+ */
+export function suggestDistinctColor(existing: string[]): string {
+    const existingRgb: Rgb[] = [];
+    for (const hex of existing) {
+        const rgb = hexToRgb(hex);
+        if (rgb) existingRgb.push(rgb);
+    }
+
+    const SATURATION = 70;
+    const LIGHTNESS = 50;
+    const CANDIDATES = 64;
+
+    if (existingRgb.length === 0) {
+        return hslToHex(Math.floor(Math.random() * 360), SATURATION, LIGHTNESS);
+    }
+
+    let bestHex = hslToHex(0, SATURATION, LIGHTNESS);
+    let bestMinDist = -1;
+
+    for (let i = 0; i < CANDIDATES; i++) {
+        const hue = (i / CANDIDATES) * 360;
+        const hex = hslToHex(hue, SATURATION, LIGHTNESS);
+        const rgb = hexToRgb(hex)!;
+
+        let minDist = Infinity;
+        for (const e of existingRgb) {
+            const dr = rgb[0] - e[0];
+            const dg = rgb[1] - e[1];
+            const db = rgb[2] - e[2];
+            const dist = dr * dr + dg * dg + db * db;
+            if (dist < minDist) minDist = dist;
+        }
+
+        if (minDist > bestMinDist) {
+            bestMinDist = minDist;
+            bestHex = hex;
+        }
+    }
+
+    return bestHex;
+}


### PR DESCRIPTION
## Summary

- Adds `description` and `deprecated` fields to the `Topic` model with a single migration.
- New superadmin CRUD UI at `/admin/topics` — table shows a unified colored Symbol (icon in colored circle), subject count, description preview, and a prominent "Deprecated" state (amber row + destructive badge + strikethrough).
- Topic dialog supports: icon dropdown sourced from `iconMap` (previews the actual icon), a "Suggest distinct color" button that picks a hue-wheel candidate maximally far from every existing topic color and from previously-suggested colors in the same session, and a deprecated toggle.
- Delete is disabled in the UI when a topic has subjects; server-side `deleteTopic` throws `ConflictError` (409) if a topic is still referenced by subjects, topic labels, or notification preferences.
- New `getActiveTopicsForTasks()` helper: **deprecated topics are never passed to the `summarize` and `processAgenda` task APIs**, so the LLM stops classifying new subjects into retired topics while existing subjects keep their assignment.

## Task API contract change (coordinate with backend)

`topicLabels` on `ProcessAgendaRequest` and `RequestOnTranscript` changes from `string[]` to `{ name: string; description: string }[]`. This affects the `summarize`, `processAgenda`, `fixTranscript`, and `generatePodcastSpec` endpoints. The backend at `TASK_API_URL` needs to accept the new shape and use the descriptions as classification guidance in its prompt templates. The response shape (`SummarizeResult.speakerSegmentSummaries[].topicLabels: string[]`) is unchanged.

## Note

While this branch was being developed, an unrelated `fixup! feat: shared Valkey cache handler for multi-instance deployments` commit (`4bceda2`) got force-pushed onto it. It's included in this PR's diff (`src/app/[locale]/(other)/admin/cache/page.tsx`, `src/components/admin/cache/CacheStats.tsx`). If that belongs to a separate PR, it should be moved before merge.

## Test plan

- [ ] `npx prisma migrate dev` applies `20260411120000_add_topic_description` cleanly; existing topics backfill with empty description and `deprecated = false`.
- [ ] `npm run prisma:generate && npx tsc --noEmit && npm test` all pass locally.
- [ ] Sign in as a superadmin, open `/admin/topics`: create, edit, delete flows all work; the Sparkles button suggests distinct colors on repeated clicks; icon dropdown shows each icon in the currently-selected color.
- [ ] Toggle Deprecated on a topic that has subjects → topic row gains the amber background + "DEPRECATED" badge + strikethrough name; the topic disappears from subsequent `processAgenda`/`summarize` task payloads (verify via the existing dev-server log in `processAgenda.ts`).
- [ ] Non-superadmin users cannot reach `/admin/topics` or `/api/admin/topics` (existing admin-layout gate + explicit `isSuperAdmin` check on the routes).
- [ ] Try to delete a topic that is still referenced by a subject → 409 with a clear message; UI delete button is also disabled for such topics.
- [ ] Mutate a topic via the admin UI → the public `GET /api/topics` returns the change immediately (cache invalidation via `revalidatePath`).
- [ ] Coordinate with the task-backend team on the `topicLabels` shape change before merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a DB schema migration and changes the task API payload shape for `topicLabels`, which can break downstream task processing if the external task backend isn’t updated. Also adds new admin write endpoints for topics, so authorization/caching invalidation paths should be reviewed.
> 
> **Overview**
> Adds `description` and `deprecated` fields to `Topic` (Prisma schema + migration) and updates task request types so `topicLabels` now send `{ name, description }` instead of strings.
> 
> Introduces a superadmin Topics admin area (`/admin/topics`) with table + dialog for create/edit/delete, including color/icon selection, deprecated toggle, and guarded deletion (UI disable + server-side `ConflictError` if referenced). Deprecated topics are filtered out from task payload generation via `getActiveTopicsForTasks()`.
> 
> Also updates the admin cache page to display new `CacheStats` (fetching `/api/admin/cache/stats`) alongside the existing cache revalidation form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa63be5dc1a24f416bf60dbbf97a01af59457e69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `description` and `deprecated` fields to the `Topic` model, a superadmin CRUD UI at `/admin/topics`, and wires deprecated-topic filtering into the `processAgenda`/`summarize`/`fixTranscript`/`generatePodcast` task APIs via a new `getActiveTopicsForTasks()` helper. The task API contract for `topicLabels` is updated from `string[]` to `{ name: string; description: string }[]` and requires backend coordination before merge (called out in the PR description).

- The UI delete guard (`canDelete = subjectCount === 0`) is incomplete: `deleteTopic` on the server also blocks deletion when `TopicLabel` or `NotificationPreference` records reference the topic, so the delete button can appear enabled while the server will always return 409.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge; one P1 UX bug where the delete button is incorrectly enabled should be addressed first.

One P1 finding: the `canDelete` guard in the UI diverges from the server-side `deleteTopic` conflict check, leading to a confusing flow where the delete button is enabled but will always fail with a 409 when topicLabel or notificationPreference references exist. The remaining findings are P2 style/convention issues.

`src/components/admin/topics/topics-table.tsx` (incomplete delete guard) and `src/lib/db/topics.ts` (type placement, unnecessary try/catch wrappers).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/db/topics.ts | New CRUD functions for Topic model; `TopicWithSubjectCount` defined here rather than in `db/types/`, and read functions have unnecessary try/catch wrappers inconsistent with the write functions. |
| src/components/admin/topics/topics-table.tsx | `canDelete` only checks subject count but server-side `deleteTopic` also blocks on topicLabel and notificationPreference references, so the delete button can be enabled when deletion would always fail. |
| src/app/api/admin/topics/[topicId]/route.ts | Superadmin-only PUT and DELETE routes; correctly delegates conflict detection to `deleteTopic` and surfaces 409 via `handleApiError`. |
| src/lib/tasks/processAgenda.ts | Now uses `getActiveTopicsForTasks()` and maps topics to `{name, description}` shape matching the updated `ProcessAgendaRequest` contract. |
| src/lib/apiTypes.ts | Introduces `TopicLabelInfo` type and updates `topicLabels` field in `ProcessAgendaRequest` and `RequestOnTranscript` from `string[]` to `TopicLabelInfo[]`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor SuperAdmin
    participant UI as TopicsTable (client)
    participant API as /api/admin/topics
    participant DB as topics.ts (server)
    participant TaskAPI as Task API (backend)

    SuperAdmin->>UI: Create / Edit / Delete topic
    UI->>API: POST/PUT/DELETE (fetch)
    API->>API: isSuperAdmin check
    API->>DB: createTopic / updateTopic / deleteTopic
    DB->>DB: withUserAuthorizedToEdit({})
    DB->>DB: Prisma query
    DB-->>API: Topic | ConflictError (409)
    API-->>UI: JSON response / error toast
    API->>API: revalidatePath("/api/topics")

    Note over UI,TaskAPI: Task dispatch flow (processAgenda / summarize)
    SuperAdmin->>UI: Trigger agenda processing
    UI->>API: POST /api/[city]/meetings/[id]/processAgenda
    API->>DB: getActiveTopicsForTasks()
    DB-->>API: Topic[] (deprecated=false only)
    API->>TaskAPI: ProcessAgendaRequest { topicLabels [{name, description}] }
    TaskAPI-->>API: ProcessAgendaResult (callback)
    API->>DB: saveSubjectsForMeeting()
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/components/admin/topics/topics-table.tsx
Line: 131

Comment:
**`canDelete` guard is incomplete — delete button enabled when server will 409**

`canDelete` checks only `subjectCount === 0`, but `deleteTopic` on the server also throws a `ConflictError` when the topic is referenced by `TopicLabel` or `NotificationPreference` records. A topic with 0 subjects but active notification preferences will show an enabled delete button, display the confirmation dialog, and then fail with a 409 error toast — giving users a misleading, confusing experience.

`getAllTopicsWithSubjectCount` only fetches `_count.subjects`, so the UI never learns about label/preference references. Either extend the query to include those counts, or broaden the check:

```suggestion
                                        const canDelete = subjectCount === 0 && topic._count.topicLabels === 0 && topic._count.notificationPreferences === 0;
```

…and update `getAllTopicsWithSubjectCount` to also select `topicLabels: true` and `notificationPreferences` in the `_count` block, and update `TopicWithSubjectCount` accordingly.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/lib/db/topics.ts
Line: 7-11

Comment:
**`TopicWithSubjectCount` should live in `src/lib/db/types/`**

The team convention is to store shared Prisma types in `src/lib/db/types/{entity}.ts`, re-export from `src/lib/db/types/index.ts`, and import from `@/lib/db/types` to prevent circular dependencies. `TopicWithSubjectCount` is currently defined in and imported directly from `@/lib/db/topics`, bypassing that convention. Move it to `src/lib/db/types/topic.ts` and re-export it.

**Context Used:** .cursor/rules/general.mdc ([source](https://app.greptile.com/review/custom-context?memory=dc2172bf-e821-4a8e-b26f-cd165ffe6599))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/lib/db/topics.ts
Line: 25-40

Comment:
**Unnecessary try/catch wrappers in read functions**

`getAllTopicsWithSubjectCount` and `getActiveTopicsForTasks` (and the pre-existing `getAllTopics`) wrap their Prisma calls in a try/catch that just logs and re-throws a generic string. The project guideline says to avoid unnecessary try/catch blocks — these wrappers hide the original Prisma error, make callers harder to debug, and are inconsistent with the new write functions (`createTopic`, `updateTopic`, `deleteTopic`) that let errors propagate naturally. Remove the wrappers and let Prisma errors surface to callers.

**Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=a3ddaa95-717d-48e6-81cd-93c42696bbed))

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fixup! Add Topic descriptions and admin ..."](https://github.com/schemalabz/opencouncil/commit/aa63be5dc1a24f416bf60dbbf97a01af59457e69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28090575)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->