### PR TITLE
Add fullscreen presentation view for council meetings

### DIFF
--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
@@ -8,6 +8,7 @@ import TranscriptControls from '@/components/meetings/TranscriptControls';
 import { Suspense } from 'react'
 import Header from '@/components/layout/Header';
 import EditButton from '@/components/meetings/EditButton';
+import PresentationViewButton from '@/components/meetings/PresentationViewButton';
 import ShareDropdown from '@/components/meetings/ShareDropdown';
 import { getMeetingDataCached } from '@/lib/getMeetingData';
 import { getNotificationPreferenceForCity } from '@/lib/db/notifications';
@@ -171,6 +172,7 @@ export default async function CouncilMeetingPage({
                                     <div className="flex items-center space-x-2">
                                         <EditButton />
                                         <CreateHighlightButton />
+                                        {editable && <PresentationViewButton cityId={cityId} meetingId={meetingId} />}
                                         <ShareDropdown meetingId={meetingId} cityId={cityId} />
                                     </div>
                                 </Header>

--- a/src/app/[locale]/(fullscreen)/present/[cityId]/[meetingId]/page.tsx
+++ b/src/app/[locale]/(fullscreen)/present/[cityId]/[meetingId]/page.tsx
@@ -1,0 +1,43 @@
+import { notFound } from "next/navigation";
+import { isUserAuthorizedToEdit } from "@/lib/auth";
+import { getMeetingDataCached } from "@/lib/getMeetingData";
+import { categorizeSubjects } from "@/lib/utils/subjects";
+import { sortSubjectsByAgendaIndex } from "@/lib/utils";
+import PresentationView from "@/components/presentation/PresentationView";
+
+export const metadata = {
+    title: "Παρουσίαση συνεδρίασης | OpenCouncil",
+};
+
+export default async function PresentationPage({
+    params: { cityId, meetingId },
+}: {
+    params: { cityId: string; meetingId: string; locale: string };
+}) {
+    const editable = await isUserAuthorizedToEdit({ cityId });
+    if (!editable) {
+        notFound();
+    }
+
+    const data = await getMeetingDataCached(cityId, meetingId);
+    if (!data || !data.city) {
+        notFound();
+    }
+
+    // Show before-agenda items first, followed by agenda items (sorted by index).
+    // Out-of-agenda items are intentionally excluded from the presentation view.
+    const { beforeAgenda, agenda } = categorizeSubjects(data.subjects);
+    const agendaSubjects = [
+        ...beforeAgenda,
+        ...sortSubjectsByAgendaIndex(agenda),
+    ];
+
+    return (
+        <PresentationView
+            meeting={data.meeting}
+            city={data.city}
+            agendaSubjects={agendaSubjects}
+            backHref={`/${cityId}/${meetingId}`}
+        />
+    );
+}

--- a/src/components/meetings/PresentationViewButton.tsx
+++ b/src/components/meetings/PresentationViewButton.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Projector } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Link } from "@/i18n/routing";

