### PR TITLE
feat: Service API keys + meeting creation for Sentinel

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"b02fc5ad-6b6f-414f-b263-45cc03a83c9c","pid":61125,"acquiredAt":1776088102969}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"b02fc5ad-6b6f-414f-b263-45cc03a83c9c","pid":61125,"acquiredAt":1776088102969}

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ result
 result-*
 
 CLAUDE.local.md
+.claude/scheduled_tasks.lock

--- a/messages/el.json
+++ b/messages/el.json
@@ -176,6 +176,8 @@
         "meetingAgenda": "Ημερήσια Διάταξη",
         "meetingAgendaPlaceholder": "https://... ή αποθέστε ένα αρχείο PDF",
         "meetingAgendaDescription": "Προσθέστε τον σύνδεσμο της ημερήσιας διάταξης ή ανεβάστε το αρχείο PDF.",
+        "processAgenda": "Εκτέλεση pipeline",
+        "processAgendaDescription": "Αυτόματη ανάλυση της ημερήσιας διάταξης σε θέματα μετά τη δημιουργία.",
         "submitting": "Υποβολή...",
         "addMeeting": "Προσθήκη Συνεδρίασης",
         "updateMeeting": "Ενημέρωση Συνεδρίασης",

--- a/messages/en.json
+++ b/messages/en.json
@@ -179,7 +179,9 @@
         "administrativeBodyDescription": "Select the administrative body for this meeting.",
         "meetingAgenda": "Meeting Agenda",
         "meetingAgendaPlaceholder": "Agenda URL or file",
