### PR TITLE
feat: deterministic ordering for speaker contributions

### DIFF
--- a/prisma/migrations/20260414000000_add_contribution_order/migration.sql
+++ b/prisma/migrations/20260414000000_add_contribution_order/migration.sql
@@ -1,0 +1,45 @@
+-- AlterTable
+ALTER TABLE "SpeakerContribution" ADD COLUMN "order" INTEGER;
+
+-- Backfill order for all existing contributions
+-- Priority: introducer first (0), unlabeled speakers (1), identified speakers by first utterance time (2+)
+WITH first_utterances AS (
+    SELECT
+        u."discussionSubjectId" AS subject_id,
+        st."personId" AS person_id,
+        MIN(u."startTimestamp") AS first_ts
+    FROM "Utterance" u
+    JOIN "SpeakerSegment" ss ON u."speakerSegmentId" = ss.id
+    JOIN "SpeakerTag" st ON ss."speakerTagId" = st.id
+    WHERE u."discussionSubjectId" IS NOT NULL
+      AND u."discussionStatus" = 'SUBJECT_DISCUSSION'
+      AND st."personId" IS NOT NULL
+    GROUP BY u."discussionSubjectId", st."personId"
+),
+ranked AS (
+    SELECT
+        sc.id AS contribution_id,
+        ROW_NUMBER() OVER (
+            PARTITION BY sc."subjectId"
+            ORDER BY
+                -- Introducer first
+                CASE WHEN sc."speakerId" IS NOT NULL
+                      AND sc."speakerId" = s."personId"
+                     THEN 0 ELSE 1 END,
+                -- Unlabeled speakers (no speakerId) second
+                CASE WHEN sc."speakerId" IS NULL THEN 0 ELSE 1 END,
+                -- Identified speakers by first utterance timestamp
+                COALESCE(fu.first_ts, 'Infinity'::float8),
+                -- Final tiebreaker
+                sc."createdAt"
+        ) - 1 AS computed_order
+    FROM "SpeakerContribution" sc
+    JOIN "Subject" s ON sc."subjectId" = s.id
+    LEFT JOIN first_utterances fu
+        ON fu.subject_id = sc."subjectId"
+       AND fu.person_id = sc."speakerId"
+)
+UPDATE "SpeakerContribution"
+SET "order" = ranked.computed_order
+FROM ranked
+WHERE "SpeakerContribution".id = ranked.contribution_id;

--- a/prisma/migrations/20260414000000_add_contribution_order/migration.sql
+++ b/prisma/migrations/20260414000000_add_contribution_order/migration.sql
@@ -2,7 +2,7 @@
 ALTER TABLE "SpeakerContribution" ADD COLUMN "order" INTEGER;
 
 -- Backfill order for all existing contributions
--- Priority: introducer first (0), unlabeled speakers (1), identified speakers by first utterance time (2+)
+-- Priority: introducer first, unlabeled speakers next (by createdAt), identified speakers last (by first utterance time)
 WITH first_utterances AS (
     SELECT
         u."discussionSubjectId" AS subject_id,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -531,6 +531,7 @@ model SpeakerContribution {
   speakerId   String?  // personId (nullable for unidentified speakers)
   speaker     Person?  @relation(fields: [speakerId], references: [id], onDelete: SetNull)
   speakerName String?  // Display name for speakers without a person record
+  order       Int?     // Display order within the subject (0-based)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -132,6 +132,7 @@ export interface SpeakerContribution {
     speakerId: string | null;
     speakerName: string | null;  // Display name for speakers without a person record
     text: string;  // Markdown with special reference links: [text](REF:UTTERANCE:id), [text](REF:PERSON:id), [text](REF:PARTY:id)
+    order?: number | null;  // Display order within the subject (0-based)
 }
 
 export enum DiscussionStatus {

--- a/src/lib/db/subject.ts
+++ b/src/lib/db/subject.ts
@@ -23,7 +23,7 @@ const contributionsInclude = {
             },
         },
     },