--- a/src/components/meetings/PresentationViewButton.tsx
+++ b/src/components/meetings/PresentationViewButton.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Projector } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Link } from "@/i18n/routing";
+
+interface PresentationViewButtonProps {
+    cityId: string;
+    meetingId: string;
+}
+
+export default function PresentationViewButton({
+    cityId,
+    meetingId,
+}: PresentationViewButtonProps) {
+    return (
+        <Button asChild variant="ghost" size="icon" title="Παρουσίαση">
+            <Link
+                href={`/present/${cityId}/${meetingId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                <Projector className="h-5 w-5" />
+                <span className="sr-only">Παρουσίαση</span>
+            </Link>
+        </Button>
+    );
+}

--- a/src/components/presentation/MeetingInfoSlide.tsx
+++ b/src/components/presentation/MeetingInfoSlide.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { CouncilMeetingWithAdminBody } from "@/lib/db/meetings";
+import { CityWithGeometry } from "@/lib/db/cities";
+import { formatDateTime } from "@/lib/formatters/time";
+
+interface MeetingInfoSlideProps {
+    meeting: CouncilMeetingWithAdminBody;
+    city: CityWithGeometry;
+    agendaCount: number;
+}
+
+export default function MeetingInfoSlide({ meeting, city, agendaCount }: MeetingInfoSlideProps) {
+    return (
+        <div className="flex flex-col items-center justify-center h-full w-full px-[6vw] text-center gap-[4vh]">
+            <div className="text-[6vw] font-bold leading-[1] max-w-[90%]">
+                {meeting.name}
+            </div>
+            <div className="text-[4vh] text-muted-foreground">
+                {formatDateTime(new Date(meeting.dateTime), city.timezone)}
+            </div>
+            <div className="text-[3vh] text-muted-foreground">
+                {agendaCount > 0
+                    ? `${agendaCount} θέματα`
+                    : "Χωρίς θέματα"}
+            </div>
+        </div>
+    );
+}

--- a/src/components/presentation/MeetingInfoSlide.tsx
+++ b/src/components/presentation/MeetingInfoSlide.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { CouncilMeetingWithAdminBody } from "@/lib/db/meetings";
 import { CityWithGeometry } from "@/lib/db/cities";
 import { formatDateTime } from "@/lib/formatters/time";

--- a/src/components/presentation/MeetingInfoSlide.tsx
+++ b/src/components/presentation/MeetingInfoSlide.tsx
@@ -20,9 +20,11 @@ export default function MeetingInfoSlide({ meeting, city, agendaCount }: Meeting
                 {formatDateTime(new Date(meeting.dateTime), city.timezone)}
             </div>
             <div className="text-[3vh] text-muted-foreground">
-                {agendaCount > 0
-                    ? `${agendaCount} θέματα`
-                    : "Χωρίς θέματα"}
+                {agendaCount === 0
+                    ? "Χωρίς θέματα"
+                    : agendaCount === 1
+                        ? "1 θέμα"
+                        : `${agendaCount} θέματα`}
             </div>
         </div>
     );

--- a/src/components/presentation/PresentationView.tsx
+++ b/src/components/presentation/PresentationView.tsx
@@ -95,7 +95,11 @@ export default function PresentationView({
 
     useEffect(() => {
         const onKeyDown = (e: KeyboardEvent) => {
-            if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+            if (
+                e.key === "ArrowLeft" ||
+                e.key === "ArrowUp" ||
+                e.key === "PageUp"
+            ) {
                 e.preventDefault();
                 goPrev();
             } else if (

--- a/src/components/presentation/PresentationView.tsx
+++ b/src/components/presentation/PresentationView.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ChevronLeft, ChevronRight, Maximize, Minimize, X } from "lucide-react";
+import Image from "next/image";
+import { useRouter } from "@/i18n/routing";
+import { CouncilMeetingWithAdminBody } from "@/lib/db/meetings";
+import { CityWithGeometry } from "@/lib/db/cities";
+import { SubjectWithRelations } from "@/lib/db/subject";
+import MeetingInfoSlide from "./MeetingInfoSlide";
+import SlideHeader from "./SlideHeader";
+import SubjectSlide from "./SubjectSlide";
+
+interface PresentationViewProps {
+    meeting: CouncilMeetingWithAdminBody;
+    city: CityWithGeometry;
+    agendaSubjects: SubjectWithRelations[];
+    backHref: string;
+}
+
+export default function PresentationView({
+    meeting,
+    city,
+    agendaSubjects,
+    backHref,
+}: PresentationViewProps) {
+    const router = useRouter();
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [index, setIndex] = useState(0);
+    const [isFullscreen, setIsFullscreen] = useState(false);
+    const total = agendaSubjects.length + 1;
+
+    const goPrev = useCallback(() => {
+        setIndex((i) => Math.max(0, i - 1));
+    }, []);
+
+    const goNext = useCallback(() => {
+        setIndex((i) => Math.min(total - 1, i + 1));
+    }, [total]);
+
+    const exit = useCallback(() => {
+        if (typeof document !== "undefined" && document.fullscreenElement) {
+            document.exitFullscreen().catch(() => { });
+        }
+        router.push(backHref);
+    }, [router, backHref]);
+
+    useEffect(() => {
+        const onChange = () => setIsFullscreen(Boolean(document.fullscreenElement));
+        onChange();
+        document.addEventListener("fullscreenchange", onChange);
+        return () => document.removeEventListener("fullscreenchange", onChange);
+    }, []);
+
+    const requestFs = useCallback(() => {
+        const el = containerRef.current;
+        if (!el || !el.requestFullscreen) return Promise.resolve();
+        if (document.fullscreenElement) return Promise.resolve();
+        return el.requestFullscreen().catch(() => { });
+    }, []);
+
+    const toggleFullscreen = useCallback(() => {
+        if (document.fullscreenElement) {
+            document.exitFullscreen().catch(() => { });
+        } else {
+            requestFs();
+        }
+    }, [requestFs]);
+
+    // Browsers require a user gesture to enter fullscreen. Try once on mount,
+    // then fall back to the first user interaction if that initial call was
+    // blocked (e.g. direct URL navigation without a click).
+    useEffect(() => {
+        let cleaned = false;
+        const cleanup = () => {
+            if (cleaned) return;
+            cleaned = true;
+            window.removeEventListener("pointerdown", onFirstGesture);
+            window.removeEventListener("keydown", onFirstGesture);
+        };
+        const onFirstGesture = () => {
+            requestFs();
+            cleanup();
+        };
+
+        requestFs().then(() => {
+            if (!cleaned && document.fullscreenElement) cleanup();
+        });
+        window.addEventListener("pointerdown", onFirstGesture);
+        window.addEventListener("keydown", onFirstGesture);
+
+        return cleanup;
+    }, [requestFs]);
+
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+                e.preventDefault();
+                goPrev();
+            } else if (
+                e.key === "ArrowRight" ||
+                e.key === "ArrowDown" ||
+                e.key === " " ||
+                e.key === "PageDown"
+            ) {
+                e.preventDefault();
+                goNext();
+            }
+            // Esc is left for the browser to exit fullscreen; use the X button to exit the presentation.
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => window.removeEventListener("keydown", onKeyDown);
+    }, [goPrev, goNext]);
+
+    const canGoPrev = index > 0;
+    const canGoNext = index < total - 1;
+
+    const currentSubject = index > 0 ? agendaSubjects[index - 1] : null;
+    const positionLabel = index === 0
+        ? "INTRO"
+        : `Θέμα ${index} / ${agendaSubjects.length}`;
+
+    const iconButtonClass = "p-1.5 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-accent/10 transition-colors cursor-pointer";
+    const fullscreenLabel = isFullscreen ? "Έξοδος πλήρους οθόνης" : "Πλήρης οθόνη";
+
+    return (
+        <div
+            ref={containerRef}
+            className="fixed inset-0 bg-background text-foreground flex flex-col overflow-hidden"
+        >
+            <NavClickZone side="left" onClick={goPrev} enabled={canGoPrev} />
+            <NavClickZone side="right" onClick={goNext} enabled={canGoNext} />
+
+            <div className="absolute top-3 right-3 z-30 flex items-center gap-1">
+                <button
+                    type="button"
+                    onClick={toggleFullscreen}
+                    aria-label={fullscreenLabel}
+                    title={fullscreenLabel}
+                    className={iconButtonClass}
+                >
+                    {isFullscreen ? <Minimize className="w-4 h-4" /> : <Maximize className="w-4 h-4" />}
+                </button>
+                <button
+                    type="button"
+                    onClick={exit}
+                    aria-label="Έξοδος από την παρουσίαση"
+                    title="Έξοδος"
+                    className={iconButtonClass}
+                >
+                    <X className="w-4 h-4" />
+                    <span className="sr-only">Έξοδος</span>
+                </button>
+            </div>
+
+            <div className="relative z-10 pointer-events-none flex-shrink-0">
+                <SlideHeader city={city} />
+            </div>
+
+            <div className="relative z-10 flex-1 min-h-0 overflow-hidden pointer-events-none">
+                <AnimatePresence mode="wait">
+                    <motion.div
+                        key={index}
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.25 }}
+                        className="absolute inset-0 [&_button]:pointer-events-auto"
+                    >
+                        {currentSubject ? (
+                            <SubjectSlide key={currentSubject.id} subject={currentSubject} />
+                        ) : (
+                            <MeetingInfoSlide
+                                meeting={meeting}
+                                city={city}
+                                agendaCount={agendaSubjects.length}
+                            />
+                        )}
+                    </motion.div>
+                </AnimatePresence>
+            </div>
+
+            <div className="absolute bottom-3 right-4 z-20 text-base text-muted-foreground font-mono tabular-nums pointer-events-none">
+                {positionLabel}
+            </div>
+
+            <div className="relative z-20 flex items-center justify-center gap-2 py-3 flex-shrink-0 pointer-events-none">
+                <div className="relative w-7 h-7">
+                    <Image
+                        src="/logo.png"
+                        alt="OpenCouncil"
+                        fill
+                        sizes="28px"
+                        style={{ objectFit: "contain" }}
+                    />
+                </div>
+                <span className="text-sm text-muted-foreground">OpenCouncil</span>
+            </div>
+        </div>
+    );
+}
+
+function NavClickZone({
+    side,
+    onClick,
+    enabled,
+}: {
+    side: "left" | "right";
+    onClick: () => void;
+    enabled: boolean;
+}) {
+    const Chevron = side === "left" ? ChevronLeft : ChevronRight;
+    const cursor = enabled
+        ? side === "left" ? "cursor-w-resize" : "cursor-e-resize"
+        : "cursor-default";
+    const position = side === "left" ? "left-0" : "right-0";
+    const chevronPosition = side === "left" ? "left-6" : "right-6";
+    return (
+        <button
+            type="button"
+            aria-label={side === "left" ? "Previous slide" : "Next slide"}
+            onClick={onClick}
+            disabled={!enabled}
+            className={`absolute inset-y-0 ${position} w-1/2 z-0 group ${cursor}`}
+        >
+            {enabled && (
+                <Chevron
+                    className={`absolute ${chevronPosition} top-1/2 -translate-y-1/2 w-16 h-16 opacity-20 group-hover:opacity-60 transition-opacity pointer-events-none`}
+                    strokeWidth={1.5}
+                />
+            )}
+        </button>
+    );
+}

--- a/src/components/presentation/SlideHeader.tsx
+++ b/src/components/presentation/SlideHeader.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Building2 } from "lucide-react";
+import { CityWithGeometry } from "@/lib/db/cities";
+
+interface SlideHeaderProps {
+    city: CityWithGeometry;
+}
+
+export default function SlideHeader({ city }: SlideHeaderProps) {
+    return (
+        <div className="flex items-center gap-8 px-[5vw] pt-[3vh]">
+            {city.logoImage ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                    src={city.logoImage}
+                    alt={city.name}
+                    className="h-[12vh] w-auto max-w-[240px] object-contain flex-shrink-0"
+                />
+            ) : (
+                <Building2 className="h-[12vh] w-[12vh] text-muted-foreground flex-shrink-0" />
+            )}
+            <div className="text-[4vh] font-semibold truncate">{city.name}</div>
+        </div>
+    );
+}

--- a/src/components/presentation/SlideHeader.tsx
+++ b/src/components/presentation/SlideHeader.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Building2 } from "lucide-react";
 import { CityWithGeometry } from "@/lib/db/cities";
 

--- a/src/components/presentation/SpeakerTimer.tsx
+++ b/src/components/presentation/SpeakerTimer.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Pause, Play, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+function formatTimerDisplay(seconds: number): string {
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+}
+
+export default function SpeakerTimer() {
+    const [startedAt, setStartedAt] = useState<number | null>(null);
+    const [pausedElapsed, setPausedElapsed] = useState(0);
+    const [running, setRunning] = useState(false);
+    const [elapsed, setElapsed] = useState(0);
+    const [countdownFrom, setCountdownFrom] = useState<number | null>(null);
+
+    useEffect(() => {
+        if (!running || startedAt === null) return;
+        const update = () => {
+            const next = pausedElapsed + Math.floor((Date.now() - startedAt) / 1000);
+            setElapsed((prev) => (prev === next ? prev : next));
+        };
+        update();
+        const interval = setInterval(update, 250);
+        return () => clearInterval(interval);
+    }, [running, startedAt, pausedElapsed]);
+
+    // Auto-stop a countdown when it reaches zero.
+    useEffect(() => {
+        if (running && countdownFrom !== null && elapsed >= countdownFrom) {
+            setRunning(false);
+        }
+    }, [running, countdownFrom, elapsed]);
+
+    const hasStarted = startedAt !== null;
+    const displayed = countdownFrom !== null
+        ? Math.max(0, countdownFrom - elapsed)
+        : elapsed;
+    const isCountdownFinished = countdownFrom !== null && elapsed >= countdownFrom;
+    const isCountdownWarning = countdownFrom !== null && displayed <= 30;
+
+    const handleToggle = () => {
+        if (isCountdownFinished) return;
+        if (running && startedAt !== null) {
+            setPausedElapsed(pausedElapsed + Math.floor((Date.now() - startedAt) / 1000));
+            setRunning(false);
+            return;
+        }
+        setStartedAt(Date.now());
+        if (!hasStarted) setPausedElapsed(0);
+        setRunning(true);
+    };
+
+    const startCountdown = (minutes: number) => {
+        setCountdownFrom(minutes * 60);
+        setPausedElapsed(0);
+        setElapsed(0);
+        setStartedAt(Date.now());
+        setRunning(true);
+    };
+
+    const handleReset = () => {
+        setStartedAt(null);
+        setPausedElapsed(0);
+        setRunning(false);
+        setElapsed(0);
+        setCountdownFrom(null);
+    };
+
+    const mainLabel = running ? "Παύση" : hasStarted ? "Συνέχεια" : "Έναρξη";
+
+    return (
+        <div className="flex items-center gap-[3vw]">
+            <div className="text-[1.8vh] uppercase tracking-widest text-muted-foreground whitespace-nowrap">
+                Χρόνος<br />Ομιλητή
+            </div>
+            <button
+                type="button"
+                onClick={handleToggle}
+                disabled={isCountdownFinished}
+                className={`font-mono tabular-nums font-bold text-[16vh] leading-none tracking-tight hover:opacity-80 active:opacity-70 transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-lg px-4 text-center min-w-[5ch] disabled:cursor-default disabled:hover:opacity-100 ${isCountdownWarning ? "text-red-600" : ""}`}
+                aria-label={mainLabel}
+            >
+                {formatTimerDisplay(displayed)}
+            </button>
+            <div className="flex flex-col gap-2">
+                <div className="flex gap-2">
+                    <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={handleToggle}
+                        disabled={isCountdownFinished}
+                        className="h-9 px-3 text-sm w-28 justify-start"
+                    >
+                        {running ? (
+                            <>
+                                <Pause className="w-4 h-4 mr-1.5" />
+                                Παύση
+                            </>
+                        ) : (
+                            <>
+                                <Play className="w-4 h-4 mr-1.5" />
+                                {hasStarted ? "Συνέχεια" : "Έναρξη"}
+                            </>
+                        )}
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => startCountdown(1)}
+                        className="h-9 w-12 px-0 text-sm tabular-nums"
+                        aria-label="Αντίστροφη μέτρηση 1 λεπτού"
+                    >
+                        1&apos;
+                    </Button>
+                    <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => startCountdown(3)}
+                        className="h-9 w-12 px-0 text-sm tabular-nums"
+                        aria-label="Αντίστροφη μέτρηση 3 λεπτών"
+                    >
+                        3&apos;
+                    </Button>
+                </div>
+                <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handleReset}
+                    disabled={!hasStarted}
+                    className="h-9 px-3 text-sm w-28 justify-start"
+                >
+                    <RotateCcw className="w-4 h-4 mr-1.5" />
+                    Επαναφορά
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/presentation/SpeakerTimer.tsx
+++ b/src/components/presentation/SpeakerTimer.tsx
@@ -29,12 +29,16 @@ export default function SpeakerTimer() {
     }, [running, startedAt, pausedElapsed]);
 
     const hasStarted = startedAt !== null;
-    // During a countdown, show remaining time. Once it reaches zero the timer
-    // keeps running and the display flips to a count-up starting from the
-    // original countdown duration (e.g. a 1' countdown becomes 1:00, 1:01, …).
-    const displayed = countdownFrom !== null && elapsed < countdownFrom
+    // During a countdown, show remaining time (inclusive of the 00:00 tick).
+    // Once it reaches zero the timer keeps running and the display flips to a
+    // count-up that resumes from the original countdown duration (e.g. a 1'
+    // countdown becomes 0:00 → 1:00 → 1:01 → …). The `- 1` offset makes the
+    // first count-up tick display `countdownFrom` itself rather than skipping it.
+    const displayed = countdownFrom !== null && elapsed <= countdownFrom
         ? countdownFrom - elapsed
-        : elapsed;
+        : countdownFrom !== null
+            ? elapsed - 1
+            : elapsed;
     // Red once we enter the final 30s of the countdown and stays red after it ends.
     const isCountdownWarning = countdownFrom !== null && elapsed >= countdownFrom - 30;
 

--- a/src/components/presentation/SpeakerTimer.tsx
+++ b/src/components/presentation/SpeakerTimer.tsx
@@ -28,22 +28,17 @@ export default function SpeakerTimer() {
         return () => clearInterval(interval);
     }, [running, startedAt, pausedElapsed]);
 
-    // Auto-stop a countdown when it reaches zero.
-    useEffect(() => {
-        if (running && countdownFrom !== null && elapsed >= countdownFrom) {
-            setRunning(false);
-        }
-    }, [running, countdownFrom, elapsed]);
-
     const hasStarted = startedAt !== null;
-    const displayed = countdownFrom !== null
-        ? Math.max(0, countdownFrom - elapsed)
+    // During a countdown, show remaining time. Once it reaches zero the timer
+    // keeps running and the display flips to a count-up starting from the
+    // original countdown duration (e.g. a 1' countdown becomes 1:00, 1:01, …).
+    const displayed = countdownFrom !== null && elapsed < countdownFrom
+        ? countdownFrom - elapsed
         : elapsed;
-    const isCountdownFinished = countdownFrom !== null && elapsed >= countdownFrom;
-    const isCountdownWarning = countdownFrom !== null && displayed <= 30;
+    // Red once we enter the final 30s of the countdown and stays red after it ends.
+    const isCountdownWarning = countdownFrom !== null && elapsed >= countdownFrom - 30;
 
     const handleToggle = () => {
-        if (isCountdownFinished) return;
         if (running && startedAt !== null) {
             setPausedElapsed(pausedElapsed + Math.floor((Date.now() - startedAt) / 1000));
             setRunning(false);
@@ -80,8 +75,7 @@ export default function SpeakerTimer() {
             <button
                 type="button"
                 onClick={handleToggle}
-                disabled={isCountdownFinished}
-                className={`font-mono tabular-nums font-bold text-[16vh] leading-none tracking-tight hover:opacity-80 active:opacity-70 transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-lg px-4 text-center min-w-[5ch] disabled:cursor-default disabled:hover:opacity-100 ${isCountdownWarning ? "text-red-600" : ""}`}
+                className={`font-mono tabular-nums font-bold text-[16vh] leading-none tracking-tight hover:opacity-80 active:opacity-70 transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-lg px-4 text-center min-w-[5ch] ${isCountdownWarning ? "text-red-600" : ""}`}
                 aria-label={mainLabel}
             >
                 {formatTimerDisplay(displayed)}
@@ -92,7 +86,6 @@ export default function SpeakerTimer() {
                         size="sm"
                         variant="outline"
                         onClick={handleToggle}
-                        disabled={isCountdownFinished}
                         className="h-9 px-3 text-sm w-28 justify-start"
                     >
                         {running ? (

--- a/src/components/presentation/SubjectSlide.tsx
+++ b/src/components/presentation/SubjectSlide.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { ImageOrInitials } from "@/components/ImageOrInitials";
+import { SubjectWithRelations } from "@/lib/db/subject";
+import { filterActiveRoles, getPartyFromRoles } from "@/lib/utils";
+import SpeakerTimer from "./SpeakerTimer";
+
+interface SubjectSlideProps {
+    subject: SubjectWithRelations;
+}
+
+export default function SubjectSlide({ subject }: SubjectSlideProps) {
+    const introducer = subject.introducedBy;
+    const introducerParty = introducer ? getPartyFromRoles(introducer.roles) : null;
+    const firstRoleName = introducer
+        ? filterActiveRoles(introducer.roles).find((r) => r.name)?.name ?? null
+        : null;
+    const introducerSubtitle = [firstRoleName, introducerParty?.name]
+        .filter(Boolean)
+        .join(" · ");
+
+    return (
+        <div className="relative h-full w-full flex flex-col">
+            <div className="flex-1 flex flex-col items-center justify-center px-[4vw] gap-[3vh] min-h-0">
+                <div className="text-[6vw] font-bold leading-[1] text-left max-w-[92%] flex items-center gap-[0.3em]">
+                    {subject.agendaItemIndex !== null && (
+                        <span
+                            className="inline-flex items-center justify-center rounded-full bg-foreground text-background tabular-nums shrink-0"
+                            style={{
+                                width: "1.3em",
+                                height: "1.3em",
+                                fontSize: "0.75em",
+                                lineHeight: 1,
+                            }}
+                        >
+                            {subject.agendaItemIndex}
+                        </span>
+                    )}
+                    <span>{subject.name}</span>
+                </div>
+
+                {introducer && (
+                    <div className="flex items-center gap-5">
+                        <div className="w-[9vh] h-[9vh] shrink-0">
+                            <ImageOrInitials
+                                imageUrl={introducer.image}
+                                width={100}
+                                height={100}
+                                name={introducer.name}
+                                color={introducerParty?.colorHex}
+                            />
+                        </div>
+                        <div className="flex flex-col items-start">
+                            <div className="text-[1.6vh] uppercase tracking-wider text-muted-foreground">
+                                Εισηγητής
+                            </div>
+                            <div className="text-[3vh] font-semibold leading-tight">{introducer.name}</div>
+                            {introducerSubtitle && (
+                                <div className="text-[2vh] text-muted-foreground leading-tight">
+                                    {introducerSubtitle}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                )}
+            </div>
+
+            <div className="flex items-center justify-center h-[28vh] border-t border-border/40 flex-shrink-0">
+                <SpeakerTimer />
+            </div>
+        </div>
+    );
+}

--- a/src/components/presentation/SubjectSlide.tsx
+++ b/src/components/presentation/SubjectSlide.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { ImageOrInitials } from "@/components/ImageOrInitials";
 import { SubjectWithRelations } from "@/lib/db/subject";
 import { filterActiveRoles, getPartyFromRoles } from "@/lib/utils";


### PR DESCRIPTION
## Summary
- Admin-only fullscreen presentation mode for council meetings at `/[locale]/present/[cityId]/[meetingId]`, intended for display on a big screen during live sessions
- Slideshow: meeting info slide → one slide per before-agenda/agenda subject (agenda number inline in title, introducer avatar + name + role); out-of-agenda subjects are excluded
- Speaker timer (Χρόνος Ομιλητή) at the bottom of each subject slide — stopwatch by default, plus 1' and 3' quick-start countdowns; timer digits turn red in the final 30 seconds of a countdown
- Browser Fullscreen API: tries on mount, falls back to first user gesture, and offers a Maximize/Minimize toggle next to the close button so users can re-enter fullscreen after Esc
- Keyboard navigation (←/→/↑/↓/Space) and left/right click-zone halves (cursor becomes a directional arrow); position indicator in the bottom-right shows `INTRO` or `Θέμα X / Y`
- New Παρουσίαση header button (`Projector` icon, ghost variant) on the meeting page — gated server-side in the meeting layout so non-admins never receive it in the RSC payload
- Heavy presentation code (slides, timer, framer-motion) lives under the existing `(fullscreen)` route group, so Next.js route-based code-splitting keeps it out of the normal meeting page bundle

## Test plan
- [ ] As a non-admin, open a meeting — Παρουσίαση button is not present; direct navigation to `/present/<cityId>/<meetingId>` returns 404
- [ ] As a city admin, open a meeting, click the Παρουσίαση button — a new tab opens in fullscreen showing the city logo+name header, the meeting info slide (meeting name, date, subject count), and the OpenCouncil footer
- [ ] Navigate with ArrowLeft/ArrowRight, Space, and by clicking the left/right halves of the screen; cursor becomes a directional arrow over each half; boundary halves are non-interactive
- [ ] Position indicator reads `INTRO` on the cover slide and `Θέμα X / Y` on subject slides; out-of-agenda subjects never appear
- [ ] On a subject slide the agenda number renders inline at the start of the title (circled, same font metric), the title is centered, and the introducer card shows `ImageOrInitials` avatar + name + role/party
- [ ] Timer stopwatch: click `00:00` → counts up with no layout shift; Παύση/Συνέχεια/Επαναφορά behave as expected
- [ ] Timer countdown: click `1'` or `3'` → countdown starts from the selected duration, auto-stops at `00:00`; digits switch to red during the last 30 seconds and the transition is smooth
- [ ] Fullscreen toggle (Maximize/Minimize) in the top-right enters/exits fullscreen; pressing Esc exits fullscreen natively, and the toggle icon updates to reflect state; the X button exits the presentation entirely and navigates back to the meeting page
- [ ] Open a meeting with zero agenda items — only the info slide shows; no right chevron

https://claude.ai/code/session_01RAFCQuAs5P4haMJfPtzfp7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new auth-gated route and substantial client-side fullscreen/navigation logic; low data risk, but potential UX/runtime issues around Fullscreen API and slide/timer interactions.
> 
> **Overview**
> Adds a new **admin-only** fullscreen presentation page at `/present/[cityId]/[meetingId]` that fetches meeting data server-side, filters subjects to *before-agenda + agenda (sorted by agenda index)*, and renders a slide deck.
> 
> The new client `PresentationView` implements slide navigation (keyboard + click zones), Fullscreen API enter/exit handling, and a close action back to the meeting page. Slides include an intro `MeetingInfoSlide`, per-subject `SubjectSlide` (agenda index + introducer details), and an embedded `SpeakerTimer` with pause/resume/reset and 1’/3’ countdown presets.
> 
> Updates the meeting page header to show a `PresentationViewButton` (opens in a new tab) only when `editable` is true, keeping the link out of non-admin RSC payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85770ee801ef83628c5c44d05e74df034d614bea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an admin-only fullscreen presentation mode at `/present/[cityId]/[meetingId]` with slide navigation, a speaker timer, and Fullscreen API integration. Auth gating is correctly done server-side (`isUserAuthorizedToEdit` with `await`) and the `PresentationViewButton` is kept out of non-admin RSC payloads. Previous thread issues (countdown "0:00" skip, Greek plural, unnecessary `"use client"`) are all addressed in this revision.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all P0/P1 prior concerns are resolved and remaining findings are P2 UX notes.

Auth gating is correct, no data mutations, all prior thread issues addressed. The two new comments are P2: a documented intentional UX behaviour in the timer and a minor fullscreen retry edge-case that degrades gracefully (toggle button remains available).

src/components/presentation/PresentationView.tsx (fullscreen first-gesture cleanup logic) and src/components/presentation/SpeakerTimer.tsx (post-countdown count-up UX)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/(fullscreen)/present/[cityId]/[meetingId]/page.tsx | Auth-gated server page; correctly awaits `isUserAuthorizedToEdit`, returns `notFound()` for non-admins, and filters subjects to before-agenda + agenda only. |
| src/components/presentation/PresentationView.tsx | Client component handling slide navigation, fullscreen API, and keyboard shortcuts; first-gesture listener silently self-destructs on any blocked fullscreen call. |
| src/components/presentation/SpeakerTimer.tsx | Timer logic is sound; countdown correctly shows "0:00" (prev fix applied); post-countdown count-up intentionally resumes from the original duration rather than zero. |
| src/components/presentation/SubjectSlide.tsx | Renders introducer info and embeds SpeakerTimer; correctly keyed per subject so each slide gets a fresh timer instance. |
| src/components/meetings/PresentationViewButton.tsx | Server-rendered link button; no `"use client"` (correctly removed), admin-gating done server-side in the layout. |
| src/components/presentation/MeetingInfoSlide.tsx | Intro slide with correct Greek plural handling (1 θέμα / N θέματα / Χωρίς θέματα); no issues. |
| src/components/presentation/SlideHeader.tsx | Minimal header showing city logo/name; suppressed `@next/next/no-img-element` lint rule is intentional for external image URLs. |
| src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx | Adds PresentationViewButton conditionally behind `editable` check; button entirely absent from RSC payload for non-admin users. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MeetingLayout as Meeting Layout (RSC)
    participant PresentPage as /present Page (RSC)
    participant PresentationView as PresentationView (Client)
    participant SpeakerTimer as SpeakerTimer (Client)

    User->>MeetingLayout: Visit meeting page
    MeetingLayout->>MeetingLayout: isUserAuthorizedToEdit()
    alt editable
        MeetingLayout-->>User: Render PresentationViewButton
        User->>PresentPage: Open /present/[cityId]/[meetingId] (new tab)
        PresentPage->>PresentPage: isUserAuthorizedToEdit() → notFound if false
        PresentPage->>PresentPage: getMeetingDataCached()
        PresentPage->>PresentPage: categorize + sort subjects
        PresentPage-->>PresentationView: meeting, city, agendaSubjects
        PresentationView->>PresentationView: requestFullscreen() on mount
        PresentationView-->>User: Render slide deck (MeetingInfoSlide or SubjectSlide)
        User->>PresentationView: Navigate (keyboard / click zone)
        PresentationView->>PresentationView: setIndex()
        PresentationView-->>User: Animate to next/prev slide
        User->>SpeakerTimer: Start / countdown / reset
        SpeakerTimer-->>User: Live timer display
    else not editable
        PresentPage-->>User: 404
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/components/presentation/SpeakerTimer.tsx
Line: 37-41

Comment:
**Post-countdown count-up phase skips 0:01–0:59**

When the countdown ends (`elapsed === countdownFrom`), `displayed` correctly shows `0:00`. But at `elapsed = countdownFrom + 1`, the formula `elapsed - 1` yields `countdownFrom` ("1:00" for the 1′ preset). The count-up phase effectively jumps from `0:00` directly to `1:00`, skipping the first 59 display values. The code comment acknowledges this ("a 1′ countdown becomes 0:00 → 1:00 → 1:01 → …"), so this appears intentional — but a presenter who expects to see elapsed overtime from zero may be confused.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/components/presentation/PresentationView.tsx
Line: 87-94

Comment:
**First-gesture `keydown` listener self-destructs on blocked fullscreen**

Both the first-gesture listener (`onFirstGesture`, line 91) and the keyboard navigation handler (line 116) are registered on `window` for `keydown`. `cleanup()` is called unconditionally inside `onFirstGesture` regardless of whether `requestFullscreen()` succeeded. If the browser blocks the request (e.g. the tab isn't focused), the listener is permanently removed after the first key press. A second key press only triggers navigation with no further fullscreen attempt. Consider tying `cleanup()` to a successful fullscreen entry (i.e. inside the `.then()` callback) rather than the gesture itself.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fixup! Add presentation view for council..."](https://github.com/schemalabz/opencouncil/commit/241a86f191ca1471dc08b7fafb0acbc26e103ca9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28093694)</sub>

<!-- /greptile_comment -->