### PR TITLE
fix: hide AI badge when speaker segment has no summary text

### DIFF
--- a/src/components/meetings/transcript/SpeakerSegment.tsx
+++ b/src/components/meetings/transcript/SpeakerSegment.tsx
@@ -383,7 +383,7 @@ const SpeakerSegment = React.memo(({ segment, isFirstSegment }: {
                                             </div>
                                         </div>
                                     </div>
-                                    {summary && (
+                                    {summary?.text && (
                                         <div className='px-2.5 sm:px-4 space-y-2'>
                                             <div className='text-xs sm:text-sm'>
                                                 {stripMarkdown(summary.text)}


### PR DESCRIPTION
## Summary

- When a speaker segment has a `summary` object but its `text` field is empty/null, the "Κείμενο από ΤΝ" (AI-generated) badge was still displayed, misleadingly suggesting the transcript below was AI-generated content
- Changed the guard from `summary &&` to `summary?.text &&` so the entire summary block (text, topic badges, and AI badge) only renders when there's actual summary text

## Test plan

- [ ] Find a speaker segment with no summary — verify the AI badge is not shown
- [ ] Find a speaker segment with a summary — verify the badge, summary text, and topic labels still display correctly
- [ ] Check mobile collapsed/expanded views for both cases

https://claude.ai/code/session_01QDdjZrfyyRaZgrMBZVBSKe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tightens a render guard; behavior changes only for segments with a `summary` object but empty/null `text`.
> 
> **Overview**
> Prevents the speaker-segment summary UI (including the AI-generated badge and topic labels) from rendering when `segment.summary` exists but has no `text`.
> 
> In `SpeakerSegment`, the conditional render guard is tightened from `summary` to `summary?.text`, avoiding misleading AI attribution for empty summaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc2de6decc3566e8fb9c820a82eb08fedcab1d2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UI bug where the "Κείμενο από ΤΝ" (AI-generated) badge was shown even when a speaker segment's `summary` object had an empty or null `text` field. The guard was changed from `summary &&` to `summary?.text &&`, so the entire summary block (text, topic badges, and AI badge) only renders when actual content exists.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, correct fix with no functional regressions.

Single-line change with a clear, correct guard. The `summary?.text` check properly handles null/undefined `summary` and empty `text`, and the surrounding logic (topic labels, AI badge) is correctly gated behind the same condition as originally intended.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/meetings/transcript/SpeakerSegment.tsx | One-line guard change from `summary &&` to `summary?.text &&` correctly prevents rendering the AI badge and summary block when summary text is empty/null. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SpeakerSegment renders] --> B{summary?.text truthy?}
    B -- No --> C[Skip summary block entirely\nNo AI badge, no topic labels,\nno summary text]
    B -- Yes --> D[Render summary block]
    D --> E[stripMarkdown summary.text]
    D --> F{topicLabels.length > 0?}
    F -- Yes --> G[Render TopicBadge list]
    F -- No --> H[Skip topic badges]
    D --> I[summary?.type === 'procedural'?\nRender Διαδικαστικό badge]
    D --> J[Render AIGeneratedBadge]
```

<sub>Reviews (1): Last reviewed commit: ["fix: hide AI badge in speaker segments w..."](https://github.com/schemalabz/opencouncil/commit/dc2de6decc3566e8fb9c820a82eb08fedcab1d2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28466932)</sub>

<!-- /greptile_comment -->