-    orderBy: { createdAt: 'asc' as const },
+    orderBy: [{ order: 'asc' as const }, { createdAt: 'asc' as const }],
 } satisfies Prisma.SpeakerContributionFindManyArgs;
 
 const introducedByInclude = {

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -373,13 +373,14 @@ export async function saveSubjectsForMeeting(
 
             if (incoming.speakerContributions.length > 0) {
                 await tx.speakerContribution.createMany({
-                    data: incoming.speakerContributions.map(contrib => ({
+                    data: incoming.speakerContributions.map((contrib, index) => ({
                         subjectId: existingId,
                         speakerId: contrib.speakerId && validSpeakerIds.has(contrib.speakerId)
                             ? contrib.speakerId
                             : null,
                         speakerName: contrib.speakerName,
-                        text: contrib.text
+                        text: contrib.text,
+                        order: contrib.order ?? index,
                     }))
                 });
             }
@@ -438,12 +439,13 @@ export async function saveSubjectsForMeeting(
                     topicImportance: subject.topicImportance,
                     proximityImportance: subject.proximityImportance,
                     contributions: {
-                        create: subject.speakerContributions.map(contrib => ({
+                        create: subject.speakerContributions.map((contrib, index) => ({
                             speakerId: contrib.speakerId && validSpeakerIds.has(contrib.speakerId)
                                 ? contrib.speakerId
                                 : null,
                             speakerName: contrib.speakerName,
-                            text: contrib.text
+                            text: contrib.text,
+                            order: contrib.order ?? index,
                         }))
                     },
                     context: subject.context?.text,


### PR DESCRIPTION
## Summary
- Adds `order` column to `SpeakerContribution` for deterministic display ordering within a subject
- Migration backfills all existing contributions: introducer first, unlabeled speakers second, identified speakers by first utterance timestamp
- New contributions from the summarize API use explicit `order` when provided, falling back to array index
- Query ordering changed from `createdAt` to `[order, createdAt]`

## Test plan
- [ ] Run migration against preview DB and verify contributions are reordered correctly
- [ ] Check a subject page — contributions should show introducer first
- [ ] Re-summarize a meeting and verify new contributions get `order` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Includes a schema migration that backfills a new ordering column and changes query/write semantics, so incorrect backfill logic or null ordering could change displayed contribution order across existing subjects.
> 
> **Overview**
> Adds an optional `order` field to `SpeakerContribution` and a migration to backfill it for existing rows using a ranked window function (introducer first, then unlabeled speakers, then identified speakers by first utterance time, with `createdAt` as a tiebreaker).
> 
> Updates subject contribution reads to sort by `order` then `createdAt`, and updates subject upsert/save paths to persist `order` (using the incoming value when provided, otherwise falling back to the array index). Also extends the API `SpeakerContribution` type to carry the optional `order`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf5c7bcf58535e4c36c1a9e3e3ccdaab8850c05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a deterministic `order` column to `SpeakerContribution` so contributions always render in a consistent sequence (introducer → unlabeled → identified-by-first-utterance) rather than insertion order. The migration backfills all existing rows, the query ordering is updated, and both subject create/update paths in `utils.ts` now persist the caller-supplied or index-derived order.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the migration logic is correct, the backfill is sound, and the application-layer changes are consistent with the schema.
- No P0 or P1 issues found. The SQL backfill correctly uses `s."personId"` (the actual FK column on Subject), `'Infinity'::float8` is valid for the Float `startTimestamp` field, and `ROW_NUMBER()-1` gives the intended 0-based ordering. The `contrib.order ?? index` fallback in utils.ts correctly handles null and undefined without mishandling an explicit `0`. NULL order values in the updated query sort last by PostgreSQL default, giving safe fallback behavior. All five files are internally consistent.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| prisma/migrations/20260414000000_add_contribution_order/migration.sql | Adds nullable `order` column and backfills existing rows with a deterministic ordering (introducer → unlabeled → identified-by-first-utterance). Logic is correct: `s."personId"` is the proper FK column, `startTimestamp` is `Float` so `'Infinity'::float8` is valid, and ROW_NUMBER()-1 gives correct 0-based ordering. |
| prisma/schema.prisma | Adds optional `order Int?` field to `SpeakerContribution`. Nullable to allow backward-compatible migration; Prisma wraps the reserved-word column name in double-quotes automatically. |
| src/lib/db/subject.ts | Updates `orderBy` in the shared `contributionsInclude` constant from `{ createdAt: 'asc' }` to `[{ order: 'asc' }, { createdAt: 'asc' }]`. NULL order values sort last (PostgreSQL default for ASC), preserving sensible fallback behavior for any rows that might lack an order value. |
| src/lib/db/utils.ts | Both the "update existing subject" and "create new subject" paths now include `order: contrib.order ?? index` when inserting contributions. Correctly handles null/undefined from the API via nullish coalescing without falsely ignoring an explicit `0`. |
| src/lib/apiTypes.ts | Adds `order?: number | null` to the `SpeakerContribution` interface, consistent with the optional/nullable field added to the schema. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Summarize API sends contributions array] --> B{contrib.order provided?}
    B -- Yes --> C[Use contrib.order]
    B -- No / null --> D[Use array index as fallback]
    C --> E[INSERT SpeakerContribution with order]
    D --> E

    F[Migration backfill] --> G[JOIN Subject on subjectId]
    G --> H{speakerId = Subject.personId?}
    H -- Yes --> I[priority 0 — introducer]
    H -- No --> J{speakerId IS NULL?}
    J -- Yes --> K[priority 1 — unlabeled, sort by createdAt]
    J -- No --> L[priority 2 — identified, sort by first utterance startTimestamp]

    I & K & L --> M[ROW_NUMBER - 1 → computed_order]
    M --> N[UPDATE SpeakerContribution SET order = computed_order]

    E & N --> O[Query: ORDER BY order ASC, createdAt ASC]
    O --> P[NULL order rows sort LAST — safe default]
```

<sub>Reviews (2): Last reviewed commit: ["fix: clarify migration comment about ord..."](https://github.com/schemalabz/opencouncil/commit/bcf5c7bcf58535e4c36c1a9e3e3ccdaab8850c05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28378749)</sub>

<!-- /greptile_comment -->