### PR TITLE
Add topic descriptions and admin CRUD UI

### DIFF
--- a/prisma/migrations/20260411120000_add_topic_description/migration.sql
+++ b/prisma/migrations/20260411120000_add_topic_description/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Topic" ADD COLUMN "description" TEXT NOT NULL DEFAULT '';
+ALTER TABLE "Topic" ADD COLUMN "deprecated" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -376,11 +376,13 @@ model TopicLabel {
 }
 
 model Topic {
-  id        String   @id  @default(cuid())
-  name      String
-  name_en   String
-  colorHex  String
-  icon      String?
+  id          String   @id  @default(cuid())
+  name        String
+  name_en     String
+  colorHex    String
+  icon        String?
+  description String   @default("")
+  deprecated  Boolean  @default(false)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/app/[locale]/(other)/admin/topics/page.tsx
+++ b/src/app/[locale]/(other)/admin/topics/page.tsx
@@ -1,0 +1,7 @@
+import { getAllTopicsWithSubjectCount } from "@/lib/db/topics";
+import { TopicsTable } from "@/components/admin/topics/topics-table";
+
+export default async function TopicsAdminPage() {
+    const topics = await getAllTopicsWithSubjectCount();
+    return <TopicsTable initialTopics={topics} />;
+}

--- a/src/app/api/admin/topics/[topicId]/route.ts
+++ b/src/app/api/admin/topics/[topicId]/route.ts
@@ -4,6 +4,8 @@ import { getCurrentUser } from "@/lib/auth";
 import { deleteTopic, updateTopic } from "@/lib/db/topics";
 import { handleApiError } from "@/lib/api/errors";
 
+const HEX_REGEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
 export async function PUT(
     request: Request,
     { params }: { params: { topicId: string } }
@@ -17,13 +19,32 @@ export async function PUT(
         const data = await request.json();
         const { name, name_en, colorHex, icon, description, deprecated } = data;
 
+        if (name !== undefined && (typeof name !== "string" || name.trim() === "")) {
+            return new NextResponse("name must be a non-empty string", { status: 400 });
+        }
+        if (name_en !== undefined && (typeof name_en !== "string" || name_en.trim() === "")) {
+            return new NextResponse("name_en must be a non-empty string", { status: 400 });
+        }
+        if (colorHex !== undefined && (typeof colorHex !== "string" || !HEX_REGEX.test(colorHex))) {
+            return new NextResponse("colorHex must be a valid hex color", { status: 400 });
+        }
+        if (description !== undefined && typeof description !== "string") {
+            return new NextResponse("description must be a string", { status: 400 });
+        }
+        if (icon !== undefined && icon !== null && typeof icon !== "string") {
+            return new NextResponse("icon must be a string or null", { status: 400 });
+        }
+        if (deprecated !== undefined && typeof deprecated !== "boolean") {
+            return new NextResponse("deprecated must be a boolean", { status: 400 });
+        }
+
         const topic = await updateTopic(params.topicId, {
-            name,
-            name_en,
+            name: name === undefined ? undefined : name.trim(),
+            name_en: name_en === undefined ? undefined : name_en.trim(),
             colorHex,
             icon: icon === undefined ? undefined : (icon || null),
             description,
-            deprecated: deprecated === undefined ? undefined : Boolean(deprecated),
+            deprecated,
         });
 
         revalidatePath("/admin/topics");

--- a/src/app/api/admin/topics/[topicId]/route.ts
+++ b/src/app/api/admin/topics/[topicId]/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { getCurrentUser } from "@/lib/auth";
+import { deleteTopic, updateTopic } from "@/lib/db/topics";
+import { handleApiError } from "@/lib/api/errors";
+
+export async function PUT(
+    request: Request,
+    { params }: { params: { topicId: string } }
+) {
+    const user = await getCurrentUser();
+    if (!user?.isSuperAdmin) {
+        return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    try {
+        const data = await request.json();
+        const { name, name_en, colorHex, icon, description, deprecated } = data;
+
+        const topic = await updateTopic(params.topicId, {
+            name,
+            name_en,
+            colorHex,
+            icon: icon === undefined ? undefined : (icon || null),
+            description,
+            deprecated: deprecated === undefined ? undefined : Boolean(deprecated),
+        });
+
+        revalidatePath("/admin/topics");
+        revalidatePath("/api/topics");
+
+        return NextResponse.json(topic);
+    } catch (error) {
+        return handleApiError(error, "Failed to update topic");
+    }
+}
+
+export async function DELETE(
+    _request: Request,
+    { params }: { params: { topicId: string } }
+) {
+    const user = await getCurrentUser();
+    if (!user?.isSuperAdmin) {
+        return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    try {
+        await deleteTopic(params.topicId);
+
+        revalidatePath("/admin/topics");
+        revalidatePath("/api/topics");
+
+        return NextResponse.json({ message: "Topic deleted successfully" });
+    } catch (error) {
+        return handleApiError(error, "Failed to delete topic");
+    }
+}

--- a/src/app/api/admin/topics/[topicId]/route.ts
+++ b/src/app/api/admin/topics/[topicId]/route.ts
@@ -6,6 +6,9 @@ import { handleApiError } from "@/lib/api/errors";
 
 const HEX_REGEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 
+const badRequest = (error: string) =>
+    NextResponse.json({ error }, { status: 400 });
+
 export async function PUT(
     request: Request,
     { params }: { params: { topicId: string } }
@@ -20,22 +23,22 @@ export async function PUT(
         const { name, name_en, colorHex, icon, description, deprecated } = data;
 
         if (name !== undefined && (typeof name !== "string" || name.trim() === "")) {
-            return new NextResponse("name must be a non-empty string", { status: 400 });
+            return badRequest("name must be a non-empty string");
         }
         if (name_en !== undefined && (typeof name_en !== "string" || name_en.trim() === "")) {
-            return new NextResponse("name_en must be a non-empty string", { status: 400 });
+            return badRequest("name_en must be a non-empty string");
         }
         if (colorHex !== undefined && (typeof colorHex !== "string" || !HEX_REGEX.test(colorHex))) {
-            return new NextResponse("colorHex must be a valid hex color", { status: 400 });
+            return badRequest("colorHex must be a valid hex color");
         }
         if (description !== undefined && typeof description !== "string") {
-            return new NextResponse("description must be a string", { status: 400 });
+            return badRequest("description must be a string");
         }
         if (icon !== undefined && icon !== null && typeof icon !== "string") {
-            return new NextResponse("icon must be a string or null", { status: 400 });
+            return badRequest("icon must be a string or null");
         }
         if (deprecated !== undefined && typeof deprecated !== "boolean") {
-            return new NextResponse("deprecated must be a boolean", { status: 400 });
+            return badRequest("deprecated must be a boolean");
         }
 
         const topic = await updateTopic(params.topicId, {

--- a/src/app/api/admin/topics/[topicId]/route.ts
+++ b/src/app/api/admin/topics/[topicId]/route.ts
@@ -1,44 +1,38 @@
 import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
-import { getCurrentUser } from "@/lib/auth";
+import { withUserAuthorizedToEdit } from "@/lib/auth";
 import { deleteTopic, updateTopic } from "@/lib/db/topics";
-import { handleApiError } from "@/lib/api/errors";
+import { BadRequestError, handleApiError } from "@/lib/api/errors";
 
 const HEX_REGEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
-
-const badRequest = (error: string) =>
-    NextResponse.json({ error }, { status: 400 });
 
 export async function PUT(
     request: Request,
     { params }: { params: { topicId: string } }
 ) {
-    const user = await getCurrentUser();
-    if (!user?.isSuperAdmin) {
-        return new NextResponse("Unauthorized", { status: 401 });
-    }
+    await withUserAuthorizedToEdit({});
 
     try {
         const data = await request.json();
         const { name, name_en, colorHex, icon, description, deprecated } = data;
 
         if (name !== undefined && (typeof name !== "string" || name.trim() === "")) {
-            return badRequest("name must be a non-empty string");
+            throw new BadRequestError("name must be a non-empty string");
         }
         if (name_en !== undefined && (typeof name_en !== "string" || name_en.trim() === "")) {
-            return badRequest("name_en must be a non-empty string");
+            throw new BadRequestError("name_en must be a non-empty string");
         }
         if (colorHex !== undefined && (typeof colorHex !== "string" || !HEX_REGEX.test(colorHex))) {
-            return badRequest("colorHex must be a valid hex color");
+            throw new BadRequestError("colorHex must be a valid hex color");
         }
         if (description !== undefined && typeof description !== "string") {
-            return badRequest("description must be a string");
+            throw new BadRequestError("description must be a string");
         }
         if (icon !== undefined && icon !== null && typeof icon !== "string") {
-            return badRequest("icon must be a string or null");
+            throw new BadRequestError("icon must be a string or null");
         }
         if (deprecated !== undefined && typeof deprecated !== "boolean") {
-            return badRequest("deprecated must be a boolean");
+            throw new BadRequestError("deprecated must be a boolean");
         }
 
         const topic = await updateTopic(params.topicId, {
@@ -63,10 +57,7 @@ export async function DELETE(
     _request: Request,
     { params }: { params: { topicId: string } }
 ) {
-    const user = await getCurrentUser();
-    if (!user?.isSuperAdmin) {
-        return new NextResponse("Unauthorized", { status: 401 });
-    }
+    await withUserAuthorizedToEdit({});
 
     try {
         await deleteTopic(params.topicId);

--- a/src/app/api/admin/topics/[topicId]/route.ts
+++ b/src/app/api/admin/topics/[topicId]/route.ts
@@ -3,8 +3,7 @@ import { revalidatePath } from "next/cache";
 import { withUserAuthorizedToEdit } from "@/lib/auth";
 import { deleteTopic, updateTopic } from "@/lib/db/topics";
 import { BadRequestError, handleApiError } from "@/lib/api/errors";
-
-const HEX_REGEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+import { HEX_REGEX } from "@/lib/utils/colorSuggestion";
 
 export async function PUT(
     request: Request,

--- a/src/app/api/admin/topics/[topicId]/route.ts
+++ b/src/app/api/admin/topics/[topicId]/route.ts
@@ -2,8 +2,8 @@ import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
 import { withUserAuthorizedToEdit } from "@/lib/auth";
 import { deleteTopic, updateTopic } from "@/lib/db/topics";
-import { BadRequestError, handleApiError } from "@/lib/api/errors";
-import { HEX_REGEX } from "@/lib/utils/colorSuggestion";
+import { handleApiError } from "@/lib/api/errors";
+import { updateTopicSchema } from "@/lib/zod-schemas/topic";
 
 export async function PUT(
     request: Request,
@@ -12,36 +12,9 @@ export async function PUT(
     await withUserAuthorizedToEdit({});
 
     try {
-        const data = await request.json();
-        const { name, name_en, colorHex, icon, description, deprecated } = data;
+        const data = updateTopicSchema.parse(await request.json());
 
-        if (name !== undefined && (typeof name !== "string" || name.trim() === "")) {
-            throw new BadRequestError("name must be a non-empty string");
-        }
-        if (name_en !== undefined && (typeof name_en !== "string" || name_en.trim() === "")) {
-            throw new BadRequestError("name_en must be a non-empty string");
-        }
-        if (colorHex !== undefined && (typeof colorHex !== "string" || !HEX_REGEX.test(colorHex))) {
-            throw new BadRequestError("colorHex must be a valid hex color");
-        }
-        if (description !== undefined && typeof description !== "string") {
-            throw new BadRequestError("description must be a string");
-        }
-        if (icon !== undefined && icon !== null && typeof icon !== "string") {
-            throw new BadRequestError("icon must be a string or null");
-        }
-        if (deprecated !== undefined && typeof deprecated !== "boolean") {
-            throw new BadRequestError("deprecated must be a boolean");
-        }
-
-        const topic = await updateTopic(params.topicId, {
-            name: name === undefined ? undefined : name.trim(),
-            name_en: name_en === undefined ? undefined : name_en.trim(),
-            colorHex,
-            icon: icon === undefined ? undefined : (icon || null),
-            description,
-            deprecated,
-        });
+        const topic = await updateTopic(params.topicId, data);
 
         revalidatePath("/admin/topics");
         revalidatePath("/api/topics");

--- a/src/app/api/admin/topics/route.ts
+++ b/src/app/api/admin/topics/route.ts
@@ -1,19 +1,13 @@
 import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
-import { getCurrentUser } from "@/lib/auth";
+import { withUserAuthorizedToEdit } from "@/lib/auth";
 import { createTopic, getAllTopicsWithSubjectCount } from "@/lib/db/topics";
-import { handleApiError } from "@/lib/api/errors";
+import { BadRequestError, handleApiError } from "@/lib/api/errors";
 
 const HEX_REGEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 
-const badRequest = (error: string) =>
-    NextResponse.json({ error }, { status: 400 });
-
 export async function GET() {
-    const user = await getCurrentUser();
-    if (!user?.isSuperAdmin) {
-        return new NextResponse("Unauthorized", { status: 401 });
-    }
+    await withUserAuthorizedToEdit({});
 
     try {
         const topics = await getAllTopicsWithSubjectCount();
@@ -24,32 +18,29 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
-    const user = await getCurrentUser();
-    if (!user?.isSuperAdmin) {
-        return new NextResponse("Unauthorized", { status: 401 });
-    }
+    await withUserAuthorizedToEdit({});
 
     try {
         const data = await request.json();
         const { name, name_en, colorHex, icon, description, deprecated } = data;
 
         if (typeof name !== "string" || name.trim() === "") {
-            return badRequest("name is required");
+            throw new BadRequestError("name is required");
         }
         if (typeof name_en !== "string" || name_en.trim() === "") {
-            return badRequest("name_en is required");
+            throw new BadRequestError("name_en is required");
         }
         if (typeof colorHex !== "string" || !HEX_REGEX.test(colorHex)) {
-            return badRequest("colorHex must be a valid hex color");
+            throw new BadRequestError("colorHex must be a valid hex color");
         }
         if (typeof description !== "string") {
-            return badRequest("description must be a string");
+            throw new BadRequestError("description must be a string");
         }
         if (icon !== undefined && icon !== null && typeof icon !== "string") {
-            return badRequest("icon must be a string or null");
+            throw new BadRequestError("icon must be a string or null");
         }
         if (deprecated !== undefined && typeof deprecated !== "boolean") {
-            return badRequest("deprecated must be a boolean");
+            throw new BadRequestError("deprecated must be a boolean");
         }
 
         const topic = await createTopic({

--- a/src/app/api/admin/topics/route.ts
+++ b/src/app/api/admin/topics/route.ts
@@ -3,8 +3,7 @@ import { revalidatePath } from "next/cache";
 import { withUserAuthorizedToEdit } from "@/lib/auth";
 import { createTopic, getAllTopicsWithSubjectCount } from "@/lib/db/topics";
 import { BadRequestError, handleApiError } from "@/lib/api/errors";
-
-const HEX_REGEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+import { HEX_REGEX } from "@/lib/utils/colorSuggestion";
 
 export async function GET() {
     await withUserAuthorizedToEdit({});

--- a/src/app/api/admin/topics/route.ts
+++ b/src/app/api/admin/topics/route.ts
@@ -6,6 +6,9 @@ import { handleApiError } from "@/lib/api/errors";
 
 const HEX_REGEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 
+const badRequest = (error: string) =>
+    NextResponse.json({ error }, { status: 400 });
+
 export async function GET() {
     const user = await getCurrentUser();
     if (!user?.isSuperAdmin) {
@@ -31,22 +34,22 @@ export async function POST(request: Request) {
         const { name, name_en, colorHex, icon, description, deprecated } = data;
 
         if (typeof name !== "string" || name.trim() === "") {
-            return new NextResponse("name is required", { status: 400 });
+            return badRequest("name is required");
         }
         if (typeof name_en !== "string" || name_en.trim() === "") {
-            return new NextResponse("name_en is required", { status: 400 });
+            return badRequest("name_en is required");
         }
         if (typeof colorHex !== "string" || !HEX_REGEX.test(colorHex)) {
-            return new NextResponse("colorHex must be a valid hex color", { status: 400 });
+            return badRequest("colorHex must be a valid hex color");
         }
         if (typeof description !== "string") {
-            return new NextResponse("description must be a string", { status: 400 });
+            return badRequest("description must be a string");
         }
         if (icon !== undefined && icon !== null && typeof icon !== "string") {
-            return new NextResponse("icon must be a string or null", { status: 400 });
+            return badRequest("icon must be a string or null");
         }
         if (deprecated !== undefined && typeof deprecated !== "boolean") {
-            return new NextResponse("deprecated must be a boolean", { status: 400 });
+            return badRequest("deprecated must be a boolean");
         }
 
         const topic = await createTopic({

--- a/src/app/api/admin/topics/route.ts
+++ b/src/app/api/admin/topics/route.ts
@@ -4,6 +4,8 @@ import { getCurrentUser } from "@/lib/auth";
 import { createTopic, getAllTopicsWithSubjectCount } from "@/lib/db/topics";
 import { handleApiError } from "@/lib/api/errors";
 
+const HEX_REGEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
 export async function GET() {
     const user = await getCurrentUser();
     if (!user?.isSuperAdmin) {
@@ -28,13 +30,28 @@ export async function POST(request: Request) {
         const data = await request.json();
         const { name, name_en, colorHex, icon, description, deprecated } = data;
 
-        if (!name || !name_en || !colorHex || typeof description !== "string") {
-            return new NextResponse("Missing required fields", { status: 400 });
+        if (typeof name !== "string" || name.trim() === "") {
+            return new NextResponse("name is required", { status: 400 });
+        }
+        if (typeof name_en !== "string" || name_en.trim() === "") {
+            return new NextResponse("name_en is required", { status: 400 });
+        }
+        if (typeof colorHex !== "string" || !HEX_REGEX.test(colorHex)) {
+            return new NextResponse("colorHex must be a valid hex color", { status: 400 });
+        }
+        if (typeof description !== "string") {
+            return new NextResponse("description must be a string", { status: 400 });
+        }
+        if (icon !== undefined && icon !== null && typeof icon !== "string") {
+            return new NextResponse("icon must be a string or null", { status: 400 });
+        }
+        if (deprecated !== undefined && typeof deprecated !== "boolean") {
+            return new NextResponse("deprecated must be a boolean", { status: 400 });
         }
 
         const topic = await createTopic({
-            name,
-            name_en,
+            name: name.trim(),
+            name_en: name_en.trim(),
             colorHex,
             icon: icon || null,
             description,

--- a/src/app/api/admin/topics/route.ts
+++ b/src/app/api/admin/topics/route.ts
@@ -2,8 +2,8 @@ import { NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
 import { withUserAuthorizedToEdit } from "@/lib/auth";
 import { createTopic, getAllTopicsWithSubjectCount } from "@/lib/db/topics";
-import { BadRequestError, handleApiError } from "@/lib/api/errors";
-import { HEX_REGEX } from "@/lib/utils/colorSuggestion";
+import { handleApiError } from "@/lib/api/errors";
+import { createTopicSchema } from "@/lib/zod-schemas/topic";
 
 export async function GET() {
     await withUserAuthorizedToEdit({});
@@ -20,36 +20,9 @@ export async function POST(request: Request) {
     await withUserAuthorizedToEdit({});
 
     try {
-        const data = await request.json();
-        const { name, name_en, colorHex, icon, description, deprecated } = data;
+        const data = createTopicSchema.parse(await request.json());
 
-        if (typeof name !== "string" || name.trim() === "") {
-            throw new BadRequestError("name is required");
-        }
-        if (typeof name_en !== "string" || name_en.trim() === "") {
-            throw new BadRequestError("name_en is required");
-        }
-        if (typeof colorHex !== "string" || !HEX_REGEX.test(colorHex)) {
-            throw new BadRequestError("colorHex must be a valid hex color");
-        }
-        if (typeof description !== "string") {
-            throw new BadRequestError("description must be a string");
-        }
-        if (icon !== undefined && icon !== null && typeof icon !== "string") {
-            throw new BadRequestError("icon must be a string or null");
-        }
-        if (deprecated !== undefined && typeof deprecated !== "boolean") {
-            throw new BadRequestError("deprecated must be a boolean");
-        }
-
-        const topic = await createTopic({
-            name: name.trim(),
-            name_en: name_en.trim(),
-            colorHex,
-            icon: icon || null,
-            description,
-            deprecated: Boolean(deprecated),
-        });
+        const topic = await createTopic(data);
 
         revalidatePath("/admin/topics");
         revalidatePath("/api/topics");

--- a/src/app/api/admin/topics/route.ts
+++ b/src/app/api/admin/topics/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { getCurrentUser } from "@/lib/auth";
+import { createTopic, getAllTopicsWithSubjectCount } from "@/lib/db/topics";
+import { handleApiError } from "@/lib/api/errors";
+
+export async function GET() {
+    const user = await getCurrentUser();
+    if (!user?.isSuperAdmin) {
+        return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    try {
+        const topics = await getAllTopicsWithSubjectCount();
+        return NextResponse.json(topics);
+    } catch (error) {
+        return handleApiError(error, "Failed to fetch topics");
+    }
+}
+
+export async function POST(request: Request) {
+    const user = await getCurrentUser();
+    if (!user?.isSuperAdmin) {
+        return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    try {
+        const data = await request.json();
+        const { name, name_en, colorHex, icon, description, deprecated } = data;
+
+        if (!name || !name_en || !colorHex || typeof description !== "string") {
+            return new NextResponse("Missing required fields", { status: 400 });
+        }
+
+        const topic = await createTopic({
+            name,
+            name_en,
+            colorHex,
+            icon: icon || null,
+            description,
+            deprecated: Boolean(deprecated),
+        });
+
+        revalidatePath("/admin/topics");
+        revalidatePath("/api/topics");
+
+        return NextResponse.json(topic);
+    } catch (error) {
+        return handleApiError(error, "Failed to create topic");
+    }
+}

--- a/src/components/admin/sidebar.tsx
+++ b/src/components/admin/sidebar.tsx
@@ -1,4 +1,4 @@
-import { LayoutDashboard, Users, FileText, Settings, Files, FileOutput, Rocket, UserRound, List, RefreshCw, Search, Bell, QrCode, ClipboardCheck, MessageSquareText, Landmark } from "lucide-react";
+import { LayoutDashboard, Users, FileText, Settings, Files, FileOutput, Rocket, UserRound, List, RefreshCw, Search, Bell, QrCode, ClipboardCheck, MessageSquareText, Landmark, Tag } from "lucide-react";
 import Link from "next/link";
 import {
     Sidebar,
@@ -43,6 +43,11 @@ const menuItems = [
         title: "Notifications",
         icon: Bell,
         url: "/admin/notifications",
+    },
+    {
+        title: "Topics",
+        icon: Tag,
+        url: "/admin/topics",
     },
     {
         title: "Offers",

--- a/src/components/admin/topics/topic-dialog.tsx
+++ b/src/components/admin/topics/topic-dialog.tsx
@@ -182,7 +182,7 @@ export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved
                                     variant="outline"
                                     size="icon"
                                     className="h-9 w-9 shrink-0"
-                                    onClick={() => setColorHex(suggestDistinctColor(existingColors))}
+                                    onClick={() => setColorHex(suggestDistinctColor([...existingColors, colorHex]))}
                                     title="Suggest a distinct color"
                                     aria-label="Suggest a distinct color"
                                 >

--- a/src/components/admin/topics/topic-dialog.tsx
+++ b/src/components/admin/topics/topic-dialog.tsx
@@ -25,7 +25,7 @@ import { Topic } from "@prisma/client";
 import { toast } from "@/hooks/use-toast";
 import { iconMap } from "@/components/icon";
 import { Sparkles } from "lucide-react";
-import { suggestDistinctColor } from "@/lib/utils/colorSuggestion";
+import { HEX_REGEX, suggestDistinctColor } from "@/lib/utils/colorSuggestion";
 
 interface TopicDialogProps {
     open: boolean;
@@ -34,8 +34,6 @@ interface TopicDialogProps {
     existingColors: string[];
     onSaved: () => void;
 }
-
-const HEX_REGEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 const NONE_ICON = "__none__";
 const ICON_NAMES = Object.keys(iconMap).sort();
 

--- a/src/components/admin/topics/topic-dialog.tsx
+++ b/src/components/admin/topics/topic-dialog.tsx
@@ -49,6 +49,7 @@ export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved
     const [icon, setIcon] = useState<string>(NONE_ICON);
     const [description, setDescription] = useState("");
     const [deprecated, setDeprecated] = useState(false);
+    const [suggestedHistory, setSuggestedHistory] = useState<string[]>([]);
 
     useEffect(() => {
         if (open) {
@@ -58,8 +59,20 @@ export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved
             setIcon(topic?.icon ?? NONE_ICON);
             setDescription(topic?.description ?? "");
             setDeprecated(topic?.deprecated ?? false);
+            setSuggestedHistory([]);
         }
     }, [open, topic]);
+
+    function onManualColorChange(value: string) {
+        setColorHex(value);
+        setSuggestedHistory([]);
+    }
+
+    function onSuggestColor() {
+        const suggestion = suggestDistinctColor([...existingColors, ...suggestedHistory, colorHex]);
+        setColorHex(suggestion);
+        setSuggestedHistory((prev) => [...prev, suggestion]);
+    }
 
     async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
         e.preventDefault();
@@ -166,14 +179,14 @@ export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved
                                     id="colorHex"
                                     type="text"
                                     value={colorHex}
-                                    onChange={(e) => setColorHex(e.target.value)}
+                                    onChange={(e) => onManualColorChange(e.target.value)}
                                     placeholder="#4f46e5"
                                     required
                                 />
                                 <input
                                     type="color"
                                     value={HEX_REGEX.test(colorHex) ? colorHex : "#4f46e5"}
-                                    onChange={(e) => setColorHex(e.target.value)}
+                                    onChange={(e) => onManualColorChange(e.target.value)}
                                     className="h-9 w-9 cursor-pointer rounded border border-input"
                                     aria-label="Color picker"
                                 />
@@ -182,7 +195,7 @@ export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved
                                     variant="outline"
                                     size="icon"
                                     className="h-9 w-9 shrink-0"
-                                    onClick={() => setColorHex(suggestDistinctColor([...existingColors, colorHex]))}
+                                    onClick={onSuggestColor}
                                     title="Suggest a distinct color"
                                     aria-label="Suggest a distinct color"
                                 >

--- a/src/components/admin/topics/topic-dialog.tsx
+++ b/src/components/admin/topics/topic-dialog.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { useEffect, useState } from "react";
+import { Topic } from "@prisma/client";
+import { toast } from "@/hooks/use-toast";
+import { iconMap } from "@/components/icon";
+import { Sparkles } from "lucide-react";
+import { suggestDistinctColor } from "@/lib/utils/colorSuggestion";
+
+interface TopicDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    topic?: Topic;
+    existingColors: string[];
+    onSaved: () => void;
+}
+
+const HEX_REGEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+const NONE_ICON = "__none__";
+const ICON_NAMES = Object.keys(iconMap).sort();
+
+export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved }: TopicDialogProps) {
+    const isEditing = !!topic;
+    const [loading, setLoading] = useState(false);
+
+    const [name, setName] = useState("");
+    const [nameEn, setNameEn] = useState("");
+    const [colorHex, setColorHex] = useState("#4f46e5");
+    const [icon, setIcon] = useState<string>(NONE_ICON);
+    const [description, setDescription] = useState("");
+    const [deprecated, setDeprecated] = useState(false);
+
+    useEffect(() => {
+        if (open) {
+            setName(topic?.name ?? "");
+            setNameEn(topic?.name_en ?? "");
+            setColorHex(topic?.colorHex ?? "#4f46e5");
+            setIcon(topic?.icon ?? NONE_ICON);
+            setDescription(topic?.description ?? "");
+            setDeprecated(topic?.deprecated ?? false);
+        }
+    }, [open, topic]);
+
+    async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+
+        if (!name.trim() || !nameEn.trim()) {
+            toast({
+                title: "Validation error",
+                description: "Name (Greek) and name (English) are required.",
+                variant: "destructive",
+            });
+            return;
+        }
+
+        if (!HEX_REGEX.test(colorHex)) {
+            toast({
+                title: "Validation error",
+                description: "Color must be a valid hex code, e.g. #4f46e5.",
+                variant: "destructive",
+            });
+            return;
+        }
+
+        setLoading(true);
+
+        const payload = {
+            name: name.trim(),
+            name_en: nameEn.trim(),
+            colorHex,
+            icon: icon === NONE_ICON ? null : icon,
+            description: description.trim(),
+            deprecated,
+        };
+
+        try {
+            const url = isEditing ? `/api/admin/topics/${topic!.id}` : "/api/admin/topics";
+            const response = await fetch(url, {
+                method: isEditing ? "PUT" : "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(payload),
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => null);
+                throw new Error(errorData?.error || "Failed to save topic");
+            }
+
+            toast({
+                title: "Success",
+                description: isEditing ? "Topic updated." : "Topic created.",
+            });
+
+            onSaved();
+            onOpenChange(false);
+        } catch (error) {
+            toast({
+                title: "Error",
+                description: error instanceof Error ? error.message : "Failed to save topic",
+                variant: "destructive",
+            });
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    const SelectedIcon = icon !== NONE_ICON ? iconMap[icon] : null;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-[560px]">
+                <DialogHeader>
+                    <DialogTitle>{isEditing ? "Edit topic" : "Create topic"}</DialogTitle>
+                    <DialogDescription>
+                        Topics are categories assigned to subjects. The description is passed to the LLM
+                        during summarization to help it classify subjects correctly.
+                    </DialogDescription>
+                </DialogHeader>
+                <form onSubmit={onSubmit} className="space-y-4">
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="name">Name (Greek)</Label>
+                            <Input
+                                id="name"
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                                required
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="name_en">Name (English)</Label>
+                            <Input
+                                id="name_en"
+                                value={nameEn}
+                                onChange={(e) => setNameEn(e.target.value)}
+                                required
+                            />
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="colorHex">Color</Label>
+                            <div className="flex items-center gap-2">
+                                <Input
+                                    id="colorHex"
+                                    type="text"
+                                    value={colorHex}
+                                    onChange={(e) => setColorHex(e.target.value)}
+                                    placeholder="#4f46e5"
+                                    required
+                                />
+                                <input
+                                    type="color"
+                                    value={HEX_REGEX.test(colorHex) ? colorHex : "#4f46e5"}
+                                    onChange={(e) => setColorHex(e.target.value)}
+                                    className="h-9 w-9 cursor-pointer rounded border border-input"
+                                    aria-label="Color picker"
+                                />
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="icon"
+                                    className="h-9 w-9 shrink-0"
+                                    onClick={() => setColorHex(suggestDistinctColor(existingColors))}
+                                    title="Suggest a distinct color"
+                                    aria-label="Suggest a distinct color"
+                                >
+                                    <Sparkles className="h-4 w-4" />
+                                </Button>
+                            </div>
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="icon">Icon</Label>
+                            <Select value={icon} onValueChange={setIcon}>
+                                <SelectTrigger id="icon">
+                                    <SelectValue placeholder="Select an icon">
+                                        <div className="flex items-center gap-2">
+                                            {SelectedIcon ? (
+                                                <>
+                                                    <SelectedIcon className="h-4 w-4" style={{ color: colorHex }} />
+                                                    <span>{icon}</span>
+                                                </>
+                                            ) : (
+                                                <span className="text-muted-foreground">None</span>
+                                            )}
+                                        </div>
+                                    </SelectValue>
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value={NONE_ICON}>
+                                        <span className="text-muted-foreground">None</span>
+                                    </SelectItem>
+                                    {ICON_NAMES.map((iconName) => {
+                                        const IconComponent = iconMap[iconName];
+                                        return (
+                                            <SelectItem key={iconName} value={iconName}>
+                                                <div className="flex items-center gap-2">
+                                                    <IconComponent
+                                                        className="h-4 w-4"
+                                                        style={{ color: colorHex }}
+                                                    />
+                                                    <span>{iconName}</span>
+                                                </div>
+                                            </SelectItem>
+                                        );
+                                    })}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="description">Description</Label>
+                        <Textarea
+                            id="description"
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            rows={5}
+                            placeholder="Describe which subjects the LLM should classify under this topic."
+                        />
+                        <p className="text-xs text-muted-foreground">
+                            Used as guidance for the LLM when classifying subjects into this topic.
+                        </p>
+                    </div>
+
+                    <div className="flex items-start justify-between gap-4 rounded-lg border p-3">
+                        <div className="space-y-1">
+                            <Label htmlFor="deprecated">Deprecated</Label>
+                            <p className="text-xs text-muted-foreground">
+                                Deprecated topics are never passed to the task API. Existing subjects keep
+                                their topic assignment, but the LLM will no longer classify new subjects
+                                into this topic.
+                            </p>
+                        </div>
+                        <Switch
+                            id="deprecated"
+                            checked={deprecated}
+                            onCheckedChange={setDeprecated}
+                        />
+                    </div>
+
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => onOpenChange(false)}
+                            disabled={loading}
+                        >
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={loading}>
+                            {loading ? "Saving..." : isEditing ? "Save changes" : "Create topic"}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/admin/topics/topics-table.tsx
+++ b/src/components/admin/topics/topics-table.tsx
@@ -128,7 +128,8 @@ export function TopicsTable({ initialTopics: topics }: TopicsTableProps) {
                                 ) : (
                                     topics.map((topic) => {
                                         const subjectCount = topic._count.subjects;
-                                        const canDelete = subjectCount === 0;
+                                        const labelCount = topic._count.topicLabels;
+                                        const canDelete = subjectCount === 0 && labelCount === 0;
                                         return (
                                             <TableRow
                                                 key={topic.id}
@@ -205,9 +206,11 @@ export function TopicsTable({ initialTopics: topics }: TopicsTableProps) {
                                                                     </span>
                                                                 </TooltipTrigger>
                                                                 <TooltipContent>
-                                                                    Cannot delete: {subjectCount} subject
-                                                                    {subjectCount === 1 ? "" : "s"} still
-                                                                    assigned to this topic.
+                                                                    Cannot delete: still referenced by
+                                                                    {subjectCount > 0 && ` ${subjectCount} subject${subjectCount === 1 ? "" : "s"}`}
+                                                                    {subjectCount > 0 && labelCount > 0 && " and"}
+                                                                    {labelCount > 0 && ` ${labelCount} topic label${labelCount === 1 ? "" : "s"}`}
+                                                                    .
                                                                 </TooltipContent>
                                                             </Tooltip>
                                                         )}

--- a/src/components/admin/topics/topics-table.tsx
+++ b/src/components/admin/topics/topics-table.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { PlusIcon, PencilIcon, Trash2Icon } from "lucide-react";
+import { toast } from "@/hooks/use-toast";
+import { TopicDialog } from "./topic-dialog";
+import { TopicWithSubjectCount } from "@/lib/db/topics";
+import Icon from "@/components/icon";
+import { Badge } from "@/components/ui/badge";
+
+interface TopicsTableProps {
+    initialTopics: TopicWithSubjectCount[];
+}
+
+export function TopicsTable({ initialTopics: topics }: TopicsTableProps) {
+    const router = useRouter();
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [selectedTopic, setSelectedTopic] = useState<TopicWithSubjectCount | undefined>();
+    const [topicToDelete, setTopicToDelete] = useState<TopicWithSubjectCount | null>(null);
+    const [deleting, setDeleting] = useState(false);
+
+    function onCreate() {
+        setSelectedTopic(undefined);
+        setDialogOpen(true);
+    }
+
+    function onEdit(topic: TopicWithSubjectCount) {
+        setSelectedTopic(topic);
+        setDialogOpen(true);
+    }
+
+    async function handleConfirmDelete() {
+        if (!topicToDelete) return;
+        setDeleting(true);
+        try {
+            const response = await fetch(`/api/admin/topics/${topicToDelete.id}`, {
+                method: "DELETE",
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => null);
+                throw new Error(errorData?.error || "Failed to delete topic");
+            }
+
+            toast({
+                title: "Success",
+                description: `Topic "${topicToDelete.name}" has been deleted.`,
+            });
+            setTopicToDelete(null);
+            router.refresh();
+        } catch (error) {
+            toast({
+                title: "Error",
+                description: error instanceof Error ? error.message : "Failed to delete topic",
+                variant: "destructive",
+            });
+        } finally {
+            setDeleting(false);
+        }
+    }
+
+    return (
+        <TooltipProvider>
+            <div className="p-6 space-y-6">
+                <div className="flex justify-between items-center">
+                    <div>
+                        <h1 className="text-2xl font-bold">Topics</h1>
+                        <p className="text-sm text-muted-foreground">
+                            Topic categories used to classify subjects. Descriptions are passed to the LLM during
+                            agenda processing and summarization.
+                        </p>
+                    </div>
+                    <Button onClick={onCreate}>
+                        <PlusIcon className="mr-2 h-4 w-4" />
+                        Create topic
+                    </Button>
+                </div>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>All topics ({topics.length})</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead className="w-20">Symbol</TableHead>
+                                    <TableHead>Name</TableHead>
+                                    <TableHead>Name (EN)</TableHead>
+                                    <TableHead className="w-24 text-right">Subjects</TableHead>
+                                    <TableHead>Description</TableHead>
+                                    <TableHead className="w-32 text-right">Actions</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {topics.length === 0 ? (
+                                    <TableRow>
+                                        <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
+                                            No topics yet. Create one to get started.
+                                        </TableCell>
+                                    </TableRow>
+                                ) : (
+                                    topics.map((topic) => {
+                                        const subjectCount = topic._count.subjects;
+                                        const canDelete = subjectCount === 0;
+                                        return (
+                                            <TableRow
+                                                key={topic.id}
+                                                className={topic.deprecated ? "bg-amber-50 dark:bg-amber-950/30" : undefined}
+                                            >
+                                                <TableCell>
+                                                    <div
+                                                        className="flex h-9 w-9 items-center justify-center rounded-full border border-border"
+                                                        style={{ backgroundColor: topic.colorHex }}
+                                                        title={topic.colorHex}
+                                                    >
+                                                        {topic.icon && (
+                                                            <Icon name={topic.icon} color="#ffffff" size={18} />
+                                                        )}
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell className="font-medium">
+                                                    <div className="flex items-center gap-2">
+                                                        <span className={topic.deprecated ? "line-through text-muted-foreground" : undefined}>
+                                                            {topic.name}
+                                                        </span>
+                                                        {topic.deprecated && (
+                                                            <Badge variant="destructive" className="uppercase tracking-wide">
+                                                                Deprecated
+                                                            </Badge>
+                                                        )}
+                                                    </div>
+                                                </TableCell>
+                                                <TableCell>{topic.name_en}</TableCell>
+                                                <TableCell className="text-right tabular-nums">
+                                                    {subjectCount}
+                                                </TableCell>
+                                                <TableCell className="max-w-[400px]">
+                                                    <span
+                                                        className="line-clamp-2 text-sm text-muted-foreground"
+                                                        title={topic.description}
+                                                    >
+                                                        {topic.description || (
+                                                            <span className="italic">No description</span>
+                                                        )}
+                                                    </span>
+                                                </TableCell>
+                                                <TableCell className="text-right">
+                                                    <div className="flex justify-end gap-1">
+                                                        <Button
+                                                            variant="ghost"
+                                                            size="sm"
+                                                            onClick={() => onEdit(topic)}
+                                                            aria-label="Edit topic"
+                                                        >
+                                                            <PencilIcon className="h-4 w-4" />
+                                                        </Button>
+                                                        {canDelete ? (
+                                                            <Button
+                                                                variant="ghost"
+                                                                size="sm"
+                                                                onClick={() => setTopicToDelete(topic)}
+                                                                aria-label="Delete topic"
+                                                            >
+                                                                <Trash2Icon className="h-4 w-4" />
+                                                            </Button>
+                                                        ) : (
+                                                            <Tooltip>
+                                                                <TooltipTrigger asChild>
+                                                                    <span>
+                                                                        <Button
+                                                                            variant="ghost"
+                                                                            size="sm"
+                                                                            disabled
+                                                                            aria-label="Delete topic (disabled)"
+                                                                        >
+                                                                            <Trash2Icon className="h-4 w-4" />
+                                                                        </Button>
+                                                                    </span>
+                                                                </TooltipTrigger>
+                                                                <TooltipContent>
+                                                                    Cannot delete: {subjectCount} subject
+                                                                    {subjectCount === 1 ? "" : "s"} still
+                                                                    assigned to this topic.
+                                                                </TooltipContent>
+                                                            </Tooltip>
+                                                        )}
+                                                    </div>
+                                                </TableCell>
+                                            </TableRow>
+                                        );
+                                    })
+                                )}
+                            </TableBody>
+                        </Table>
+                    </CardContent>
+                </Card>
+
+                <TopicDialog
+                    open={dialogOpen}
+                    onOpenChange={setDialogOpen}
+                    topic={selectedTopic}
+                    existingColors={topics
+                        .filter((t) => t.id !== selectedTopic?.id)
+                        .map((t) => t.colorHex)}
+                    onSaved={() => router.refresh()}
+                />
+
+                <Dialog open={!!topicToDelete} onOpenChange={(open) => !open && setTopicToDelete(null)}>
+                    <DialogContent>
+                        <DialogHeader>
+                            <DialogTitle>Delete topic</DialogTitle>
+                            <DialogDescription>
+                                This will permanently delete the topic{" "}
+                                <span className="font-semibold">{topicToDelete?.name}</span>. This cannot be
+                                undone.
+                            </DialogDescription>
+                        </DialogHeader>
+                        <DialogFooter>
+                            <DialogClose asChild>
+                                <Button variant="outline" disabled={deleting}>
+                                    Cancel
+                                </Button>
+                            </DialogClose>
+                            <Button variant="destructive" onClick={handleConfirmDelete} disabled={deleting}>
+                                {deleting ? "Deleting..." : "Delete topic"}
+                            </Button>
+                        </DialogFooter>
+                    </DialogContent>
+                </Dialog>
+            </div>
+        </TooltipProvider>
+    );
+}

--- a/src/components/admin/topics/topics-table.tsx
+++ b/src/components/admin/topics/topics-table.tsx
@@ -129,7 +129,8 @@ export function TopicsTable({ initialTopics: topics }: TopicsTableProps) {
                                     topics.map((topic) => {
                                         const subjectCount = topic._count.subjects;
                                         const labelCount = topic._count.topicLabels;
-                                        const canDelete = subjectCount === 0 && labelCount === 0;
+                                        const notificationCount = topic._count.notificationPreferences;
+                                        const canDelete = subjectCount === 0 && labelCount === 0 && notificationCount === 0;
                                         return (
                                             <TableRow
                                                 key={topic.id}
@@ -206,10 +207,14 @@ export function TopicsTable({ initialTopics: topics }: TopicsTableProps) {
                                                                     </span>
                                                                 </TooltipTrigger>
                                                                 <TooltipContent>
-                                                                    Cannot delete: still referenced by
-                                                                    {subjectCount > 0 && ` ${subjectCount} subject${subjectCount === 1 ? "" : "s"}`}
-                                                                    {subjectCount > 0 && labelCount > 0 && " and"}
-                                                                    {labelCount > 0 && ` ${labelCount} topic label${labelCount === 1 ? "" : "s"}`}
+                                                                    Cannot delete: still referenced by{" "}
+                                                                    {[
+                                                                        subjectCount > 0 && `${subjectCount} subject${subjectCount === 1 ? "" : "s"}`,
+                                                                        labelCount > 0 && `${labelCount} topic label${labelCount === 1 ? "" : "s"}`,
+                                                                        notificationCount > 0 && `${notificationCount} notification preference${notificationCount === 1 ? "" : "s"}`,
+                                                                    ]
+                                                                        .filter(Boolean)
+                                                                        .join(", ")}
                                                                     .
                                                                 </TooltipContent>
                                                             </Tooltip>

--- a/src/components/onboarding/selectors/TopicSelector.tsx
+++ b/src/components/onboarding/selectors/TopicSelector.tsx
@@ -56,7 +56,7 @@ export function TopicSelector({
                     throw new Error('Failed to fetch topics');
                 }
 
-                setTopics(topics);
+                setTopics(topics.filter(t => !t.deprecated));
             } catch (err) {
                 setError('Υπήρξε πρόβλημα στη φόρτωση των θεμάτων');
                 console.error(err);

--- a/src/lib/__tests__/db-utils.test.ts
+++ b/src/lib/__tests__/db-utils.test.ts
@@ -10,7 +10,10 @@ jest.mock('../db/prisma', () => ({
 jest.mock('../db/transcript', () => ({ getTranscript: jest.fn() }));
 jest.mock('../db/people', () => ({ getPeopleForMeeting: jest.fn() }));
 jest.mock('../db/parties', () => ({ getPartiesForCity: jest.fn() }));
-jest.mock('../db/topics', () => ({ getAllTopics: jest.fn() }));
+jest.mock('../db/topics', () => ({
+    getAllTopics: jest.fn(),
+    getActiveTopicsForTasks: jest.fn(),
+}));
 jest.mock('../db/cities', () => ({ getCity: jest.fn() }));
 jest.mock('../db/meetings', () => ({ getCouncilMeeting: jest.fn() }));
 
@@ -18,7 +21,7 @@ import prisma from '../db/prisma';
 import { getTranscript } from '../db/transcript';
 import { getPeopleForMeeting } from '../db/people';
 import { getPartiesForCity } from '../db/parties';
-import { getAllTopics } from '../db/topics';
+import { getAllTopics, getActiveTopicsForTasks } from '../db/topics';
 import { getCity } from '../db/cities';
 import { getCouncilMeeting } from '../db/meetings';
 import { getRequestOnTranscriptRequestBody } from '../db/utils';
@@ -29,6 +32,7 @@ const mockGetCouncilMeeting = getCouncilMeeting as jest.MockedFunction<typeof ge
 const mockGetPeopleForMeeting = getPeopleForMeeting as jest.MockedFunction<typeof getPeopleForMeeting>;
 const mockGetPartiesForCity = getPartiesForCity as jest.MockedFunction<typeof getPartiesForCity>;
 const mockGetAllTopics = getAllTopics as jest.MockedFunction<typeof getAllTopics>;
+const mockGetActiveTopicsForTasks = getActiveTopicsForTasks as jest.MockedFunction<typeof getActiveTopicsForTasks>;
 const mockGetCity = getCity as jest.MockedFunction<typeof getCity>;
 const mockPrismaPersonFindMany = (prisma.person.findMany as jest.Mock);
 
@@ -53,6 +57,10 @@ function setupCommonMocks() {
 
     mockGetAllTopics.mockResolvedValue([
         { id: 'topic-1', name: 'Environment' },
+    ] as any);
+
+    mockGetActiveTopicsForTasks.mockResolvedValue([
+        { id: 'topic-1', name: 'Environment', description: '' },
     ] as any);
 
     mockGetCity.mockResolvedValue({

--- a/src/lib/__tests__/db-utils.test.ts
+++ b/src/lib/__tests__/db-utils.test.ts
@@ -11,7 +11,6 @@ jest.mock('../db/transcript', () => ({ getTranscript: jest.fn() }));
 jest.mock('../db/people', () => ({ getPeopleForMeeting: jest.fn() }));
 jest.mock('../db/parties', () => ({ getPartiesForCity: jest.fn() }));
 jest.mock('../db/topics', () => ({
-    getAllTopics: jest.fn(),
     getActiveTopicsForTasks: jest.fn(),
 }));
 jest.mock('../db/cities', () => ({ getCity: jest.fn() }));
@@ -21,7 +20,7 @@ import prisma from '../db/prisma';
 import { getTranscript } from '../db/transcript';
 import { getPeopleForMeeting } from '../db/people';
 import { getPartiesForCity } from '../db/parties';
-import { getAllTopics, getActiveTopicsForTasks } from '../db/topics';
+import { getActiveTopicsForTasks } from '../db/topics';
 import { getCity } from '../db/cities';
 import { getCouncilMeeting } from '../db/meetings';
 import { getRequestOnTranscriptRequestBody } from '../db/utils';
@@ -31,7 +30,6 @@ const mockGetTranscript = getTranscript as jest.MockedFunction<typeof getTranscr
 const mockGetCouncilMeeting = getCouncilMeeting as jest.MockedFunction<typeof getCouncilMeeting>;
 const mockGetPeopleForMeeting = getPeopleForMeeting as jest.MockedFunction<typeof getPeopleForMeeting>;
 const mockGetPartiesForCity = getPartiesForCity as jest.MockedFunction<typeof getPartiesForCity>;
-const mockGetAllTopics = getAllTopics as jest.MockedFunction<typeof getAllTopics>;
 const mockGetActiveTopicsForTasks = getActiveTopicsForTasks as jest.MockedFunction<typeof getActiveTopicsForTasks>;
 const mockGetCity = getCity as jest.MockedFunction<typeof getCity>;
 const mockPrismaPersonFindMany = (prisma.person.findMany as jest.Mock);
@@ -53,10 +51,6 @@ function setupCommonMocks() {
     mockGetPartiesForCity.mockResolvedValue([
         { id: 'party-a', name: 'Party A', cityId: CITY_ID },
         { id: 'party-b', name: 'Party B', cityId: CITY_ID },
-    ] as any);
-
-    mockGetAllTopics.mockResolvedValue([
-        { id: 'topic-1', name: 'Environment' },
     ] as any);
 
     mockGetActiveTopicsForTasks.mockResolvedValue([

--- a/src/lib/__tests__/db-utils.test.ts
+++ b/src/lib/__tests__/db-utils.test.ts
@@ -92,6 +92,7 @@ describe('getRequestOnTranscriptRequestBody', () => {
         expect(result.transcript[0].speakerName).toBe('Maria K.');
         expect(result.transcript[0].speakerParty).toBe('Party A');
         expect(result.transcript[0].speakerId).toBe('person-1');
+        expect(result.topicLabels).toEqual([{ name: 'Environment', description: '' }]);
     });
 
     it('resolves speakers NOT in the meeting people list but identified in transcript', async () => {

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { ZodError } from "zod";
 
 /**
  * Base class for API errors with explicit status codes.
@@ -68,7 +69,12 @@ export function handleApiError(error: unknown, fallbackMessage: string = "An err
     if (error instanceof ApiError) {
         return NextResponse.json({ error: error.message }, { status: error.statusCode });
     }
-    
+
+    if (error instanceof ZodError) {
+        const message = error.errors.map(e => e.message).join(", ");
+        return NextResponse.json({ error: message }, { status: 400 });
+    }
+
     const message = error instanceof Error ? error.message : fallbackMessage;
     return NextResponse.json({ error: message }, { status: 500 });
 }

--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -105,6 +105,11 @@ export type Voiceprint = {
  * Task: Process Agenda
  */
 
+export interface TopicLabelInfo {
+    name: string;
+    description: string;
+}
+
 export interface ProcessAgendaRequest extends TaskRequest {
     agendaUrl: string;
     people: {
@@ -113,7 +118,7 @@ export interface ProcessAgendaRequest extends TaskRequest {
         role: string;
         party: string;
     }[];
-    topicLabels: string[];
+    topicLabels: TopicLabelInfo[];
     cityName: string;
     date: string;
 }
@@ -238,7 +243,7 @@ export interface RequestOnTranscript extends TaskRequest {
             endTimestamp: number;
         }[];
     }[];
-    topicLabels: string[];
+    topicLabels: TopicLabelInfo[];
     cityName: string;
     administrativeBodyName: string | null;
     partiesWithPeople: {

--- a/src/lib/db/topics.ts
+++ b/src/lib/db/topics.ts
@@ -8,6 +8,7 @@ export type TopicWithSubjectCount = Topic & {
     _count: {
         subjects: number;
         topicLabels: number;
+        notificationPreferences: number;
     };
 };
 
@@ -29,7 +30,11 @@ export async function getAllTopicsWithSubjectCount(): Promise<TopicWithSubjectCo
             orderBy: { name: 'asc' },
             include: {
                 _count: {
-                    select: { subjects: true, topicLabels: true },
+                    select: {
+                        subjects: true,
+                        topicLabels: true,
+                        notificationPreferences: true,
+                    },
                 },
             },
         });

--- a/src/lib/db/topics.ts
+++ b/src/lib/db/topics.ts
@@ -1,13 +1,113 @@
 "use server";
 import { Topic } from '@prisma/client';
 import prisma from "./prisma";
+import { withUserAuthorizedToEdit } from "../auth";
+import { ConflictError } from "../api/errors";
+
+export type TopicWithSubjectCount = Topic & {
+    _count: {
+        subjects: number;
+    };
+};
 
 export async function getAllTopics(): Promise<Topic[]> {
     try {
-        const topics = await prisma.topic.findMany();
+        const topics = await prisma.topic.findMany({
+            orderBy: { name: 'asc' }
+        });
         return topics;
     } catch (error) {
         console.error('Error fetching topics:', error);
         throw new Error('Failed to fetch topics');
     }
+}
+
+export async function getAllTopicsWithSubjectCount(): Promise<TopicWithSubjectCount[]> {
+    try {
+        const topics = await prisma.topic.findMany({
+            orderBy: { name: 'asc' },
+            include: {
+                _count: {
+                    select: { subjects: true },
+                },
+            },
+        });
+        return topics;
+    } catch (error) {
+        console.error('Error fetching topics with counts:', error);
+        throw new Error('Failed to fetch topics');
+    }
+}
+
+export type TopicInput = {
+    name: string;
+    name_en: string;
+    colorHex: string;
+    icon?: string | null;
+    description: string;
+    deprecated?: boolean;
+};
+
+export async function getActiveTopicsForTasks(): Promise<Topic[]> {
+    try {
+        const topics = await prisma.topic.findMany({
+            where: { deprecated: false },
+            orderBy: { name: 'asc' },
+        });
+        return topics;
+    } catch (error) {
+        console.error('Error fetching active topics:', error);
+        throw new Error('Failed to fetch active topics');
+    }
+}
+
+export async function createTopic(data: TopicInput): Promise<Topic> {
+    await withUserAuthorizedToEdit({});
+    return prisma.topic.create({
+        data: {
+            name: data.name,
+            name_en: data.name_en,
+            colorHex: data.colorHex,
+            icon: data.icon ?? null,
+            description: data.description,
+            deprecated: data.deprecated ?? false,
+        },
+    });
+}
+
+export async function updateTopic(id: string, data: Partial<TopicInput>): Promise<Topic> {
+    await withUserAuthorizedToEdit({});
+    return prisma.topic.update({
+        where: { id },
+        data: {
+            ...(data.name !== undefined && { name: data.name }),
+            ...(data.name_en !== undefined && { name_en: data.name_en }),
+            ...(data.colorHex !== undefined && { colorHex: data.colorHex }),
+            ...(data.icon !== undefined && { icon: data.icon }),
+            ...(data.description !== undefined && { description: data.description }),
+            ...(data.deprecated !== undefined && { deprecated: data.deprecated }),
+        },
+    });
+}
+
+export async function deleteTopic(id: string): Promise<void> {
+    await withUserAuthorizedToEdit({});
+
+    const [subjectCount, labelCount, notificationCount] = await Promise.all([
+        prisma.subject.count({ where: { topicId: id } }),
+        prisma.topicLabel.count({ where: { topicId: id } }),
+        prisma.notificationPreference.count({ where: { interests: { some: { id } } } }),
+    ]);
+
+    if (subjectCount > 0 || labelCount > 0 || notificationCount > 0) {
+        const parts: string[] = [];
+        if (subjectCount > 0) parts.push(`${subjectCount} subject(s)`);
+        if (labelCount > 0) parts.push(`${labelCount} topic label(s)`);
+        if (notificationCount > 0) parts.push(`${notificationCount} notification preference(s)`);
+        throw new ConflictError(
+            `Cannot delete topic: it is still referenced by ${parts.join(', ')}.`
+        );
+    }
+
+    await prisma.topic.delete({ where: { id } });
 }

--- a/src/lib/db/topics.ts
+++ b/src/lib/db/topics.ts
@@ -7,6 +7,7 @@ import { ConflictError } from "../api/errors";
 export type TopicWithSubjectCount = Topic & {
     _count: {
         subjects: number;
+        topicLabels: number;
     };
 };
 
@@ -28,7 +29,7 @@ export async function getAllTopicsWithSubjectCount(): Promise<TopicWithSubjectCo
             orderBy: { name: 'asc' },
             include: {
                 _count: {
-                    select: { subjects: true },
+                    select: { subjects: true, topicLabels: true },
                 },
             },
         });
@@ -93,21 +94,23 @@ export async function updateTopic(id: string, data: Partial<TopicInput>): Promis
 export async function deleteTopic(id: string): Promise<void> {
     await withUserAuthorizedToEdit({});
 
-    const [subjectCount, labelCount, notificationCount] = await Promise.all([
-        prisma.subject.count({ where: { topicId: id } }),
-        prisma.topicLabel.count({ where: { topicId: id } }),
-        prisma.notificationPreference.count({ where: { interests: { some: { id } } } }),
-    ]);
+    await prisma.$transaction(async (tx) => {
+        const [subjectCount, labelCount, notificationCount] = await Promise.all([
+            tx.subject.count({ where: { topicId: id } }),
+            tx.topicLabel.count({ where: { topicId: id } }),
+            tx.notificationPreference.count({ where: { interests: { some: { id } } } }),
+        ]);
 
-    if (subjectCount > 0 || labelCount > 0 || notificationCount > 0) {
-        const parts: string[] = [];
-        if (subjectCount > 0) parts.push(`${subjectCount} subject(s)`);
-        if (labelCount > 0) parts.push(`${labelCount} topic label(s)`);
-        if (notificationCount > 0) parts.push(`${notificationCount} notification preference(s)`);
-        throw new ConflictError(
-            `Cannot delete topic: it is still referenced by ${parts.join(', ')}.`
-        );
-    }
+        if (subjectCount > 0 || labelCount > 0 || notificationCount > 0) {
+            const parts: string[] = [];
+            if (subjectCount > 0) parts.push(`${subjectCount} subject(s)`);
+            if (labelCount > 0) parts.push(`${labelCount} topic label(s)`);
+            if (notificationCount > 0) parts.push(`${notificationCount} notification preference(s)`);
+            throw new ConflictError(
+                `Cannot delete topic: it is still referenced by ${parts.join(', ')}.`
+            );
+        }
 
-    await prisma.topic.delete({ where: { id } });
+        await tx.topic.delete({ where: { id } });
+    });
 }

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -153,7 +153,7 @@ export async function getAvailableSpeakerSegmentIds(councilMeetingId: string, ci
 // --- Internal helpers for saveSubjectsForMeeting ---
 
 async function validateSubjectPersons(subjects: Subject[], cityId: string) {
-    const topics = await prisma.topic.findMany();
+    const topics = await prisma.topic.findMany({ where: { deprecated: false } });
     const topicsByName = Object.fromEntries(topics.map(t => [t.name, t]));
 
     const speakerIds = subjects

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -3,7 +3,7 @@
 import { getTranscript } from "./transcript";
 import { getPeopleForMeeting } from "./people";
 import { getPartiesForCity } from "./parties";
-import { getAllTopics } from "./topics";
+import { getActiveTopicsForTasks } from "./topics";
 import { getCity } from "./cities";
 import { getCouncilMeeting } from "./meetings";
 import { RequestOnTranscript, SummarizeRequest, TranscribeRequest, Subject } from "../apiTypes";
@@ -41,7 +41,7 @@ export async function getRequestOnTranscriptRequestBody(councilMeetingId: string
     // People filtered by meeting's administrative body (for LLM context)
     const meetingPeople = await getPeopleForMeeting(cityId, councilMeeting.administrativeBodyId);
     const parties = await getPartiesForCity(cityId);
-    const topics = await getAllTopics();
+    const topics = await getActiveTopicsForTasks();
     const city = await getCity(cityId);
 
     if (!city) {
@@ -69,7 +69,7 @@ export async function getRequestOnTranscriptRequestBody(councilMeetingId: string
                 }))
             };
         }),
-        topicLabels: topics.map(t => t.name),
+        topicLabels: topics.map(t => ({ name: t.name, description: t.description })),
         cityName: city.name,
         administrativeBodyName: councilMeeting.administrativeBody?.name || null,
         partiesWithPeople: parties.map(p => ({

--- a/src/lib/tasks/processAgenda.ts
+++ b/src/lib/tasks/processAgenda.ts
@@ -5,7 +5,7 @@ import { startTask } from "./tasks";
 import prisma from "../db/prisma";
 import { saveSubjectsForMeeting } from "../db/utils";
 import { withUserAuthorizedToEdit } from "../auth";
-import { getAllTopics } from "../db/topics";
+import { getActiveTopicsForTasks } from "../db/topics";
 import { getPartyFromRoles, getRoleNameForPerson } from "../utils";
 import { getPeopleForMeeting } from "../db/people";
 
@@ -65,7 +65,7 @@ export async function requestProcessAgenda(agendaUrl: string, councilMeetingId: 
 
     // Get relevant people for the meeting (filtered by administrative body)
     const people = await getPeopleForMeeting(cityId, councilMeeting.administrativeBodyId);
-    const topicLabels = await getAllTopics();
+    const topicLabels = await getActiveTopicsForTasks();
 
     // Build people array with deduplication by ID (keep last entry)
     const peopleMap = new Map();
@@ -87,7 +87,7 @@ export async function requestProcessAgenda(agendaUrl: string, councilMeetingId: 
         agendaUrl,
         date: councilMeeting.dateTime.toISOString(),
         people: Array.from(peopleMap.values()),
-        topicLabels: topicLabels.map(t => t.name),
+        topicLabels: topicLabels.map(t => ({ name: t.name, description: t.description })),
         cityName: councilMeeting.city.name
     }
 

--- a/src/lib/tasks/summarize.ts
+++ b/src/lib/tasks/summarize.ts
@@ -3,7 +3,6 @@ import { CouncilMeeting, Prisma, SpeakerSegment } from "@prisma/client";
 import { Utterance as ApiUtterance, SummarizeRequest, SummarizeResult } from "../apiTypes";
 import { getTranscript } from "../db/transcript";
 import { getPartiesForCity } from "../db/parties";
-import { getAllTopics } from "../db/topics";
 import { startTask } from "./tasks";
 import { getCity } from "../db/cities";
 import { getCouncilMeeting } from "../db/meetings";

--- a/src/lib/tasks/summarize.ts
+++ b/src/lib/tasks/summarize.ts
@@ -82,7 +82,7 @@ export async function handleSummarizeResult(taskId: string, response: SummarizeR
     }
 
     const topics = await prisma.topic.findMany({
-        where: { name: { in: Array.from(allTopicNames) } }
+        where: { name: { in: Array.from(allTopicNames) }, deprecated: false }
     });
     const topicByName = new Map(topics.map(t => [t.name, t]));
 

--- a/src/lib/utils/colorSuggestion.ts
+++ b/src/lib/utils/colorSuggestion.ts
@@ -3,10 +3,12 @@
  * from a set of existing colors.
  */
 
+export const HEX_REGEX = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
 type Rgb = [number, number, number];
 
 function hexToRgb(hex: string): Rgb | null {
-    const match = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.exec(hex);
+    const match = HEX_REGEX.exec(hex);
     if (!match) return null;
     const raw = match[1];
     const full = raw.length === 3 ? raw.split("").map((c) => c + c).join("") : raw;

--- a/src/lib/utils/colorSuggestion.ts
+++ b/src/lib/utils/colorSuggestion.ts
@@ -1,0 +1,88 @@
+/**
+ * Color utilities for suggesting a hex color that is visually distinct
+ * from a set of existing colors.
+ */
+
+type Rgb = [number, number, number];
+
+function hexToRgb(hex: string): Rgb | null {
+    const match = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.exec(hex);
+    if (!match) return null;
+    const raw = match[1];
+    const full = raw.length === 3 ? raw.split("").map((c) => c + c).join("") : raw;
+    return [
+        parseInt(full.slice(0, 2), 16),
+        parseInt(full.slice(2, 4), 16),
+        parseInt(full.slice(4, 6), 16),
+    ];
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+    const sn = s / 100;
+    const ln = l / 100;
+    const c = (1 - Math.abs(2 * ln - 1)) * sn;
+    const hPrime = h / 60;
+    const x = c * (1 - Math.abs((hPrime % 2) - 1));
+    let r = 0;
+    let g = 0;
+    let b = 0;
+    if (hPrime < 1) [r, g, b] = [c, x, 0];
+    else if (hPrime < 2) [r, g, b] = [x, c, 0];
+    else if (hPrime < 3) [r, g, b] = [0, c, x];
+    else if (hPrime < 4) [r, g, b] = [0, x, c];
+    else if (hPrime < 5) [r, g, b] = [x, 0, c];
+    else [r, g, b] = [c, 0, x];
+    const m = ln - c / 2;
+    const toHex = (v: number) =>
+        Math.round((v + m) * 255)
+            .toString(16)
+            .padStart(2, "0");
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+/**
+ * Returns a hex color that maximizes the minimum RGB distance to every
+ * color in `existing`. Candidates are sampled along the hue circle at a
+ * fixed saturation and lightness so the result always looks reasonable.
+ * If `existing` is empty, returns a random saturated color.
+ */
+export function suggestDistinctColor(existing: string[]): string {
+    const existingRgb: Rgb[] = [];
+    for (const hex of existing) {
+        const rgb = hexToRgb(hex);
+        if (rgb) existingRgb.push(rgb);
+    }
+
+    const SATURATION = 70;
+    const LIGHTNESS = 50;
+    const CANDIDATES = 64;
+
+    if (existingRgb.length === 0) {
+        return hslToHex(Math.floor(Math.random() * 360), SATURATION, LIGHTNESS);
+    }
+
+    let bestHex = hslToHex(0, SATURATION, LIGHTNESS);
+    let bestMinDist = -1;
+
+    for (let i = 0; i < CANDIDATES; i++) {
+        const hue = (i / CANDIDATES) * 360;
+        const hex = hslToHex(hue, SATURATION, LIGHTNESS);
+        const rgb = hexToRgb(hex)!;
+
+        let minDist = Infinity;
+        for (const e of existingRgb) {
+            const dr = rgb[0] - e[0];
+            const dg = rgb[1] - e[1];
+            const db = rgb[2] - e[2];
+            const dist = dr * dr + dg * dg + db * db;
+            if (dist < minDist) minDist = dist;
+        }
+
+        if (minDist > bestMinDist) {
+            bestMinDist = minDist;
+            bestHex = hex;
+        }
+    }
+
+    return bestHex;
+}

--- a/src/lib/zod-schemas/__tests__/topic.test.ts
+++ b/src/lib/zod-schemas/__tests__/topic.test.ts
@@ -1,0 +1,143 @@
+import { createTopicSchema, updateTopicSchema } from '../topic';
+
+const validTopic = {
+    name: 'Περιβάλλον',
+    name_en: 'Environment',
+    colorHex: '#4f46e5',
+    description: 'Topics related to the environment',
+};
+
+describe('createTopicSchema', () => {
+    it('should validate a complete topic', () => {
+        const parsed = createTopicSchema.parse(validTopic);
+        expect(parsed.name).toBe('Περιβάλλον');
+        expect(parsed.name_en).toBe('Environment');
+        expect(parsed.colorHex).toBe('#4f46e5');
+        expect(parsed.description).toBe('Topics related to the environment');
+    });
+
+    it('should trim name and name_en', () => {
+        const parsed = createTopicSchema.parse({
+            ...validTopic,
+            name: '  Περιβάλλον  ',
+            name_en: '  Environment  ',
+        });
+        expect(parsed.name).toBe('Περιβάλλον');
+        expect(parsed.name_en).toBe('Environment');
+    });
+
+    it('should reject empty name after trimming', () => {
+        expect(() => createTopicSchema.parse({
+            ...validTopic,
+            name: '   ',
+        })).toThrow();
+    });
+
+    it('should reject empty name_en after trimming', () => {
+        expect(() => createTopicSchema.parse({
+            ...validTopic,
+            name_en: '   ',
+        })).toThrow();
+    });
+
+    it('should reject missing required fields', () => {
+        expect(() => createTopicSchema.parse({ name: 'Test' })).toThrow();
+    });
+
+    it('should validate hex color format', () => {
+        expect(() => createTopicSchema.parse({
+            ...validTopic,
+            colorHex: 'not-a-color',
+        })).toThrow();
+    });
+
+    it('should accept 3-character hex colors', () => {
+        const parsed = createTopicSchema.parse({
+            ...validTopic,
+            colorHex: '#abc',
+        });
+        expect(parsed.colorHex).toBe('#abc');
+    });
+
+    it('should reject hex without # prefix', () => {
+        expect(() => createTopicSchema.parse({
+            ...validTopic,
+            colorHex: '4f46e5',
+        })).toThrow();
+    });
+
+    it('should coerce null/undefined icon to null', () => {
+        expect(createTopicSchema.parse(validTopic).icon).toBeNull();
+        expect(createTopicSchema.parse({ ...validTopic, icon: null }).icon).toBeNull();
+        expect(createTopicSchema.parse({ ...validTopic, icon: '' }).icon).toBeNull();
+    });
+
+    it('should keep valid icon string', () => {
+        const parsed = createTopicSchema.parse({ ...validTopic, icon: 'Trees' });
+        expect(parsed.icon).toBe('Trees');
+    });
+
+    it('should default deprecated to false', () => {
+        expect(createTopicSchema.parse(validTopic).deprecated).toBe(false);
+    });
+
+    it('should accept explicit deprecated value', () => {
+        const parsed = createTopicSchema.parse({ ...validTopic, deprecated: true });
+        expect(parsed.deprecated).toBe(true);
+    });
+
+    it('should reject non-boolean deprecated', () => {
+        expect(() => createTopicSchema.parse({
+            ...validTopic,
+            deprecated: 'yes',
+        })).toThrow();
+    });
+
+    it('should reject non-string description', () => {
+        expect(() => createTopicSchema.parse({
+            ...validTopic,
+            description: 123,
+        })).toThrow();
+    });
+});
+
+describe('updateTopicSchema', () => {
+    it('should allow all fields to be optional', () => {
+        const parsed = updateTopicSchema.parse({});
+        expect(parsed).toEqual({});
+    });
+
+    it('should leave unprovided fields as undefined', () => {
+        const parsed = updateTopicSchema.parse({ name: 'Updated' });
+        expect(parsed.name).toBe('Updated');
+        expect(parsed.name_en).toBeUndefined();
+        expect(parsed.colorHex).toBeUndefined();
+        expect(parsed.description).toBeUndefined();
+        expect(parsed.deprecated).toBeUndefined();
+    });
+
+    it('should validate provided fields', () => {
+        expect(() => updateTopicSchema.parse({
+            colorHex: 'invalid',
+        })).toThrow();
+    });
+
+    it('should trim provided name', () => {
+        const parsed = updateTopicSchema.parse({ name: '  Updated  ' });
+        expect(parsed.name).toBe('Updated');
+    });
+
+    it('should reject empty name after trimming', () => {
+        expect(() => updateTopicSchema.parse({ name: '   ' })).toThrow();
+    });
+
+    it('should accept partial updates with valid data', () => {
+        const parsed = updateTopicSchema.parse({
+            description: 'New description',
+            deprecated: true,
+        });
+        expect(parsed.description).toBe('New description');
+        expect(parsed.deprecated).toBe(true);
+        expect(parsed.name).toBeUndefined();
+    });
+});

--- a/src/lib/zod-schemas/topic.ts
+++ b/src/lib/zod-schemas/topic.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { HEX_REGEX } from '@/lib/utils/colorSuggestion';
+
+const trimmedString = z.string().transform(val => val.trim());
+
+const baseTopicFields = {
+    name: trimmedString.pipe(z.string().min(1, "name is required")),
+    name_en: trimmedString.pipe(z.string().min(1, "name_en is required")),
+    colorHex: z.string().regex(HEX_REGEX, "colorHex must be a valid hex color"),
+    description: z.string(),
+    icon: z.string().nullable().optional().transform(val => val || null),
+    deprecated: z.boolean().optional().transform(val => val ?? false),
+};
+
+export const createTopicSchema = z.object(baseTopicFields);
+
+// All fields optional for partial updates — absent fields stay undefined.
+export const updateTopicSchema = z.object(baseTopicFields).partial();
+
+export type CreateTopicData = z.infer<typeof createTopicSchema>;
+export type UpdateTopicData = z.infer<typeof updateTopicSchema>;


### PR DESCRIPTION
Replaces #312 (which had an unrelated Valkey cache fixup swept into its diff).

Goes together with the corresponding backend change https://github.com/schemalabz/opencouncil-tasks/pull/34

## Summary

- Adds `description` and `deprecated` fields to the `Topic` model with a single migration.
- New superadmin CRUD UI at `/admin/topics` — table shows a unified colored Symbol (icon in colored circle), subject count, description preview, and a prominent "Deprecated" state (amber row + destructive badge + strikethrough).
- Topic dialog supports: icon dropdown sourced from `iconMap` (previews the actual icon), a "Suggest distinct color" button that picks a hue-wheel candidate maximally far from every existing topic color and from previously-suggested colors in the same session, and a deprecated toggle.
- Delete is disabled in the UI when a topic has subjects; server-side `deleteTopic` throws `ConflictError` (409) if a topic is still referenced by subjects, topic labels, or notification preferences.
- New `getActiveTopicsForTasks()` helper: **deprecated topics are never passed to the `summarize` and `processAgenda` task APIs**, so the LLM stops classifying new subjects into retired topics while existing subjects keep their assignment.

## Task API contract change (coordinate with backend)

`topicLabels` on `ProcessAgendaRequest` and `RequestOnTranscript` changes from `string[]` to `{ name: string; description: string }[]`. This affects the `summarize`, `processAgenda`, `fixTranscript`, and `generatePodcastSpec` endpoints. The backend at `TASK_API_URL` needs to accept the new shape and use the descriptions as classification guidance in its prompt templates. The response shape (`SummarizeResult.speakerSegmentSummaries[].topicLabels: string[]`) is unchanged.

## Test plan

- [ ] `npx prisma migrate dev` applies `20260411120000_add_topic_description` cleanly; existing topics backfill with empty description and `deprecated = false`.
- [ ] `npm run prisma:generate && npx tsc --noEmit && npm test` all pass locally.
- [ ] Sign in as a superadmin, open `/admin/topics`: create, edit, delete flows all work; the Sparkles button suggests distinct colors on repeated clicks; icon dropdown shows each icon in the currently-selected color.
- [ ] Toggle Deprecated on a topic that has subjects → topic row gains the amber background + "DEPRECATED" badge + strikethrough name; the topic disappears from subsequent `processAgenda`/`summarize` task payloads (verify via the existing dev-server log in `processAgenda.ts`).
- [ ] Non-superadmin users cannot reach `/admin/topics` or `/api/admin/topics` (existing admin-layout gate + explicit `isSuperAdmin` check on the routes).
- [ ] Try to delete a topic that is still referenced by a subject → 409 with a clear message; UI delete button is also disabled for such topics.
- [ ] Mutate a topic via the admin UI → the public `GET /api/topics` returns the change immediately (cache invalidation via `revalidatePath`).
- [ ] Coordinate with the task-backend team on the `topicLabels` shape change before merging.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a DB schema change and a breaking `topicLabels` contract change for task payloads, which can impact task-backend integration and topic classification behavior. Also adds new admin write endpoints and delete constraints that could affect existing workflows if misconfigured.
> 
> **Overview**
> Adds `description` and `deprecated` fields to `Topic`, with migration and Prisma schema updates.
> 
> Introduces a superadmin-only Topics admin surface (`/admin/topics`) with full CRUD via new `/api/admin/topics` endpoints, including server-side validation, cache revalidation, and guarded deletion that returns `409` when a topic is still referenced (subjects/topic labels/notification preferences).
> 
> Updates task request payloads so `topicLabels` becomes `{ name, description }[]` and ensures *deprecated topics are excluded* from agenda/summarize task inputs and from topic matching during task result ingestion; onboarding topic selection also hides deprecated topics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d514e6445ae6b5bd28ed2a4cde498f885bfda1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `description` and `deprecated` fields to the `Topic` model, introduces a superadmin CRUD admin UI at `/admin/topics`, and updates the task API contract so `topicLabels` becomes `{ name, description }[]` instead of `string[]`. Deprecated topics are excluded from task requests and from new subject ingestion, while the onboarding `TopicSelector` filters them client-side.

All three concerns from the previous review round (non-atomic delete, incomplete `canDelete` guard, missing `topicLabels` assertion in tests) are fully resolved in this revision.

<h3>Confidence Score: 5/5</h3>

Safe to merge after coordinating the `topicLabels` contract change with the task backend team.

All three previous P1 concerns (non-atomic delete, incomplete canDelete guard, missing topicLabels test assertion) are fully resolved. Auth gating via `withUserAuthorizedToEdit({})` is correctly superadmin-only per auth.ts. Migration is backward-compatible. The only remaining finding is a P2 icon-name validation gap that is low-risk in practice since the UI enforces the constraint via a dropdown.

No files require special attention — the schema, DB layer, API routes, and admin UI components are all solid.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/db/topics.ts | Adds CRUD helpers; `deleteTopic` now runs inside a `$transaction` with all three reference counts, resolving the prior atomicity concern. Auth gating is correct (`withUserAuthorizedToEdit({})` with empty params is superadmin-only per auth.ts line 59-60). |
| src/components/admin/topics/topics-table.tsx | Uses all three counts (subjects, topicLabels, notificationPreferences) to compute `canDelete` and render the correct tooltip — resolves the previous gap where label and notification counts were ignored. |
| src/lib/zod-schemas/topic.ts | Well-structured base fields with proper transforms; `createTopicSchema` defaults `deprecated` to `false`, `updateTopicSchema.partial()` leaves absent fields as `undefined` so `updateTopic` skips them correctly. |
| src/lib/db/utils.ts | Switches to `getActiveTopicsForTasks()` for the task request payload and filters deprecated topics from the `validateSubjectPersons` lookup so incoming task results can't silently assign subjects to retired topics. |
| src/lib/tasks/summarize.ts | Adds `deprecated: false` guard in the topic-name lookup within `handleSummarizeResult`; safe fail-open behavior (subject created without topic) if a deprecated name somehow appears in the task response. |
| src/lib/apiTypes.ts | Introduces `TopicLabelInfo` and updates `topicLabels` in both `ProcessAgendaRequest` and `RequestOnTranscript` (which covers `SummarizeRequest`, `FixTranscriptRequest`, `GeneratePodcastSpecRequest` via inheritance). |
| src/lib/__tests__/db-utils.test.ts | Updated to use `getActiveTopicsForTasks`, mock includes `description`, and the new assertion `expect(result.topicLabels).toEqual([{ name: 'Environment', description: '' }])` closes the contract regression gap flagged in the previous review. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Admin UI] --> B[PUT/POST/DELETE /api/admin/topics]
    B --> C{withUserAuthorizedToEdit}
    C -->|not superadmin| D[Throws 401]
    C -->|superadmin| E[DB function]
    E --> F{deleteTopic transaction}
    F --> G[Count subjects + topicLabels + notificationPrefs]
    G -->|any refs exist| H[ConflictError 409]
    G -->|no refs| I[tx.topic.delete]
    E --> J[revalidatePath /api/topics]
    K[processAgenda / summarize task] --> L[getActiveTopicsForTasks]
    L --> M[WHERE deprecated = false]
    M --> N[topicLabels as name+description pairs]
    O[handleSummarizeResult] --> P[findMany WHERE deprecated=false]
    P --> Q[Silently skip deprecated topic names in result]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/zod-schemas/topic.ts
Line: 13

Comment:
**Icon value not validated against `iconMap`**

`icon` accepts any non-empty string, so a direct API call with an arbitrary value like `"FakeIcon"` would be stored. In the admin table, `iconMap["FakeIcon"]` resolves to `undefined`, and in `topic-dialog.tsx` the `SelectItem` would try to render `<IconComponent … />` with `undefined` — a runtime crash. Restricting to `iconMap` keys in the schema closes the gap:

```ts
import { iconMap } from "@/components/icon";
const VALID_ICON_NAMES = Object.keys(iconMap);
// ...
icon: z
    .string()
    .refine((v) => VALID_ICON_NAMES.includes(v), { message: "icon must be a valid icon name" })
    .nullable()
    .optional()
    .transform((val) => val || null),
```

This is only reachable via direct API calls since the UI enforces the constraint through the `Select` dropdown, so risk is low but the schema is the right place to enforce it.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (11): Last reviewed commit: ["refactor: replace manual validation with..."](https://github.com/schemalabz/opencouncil/commit/60cc90d0563a3cdebea3e624587b9bdd22e64fe2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28090680)</sub>

<!-- /greptile_comment -->