-        "meetingAgendaDescription": "Provide a URL or upload a file with the meeting agenda."
+        "meetingAgendaDescription": "Provide a URL or upload a file with the meeting agenda.",
+        "processAgenda": "Run pipeline",
+        "processAgendaDescription": "Automatically parse the agenda into structured items after creation."
     },
     "NotFoundPage": {
         "title": "Page Not Found",

--- a/prisma/migrations/20260416000002_add_service_api_keys/migration.sql
+++ b/prisma/migrations/20260416000002_add_service_api_keys/migration.sql
@@ -15,8 +15,5 @@ CREATE TABLE "ServiceApiKey" (
 -- CreateIndex
 CREATE UNIQUE INDEX "ServiceApiKey_hashedKey_key" ON "ServiceApiKey"("hashedKey");
 
--- CreateIndex
-CREATE INDEX "ServiceApiKey_hashedKey_idx" ON "ServiceApiKey"("hashedKey");
-
 -- AddForeignKey
 ALTER TABLE "ServiceApiKey" ADD CONSTRAINT "ServiceApiKey_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260416000002_add_service_api_keys/migration.sql
+++ b/prisma/migrations/20260416000002_add_service_api_keys/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "ServiceApiKey" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "hashedKey" TEXT NOT NULL,
+    "keyPrefix" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdById" TEXT NOT NULL,
+
+    CONSTRAINT "ServiceApiKey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ServiceApiKey_hashedKey_key" ON "ServiceApiKey"("hashedKey");
+
+-- CreateIndex
+CREATE INDEX "ServiceApiKey_hashedKey_idx" ON "ServiceApiKey"("hashedKey");
+
+-- AddForeignKey
+ALTER TABLE "ServiceApiKey" ADD CONSTRAINT "ServiceApiKey_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -769,6 +769,7 @@ model User {
   meetingOperatorAssignments MeetingOperator[]
   subjectAttendance SubjectAttendance[]
   subjectVotes SubjectVote[]
+  serviceApiKeys ServiceApiKey[]
 }
  
 model Account {
@@ -843,6 +844,21 @@ model Administers {
   updatedAt DateTime @updatedAt
 
   @@unique([userId, cityId, partyId, personId])
+}
+
+model ServiceApiKey {
+  id          String    @id @default(cuid())
+  name        String    // Display name (e.g. "Sentinel")
+  hashedKey   String    @unique // SHA-256 hash of the API key
+  keyPrefix   String    // First 8 chars for display (e.g. "sk_a1b2c3")
+  createdAt   DateTime  @default(now())
+  lastUsedAt  DateTime?
+  revokedAt   DateTime?
+
+  createdBy   User      @relation(fields: [createdById], references: [id])
+  createdById String
+
+  @@index([hashedKey])
 }
 
 model UtteranceEdit {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -850,15 +850,13 @@ model ServiceApiKey {
   id          String    @id @default(cuid())
   name        String    // Display name (e.g. "Sentinel")
   hashedKey   String    @unique // SHA-256 hash of the API key
-  keyPrefix   String    // First 8 chars for display (e.g. "sk_a1b2c3")
+  keyPrefix   String    // First 10 chars for display (e.g. "sk_a1b2c3d")
   createdAt   DateTime  @default(now())
   lastUsedAt  DateTime?
   revokedAt   DateTime?
 
   createdBy   User      @relation(fields: [createdById], references: [id])
   createdById String
-
-  @@index([hashedKey])
 }
 
 model UtteranceEdit {

--- a/src/app/[locale]/(other)/admin/settings/api-keys/page.tsx
+++ b/src/app/[locale]/(other)/admin/settings/api-keys/page.tsx
@@ -1,0 +1,291 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Badge } from "@/components/ui/badge"
+import { PlusIcon, Copy, Check, AlertTriangle } from "lucide-react"
+import { useState, useEffect } from "react"
+import { toast } from "@/hooks/use-toast"
+
+interface ApiKey {
+    id: string
+    name: string
+    keyPrefix: string
+    createdAt: string
+    lastUsedAt: string | null
+    revokedAt: string | null
+    createdBy: { name: string | null; email: string }
+}
+
+export default function ApiKeysPage() {
+    const [keys, setKeys] = useState<ApiKey[]>([])
+    const [loading, setLoading] = useState(true)
+    const [createDialogOpen, setCreateDialogOpen] = useState(false)
+    const [newKeyName, setNewKeyName] = useState("")
+    const [createdKey, setCreatedKey] = useState<string | null>(null)
+    const [creating, setCreating] = useState(false)
+    const [copied, setCopied] = useState(false)
+    const [keyToRevoke, setKeyToRevoke] = useState<ApiKey | null>(null)
+    const [revoking, setRevoking] = useState(false)
+
+    async function refreshKeys() {
+        try {
+            const response = await fetch("/api/admin/api-keys")
+            if (!response.ok) throw new Error("Failed to fetch API keys")
+            const data = await response.json()
+            setKeys(data)
+        } catch (error) {
+            console.error("Failed to fetch API keys:", error)
+            toast({ title: "Error", description: "Failed to fetch API keys", variant: "destructive" })
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    useEffect(() => { refreshKeys() }, [])
+
+    async function handleCreate() {
+        if (!newKeyName.trim()) return
+        setCreating(true)
+        try {
+            const response = await fetch("/api/admin/api-keys", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ name: newKeyName.trim() }),
+            })
+            if (!response.ok) throw new Error("Failed to create API key")
+            const data = await response.json()
+            setCreatedKey(data.rawKey)
+            refreshKeys()
+        } catch (error) {
+            console.error("Failed to create API key:", error)
+            toast({ title: "Error", description: "Failed to create API key", variant: "destructive" })
+            setCreateDialogOpen(false)
+        } finally {
+            setCreating(false)
+        }
+    }
+
+    async function handleRevoke() {
+        if (!keyToRevoke) return
+        setRevoking(true)
+        try {
+            const response = await fetch(`/api/admin/api-keys/${keyToRevoke.id}`, { method: "DELETE" })
+            if (!response.ok) throw new Error("Failed to revoke API key")
+            toast({ title: "Success", description: `API key "${keyToRevoke.name}" has been revoked.` })
+            refreshKeys()
+        } catch (error) {
+            console.error("Failed to revoke API key:", error)
+            toast({ title: "Error", description: "Failed to revoke API key", variant: "destructive" })
+        } finally {
+            setRevoking(false)
+            setKeyToRevoke(null)
+        }
+    }
+
+    function handleCopy() {
+        if (!createdKey) return
+        navigator.clipboard.writeText(createdKey)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+    }
+
+    function handleCloseCreateDialog() {
+        setCreateDialogOpen(false)
+        setCreatedKey(null)
+        setNewKeyName("")
+        setCopied(false)
+    }
+
+    const activeKeys = keys.filter(k => !k.revokedAt)
+    const revokedKeys = keys.filter(k => k.revokedAt)
+
+    if (loading) {
+        return (
+            <div className="p-6">
+                <h1 className="text-2xl font-bold mb-6">API Keys</h1>
+                <Card><CardContent className="p-6">Loading...</CardContent></Card>
+            </div>
+        )
+    }
+
+    return (
+        <div className="p-6 space-y-6">
+            <div className="flex justify-between items-center">
+                <h1 className="text-2xl font-bold">API Keys</h1>
+                <Button onClick={() => setCreateDialogOpen(true)}>
+                    <PlusIcon className="mr-2 h-4 w-4" />
+                    Create API Key
+                </Button>
+            </div>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Active Keys</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    {activeKeys.length === 0 ? (
+                        <p className="text-muted-foreground text-sm">No active API keys. Create one to get started.</p>
+                    ) : (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Name</TableHead>
+                                    <TableHead>Key</TableHead>
+                                    <TableHead>Created</TableHead>
+                                    <TableHead>Last Used</TableHead>
+                                    <TableHead>Created By</TableHead>
+                                    <TableHead>Actions</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {activeKeys.map((key) => (
+                                    <TableRow key={key.id}>
+                                        <TableCell className="font-medium">{key.name}</TableCell>
+                                        <TableCell>
+                                            <code className="text-sm bg-muted px-2 py-1 rounded">{key.keyPrefix}...</code>
+                                        </TableCell>
+                                        <TableCell>{new Date(key.createdAt).toLocaleDateString()}</TableCell>
+                                        <TableCell>
+                                            {key.lastUsedAt
+                                                ? new Date(key.lastUsedAt).toLocaleDateString()
+                                                : <span className="text-muted-foreground">Never</span>
+                                            }
+                                        </TableCell>
+                                        <TableCell>{key.createdBy.name || key.createdBy.email}</TableCell>
+                                        <TableCell>
+                                            <Button
+                                                variant="destructive"
+                                                size="sm"
+                                                onClick={() => setKeyToRevoke(key)}
+                                            >
+                                                Revoke
+                                            </Button>
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    )}
+                </CardContent>
+            </Card>
+
+            {revokedKeys.length > 0 && (
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Revoked Keys</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Name</TableHead>
+                                    <TableHead>Key</TableHead>
+                                    <TableHead>Created</TableHead>
+                                    <TableHead>Revoked</TableHead>
+                                    <TableHead>Status</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {revokedKeys.map((key) => (
+                                    <TableRow key={key.id} className="opacity-60">
+                                        <TableCell className="font-medium">{key.name}</TableCell>
+                                        <TableCell>
+                                            <code className="text-sm bg-muted px-2 py-1 rounded">{key.keyPrefix}...</code>
+                                        </TableCell>
+                                        <TableCell>{new Date(key.createdAt).toLocaleDateString()}</TableCell>
+                                        <TableCell>{key.revokedAt ? new Date(key.revokedAt).toLocaleDateString() : '-'}</TableCell>
+                                        <TableCell><Badge variant="secondary">Revoked</Badge></TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    </CardContent>
+                </Card>
+            )}
+
+            {/* Create API Key Dialog */}
+            <Dialog open={createDialogOpen} onOpenChange={(open) => { if (!open) handleCloseCreateDialog() }}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>{createdKey ? "API Key Created" : "Create API Key"}</DialogTitle>
+                        <DialogDescription>
+                            {createdKey
+                                ? "Copy this key now. You won't be able to see it again."
+                                : "Give this key a descriptive name so you can identify it later."
+                            }
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    {createdKey ? (
+                        <div className="space-y-4">
+                            <div className="flex items-center gap-2 p-3 bg-muted rounded-md">
+                                <code className="text-sm flex-1 break-all">{createdKey}</code>
+                                <Button variant="ghost" size="sm" onClick={handleCopy}>
+                                    {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                                </Button>
+                            </div>
+                            <div className="flex items-center gap-2 text-sm text-amber-600">
+                                <AlertTriangle className="h-4 w-4" />
+                                <span>This key will only be shown once. Store it securely.</span>
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="space-y-4">
+                            <div>
+                                <Label htmlFor="keyName">Key Name</Label>
+                                <Input
+                                    id="keyName"
+                                    placeholder="e.g. Sentinel"
+                                    value={newKeyName}
+                                    onChange={(e) => setNewKeyName(e.target.value)}
+                                    onKeyDown={(e) => { if (e.key === 'Enter') handleCreate() }}
+                                />
+                            </div>
+                        </div>
+                    )}
+
+                    <DialogFooter>
+                        {createdKey ? (
+                            <Button onClick={handleCloseCreateDialog}>Done</Button>
+                        ) : (
+                            <>
+                                <DialogClose asChild>
+                                    <Button variant="outline">Cancel</Button>
+                                </DialogClose>
+                                <Button onClick={handleCreate} disabled={creating || !newKeyName.trim()}>
+                                    {creating ? "Creating..." : "Create Key"}
+                                </Button>
+                            </>
+                        )}
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Revoke Confirmation Dialog */}
+            <Dialog open={!!keyToRevoke} onOpenChange={() => setKeyToRevoke(null)}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Revoke API Key</DialogTitle>
+                        <DialogDescription>
+                            Are you sure you want to revoke the API key <span className="font-semibold">{keyToRevoke?.name}</span>?
+                            Any service using this key will immediately lose access.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <DialogClose asChild>
+                            <Button variant="outline" disabled={revoking}>Cancel</Button>
+                        </DialogClose>
+                        <Button variant="destructive" onClick={handleRevoke} disabled={revoking}>
+                            {revoking ? "Revoking..." : "Yes, revoke key"}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
+    )
+}

--- a/src/app/api/admin/api-keys/[id]/route.ts
+++ b/src/app/api/admin/api-keys/[id]/route.ts
@@ -8,8 +8,11 @@ export async function DELETE(
     { params }: { params: { id: string } }
 ) {
     const user = await getCurrentUser();
-    if (!user?.isSuperAdmin) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (!user) {
+        return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+    }
+    if (!user.isSuperAdmin) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     try {

--- a/src/app/api/admin/api-keys/[id]/route.ts
+++ b/src/app/api/admin/api-keys/[id]/route.ts
@@ -1,0 +1,21 @@
+import { getCurrentUser } from "@/lib/auth";
+import { NextResponse } from "next/server";
+import { revokeServiceApiKey } from "@/lib/db/apiKeys";
+import { handleApiError } from "@/lib/api/errors";
+
+export async function DELETE(
+    _request: Request,
+    { params }: { params: { id: string } }
+) {
+    const user = await getCurrentUser();
+    if (!user?.isSuperAdmin) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    try {
+        await revokeServiceApiKey(params.id);
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        return handleApiError(error, "Failed to revoke API key");
+    }
+}

--- a/src/app/api/admin/api-keys/route.ts
+++ b/src/app/api/admin/api-keys/route.ts
@@ -2,11 +2,19 @@ import { getCurrentUser } from "@/lib/auth";
 import { NextResponse } from "next/server";
 import { createServiceApiKey, getServiceApiKeys } from "@/lib/db/apiKeys";
 import { handleApiError } from "@/lib/api/errors";
+import { z } from "zod";
+
+const createKeySchema = z.object({
+    name: z.string().min(1).max(100).trim(),
+});
 
 export async function GET() {
     const user = await getCurrentUser();
-    if (!user?.isSuperAdmin) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (!user) {
+        return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+    }
+    if (!user.isSuperAdmin) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     try {
@@ -19,17 +27,18 @@ export async function GET() {
 
 export async function POST(request: Request) {
     const user = await getCurrentUser();
-    if (!user?.isSuperAdmin) {
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (!user) {
+        return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+    }
+    if (!user.isSuperAdmin) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     try {
-        const { name } = await request.json();
-        if (!name || typeof name !== 'string' || name.trim().length === 0) {
-            return NextResponse.json({ error: "Name is required" }, { status: 400 });
-        }
+        const body = await request.json();
+        const { name } = createKeySchema.parse(body);
 
-        const result = await createServiceApiKey(name.trim(), user.id);
+        const result = await createServiceApiKey(name, user.id);
 
         // Return the raw key in the response — this is the only time it's visible
         return NextResponse.json({
@@ -40,6 +49,9 @@ export async function POST(request: Request) {
             createdAt: result.createdAt,
         }, { status: 201 });
     } catch (error) {
+        if (error instanceof z.ZodError) {
+            return NextResponse.json({ error: error.errors }, { status: 400 });
+        }
         return handleApiError(error, "Failed to create API key");
     }
 }

--- a/src/app/api/admin/api-keys/route.ts
+++ b/src/app/api/admin/api-keys/route.ts
@@ -1,0 +1,45 @@
+import { getCurrentUser } from "@/lib/auth";
+import { NextResponse } from "next/server";
+import { createServiceApiKey, getServiceApiKeys } from "@/lib/db/apiKeys";
+import { handleApiError } from "@/lib/api/errors";
+
+export async function GET() {
+    const user = await getCurrentUser();
+    if (!user?.isSuperAdmin) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    try {
+        const keys = await getServiceApiKeys();
+        return NextResponse.json(keys);
+    } catch (error) {
+        return handleApiError(error, "Failed to fetch API keys");
+    }
+}
+
+export async function POST(request: Request) {
+    const user = await getCurrentUser();
+    if (!user?.isSuperAdmin) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    try {
+        const { name } = await request.json();
+        if (!name || typeof name !== 'string' || name.trim().length === 0) {
+            return NextResponse.json({ error: "Name is required" }, { status: 400 });
+        }
+
+        const result = await createServiceApiKey(name.trim(), user.id);
+
+        // Return the raw key in the response — this is the only time it's visible
+        return NextResponse.json({
+            id: result.id,
+            name: result.name,
+            keyPrefix: result.keyPrefix,
+            rawKey: result.rawKey,
+            createdAt: result.createdAt,
+        }, { status: 201 });
+    } catch (error) {
+        return handleApiError(error, "Failed to create API key");
+    }
+}

--- a/src/app/api/cities/[cityId]/meetings/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/route.ts
@@ -1,16 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { revalidatePath, revalidateTag } from 'next/cache';
 import { z } from 'zod';
-import { createCouncilMeetingDirect, getCouncilMeetingsForCity } from '@/lib/db/meetings';
+import { createCouncilMeetingDirect, getCouncilMeetingsForCity, generateUniqueMeetingId } from '@/lib/db/meetings';
 import { withServiceOrUserAuth } from '@/lib/auth';
 import { sendMeetingCreatedAdminAlert } from '@/lib/discord';
 import { createMeetingCalendarEvent, calculateMeetingEndTime } from '@/lib/google-calendar';
 import { requestProcessAgendaInternal } from '@/lib/tasks/processAgendaInternal';
-import { generateUniqueMeetingId } from '@/lib/utils/meetingId';
 import { handleApiError } from '@/lib/api/errors';
 import { env } from '@/env.mjs';
 import prisma from '@/lib/db/prisma';
-import { Prisma } from '@prisma/client';
 import { Prisma } from '@prisma/client';
 
 const meetingSchema = z.object({

--- a/src/app/api/cities/[cityId]/meetings/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/route.ts
@@ -80,25 +80,27 @@ export async function POST(
             administrativeBodyId: administrativeBodyId || null,
         });
 
+        // Direct prisma create — used for service auth and for TOCTOU retry
+        const createMeetingDirect = (id: string) =>
+            prisma.councilMeeting.create({
+                data: buildMeetingData(id),
+                include: { administrativeBody: true },
+            });
+
         // Service auth: route already verified the API key, so create directly.
         // User auth: delegate to createCouncilMeeting which re-checks session auth.
-        const createMeeting = async (id: string) =>
-            authResult.type === 'service'
-                ? prisma.councilMeeting.create({
-                    data: buildMeetingData(id),
-                    include: { administrativeBody: true },
-                })
-                : createCouncilMeeting(buildMeetingData(id));
-
-        // Retry with a fresh ID on unique constraint violation (TOCTOU race)
         let meeting;
         try {
-            meeting = await createMeeting(meetingId);
+            meeting = authResult.type === 'service'
+                ? await createMeetingDirect(meetingId)
+                : await createCouncilMeeting(buildMeetingData(meetingId));
         } catch (error) {
+            // Retry with a fresh ID on unique constraint violation (TOCTOU race).
+            // Always use direct create for retry — auth was already verified above.
             const isUniqueViolation = error instanceof Error && 'code' in error && (error as { code: string }).code === 'P2002';
             if (!isUniqueViolation || providedMeetingId) throw error;
             meetingId = await generateUniqueMeetingId(cityId, date);
-            meeting = await createMeeting(meetingId);
+            meeting = await createMeetingDirect(meetingId);
         }
 
         revalidateTag(`city:${cityId}:meetings`);

--- a/src/app/api/cities/[cityId]/meetings/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/route.ts
@@ -5,7 +5,7 @@ import { createCouncilMeeting, getCouncilMeetingsForCity } from '@/lib/db/meetin
 import { withServiceOrUserAuth } from '@/lib/auth';
 import { sendMeetingCreatedAdminAlert } from '@/lib/discord';
 import { createMeetingCalendarEvent, calculateMeetingEndTime } from '@/lib/google-calendar';
-import { requestProcessAgendaInternal } from '@/lib/tasks/processAgenda';
+import { requestProcessAgendaInternal } from '@/lib/tasks/processAgendaInternal';
 import { generateUniqueMeetingId } from '@/lib/utils/meetingId';
 import { handleApiError } from '@/lib/api/errors';
 import { env } from '@/env.mjs';

--- a/src/app/api/cities/[cityId]/meetings/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/route.ts
@@ -67,27 +67,39 @@ export async function POST(
         // Auto-generate meetingId if not provided
         const meetingId = providedMeetingId || await generateUniqueMeetingId(cityId, date);
 
-        const meetingData = {
+        const buildMeetingData = (id: string) => ({
             name,
             name_en,
-            id: meetingId,
+            id,
             dateTime: date,
             cityId,
             youtubeUrl: youtubeUrl || null,
             agendaUrl: agendaUrl || null,
-            released: false,
+            released: false as const,
             muxPlaybackId: null,
             administrativeBodyId: administrativeBodyId || null,
-        };
+        });
 
         // Service auth: route already verified the API key, so create directly.
         // User auth: delegate to createCouncilMeeting which re-checks session auth.
-        const meeting = authResult.type === 'service'
-            ? await prisma.councilMeeting.create({
-                data: meetingData,
-                include: { administrativeBody: true },
-            })
-            : await createCouncilMeeting(meetingData);
+        const createMeeting = async (id: string) =>
+            authResult.type === 'service'
+                ? prisma.councilMeeting.create({
+                    data: buildMeetingData(id),
+                    include: { administrativeBody: true },
+                })
+                : createCouncilMeeting(buildMeetingData(id));
+
+        // Retry with a fresh ID on unique constraint violation (TOCTOU race)
+        let meeting;
+        try {
+            meeting = await createMeeting(meetingId);
+        } catch (error) {
+            const isUniqueViolation = error instanceof Error && 'code' in error && (error as { code: string }).code === 'P2002';
+            if (!isUniqueViolation || providedMeetingId) throw error;
+            const retryId = await generateUniqueMeetingId(cityId, date);
+            meeting = await createMeeting(retryId);
+        }
 
         revalidateTag(`city:${cityId}:meetings`);
         revalidatePath(`/${cityId}`, "layout");

--- a/src/app/api/cities/[cityId]/meetings/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { revalidatePath, revalidateTag } from 'next/cache';
 import { z } from 'zod';
-import { createCouncilMeeting, getCouncilMeetingsForCity } from '@/lib/db/meetings';
+import { createCouncilMeetingDirect, getCouncilMeetingsForCity } from '@/lib/db/meetings';
 import { withServiceOrUserAuth } from '@/lib/auth';
 import { sendMeetingCreatedAdminAlert } from '@/lib/discord';
 import { createMeetingCalendarEvent, calculateMeetingEndTime } from '@/lib/google-calendar';
@@ -10,6 +10,8 @@ import { generateUniqueMeetingId } from '@/lib/utils/meetingId';
 import { handleApiError } from '@/lib/api/errors';
 import { env } from '@/env.mjs';
 import prisma from '@/lib/db/prisma';
+import { Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 
 const meetingSchema = z.object({
     name: z.string().min(2, {
@@ -80,27 +82,17 @@ export async function POST(
             administrativeBodyId: administrativeBodyId || null,
         });
 
-        // Direct prisma create — used for service auth and for TOCTOU retry
-        const createMeetingDirect = (id: string) =>
-            prisma.councilMeeting.create({
-                data: buildMeetingData(id),
-                include: { administrativeBody: true },
-            });
-
-        // Service auth: route already verified the API key, so create directly.
-        // User auth: delegate to createCouncilMeeting which re-checks session auth.
+        // Auth was already verified by withServiceOrUserAuth above,
+        // so use createCouncilMeetingDirect which skips the internal session check.
         let meeting;
         try {
-            meeting = authResult.type === 'service'
-                ? await createMeetingDirect(meetingId)
-                : await createCouncilMeeting(buildMeetingData(meetingId));
+            meeting = await createCouncilMeetingDirect(buildMeetingData(meetingId));
         } catch (error) {
             // Retry with a fresh ID on unique constraint violation (TOCTOU race).
-            // Always use direct create for retry — auth was already verified above.
-            const isUniqueViolation = error instanceof Error && 'code' in error && (error as { code: string }).code === 'P2002';
-            if (!isUniqueViolation || providedMeetingId) throw error;
+            if (!(error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002')) throw error;
+            if (providedMeetingId) throw error;
             meetingId = await generateUniqueMeetingId(cityId, date);
-            meeting = await createMeetingDirect(meetingId);
+            meeting = await createCouncilMeetingDirect(buildMeetingData(meetingId));
         }
 
         revalidateTag(`city:${cityId}:meetings`);

--- a/src/app/api/cities/[cityId]/meetings/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/route.ts
@@ -2,9 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import { revalidatePath, revalidateTag } from 'next/cache';
 import { z } from 'zod';
 import { createCouncilMeeting, getCouncilMeetingsForCity } from '@/lib/db/meetings';
-import { withUserAuthorizedToEdit } from '@/lib/auth';
+import { withServiceOrUserAuth } from '@/lib/auth';
 import { sendMeetingCreatedAdminAlert } from '@/lib/discord';
 import { createMeetingCalendarEvent, calculateMeetingEndTime } from '@/lib/google-calendar';
+import { requestProcessAgendaInternal } from '@/lib/tasks/processAgenda';
+import { generateUniqueMeetingId } from '@/lib/utils/meetingId';
+import { handleApiError } from '@/lib/api/errors';
+import { env } from '@/env.mjs';
 import prisma from '@/lib/db/prisma';
 
 const meetingSchema = z.object({
@@ -25,10 +29,9 @@ const meetingSchema = z.object({
     agendaUrl: z.string().url({
         message: "Invalid Agenda URL.",
     }).optional().or(z.literal("")),
-    meetingId: z.string().min(1, {
-        message: "Meeting ID is required.",
-    }),
+    meetingId: z.string().min(1).optional(),
     administrativeBodyId: z.string().optional(),
+    processAgenda: z.boolean().optional().default(false),
 });
 
 const getMeetingsQuerySchema = z.object({
@@ -37,7 +40,18 @@ const getMeetingsQuerySchema = z.object({
         .transform((val) => val ? parseInt(val, 10) : undefined)
         .refine((val) => val === undefined || (!isNaN(val) && val >= 1 && val <= 100), {
             message: "Limit must be a number between 1 and 100"
-        })
+        }),
+    from: z.string()
+        .optional()
+        .refine((val) => !val || !isNaN(new Date(val).getTime()), { message: "Invalid 'from' date" })
+        .transform((val) => val ? new Date(val) : undefined),
+    to: z.string()
+        .optional()
+        .refine((val) => !val || !isNaN(new Date(val).getTime()), { message: "Invalid 'to' date" })
+        .transform((val) => val ? new Date(val) : undefined),
+    includeUnreleased: z.string()
+        .optional()
+        .transform((val) => val === 'true'),
 });
 
 export async function POST(
@@ -45,12 +59,15 @@ export async function POST(
     { params }: { params: { cityId: string } }
 ) {
     try {
-        await withUserAuthorizedToEdit({ cityId: params.cityId });
+        const authResult = await withServiceOrUserAuth(request, { cityId: params.cityId });
         const body = await request.json();
-        const { name, name_en, date, youtubeUrl, agendaUrl, meetingId, administrativeBodyId } = meetingSchema.parse(body);
+        const { name, name_en, date, youtubeUrl, agendaUrl, meetingId: providedMeetingId, administrativeBodyId, processAgenda } = meetingSchema.parse(body);
         const cityId = params.cityId;
 
-        const meeting = await createCouncilMeeting({
+        // Auto-generate meetingId if not provided
+        const meetingId = providedMeetingId || await generateUniqueMeetingId(cityId, date);
+
+        const meetingData = {
             name,
             name_en,
             id: meetingId,
@@ -58,10 +75,19 @@ export async function POST(
             cityId,
             youtubeUrl: youtubeUrl || null,
             agendaUrl: agendaUrl || null,
-            released: false, // Set as unpublished by default
+            released: false,
             muxPlaybackId: null,
             administrativeBodyId: administrativeBodyId || null,
-        });
+        };
+
+        // Service auth: route already verified the API key, so create directly.
+        // User auth: delegate to createCouncilMeeting which re-checks session auth.
+        const meeting = authResult.type === 'service'
+            ? await prisma.councilMeeting.create({
+                data: meetingData,
+                include: { administrativeBody: true },
+            })
+            : await createCouncilMeeting(meetingData);
 
         revalidateTag(`city:${cityId}:meetings`);
         revalidatePath(`/${cityId}`, "layout");
@@ -89,23 +115,23 @@ export async function POST(
             try {
                 // Build title in format: "city.name: administrative body.name" (using local names)
                 let calendarTitle = city.name;
-                
+
                 if (meeting.administrativeBody?.name) {
                     calendarTitle += `: ${meeting.administrativeBody.name}`;
                 }
 
                 // Build description with agenda URL and meeting link
-                const meetingUrl = `${process.env.NEXTAUTH_URL}/${cityId}/${meetingId}`;
+                const meetingUrl = `${env.NEXTAUTH_URL}/${cityId}/${meetingId}`;
                 const descriptionParts: string[] = [];
-                
+
                 if (meeting.agendaUrl) {
                     descriptionParts.push(`Ημερήσια Διάταξη: ${meeting.agendaUrl}`);
                 }
-                
+
                 descriptionParts.push(`${meetingUrl}`);
 
                 const endTime = calculateMeetingEndTime(date, 2); // Default 2 hour meetings
-                
+
                 await createMeetingCalendarEvent({
                     title: calendarTitle,
                     description: descriptionParts.join('\n\n'),
@@ -121,17 +147,28 @@ export async function POST(
             }
         }
 
-        return NextResponse.json(meeting, { status: 201 });
+        // Auto-trigger processAgenda if requested and agenda URL is present
+        let processAgendaStatus: string | undefined;
+        if (processAgenda && agendaUrl) {
+            try {
+                const task = await requestProcessAgendaInternal(agendaUrl, meetingId, cityId);
+                processAgendaStatus = task.status;
+                console.log(`processAgenda triggered for meeting ${meetingId}: ${task.status}`);
+            } catch (error) {
+                console.error('Failed to trigger processAgenda:', error);
+                processAgendaStatus = 'failed';
+            }
+        }
+
+        return NextResponse.json({
+            ...meeting,
+            ...(processAgenda && { processAgendaStatus: processAgendaStatus || 'skipped_no_agenda' }),
+        }, { status: 201 });
     } catch (error) {
         if (error instanceof z.ZodError) {
-            console.log(error.errors);
             return NextResponse.json({ error: error.errors }, { status: 400 });
         }
-        console.error('Failed to create meeting:', error);
-        return NextResponse.json(
-            { error: 'Failed to create meeting' },
-            { status: 500 }
-        );
+        return handleApiError(error, 'Failed to create meeting');
     }
 }
 
@@ -143,25 +180,25 @@ export async function GET(
         const { searchParams } = request.nextUrl;
         const queryParams = Object.fromEntries(searchParams.entries());
 
-        const { limit } = getMeetingsQuerySchema.parse(queryParams);
+        const { limit, from, to, includeUnreleased } = getMeetingsQuerySchema.parse(queryParams);
+
+        // includeUnreleased requires auth (service key or authorized user)
+        if (includeUnreleased) {
+            await withServiceOrUserAuth(request, { cityId: params.cityId });
+        }
 
         const meetings = await getCouncilMeetingsForCity(params.cityId, {
-            includeUnreleased: false,
-            limit
+            includeUnreleased,
+            limit,
+            from,
+            to,
         });
 
         return NextResponse.json(meetings);
     } catch (error) {
         if (error instanceof z.ZodError) {
-            return NextResponse.json(
-                { error: error.errors },
-                { status: 400 }
-            );
+            return NextResponse.json({ error: error.errors }, { status: 400 });
         }
-        console.error('Error fetching meetings:', error);
-        return NextResponse.json(
-            { error: 'Failed to fetch meetings' },
-            { status: 500 }
-        );
+        return handleApiError(error, 'Failed to fetch meetings');
     }
 }

--- a/src/app/api/cities/[cityId]/meetings/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/route.ts
@@ -65,7 +65,7 @@ export async function POST(
         const cityId = params.cityId;
 
         // Auto-generate meetingId if not provided
-        const meetingId = providedMeetingId || await generateUniqueMeetingId(cityId, date);
+        let meetingId = providedMeetingId || await generateUniqueMeetingId(cityId, date);
 
         const buildMeetingData = (id: string) => ({
             name,
@@ -97,8 +97,8 @@ export async function POST(
         } catch (error) {
             const isUniqueViolation = error instanceof Error && 'code' in error && (error as { code: string }).code === 'P2002';
             if (!isUniqueViolation || providedMeetingId) throw error;
-            const retryId = await generateUniqueMeetingId(cityId, date);
-            meeting = await createMeeting(retryId);
+            meetingId = await generateUniqueMeetingId(cityId, date);
+            meeting = await createMeeting(meetingId);
         }
 
         revalidateTag(`city:${cityId}:meetings`);

--- a/src/app/api/upload/presigned-url/route.ts
+++ b/src/app/api/upload/presigned-url/route.ts
@@ -4,7 +4,7 @@ import { PutObjectCommand } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { v4 as uuidv4 } from 'uuid'
 import { env } from '@/env.mjs'
-import { isUserAuthorizedToEdit } from '@/lib/auth'
+import { withServiceOrUserAuth } from '@/lib/auth'
 import { UploadConfig } from '@/types/upload'
 
 /**
@@ -92,15 +92,11 @@ export async function POST(request: NextRequest) {
             )
         }
 
-        // Check user authorization
-        // If cityId is provided in config, check city-specific permissions
-        // Otherwise, check general upload permissions
+        // Check authorization via service API key or user session
         const cityId = config?.cityId
-        const authorizedToEdit = await isUserAuthorizedToEdit(
-            cityId ? { cityId } : {}
-        )
-
-        if (!authorizedToEdit) {
+        try {
+            await withServiceOrUserAuth(request, cityId ? { cityId } : {})
+        } catch {
             return NextResponse.json(
                 { error: 'Unauthorized to upload files' },
                 { status: 403 }

--- a/src/app/api/upload/presigned-url/route.ts
+++ b/src/app/api/upload/presigned-url/route.ts
@@ -5,6 +5,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { v4 as uuidv4 } from 'uuid'
 import { env } from '@/env.mjs'
 import { withServiceOrUserAuth } from '@/lib/auth'
+import { ApiError } from '@/lib/api/errors'
 import { UploadConfig } from '@/types/upload'
 
 /**
@@ -96,11 +97,11 @@ export async function POST(request: NextRequest) {
         const cityId = config?.cityId
         try {
             await withServiceOrUserAuth(request, cityId ? { cityId } : {})
-        } catch {
-            return NextResponse.json(
-                { error: 'Unauthorized to upload files' },
-                { status: 403 }
-            )
+        } catch (error) {
+            if (error instanceof ApiError) {
+                return NextResponse.json({ error: error.message }, { status: error.statusCode })
+            }
+            throw error
         }
 
         // Extract file extension

--- a/src/components/admin/sidebar.tsx
+++ b/src/components/admin/sidebar.tsx
@@ -1,4 +1,4 @@
-import { LayoutDashboard, Users, FileText, Settings, Files, FileOutput, Rocket, UserRound, List, RefreshCw, Search, Bell, QrCode, ClipboardCheck, MessageSquareText, Landmark, Tag } from "lucide-react";
+import { LayoutDashboard, Users, FileText, Settings, Files, FileOutput, Rocket, UserRound, List, RefreshCw, Search, Bell, QrCode, ClipboardCheck, MessageSquareText, Landmark, Tag, KeyRound } from "lucide-react";
 import Link from "next/link";
 import {
     Sidebar,
@@ -88,6 +88,11 @@ const menuItems = [
         title: "Cache",
         icon: RefreshCw,
         url: "/admin/cache",
+    },
+    {
+        title: "API Keys",
+        icon: KeyRound,
+        url: "/admin/settings/api-keys",
     },
     {
         title: "Settings",

--- a/src/components/meetings/AddMeetingForm.tsx
+++ b/src/components/meetings/AddMeetingForm.tsx
@@ -17,6 +17,7 @@ import {
 import { Input } from "../ui/input"
 import { SheetClose } from "../ui/sheet"
 import { Loader2, ChevronDown, ChevronUp } from "lucide-react"
+import { Checkbox } from "../ui/checkbox"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select"
 import { useTranslations } from 'next-intl'
 import { Calendar } from "../ui/calendar"
@@ -53,6 +54,7 @@ const formSchema = z.object({
         message: "Meeting ID is required.",
     }),
     administrativeBodyId: z.string().optional(),
+    processAgenda: z.boolean().default(true),
 })
 
 interface AddMeetingFormProps {
@@ -87,6 +89,7 @@ export default function AddMeetingForm({ cityId, meeting, onSuccess }: AddMeetin
             agendaUrl: meeting?.agendaUrl || "",
             meetingId: meeting?.id || formatDateAsMeetingId(meeting ? new Date(meeting.dateTime) : new Date()),
             administrativeBodyId: meeting?.administrativeBodyId || "none",
+            processAgenda: true,
         },
     })
 
@@ -337,6 +340,35 @@ export default function AddMeetingForm({ cityId, meeting, onSuccess }: AddMeetin
                             )
                         }}
                     />
+                    {!meeting && (
+                        <FormField
+                            control={form.control}
+                            name="processAgenda"
+                            render={({ field }) => {
+                                const agendaUrl = form.watch('agendaUrl')
+                                const hasAgenda = !!agendaUrl && agendaUrl.length > 0
+                                return (
+                                    <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                                        <FormControl>
+                                            <Checkbox
+                                                checked={field.value && hasAgenda}
+                                                onCheckedChange={field.onChange}
+                                                disabled={!hasAgenda}
+                                            />
+                                        </FormControl>
+                                        <div className="space-y-1 leading-none">
+                                            <FormLabel className={!hasAgenda ? "text-muted-foreground" : ""}>
+                                                {t('processAgenda')}
+                                            </FormLabel>
+                                            <FormDescription>
+                                                {t('processAgendaDescription')}
+                                            </FormDescription>
+                                        </div>
+                                    </FormItem>
+                                )
+                            }}
+                        />
+                    )}
                     <Collapsible open={isDetailsOpen} onOpenChange={setIsDetailsOpen}>
                         <CollapsibleTrigger asChild>
                             <Button variant="ghost" className="flex w-full justify-between p-0">

--- a/src/components/meetings/AddMeetingForm.tsx
+++ b/src/components/meetings/AddMeetingForm.tsx
@@ -28,6 +28,7 @@ import InputWithDerivatives from "../InputWithDerivatives"
 import { LinkOrDrop } from "../ui/link-or-drop"
 import { YouTubePreview } from "./YouTubePreview"
 import { CouncilMeeting } from '@prisma/client'
+import { formatDateAsMeetingId } from '@/lib/utils/meetingId'
 import { useToast } from "@/hooks/use-toast"
 // @ts-ignore
 import { toPhoneticLatin as toGreeklish } from 'greek-utils'
@@ -71,12 +72,6 @@ export default function AddMeetingForm({ cityId, meeting, onSuccess }: AddMeetin
     const [isDetailsOpen, setIsDetailsOpen] = useState(false)
     const [administrativeBodies, setAdministrativeBodies] = useState<Array<{ id: string, name: string, type: string }>>([])
     const t = useTranslations('AddMeetingForm')
-
-    // Helper function to format date as meeting ID
-    const formatDateAsMeetingId = (date: Date) => {
-        return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-            .toLowerCase().replace(/\s/g, '').replace(',', '_');
-    }
 
     const form = useForm<z.infer<typeof formSchema>>({
         resolver: zodResolver(formSchema),

--- a/src/lib/__tests__/meetings.test.ts
+++ b/src/lib/__tests__/meetings.test.ts
@@ -14,7 +14,7 @@ jest.mock('../db/prisma', () => ({
   }
 }));
 
-import { getCouncilMeetingsForCity } from '../db/meetings';
+import { getCouncilMeetingsForCity, generateUniqueMeetingId } from '../db/meetings';
 import prisma from '../db/prisma';
 
 const mockFindMany = prisma.councilMeeting.findMany as jest.MockedFunction<typeof prisma.councilMeeting.findMany>;
@@ -92,5 +92,67 @@ describe('getCouncilMeetingsForCity - Pagination', () => {
         skip: expect.anything()
       })
     );
+  });
+});
+
+describe('generateUniqueMeetingId', () => {
+  const april20 = new Date('2026-04-20T12:00:00+03:00');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns base ID when no collisions exist', async () => {
+    mockFindMany.mockResolvedValue([]);
+    const id = await generateUniqueMeetingId('city-1', april20);
+    expect(id).toBe('apr20_2026');
+  });
+
+  it('returns _2 suffix when base ID exists', async () => {
+    mockFindMany.mockResolvedValue([{ id: 'apr20_2026' }] as never);
+    const id = await generateUniqueMeetingId('city-1', april20);
+    expect(id).toBe('apr20_2026_2');
+  });
+
+  it('skips over existing suffixes', async () => {
+    mockFindMany.mockResolvedValue([
+      { id: 'apr20_2026' },
+      { id: 'apr20_2026_2' },
+      { id: 'apr20_2026_3' },
+    ] as never);
+    const id = await generateUniqueMeetingId('city-1', april20);
+    expect(id).toBe('apr20_2026_4');
+  });
+
+  it('handles gaps in suffixes', async () => {
+    mockFindMany.mockResolvedValue([
+      { id: 'apr20_2026' },
+      { id: 'apr20_2026_3' },
+    ] as never);
+    const id = await generateUniqueMeetingId('city-1', april20);
+    expect(id).toBe('apr20_2026_2');
+  });
+
+  it('throws when all 20 suffixes are exhausted', async () => {
+    const existing = [{ id: 'apr20_2026' }];
+    for (let i = 2; i <= 20; i++) {
+      existing.push({ id: `apr20_2026_${i}` });
+    }
+    mockFindMany.mockResolvedValue(existing as never);
+    await expect(generateUniqueMeetingId('city-1', april20)).rejects.toThrow(
+      'Could not generate unique meeting ID'
+    );
+  });
+
+  it('queries with the correct cityId and startsWith filter', async () => {
+    mockFindMany.mockResolvedValue([]);
+    await generateUniqueMeetingId('chania', april20);
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: {
+        cityId: 'chania',
+        id: { startsWith: 'apr20_2026' },
+      },
+      select: { id: true },
+    });
   });
 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,9 @@
 import { type City, type Party, type Person, type CouncilMeeting, type User } from "@prisma/client";
 import { auth } from "@/auth";
 import prisma from "@/lib/db/prisma";
+import { validateServiceApiKey } from "@/lib/db/apiKeys";
+import { UnauthorizedError } from "@/lib/api/errors";
+import { type NextRequest } from "next/server";
 
 export async function getCurrentUser() {
     const session = await auth();
@@ -145,6 +148,43 @@ export async function isUserAuthorizedToEdit({
         personId,
         councilMeetingId
     });
+}
+
+export type ServiceAuthResult =
+    | { type: 'service'; keyName: string }
+    | { type: 'user'; userId: string };
+
+/**
+ * Authenticate a request via either a service API key (Bearer token)
+ * or a user session. Service keys get full access (equivalent to superadmin).
+ * User sessions are checked against the standard authorization hierarchy.
+ *
+ * Throws if neither auth method succeeds.
+ */
+export async function withServiceOrUserAuth(
+    request: NextRequest,
+    { cityId }: { cityId?: string } = {}
+): Promise<ServiceAuthResult> {
+    // Check for Bearer token first
+    const authHeader = request.headers.get('authorization');
+    if (authHeader?.startsWith('Bearer ')) {
+        const token = authHeader.slice(7);
+        const apiKey = await validateServiceApiKey(token);
+        if (apiKey) {
+            return { type: 'service', keyName: apiKey.name };
+        }
+        // Invalid bearer token — don't fall through to session auth
+        throw new UnauthorizedError("Invalid API key");
+    }
+
+    // Fall back to session auth
+    await withUserAuthorizedToEdit({ cityId });
+
+    const user = await getCurrentUser();
+    if (!user) {
+        throw new UnauthorizedError("Session expired");
+    }
+    return { type: 'user', userId: user.id };
 }
 
 export async function getOrCreateUserFromRequest(

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -177,14 +177,17 @@ export async function withServiceOrUserAuth(
         throw new UnauthorizedError("Invalid API key");
     }
 
-    // Fall back to session auth
-    await withUserAuthorizedToEdit({ cityId });
-
-    const user = await getCurrentUser();
-    if (!user) {
-        throw new UnauthorizedError("Session expired");
+    // Fall back to session auth — reuse the result to avoid a second DB round-trip
+    const isAuthorized = await checkUserAuthorization({ cityId });
+    if (!isAuthorized) {
+        throw new UnauthorizedError("Not authorized");
     }
-    return { type: 'user', userId: user.id };
+
+    // checkUserAuthorization already verified the user exists and is authorized,
+    // so getCurrentUser() is guaranteed to return non-null here. However this is
+    // still a second DB call. TODO: refactor checkUserAuthorization to return the user.
+    const user = await getCurrentUser();
+    return { type: 'user', userId: user!.id };
 }
 
 export async function getOrCreateUserFromRequest(

--- a/src/lib/db/apiKeys.ts
+++ b/src/lib/db/apiKeys.ts
@@ -45,7 +45,13 @@ export async function createServiceApiKey(name: string, createdById: string) {
 export async function getServiceApiKeys() {
     return prisma.serviceApiKey.findMany({
         orderBy: { createdAt: 'desc' },
-        include: {
+        select: {
+            id: true,
+            name: true,
+            keyPrefix: true,
+            createdAt: true,
+            lastUsedAt: true,
+            revokedAt: true,
             createdBy: {
                 select: { name: true, email: true },
             },

--- a/src/lib/db/apiKeys.ts
+++ b/src/lib/db/apiKeys.ts
@@ -1,0 +1,91 @@
+import { createHash, randomBytes } from 'crypto';
+import prisma from '@/lib/db/prisma';
+
+const API_KEY_PREFIX = 'sk_';
+const KEY_BYTE_LENGTH = 32; // 256-bit key
+
+function hashKey(rawKey: string): string {
+    return createHash('sha256').update(rawKey).digest('hex');
+}
+
+function generateRawKey(): string {
+    const randomPart = randomBytes(KEY_BYTE_LENGTH).toString('base64url');
+    return `${API_KEY_PREFIX}${randomPart}`;
+}
+
+/**
+ * Create a new service API key. Returns the raw key exactly once —
+ * only the hash is stored in the database.
+ */
+export async function createServiceApiKey(name: string, createdById: string) {
+    const rawKey = generateRawKey();
+    const hashedKey = hashKey(rawKey);
+    const keyPrefix = rawKey.substring(0, 10); // "sk_" + first 7 chars
+
+    const apiKey = await prisma.serviceApiKey.create({
+        data: {
+            name,
+            hashedKey,
+            keyPrefix,
+            createdById,
+        },
+        include: {
+            createdBy: {
+                select: { name: true, email: true },
+            },
+        },
+    });
+
+    return { ...apiKey, rawKey };
+}
+
+/**
+ * List all service API keys (without revealing the actual key).
+ */
+export async function getServiceApiKeys() {
+    return prisma.serviceApiKey.findMany({
+        orderBy: { createdAt: 'desc' },
+        include: {
+            createdBy: {
+                select: { name: true, email: true },
+            },
+        },
+    });
+}
+
+/**
+ * Revoke (soft-delete) a service API key.
+ */
+export async function revokeServiceApiKey(id: string) {
+    return prisma.serviceApiKey.update({
+        where: { id },
+        data: { revokedAt: new Date() },
+    });
+}
+
+/**
+ * Validate a bearer token against stored API keys.
+ * Returns the key record if valid, null otherwise.
+ * Updates lastUsedAt on successful validation.
+ */
+export async function validateServiceApiKey(rawKey: string) {
+    const hashedKey = hashKey(rawKey);
+
+    const apiKey = await prisma.serviceApiKey.findUnique({
+        where: { hashedKey },
+    });
+
+    if (!apiKey || apiKey.revokedAt) {
+        return null;
+    }
+
+    // Update lastUsedAt without awaiting — fire and forget
+    prisma.serviceApiKey.update({
+        where: { id: apiKey.id },
+        data: { lastUsedAt: new Date() },
+    }).catch((err) => {
+        console.error('Failed to update lastUsedAt for API key:', err);
+    });
+
+    return apiKey;
+}

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -79,16 +79,26 @@ export async function getCouncilMeeting(cityId: string, id: string): Promise<Cou
     }
 }
 
-export async function getCouncilMeetingsForCity(cityId: string, { includeUnreleased, limit, page, pageSize = 12 }: { includeUnreleased?: boolean; limit?: number; page?: number; pageSize?: number } = {}): Promise<CouncilMeetingWithAdminBodyAndSubjects[]> {
+export async function getCouncilMeetingsForCity(cityId: string, { includeUnreleased, limit, page, pageSize = 12, from, to }: { includeUnreleased?: boolean; limit?: number; page?: number; pageSize?: number; from?: Date; to?: Date } = {}): Promise<CouncilMeetingWithAdminBodyAndSubjects[]> {
 
     try {
         // Calculate pagination
         const skip = page ? (page - 1) * pageSize : undefined;
         const take = page ? pageSize : limit;
 
+        // Build dateTime filter
+        const dateTimeFilter = (from || to) ? {
+            ...(from && { gte: from }),
+            ...(to && { lte: to }),
+        } : undefined;
+
         // First, get meetings with subjects and basic relationships
         const meetings = await prisma.councilMeeting.findMany({
-            where: { cityId, released: includeUnreleased ? undefined : true },
+            where: {
+                cityId,
+                released: includeUnreleased ? undefined : true,
+                ...(dateTimeFilter && { dateTime: dateTimeFilter }),
+            },
             orderBy: [
                 { dateTime: 'desc' },
                 { createdAt: 'desc' }

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -27,18 +27,21 @@ export async function deleteCouncilMeeting(cityId: string, id: string): Promise<
 
 export async function createCouncilMeeting(meetingData: Omit<CouncilMeeting, 'createdAt' | 'updatedAt' | 'audioUrl' | 'videoUrl'> & { audioUrl?: string, videoUrl?: string }): Promise<CouncilMeetingWithAdminBody> {
     await withUserAuthorizedToEdit({ cityId: meetingData.cityId });
-    try {
-        const newMeeting = await prisma.councilMeeting.create({
-            data: meetingData,
-            include: {
-                administrativeBody: true
-            }
-        });
-        return newMeeting;
-    } catch (error) {
-        console.error('Error creating council meeting:', error);
-        throw new Error('Failed to create council meeting');
-    }
+    return createCouncilMeetingDirect(meetingData);
+}
+
+/**
+ * Create a council meeting without auth checks.
+ * Use when authorization has already been verified by the caller
+ * (e.g., via withServiceOrUserAuth in API route handlers).
+ */
+export async function createCouncilMeetingDirect(meetingData: Omit<CouncilMeeting, 'createdAt' | 'updatedAt' | 'audioUrl' | 'videoUrl'> & { audioUrl?: string, videoUrl?: string }): Promise<CouncilMeetingWithAdminBody> {
+    return prisma.councilMeeting.create({
+        data: meetingData,
+        include: {
+            administrativeBody: true
+        }
+    });
 }
 
 export async function editCouncilMeeting(cityId: string, id: string, meetingData: Partial<Omit<CouncilMeeting, 'id' | 'cityId' | 'createdAt' | 'updatedAt'>>): Promise<CouncilMeetingWithAdminBody> {

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -4,6 +4,7 @@ import { revalidateTag, revalidatePath } from 'next/cache';
 import prisma from "./prisma";
 import { withUserAuthorizedToEdit, isUserAuthorizedToEdit } from '../auth';
 import { buildDateFilter } from './reviews/dateFilters';
+import { formatDateAsMeetingId } from '../utils/meetingId';
 
 export type CouncilMeetingWithAdminBody = CouncilMeeting & {
     administrativeBody: AdministrativeBody | null
@@ -42,6 +43,38 @@ export async function createCouncilMeetingDirect(meetingData: Omit<CouncilMeetin
             administrativeBody: true
         }
     });
+}
+
+/**
+ * Generate a unique meeting ID for a city, handling collisions
+ * by appending _2, _3, etc. (matches existing convention).
+ */
+export async function generateUniqueMeetingId(cityId: string, date: Date): Promise<string> {
+    const baseId = formatDateAsMeetingId(date);
+
+    // Fetch all existing meeting IDs with this base prefix in one query
+    const existing = await prisma.councilMeeting.findMany({
+        where: {
+            cityId,
+            id: { startsWith: baseId },
+        },
+        select: { id: true },
+    });
+
+    const existingIds = new Set(existing.map(m => m.id));
+
+    if (!existingIds.has(baseId)) {
+        return baseId;
+    }
+
+    for (let suffix = 2; suffix <= 20; suffix++) {
+        const candidateId = `${baseId}_${suffix}`;
+        if (!existingIds.has(candidateId)) {
+            return candidateId;
+        }
+    }
+
+    throw new Error(`Could not generate unique meeting ID for ${cityId} on ${baseId} — too many meetings on this date`);
 }
 
 export async function editCouncilMeeting(cityId: string, id: string, meetingData: Partial<Omit<CouncilMeeting, 'id' | 'cityId' | 'createdAt' | 'updatedAt'>>): Promise<CouncilMeetingWithAdminBody> {

--- a/src/lib/tasks/processAgenda.ts
+++ b/src/lib/tasks/processAgenda.ts
@@ -1,106 +1,13 @@
 "use server";
 
-import { ProcessAgendaRequest, ProcessAgendaResult } from "../apiTypes";
-import { startTask } from "./tasks";
+import { ProcessAgendaResult } from "../apiTypes";
 import prisma from "../db/prisma";
 import { saveSubjectsForMeeting } from "../db/utils";
 import { withUserAuthorizedToEdit } from "../auth";
-import { getActiveTopicsForTasks } from "../db/topics";
-import { getPartyFromRoles, getRoleNameForPerson } from "../utils";
-import { getPeopleForMeeting } from "../db/people";
+import { requestProcessAgendaInternal } from "./processAgendaInternal";
 
 /**
- * Core processAgenda logic without auth checks.
- * Called by the route handler (which already authenticated the request)
- * and by the user-facing wrapper below.
- */
-export async function requestProcessAgendaInternal(agendaUrl: string, councilMeetingId: string, cityId: string, {
-    force = false
-}: {
-    force?: boolean;
-} = {}) {
-    console.log(`Requesting agenda processing for ${agendaUrl}`);
-    const councilMeeting = await prisma.councilMeeting.findUnique({
-        where: {
-            cityId_id: {
-                id: councilMeetingId,
-                cityId
-            }
-        },
-        include: {
-            subjects: {
-                select: {
-                    id: true
-                },
-                take: 1
-            },
-            city: {
-                select: {
-                    name: true
-                }
-            }
-        }
-    });
-
-    if (!councilMeeting) {
-        throw new Error("Council meeting not found");
-    }
-
-    if (councilMeeting.subjects.length > 0) {
-        if (force) {
-            console.log(`Deleting existing subjects for meeting ${councilMeetingId}`);
-            // Delete auto-generated subject-linked highlights before subjects to avoid orphans.
-            // User-created highlights (createdById is set) are preserved — their subjectId
-            // will be set to null by the onDelete: SetNull cascade when subjects are deleted.
-            await prisma.highlight.deleteMany({
-                where: { meetingId: councilMeetingId, cityId, subjectId: { not: null }, createdById: null }
-            });
-            await prisma.subject.deleteMany({
-                where: {
-                    councilMeetingId,
-                    cityId
-                }
-            });
-        } else {
-            console.log(`Meeting already has subjects`);
-            throw new Error('Meeting already has subjects');
-        }
-    }
-
-    // Get relevant people for the meeting (filtered by administrative body)
-    const people = await getPeopleForMeeting(cityId, councilMeeting.administrativeBodyId);
-    const topicLabels = await getActiveTopicsForTasks();
-
-    // Build people array with deduplication by ID (keep last entry)
-    const peopleMap = new Map();
-    for (const p of people) {
-        const roleName = getRoleNameForPerson(p.roles, councilMeeting.dateTime, councilMeeting.administrativeBodyId);
-        const party = getPartyFromRoles(p.roles, councilMeeting.dateTime);
-
-        peopleMap.set(p.id, {
-            id: p.id,
-            name: p.name, // Use full name, not name_short
-            role: roleName,
-            party: party?.name || ''
-        });
-    }
-
-    console.log(`ProcessAgenda people array:`, Array.from(peopleMap.values()));
-
-    const body: Omit<ProcessAgendaRequest, 'callbackUrl'> = {
-        agendaUrl,
-        date: councilMeeting.dateTime.toISOString(),
-        people: Array.from(peopleMap.values()),
-        topicLabels: topicLabels.map(t => ({ name: t.name, description: t.description })),
-        cityName: councilMeeting.city.name
-    }
-
-    console.log(`Process agenda body: ${JSON.stringify(body)}`);
-    return startTask('processAgenda', body, councilMeetingId, cityId, { force });
-}
-
-/**
- * User-facing wrapper that checks authorization before processing.
+ * User-facing Server Action that checks authorization before processing.
  */
 export async function requestProcessAgenda(agendaUrl: string, councilMeetingId: string, cityId: string, {
     force = false

--- a/src/lib/tasks/processAgenda.ts
+++ b/src/lib/tasks/processAgenda.ts
@@ -9,12 +9,16 @@ import { getActiveTopicsForTasks } from "../db/topics";
 import { getPartyFromRoles, getRoleNameForPerson } from "../utils";
 import { getPeopleForMeeting } from "../db/people";
 
-export async function requestProcessAgenda(agendaUrl: string, councilMeetingId: string, cityId: string, {
+/**
+ * Core processAgenda logic without auth checks.
+ * Called by the route handler (which already authenticated the request)
+ * and by the user-facing wrapper below.
+ */
+export async function requestProcessAgendaInternal(agendaUrl: string, councilMeetingId: string, cityId: string, {
     force = false
 }: {
     force?: boolean;
 } = {}) {
-    await withUserAuthorizedToEdit({ cityId });
     console.log(`Requesting agenda processing for ${agendaUrl}`);
     const councilMeeting = await prisma.councilMeeting.findUnique({
         where: {
@@ -93,6 +97,18 @@ export async function requestProcessAgenda(agendaUrl: string, councilMeetingId: 
 
     console.log(`Process agenda body: ${JSON.stringify(body)}`);
     return startTask('processAgenda', body, councilMeetingId, cityId, { force });
+}
+
+/**
+ * User-facing wrapper that checks authorization before processing.
+ */
+export async function requestProcessAgenda(agendaUrl: string, councilMeetingId: string, cityId: string, {
+    force = false
+}: {
+    force?: boolean;
+} = {}) {
+    await withUserAuthorizedToEdit({ cityId });
+    return requestProcessAgendaInternal(agendaUrl, councilMeetingId, cityId, { force });
 }
 
 export async function handleProcessAgendaResult(taskId: string, response: ProcessAgendaResult) {

--- a/src/lib/tasks/processAgendaInternal.ts
+++ b/src/lib/tasks/processAgendaInternal.ts
@@ -1,0 +1,99 @@
+import { ProcessAgendaRequest } from "../apiTypes";
+import { startTask } from "./tasks";
+import prisma from "../db/prisma";
+import { getActiveTopicsForTasks } from "../db/topics";
+import { getPartyFromRoles, getRoleNameForPerson } from "../utils";
+import { getPeopleForMeeting } from "../db/people";
+
+/**
+ * Core processAgenda logic without auth checks.
+ *
+ * NOT in a "use server" file — this must not be callable as a Server Action.
+ * Only called from:
+ *   - The meeting creation API route (after withServiceOrUserAuth)
+ *   - requestProcessAgenda (after withUserAuthorizedToEdit)
+ */
+export async function requestProcessAgendaInternal(agendaUrl: string, councilMeetingId: string, cityId: string, {
+    force = false
+}: {
+    force?: boolean;
+} = {}) {
+    console.log(`Requesting agenda processing for ${agendaUrl}`);
+    const councilMeeting = await prisma.councilMeeting.findUnique({
+        where: {
+            cityId_id: {
+                id: councilMeetingId,
+                cityId
+            }
+        },
+        include: {
+            subjects: {
+                select: {
+                    id: true
+                },
+                take: 1
+            },
+            city: {
+                select: {
+                    name: true
+                }
+            }
+        }
+    });
+
+    if (!councilMeeting) {
+        throw new Error("Council meeting not found");
+    }
+
+    if (councilMeeting.subjects.length > 0) {
+        if (force) {
+            console.log(`Deleting existing subjects for meeting ${councilMeetingId}`);
+            // Delete auto-generated subject-linked highlights before subjects to avoid orphans.
+            // User-created highlights (createdById is set) are preserved — their subjectId
+            // will be set to null by the onDelete: SetNull cascade when subjects are deleted.
+            await prisma.highlight.deleteMany({
+                where: { meetingId: councilMeetingId, cityId, subjectId: { not: null }, createdById: null }
+            });
+            await prisma.subject.deleteMany({
+                where: {
+                    councilMeetingId,
+                    cityId
+                }
+            });
+        } else {
+            console.log(`Meeting already has subjects`);
+            throw new Error('Meeting already has subjects');
+        }
+    }
+
+    // Get relevant people for the meeting (filtered by administrative body)
+    const people = await getPeopleForMeeting(cityId, councilMeeting.administrativeBodyId);
+    const topicLabels = await getActiveTopicsForTasks();
+
+    // Build people array with deduplication by ID (keep last entry)
+    const peopleMap = new Map();
+    for (const p of people) {
+        const roleName = getRoleNameForPerson(p.roles, councilMeeting.dateTime, councilMeeting.administrativeBodyId);
+        const party = getPartyFromRoles(p.roles, councilMeeting.dateTime);
+
+        peopleMap.set(p.id, {
+            id: p.id,
+            name: p.name, // Use full name, not name_short
+            role: roleName,
+            party: party?.name || ''
+        });
+    }
+
+    console.log(`ProcessAgenda people array:`, Array.from(peopleMap.values()));
+
+    const body: Omit<ProcessAgendaRequest, 'callbackUrl'> = {
+        agendaUrl,
+        date: councilMeeting.dateTime.toISOString(),
+        people: Array.from(peopleMap.values()),
+        topicLabels: topicLabels.map(t => ({ name: t.name, description: t.description })),
+        cityName: councilMeeting.city.name
+    }
+
+    console.log(`Process agenda body: ${JSON.stringify(body)}`);
+    return startTask('processAgenda', body, councilMeetingId, cityId, { force });
+}

--- a/src/lib/utils/__tests__/meetingId.test.ts
+++ b/src/lib/utils/__tests__/meetingId.test.ts
@@ -1,0 +1,32 @@
+import { formatDateAsMeetingId } from '../meetingId';
+
+describe('formatDateAsMeetingId', () => {
+  it('formats a standard date', () => {
+    // April 20, 2026 at noon Athens time
+    const date = new Date('2026-04-20T12:00:00+03:00');
+    expect(formatDateAsMeetingId(date)).toBe('apr20_2026');
+  });
+
+  it('formats a single-digit day', () => {
+    const date = new Date('2026-04-05T12:00:00+03:00');
+    expect(formatDateAsMeetingId(date)).toBe('apr5_2026');
+  });
+
+  it('formats December correctly', () => {
+    const date = new Date('2026-12-31T12:00:00+02:00');
+    expect(formatDateAsMeetingId(date)).toBe('dec31_2026');
+  });
+
+  it('uses Athens timezone — UTC midnight shifts to previous day', () => {
+    // Midnight UTC on April 20 is 3:00 AM in Athens (EEST, UTC+3)
+    // so this should still be April 20
+    const date = new Date('2026-04-20T00:00:00Z');
+    expect(formatDateAsMeetingId(date)).toBe('apr20_2026');
+  });
+
+  it('uses Athens timezone — late UTC shifts to next day', () => {
+    // 10 PM UTC on April 19 is 1:00 AM April 20 in Athens (EEST, UTC+3)
+    const date = new Date('2026-04-19T22:00:00Z');
+    expect(formatDateAsMeetingId(date)).toBe('apr20_2026');
+  });
+});

--- a/src/lib/utils/meetingId.ts
+++ b/src/lib/utils/meetingId.ts
@@ -9,7 +9,7 @@ import prisma from '@/lib/db/prisma';
  */
 export function formatDateAsMeetingId(date: Date): string {
     return date
-        .toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+        .toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'Europe/Athens' })
         .toLowerCase()
         .replace(/\s/g, '')
         .replace(',', '_');

--- a/src/lib/utils/meetingId.ts
+++ b/src/lib/utils/meetingId.ts
@@ -1,11 +1,6 @@
-import prisma from '@/lib/db/prisma';
-
 /**
  * Generate a meeting ID slug from a date.
  * Example: 2026-04-20 → "apr20_2026"
- *
- * This logic was originally in AddMeetingForm (client-side).
- * Extracted here so it can be used server-side for auto-generation.
  */
 export function formatDateAsMeetingId(date: Date): string {
     return date
@@ -13,36 +8,4 @@ export function formatDateAsMeetingId(date: Date): string {
         .toLowerCase()
         .replace(/\s/g, '')
         .replace(',', '_');
-}
-
-/**
- * Generate a unique meeting ID for a city, handling collisions
- * by appending _2, _3, etc. (matches existing convention).
- */
-export async function generateUniqueMeetingId(cityId: string, date: Date): Promise<string> {
-    const baseId = formatDateAsMeetingId(date);
-
-    // Fetch all existing meeting IDs with this base prefix in one query
-    const existing = await prisma.councilMeeting.findMany({
-        where: {
-            cityId,
-            id: { startsWith: baseId },
-        },
-        select: { id: true },
-    });
-
-    const existingIds = new Set(existing.map(m => m.id));
-
-    if (!existingIds.has(baseId)) {
-        return baseId;
-    }
-
-    for (let suffix = 2; suffix <= 20; suffix++) {
-        const candidateId = `${baseId}_${suffix}`;
-        if (!existingIds.has(candidateId)) {
-            return candidateId;
-        }
-    }
-
-    throw new Error(`Could not generate unique meeting ID for ${cityId} on ${baseId} — too many meetings on this date`);
 }

--- a/src/lib/utils/meetingId.ts
+++ b/src/lib/utils/meetingId.ts
@@ -1,0 +1,48 @@
+import prisma from '@/lib/db/prisma';
+
+/**
+ * Generate a meeting ID slug from a date.
+ * Example: 2026-04-20 → "apr20_2026"
+ *
+ * This logic was originally in AddMeetingForm (client-side).
+ * Extracted here so it can be used server-side for auto-generation.
+ */
+export function formatDateAsMeetingId(date: Date): string {
+    return date
+        .toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+        .toLowerCase()
+        .replace(/\s/g, '')
+        .replace(',', '_');
+}
+
+/**
+ * Generate a unique meeting ID for a city, handling collisions
+ * by appending _2, _3, etc. (matches existing convention).
+ */
+export async function generateUniqueMeetingId(cityId: string, date: Date): Promise<string> {
+    const baseId = formatDateAsMeetingId(date);
+
+    // Fetch all existing meeting IDs with this base prefix in one query
+    const existing = await prisma.councilMeeting.findMany({
+        where: {
+            cityId,
+            id: { startsWith: baseId },
+        },
+        select: { id: true },
+    });
+
+    const existingIds = new Set(existing.map(m => m.id));
+
+    if (!existingIds.has(baseId)) {
+        return baseId;
+    }
+
+    for (let suffix = 2; suffix <= 20; suffix++) {
+        const candidateId = `${baseId}_${suffix}`;
+        if (!existingIds.has(candidateId)) {
+            return candidateId;
+        }
+    }
+
+    throw new Error(`Could not generate unique meeting ID for ${cityId} on ${baseId} — too many meetings on this date`);
+}


### PR DESCRIPTION
## Summary
- Adds service API key infrastructure (create, validate, revoke with SHA-256 hashing) so Sentinel can authenticate via `Authorization: Bearer <key>`
- Meeting creation now supports optional `meetingId` (auto-generated with `_2` collision handling), `processAgenda: true` to auto-trigger agenda parsing, and date range filtering on GET
- Admin UI at `/admin/settings/api-keys` for key lifecycle management
- "Run pipeline" checkbox (default on) in the meeting creation form

## Test plan
- [x] Create API key via admin UI, copy raw key
- [x] Use key to list cities, list meetings, create meeting with auto-generated ID
- [x] Verify `meetingId` collision handling (`apr20_2026` → `apr20_2026_2`)
- [x] Verify `includeUnreleased=true` is auth-gated (401 without token)
- [x] Revoke key, confirm subsequent requests return 401
- [x] Test `processAgenda: true` with a real agenda PDF URL
- [x] Verify "Run pipeline" checkbox in the UI form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a new service authentication path (Bearer API keys) that effectively grants superadmin-equivalent access to multiple endpoints, plus new DB storage for keys. Changes touch auth, meeting creation, and upload flows, so mistakes could widen access or leak secrets.
> 
> **Overview**
> Enables programmatic access for trusted services via **service API keys** (Bearer tokens), including a new `ServiceApiKey` table, key hashing/storage, last-used tracking, and superadmin-only endpoints/UI to create/list/revoke keys (raw key shown only once).
> 
> Updates city meetings and upload APIs to accept **service-or-session auth** via `withServiceOrUserAuth`, adds optional `meetingId` auto-generation with collision handling, supports `processAgenda` to auto-trigger agenda parsing on create, and expands meetings listing with `from`/`to` filtering plus auth-gated `includeUnreleased`.
> 
> Refactors agenda processing by extracting core logic into `requestProcessAgendaInternal` (no auth) and adds a meeting-creation form checkbox + i18n strings to opt into running the pipeline after creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7f9030d4c93c5d49bd213c455036a86c001c00a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces service API key infrastructure (SHA-256 hashed Bearer tokens) for programmatic access by Sentinel, with a superadmin UI and lifecycle management (create/list/revoke). It also extends the meetings API with optional `meetingId` auto-generation, `processAgenda` triggering, date-range filtering, and auth-gated `includeUnreleased`. Previous review rounds addressed the TOCTOU race condition, the stale `meetingId` after retry, redundant DB round-trips, and the `hashedKey` exposure — all confirmed fixed in this revision.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all previously flagged critical issues are resolved and only a minor P2 remains.

All P0/P1 findings from prior review rounds (TOCTOU race, stale `meetingId` after retry, `hashedKey` exposure, redundant DB round-trip) have been fixed. The one remaining comment is P2: a Prisma P2025 on the DELETE handler returning 500 instead of 404 in the edge case of revoking an already-deleted key, which is a superadmin-only path and low impact.

src/app/api/admin/api-keys/[id]/route.ts — minor P2025 handling gap

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/auth.ts | Adds `withServiceOrUserAuth` — Bearer token checked first (invalid token rejects without session fallback), then falls back to `checkUserAuthorization`. Second `getCurrentUser()` call acknowledged with TODO. Logic is sound. |
| src/lib/db/apiKeys.ts | SHA-256 hashing, `base64url` encoding for raw keys, fire-and-forget `lastUsedAt` update, `select`-based listing (no hash leak). Solid implementation. |
| src/app/api/admin/api-keys/[id]/route.ts | Superadmin DELETE handler; will 500 instead of 404 on missing key ID because Prisma P2025 is not mapped to a 404 in `handleApiError`. |
| src/app/api/cities/[cityId]/meetings/route.ts | POST now accepts optional `meetingId`, auto-generates via `generateUniqueMeetingId`, retries on P2002, updates `meetingId` before side-effects. GET adds `from`/`to` filtering and auth-gated `includeUnreleased`. All previously flagged race-condition issues are addressed. |
| src/lib/db/meetings.ts | Adds `createCouncilMeetingDirect` (auth-free) and `generateUniqueMeetingId` with startsWith prefix query + Set-based exact matching. Collision loop capped at 20 suffixes. Date filtering added to `getCouncilMeetingsForCity`. |
| src/lib/tasks/processAgendaInternal.ts | Correctly extracted core agenda-processing logic into a non-"use server" module. Auth-free by design; callers are responsible for prior authorization. |
| src/components/meetings/AddMeetingForm.tsx | Adds "Run pipeline" checkbox (default on, disabled without agenda URL). Visual state correctly derived from `field.value && hasAgenda`; form state and backend behaviour are consistent. |
| src/lib/utils/meetingId.ts | Extracts `formatDateAsMeetingId` with Athens timezone pinning. Well-tested for edge cases (midnight UTC, single-digit day). |
| prisma/migrations/20260416000002_add_service_api_keys/migration.sql | Creates `ServiceApiKey` table with unique index on `hashedKey`, FK to `User` with RESTRICT on delete. Schema is clean and minimal. |
| src/app/api/upload/presigned-url/route.ts | Replaces `isUserAuthorizedToEdit` with `withServiceOrUserAuth`, properly catching `ApiError` to return the correct HTTP status. Semantic change from 403 to 401/403 depending on auth failure type is acceptable. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant S as Sentinel / Client
    participant MW as withServiceOrUserAuth
    participant AK as validateServiceApiKey
    participant DB as Prisma (DB)
    participant PA as requestProcessAgendaInternal

    S->>MW: POST /api/cities/{cityId}/meetings Authorization: Bearer sk_...
    MW->>AK: validateServiceApiKey(token)
    AK->>DB: findUnique(hashedKey)
    DB-->>AK: ServiceApiKey row
    AK-->>MW: { name: Sentinel }
    MW-->>S: { type: service, keyName }

    Note over S,DB: Auth passed — proceed with meeting creation
    S->>DB: generateUniqueMeetingId(cityId, date)
    DB-->>S: apr20_2026
    S->>DB: createCouncilMeetingDirect(...)
    alt P2002 collision
        DB-->>S: PrismaClientKnownRequestError
        S->>DB: generateUniqueMeetingId (retry)
        DB-->>S: apr20_2026_2
        S->>DB: createCouncilMeetingDirect(...)
    end
    DB-->>S: CouncilMeeting

    opt processAgenda=true and agendaUrl present
        S->>PA: requestProcessAgendaInternal(agendaUrl, meetingId, cityId)
        PA->>DB: findUnique(councilMeeting)
        PA-->>S: Task status
    end

    S-->>S: 201 meeting + processAgendaStatus
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/meetings/AddMeetingForm.tsx`, line 76-79 ([link](https://github.com/schemalabz/opencouncil/blob/f5f1de5d30c8dba89d51332aeed340526df74da6/src/components/meetings/AddMeetingForm.tsx#L76-L79)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Duplicate `formatDateAsMeetingId` not consolidated**

   This PR extracts `formatDateAsMeetingId` into `src/lib/utils/meetingId.ts` specifically so it can be shared, but the local copy inside this component was not replaced. The two implementations are currently identical, but they can drift. The component can safely import the shared version (it's a pure function with no server-only dependencies).

   Remove the inline definition and add the import at the top of the file:
   ```
   import { formatDateAsMeetingId } from "@/lib/utils/meetingId"
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/meetings/AddMeetingForm.tsx
   Line: 76-79

   Comment:
   **Duplicate `formatDateAsMeetingId` not consolidated**

   This PR extracts `formatDateAsMeetingId` into `src/lib/utils/meetingId.ts` specifically so it can be shared, but the local copy inside this component was not replaced. The two implementations are currently identical, but they can drift. The component can safely import the shared version (it's a pure function with no server-only dependencies).

   Remove the inline definition and add the import at the top of the file:
   ```
   import { formatDateAsMeetingId } from "@/lib/utils/meetingId"
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/api/admin/api-keys/[id]/route.ts
Line: 15-21

Comment:
**Revoking a non-existent key returns 500 instead of 404**

`prisma.serviceApiKey.update` throws a `PrismaClientKnownRequestError` with code `P2025` when the record doesn't exist. `handleApiError` doesn't recognise Prisma errors and falls back to returning the raw `error.message` with a 500 status, rather than a clean 404. In practice this only affects stale UI (e.g. two admins revoking the same key concurrently), but it's noisy and leaks the internal Prisma error message.

```suggestion
    try {
        await revokeServiceApiKey(params.id);
        return NextResponse.json({ success: true });
    } catch (error) {
        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
            return NextResponse.json({ error: "API key not found" }, { status: 404 });
        }
        return handleApiError(error, "Failed to revoke API key");
    }
```

(Requires adding `import { Prisma } from '@prisma/client';` at the top.)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/lib/db/meetings.ts
Line: 1143-1155

Comment:
**`startsWith` filter may include false-positive rows from other meetings**

The query `id: { startsWith: baseId }` is intended to find all collision variants for a given date slug (e.g. `apr20_2026`, `apr20_2026_2`, …). However, if another meeting in the same city has an ID that happens to share the same prefix for unrelated reasons (e.g. a manually created `apr20_2026_custom`), it will be pulled into `existingIds`. Because the loop then only checks for `apr20_2026_2`, `apr20_2026_3`, etc. (exact match), the extra row is benign — it just adds a tiny overhead.

More concretely: the loop will still skip over the manually-created ID and return the first `_N` suffix that is absent, so there is no correctness issue. Worth noting in a comment so future readers don't second-guess the `Set` lookup strategy.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (8): Last reviewed commit: ["fix: move generateUniqueMeetingId to db ..."](https://github.com/schemalabz/opencouncil/commit/f47441ea158cdd5f4541f7232ef6c28846b14b53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28209558)</sub>

<!-- /greptile_comment -->