### PR TITLE
fix: resolve transcript editing lag from context re-render cascade

### DIFF
--- a/src/components/meetings/CouncilMeetingDataContext.tsx
+++ b/src/components/meetings/CouncilMeetingDataContext.tsx
@@ -16,6 +16,7 @@ import type { HighlightWithUtterances } from '@/lib/db/highlights';
 
 interface CouncilMeetingTranscriptContextType {
     transcript: Transcript;
+    getSpeakerSegmentById: (id: string) => Transcript[number] | undefined;
 }
 
 const CouncilMeetingTranscriptContext = createContext<CouncilMeetingTranscriptContextType | undefined>(undefined);
@@ -60,11 +61,6 @@ export interface CouncilMeetingDataContext extends MeetingData {
     updateHighlight: (highlightId: string, updates: Partial<HighlightWithUtterances>) => void;
     removeHighlight: (highlightId: string) => void;
     extractSpeakerSegment: (segmentId: string, startUtteranceId: string, endUtteranceId: string) => Promise<void>;
-
-    // Backward compat — TEMPORARY, remove after all consumers migrate to useCouncilMeetingTranscript()
-    transcript: Transcript;
-    getSpeakerSegmentById: (id: string) => Transcript[number] | undefined;
-    getSpeakerSegmentCount: (tagId: string) => number;
 }
 
 const CouncilMeetingDataContext = createContext<CouncilMeetingDataContext | undefined>(undefined);
@@ -85,17 +81,6 @@ export function CouncilMeetingDataProvider({ children, data }: {
     // === DERIVED MAPS FROM MUTABLE STATE ===
     const speakerTagsMap = useMemo(() => new Map(speakerTags.map(tag => [tag.id, tag])), [speakerTags]);
     const highlightsMap = useMemo(() => new Map(highlights.map(h => [h.id, h])), [highlights]);
-
-    // These are transcript-derived and change on every edit, but needed for backward compat
-    const speakerSegmentsMap = useMemo(() => new Map(transcript.map(segment => [segment.id, segment])), [transcript]);
-    const speakerTagSegmentCounts = useMemo(() => {
-        const counts = new Map<string, number>();
-        transcript.forEach(segment => {
-            const count = counts.get(segment.speakerTag.id) || 0;
-            counts.set(segment.speakerTag.id, count + 1);
-        });
-        return counts;
-    }, [transcript]);
 
     // === HELPERS ===
     const recalculateSegmentTimestamps = useCallback((utterances: Array<{ startTimestamp: number; endTimestamp: number }>) => {
@@ -311,9 +296,11 @@ export function CouncilMeetingDataProvider({ children, data }: {
     }, [recalculateSegmentTimestamps]);
 
     // === TRANSCRIPT CONTEXT VALUE (volatile — changes on every edit) ===
+    const speakerSegmentsMap = useMemo(() => new Map(transcript.map(segment => [segment.id, segment])), [transcript]);
     const transcriptValue = useMemo(() => ({
         transcript,
-    }), [transcript]);
+        getSpeakerSegmentById: (id: string) => speakerSegmentsMap.get(id),
+    }), [transcript, speakerSegmentsMap]);
 
     // === MAIN CONTEXT VALUE (stable during normal utterance editing) ===
     // Deps: data, maps derived from speakerTags/highlights (rarely change), stable callbacks.
@@ -345,10 +332,6 @@ export function CouncilMeetingDataProvider({ children, data }: {
         updateHighlight: updateHighlightFn,
         removeHighlight,
         extractSpeakerSegment: extractSpeakerSegmentFn,
-        // TEMPORARY backward compat — remove after all consumers migrate to useCouncilMeetingTranscript()
-        transcript,
-        getSpeakerSegmentById: (id: string) => speakerSegmentsMap.get(id),
-        getSpeakerSegmentCount: (tagId: string) => speakerTagSegmentCounts.get(tagId) || 0,
     }), [
         data, peopleMap, partiesMap,
         speakerTags, speakerTagsMap,
@@ -361,8 +344,6 @@ export function CouncilMeetingDataProvider({ children, data }: {
         addUtteranceToSegmentFn, extractSpeakerSegmentFn,
         deleteUtteranceFn, updateUtteranceFn,
         addHighlight, updateHighlightFn, removeHighlight,
-        // TEMPORARY — these re-introduce transcript volatility until backward compat is removed
-        transcript, speakerSegmentsMap, speakerTagSegmentCounts,
     ]);
 
     return (

--- a/src/components/meetings/CouncilMeetingDataContext.tsx
+++ b/src/components/meetings/CouncilMeetingDataContext.tsx
@@ -1,5 +1,5 @@
 "use client"
-import React, { createContext, useContext, ReactNode, useMemo, useState, useCallback } from 'react';
+import React, { createContext, useContext, ReactNode, useMemo, useState, useCallback, useRef } from 'react';
 import { Party, SpeakerTag, LastModifiedBy } from '@prisma/client';
 import { updateSpeakerTag } from '@/lib/db/speakerTags';
 import { createEmptySpeakerSegmentAfter, createEmptySpeakerSegmentBefore, moveUtterancesToPreviousSegment, moveUtterancesToNextSegment, deleteEmptySpeakerSegment, updateSpeakerSegmentData, EditableSpeakerSegmentData, extractSpeakerSegment, addUtteranceToSegment } from '@/lib/db/speakerSegments';
@@ -10,12 +10,41 @@ import { PersonWithRelations } from '@/lib/db/people';
 import { getPartyFromRoles } from "@/lib/utils";
 import type { HighlightWithUtterances } from '@/lib/db/highlights';
 
+// ============================================================
+// Transcript Context — volatile, changes on every utterance edit
+// ============================================================
+
+interface CouncilMeetingTranscriptContextType {
+    transcript: Transcript;
+}
+
+const CouncilMeetingTranscriptContext = createContext<CouncilMeetingTranscriptContextType | undefined>(undefined);
+
+export function useCouncilMeetingTranscript() {
+    const context = useContext(CouncilMeetingTranscriptContext);
+    if (context === undefined) {
+        throw new Error('useCouncilMeetingTranscript must be used within a CouncilMeetingDataProvider');
+    }
+    return context;
+}
+
+// ============================================================
+// Main Data Context — stable during normal utterance editing
+// ============================================================
+
 export interface CouncilMeetingDataContext extends MeetingData {
+    // Mutable state (changes rarely — not on every utterance edit)
+    speakerTags: SpeakerTag[];
+    highlights: HighlightWithUtterances[];
+
+    // Lookup functions
     getPerson: (id: string) => PersonWithRelations | undefined;
     getParty: (id: string) => Party | undefined;
     getSpeakerTag: (id: string) => SpeakerTag | undefined;
-    getSpeakerSegmentCount: (tagId: string) => number;
-    getSpeakerSegmentById: (id: string) => Transcript[number] | undefined;
+    getPersonsForParty: (partyId: string) => PersonWithRelations[];
+    getHighlight: (highlightId: string) => HighlightWithUtterances | undefined;
+
+    // Mutation functions
     updateSpeakerTagPerson: (tagId: string, personId: string | null) => void;
     updateSpeakerTagLabel: (tagId: string, label: string) => void;
     createEmptySegmentAfter: (afterSegmentId: string) => Promise<void>;
@@ -27,12 +56,15 @@ export interface CouncilMeetingDataContext extends MeetingData {
     addUtteranceToSegment: (segmentId: string) => Promise<string>;
     deleteUtterance: (utteranceId: string) => Promise<void>;
     updateUtterance: (segmentId: string, utteranceId: string, updates: Partial<{ text: string; startTimestamp: number; endTimestamp: number; lastModifiedBy: LastModifiedBy | null }>) => void;
-    getPersonsForParty: (partyId: string) => PersonWithRelations[];
-    getHighlight: (highlightId: string) => HighlightWithUtterances | undefined;
     addHighlight: (highlight: HighlightWithUtterances) => void;
     updateHighlight: (highlightId: string, updates: Partial<HighlightWithUtterances>) => void;
     removeHighlight: (highlightId: string) => void;
     extractSpeakerSegment: (segmentId: string, startUtteranceId: string, endUtteranceId: string) => Promise<void>;
+
+    // Backward compat — TEMPORARY, remove after all consumers migrate to useCouncilMeetingTranscript()
+    transcript: Transcript;
+    getSpeakerSegmentById: (id: string) => Transcript[number] | undefined;
+    getSpeakerSegmentCount: (tagId: string) => number;
 }
 
 const CouncilMeetingDataContext = createContext<CouncilMeetingDataContext | undefined>(undefined);
@@ -41,26 +73,21 @@ export function CouncilMeetingDataProvider({ children, data }: {
     children: ReactNode,
     data: MeetingData
 }) {
+    // === DERIVED MAPS (stable unless their source state changes) ===
     const peopleMap = useMemo(() => new Map(data.people.map(person => [person.id, person])), [data.people]);
     const partiesMap = useMemo(() => new Map(data.parties.map(party => [party.id, party])), [data.parties]);
+
+    // === MUTABLE STATE ===
     const [speakerTags, setSpeakerTags] = useState(data.speakerTags);
     const [transcript, setTranscript] = useState(data.transcript);
     const [highlights, setHighlights] = useState(data.highlights);
+
+    // === DERIVED MAPS FROM MUTABLE STATE ===
     const speakerTagsMap = useMemo(() => new Map(speakerTags.map(tag => [tag.id, tag])), [speakerTags]);
-    const speakerSegmentsMap = useMemo(() => new Map(transcript.map(segment => [segment.id, segment])), [transcript]);
     const highlightsMap = useMemo(() => new Map(highlights.map(h => [h.id, h])), [highlights]);
 
-    // Helper function to recalculate segment timestamps based on utterances
-    const recalculateSegmentTimestamps = useCallback((utterances: Array<{ startTimestamp: number; endTimestamp: number }>) => {
-        if (utterances.length === 0) return null;
-        const allTimestamps = utterances.flatMap(u => [u.startTimestamp, u.endTimestamp]);
-        return {
-            startTimestamp: Math.min(...allTimestamps),
-            endTimestamp: Math.max(...allTimestamps)
-        };
-    }, []);
-
-    // Create a map of speaker tag IDs to their segment counts
+    // These are transcript-derived and change on every edit, but needed for backward compat
+    const speakerSegmentsMap = useMemo(() => new Map(transcript.map(segment => [segment.id, segment])), [transcript]);
     const speakerTagSegmentCounts = useMemo(() => {
         const counts = new Map<string, number>();
         transcript.forEach(segment => {
@@ -70,21 +97,27 @@ export function CouncilMeetingDataProvider({ children, data }: {
         return counts;
     }, [transcript]);
 
-    // Highlight management methods
+    // === HELPERS ===
+    const recalculateSegmentTimestamps = useCallback((utterances: Array<{ startTimestamp: number; endTimestamp: number }>) => {
+        if (utterances.length === 0) return null;
+        const allTimestamps = utterances.flatMap(u => [u.startTimestamp, u.endTimestamp]);
+        return {
+            startTimestamp: Math.min(...allTimestamps),
+            endTimestamp: Math.max(...allTimestamps)
+        };
+    }, []);
+
+    // === HIGHLIGHT MUTATIONS (stable) ===
     const addHighlight = useCallback((highlight: HighlightWithUtterances) => {
         setHighlights(prev => [highlight, ...prev]);
     }, []);
 
-    const updateHighlight = useCallback((highlightId: string, updates: Partial<HighlightWithUtterances>) => {
+    const updateHighlightFn = useCallback((highlightId: string, updates: Partial<HighlightWithUtterances>) => {
         setHighlights(prev => {
             const highlightIndex = prev.findIndex(h => h.id === highlightId);
             if (highlightIndex === -1) return prev;
-            
-            // Remove the highlight from its current position
             const updatedHighlight = { ...prev[highlightIndex], ...updates };
             const newHighlights = prev.filter(h => h.id !== highlightId);
-            
-            // Add it to the start of the list
             return [updatedHighlight, ...newHighlights];
         });
     }, []);
@@ -93,268 +126,250 @@ export function CouncilMeetingDataProvider({ children, data }: {
         setHighlights(prev => prev.filter(h => h.id !== highlightId));
     }, []);
 
-    const getHighlight = useCallback((highlightId: string) => {
-        return highlightsMap.get(highlightId);
-    }, [highlightsMap]);
+    // === SPEAKER TAG MUTATIONS (stable) ===
+    const updateSpeakerTagPersonFn = useCallback(async (tagId: string, personId: string | null) => {
+        await updateSpeakerTag(tagId, { personId });
+        setSpeakerTags(prevTags =>
+            prevTags.map(tag =>
+                tag.id === tagId ? { ...tag, personId } : tag
+            )
+        );
+    }, []);
 
+    const updateSpeakerTagLabelFn = useCallback(async (tagId: string, label: string) => {
+        await updateSpeakerTag(tagId, { label });
+        setSpeakerTags(prevTags =>
+            prevTags.map(tag =>
+                tag.id === tagId ? { ...tag, label } : tag
+            )
+        );
+    }, []);
+
+    // === TRANSCRIPT MUTATIONS (stable — all use setTranscript(prev => ...)) ===
+    const createEmptySegmentAfterFn = useCallback(async (afterSegmentId: string) => {
+        const newSegment = await createEmptySpeakerSegmentAfter(
+            afterSegmentId,
+            data.meeting.cityId,
+            data.meeting.id
+        );
+        setTranscript(prev => {
+            const segmentIndex = prev.findIndex(s => s.id === afterSegmentId);
+            if (segmentIndex === -1) return prev;
+            return [
+                ...prev.slice(0, segmentIndex + 1),
+                newSegment,
+                ...prev.slice(segmentIndex + 1)
+            ];
+        });
+        setSpeakerTags(prev => [...prev, newSegment.speakerTag]);
+    }, [data.meeting.cityId, data.meeting.id]);
+
+    const createEmptySegmentBeforeFn = useCallback(async (beforeSegmentId: string) => {
+        const newSegment = await createEmptySpeakerSegmentBefore(
+            beforeSegmentId,
+            data.meeting.cityId,
+            data.meeting.id
+        );
+        setTranscript(prev => {
+            const segmentIndex = prev.findIndex(s => s.id === beforeSegmentId);
+            if (segmentIndex === -1) return prev;
+            return [
+                ...prev.slice(0, segmentIndex),
+                newSegment,
+                ...prev.slice(segmentIndex)
+            ];
+        });
+        setSpeakerTags(prev => [...prev, newSegment.speakerTag]);
+    }, [data.meeting.cityId, data.meeting.id]);
+
+    const moveUtterancesToPreviousFn = useCallback(async (utteranceId: string, currentSegmentId: string) => {
+        const result = await moveUtterancesToPreviousSegment(utteranceId, currentSegmentId);
+        if (!result.previousSegment || !result.currentSegment) return;
+        setTranscript(prev => {
+            const updated = [...prev];
+            const prevIndex = updated.findIndex(s => s.id === result.previousSegment?.id);
+            const currIndex = updated.findIndex(s => s.id === result.currentSegment?.id);
+            if (prevIndex !== -1 && currIndex !== -1 && result.previousSegment && result.currentSegment) {
+                updated[prevIndex] = {
+                    ...updated[prevIndex],
+                    ...result.previousSegment,
+                    utterances: result.previousSegment.utterances || []
+                };
+                updated[currIndex] = {
+                    ...updated[currIndex],
+                    ...result.currentSegment,
+                    utterances: result.currentSegment.utterances || []
+                };
+            }
+            return updated;
+        });
+    }, []);
+
+    const moveUtterancesToNextFn = useCallback(async (utteranceId: string, currentSegmentId: string) => {
+        const result = await moveUtterancesToNextSegment(utteranceId, currentSegmentId);
+        if (!result.currentSegment || !result.nextSegment) return;
+        setTranscript(prev => {
+            const updated = [...prev];
+            const currIndex = updated.findIndex(s => s.id === result.currentSegment?.id);
+            const nextIndex = updated.findIndex(s => s.id === result.nextSegment?.id);
+            if (currIndex !== -1 && nextIndex !== -1 && result.currentSegment && result.nextSegment) {
+                updated[currIndex] = {
+                    ...updated[currIndex],
+                    ...result.currentSegment,
+                    utterances: result.currentSegment.utterances || []
+                };
+                updated[nextIndex] = {
+                    ...updated[nextIndex],
+                    ...result.nextSegment,
+                    utterances: result.nextSegment.utterances || []
+                };
+            }
+            return updated;
+        });
+    }, []);
+
+    const deleteEmptySegmentFn = useCallback(async (segmentId: string) => {
+        await deleteEmptySpeakerSegment(segmentId, data.meeting.cityId);
+        // Read from prev inside functional updater instead of speakerSegmentsMap
+        setTranscript(prev => {
+            const segment = prev.find(s => s.id === segmentId);
+            const deletedSpeakerTagId = segment?.speakerTagId;
+            const updated = prev.filter(s => s.id !== segmentId);
+            if (deletedSpeakerTagId) {
+                const isTagStillInUse = updated.some(s => s.speakerTagId === deletedSpeakerTagId);
+                if (!isTagStillInUse) {
+                    setSpeakerTags(prevTags => prevTags.filter(t => t.id !== deletedSpeakerTagId));
+                }
+            }
+            return updated;
+        });
+    }, [data.meeting.cityId]);
+
+    const updateSpeakerSegmentDataFn = useCallback(async (segmentId: string, editData: EditableSpeakerSegmentData) => {
+        const updatedSegment = await updateSpeakerSegmentData(segmentId, editData, data.meeting.cityId);
+        setTranscript(prev => prev.map(segment =>
+            segment.id === segmentId ? updatedSegment : segment
+        ));
+    }, [data.meeting.cityId]);
+
+    const addUtteranceToSegmentFn = useCallback(async (segmentId: string) => {
+        const updatedSegment = await addUtteranceToSegment(segmentId, data.meeting.cityId);
+        setTranscript(prev => prev.map(segment =>
+            segment.id === segmentId ? updatedSegment : segment
+        ));
+        const newUtterance = updatedSegment.utterances[updatedSegment.utterances.length - 1];
+        return newUtterance?.id || '';
+    }, [data.meeting.cityId]);
+
+    const extractSpeakerSegmentFn = useCallback(async (segmentId: string, startUtteranceId: string, endUtteranceId: string) => {
+        const newSegments = await extractSpeakerSegment(data.meeting.cityId, data.meeting.id, segmentId, startUtteranceId, endUtteranceId);
+        setTranscript(prev => {
+            const originalIndex = prev.findIndex(s => s.id === segmentId);
+            if (originalIndex === -1) return prev;
+            const updatedTranscript = [...prev];
+            updatedTranscript.splice(originalIndex, 1, ...newSegments);
+            return updatedTranscript;
+        });
+        const newTags = newSegments.map(s => s.speakerTag);
+        setSpeakerTags(prev => {
+            const prevIds = new Set(prev.map(t => t.id));
+            const tagsToAdd = newTags.filter(t => !prevIds.has(t.id));
+            return [...prev, ...tagsToAdd];
+        });
+    }, [data.meeting.cityId, data.meeting.id]);
+
+    const deleteUtteranceFn = useCallback(async (utteranceId: string) => {
+        const { segmentId, remainingUtterances } = await deleteUtterance(utteranceId);
+        setTranscript(prev => prev.map(segment => {
+            if (segment.id === segmentId) {
+                const updatedUtterances = segment.utterances.filter(u => u.id !== utteranceId);
+                if (remainingUtterances === 0) {
+                    return { ...segment, utterances: [] };
+                }
+                const newTimestamps = recalculateSegmentTimestamps(updatedUtterances);
+                return { ...segment, utterances: updatedUtterances, ...newTimestamps };
+            }
+            return segment;
+        }));
+    }, [recalculateSegmentTimestamps]);
+
+    const updateUtteranceFn = useCallback((segmentId: string, utteranceId: string, updates: Partial<{ text: string; startTimestamp: number; endTimestamp: number; lastModifiedBy: LastModifiedBy | null }>) => {
+        setTranscript(prev => prev.map(segment => {
+            if (segment.id === segmentId) {
+                const updatedUtterances = segment.utterances.map(u =>
+                    u.id === utteranceId ? { ...u, ...updates } : u
+                );
+                const timestampsChanged = 'startTimestamp' in updates || 'endTimestamp' in updates;
+                if (timestampsChanged) {
+                    const newTimestamps = recalculateSegmentTimestamps(updatedUtterances);
+                    return { ...segment, utterances: updatedUtterances, ...newTimestamps };
+                }
+                return { ...segment, utterances: updatedUtterances };
+            }
+            return segment;
+        }));
+    }, [recalculateSegmentTimestamps]);
+
+    // === TRANSCRIPT CONTEXT VALUE (volatile — changes on every edit) ===
+    const transcriptValue = useMemo(() => ({
+        transcript,
+    }), [transcript]);
+
+    // === MAIN CONTEXT VALUE (stable during normal utterance editing) ===
+    // Deps: data, maps derived from speakerTags/highlights (rarely change), stable callbacks.
+    // Does NOT depend on transcript — that's the key to preventing the cascade.
     const contextValue = useMemo(() => ({
         ...data,
-        transcript,
         speakerTags,
         highlights,
         getPerson: (id: string) => peopleMap.get(id),
         getParty: (id: string) => partiesMap.get(id),
         getSpeakerTag: (id: string) => speakerTagsMap.get(id),
-        getSpeakerSegmentCount: (tagId: string) => speakerTagSegmentCounts.get(tagId) || 0,
-        getSpeakerSegmentById: (id: string) => speakerSegmentsMap.get(id),
         getPersonsForParty: (partyId: string) => data.people.filter(person => {
             const party = getPartyFromRoles(person.roles);
             return party?.id === partyId;
         }),
-        getHighlight,
-        updateSpeakerTagPerson: async (tagId: string, personId: string | null) => {
-            console.log(`Updating speaker tag ${tagId} to person ${personId}`);
-            await updateSpeakerTag(tagId, { personId });
-            setSpeakerTags(prevTags =>
-                prevTags.map(tag =>
-                    tag.id === tagId ? { ...tag, personId } : tag
-                )
-            );
-        },
-        updateSpeakerTagLabel: async (tagId: string, label: string) => {
-            console.log(`Updating speaker tag ${tagId} label to ${label}`);
-            await updateSpeakerTag(tagId, { label });
-            setSpeakerTags(prevTags =>
-                prevTags.map(tag =>
-                    tag.id === tagId ? { ...tag, label } : tag
-                )
-            );
-        },
-        createEmptySegmentAfter: async (afterSegmentId: string) => {
-            const newSegment = await createEmptySpeakerSegmentAfter(
-                afterSegmentId,
-                data.meeting.cityId,
-                data.meeting.id
-            );
-
-            // Insert the new segment after it
-            setTranscript(prev => {
-                // Find the index of the segment we're inserting after using fresh state
-                const segmentIndex = prev.findIndex(s => s.id === afterSegmentId);
-                if (segmentIndex === -1) return prev;
-                
-                return [
-                    ...prev.slice(0, segmentIndex + 1),
-                    newSegment,
-                    ...prev.slice(segmentIndex + 1)
-                ];
-            });
-
-            // Add the new speaker tag to our state
-            setSpeakerTags(prev => [...prev, newSegment.speakerTag]);
-        },
-        createEmptySegmentBefore: async (beforeSegmentId: string) => {
-            const newSegment = await createEmptySpeakerSegmentBefore(
-                beforeSegmentId,
-                data.meeting.cityId,
-                data.meeting.id
-            );
-
-            // Insert the new segment before it
-            setTranscript(prev => {
-                // Find the index of the segment we're inserting before using fresh state
-                const segmentIndex = prev.findIndex(s => s.id === beforeSegmentId);
-                if (segmentIndex === -1) return prev;
-                
-                return [
-                    ...prev.slice(0, segmentIndex),
-                    newSegment,
-                    ...prev.slice(segmentIndex)
-                ];
-            });
-
-            // Add the new speaker tag to our state
-            setSpeakerTags(prev => [...prev, newSegment.speakerTag]);
-        },
-        moveUtterancesToPrevious: async (utteranceId: string, currentSegmentId: string) => {
-            const result = await moveUtterancesToPreviousSegment(utteranceId, currentSegmentId);
-
-            if (!result.previousSegment || !result.currentSegment) return;
-
-            // Update the transcript state with the modified segments
-            setTranscript(prev => {
-                const updated = [...prev];
-                const prevIndex = updated.findIndex(s => s.id === result.previousSegment?.id);
-                const currIndex = updated.findIndex(s => s.id === result.currentSegment?.id);
-
-                // Only update if we found both segments and they're not null
-                if (prevIndex !== -1 && currIndex !== -1 && result.previousSegment && result.currentSegment) {
-                    updated[prevIndex] = {
-                        ...updated[prevIndex],
-                        ...result.previousSegment,
-                        utterances: result.previousSegment.utterances || []
-                    };
-                    updated[currIndex] = {
-                        ...updated[currIndex],
-                        ...result.currentSegment,
-                        utterances: result.currentSegment.utterances || []
-                    };
-                }
-                return updated;
-            });
-        },
-        moveUtterancesToNext: async (utteranceId: string, currentSegmentId: string) => {
-            const result = await moveUtterancesToNextSegment(utteranceId, currentSegmentId);
-
-            if (!result.currentSegment || !result.nextSegment) return;
-
-            // Update the transcript state with the modified segments
-            setTranscript(prev => {
-                const updated = [...prev];
-                const currIndex = updated.findIndex(s => s.id === result.currentSegment?.id);
-                const nextIndex = updated.findIndex(s => s.id === result.nextSegment?.id);
-
-                // Only update if we found both segments and they're not null
-                if (currIndex !== -1 && nextIndex !== -1 && result.currentSegment && result.nextSegment) {
-                    updated[currIndex] = {
-                        ...updated[currIndex],
-                        ...result.currentSegment,
-                        utterances: result.currentSegment.utterances || []
-                    };
-                    updated[nextIndex] = {
-                        ...updated[nextIndex],
-                        ...result.nextSegment,
-                        utterances: result.nextSegment.utterances || []
-                    };
-                }
-                return updated;
-            });
-        },
-        deleteEmptySegment: async (segmentId: string) => {
-            await deleteEmptySpeakerSegment(segmentId, data.meeting.cityId);
-
-            const segment = speakerSegmentsMap.get(segmentId);
-            const deletedSpeakerTagId = segment?.speakerTagId;
-
-            // Remove the segment from the transcript
-            setTranscript(prev => {
-                const updated = prev.filter(s => s.id !== segmentId);
-                
-                // Only remove the speaker tag if no other segments are using it
-                if (deletedSpeakerTagId) {
-                    const isTagStillInUse = updated.some(s => s.speakerTagId === deletedSpeakerTagId);
-                    if (!isTagStillInUse) {
-                        setSpeakerTags(prevTags => prevTags.filter(t => t.id !== deletedSpeakerTagId));
-                    }
-                }
-                
-                return updated;
-            });
-        },
+        getHighlight: (highlightId: string) => highlightsMap.get(highlightId),
+        updateSpeakerTagPerson: updateSpeakerTagPersonFn,
+        updateSpeakerTagLabel: updateSpeakerTagLabelFn,
+        createEmptySegmentAfter: createEmptySegmentAfterFn,
+        createEmptySegmentBefore: createEmptySegmentBeforeFn,
+        moveUtterancesToPrevious: moveUtterancesToPreviousFn,
+        moveUtterancesToNext: moveUtterancesToNextFn,
+        deleteEmptySegment: deleteEmptySegmentFn,
+        updateSpeakerSegmentData: updateSpeakerSegmentDataFn,
+        addUtteranceToSegment: addUtteranceToSegmentFn,
+        deleteUtterance: deleteUtteranceFn,
+        updateUtterance: updateUtteranceFn,
         addHighlight,
-        updateHighlight,
+        updateHighlight: updateHighlightFn,
         removeHighlight,
-        updateSpeakerSegmentData: async (segmentId: string, editData: EditableSpeakerSegmentData) => {
-            console.log(`Updating speaker segment ${segmentId} data`);
-            const updatedSegment = await updateSpeakerSegmentData(segmentId, editData, data.meeting.cityId);
-            
-            // Update transcript state with the fully updated segment data
-            setTranscript(prev => prev.map(segment =>
-                segment.id === segmentId ? updatedSegment : segment
-            ));
-        },
-        addUtteranceToSegment: async (segmentId: string) => {
-            console.log(`Adding utterance to segment ${segmentId}`);
-            const updatedSegment = await addUtteranceToSegment(segmentId, data.meeting.cityId);
-            
-            // Update transcript state with the fully updated segment data
-            setTranscript(prev => prev.map(segment =>
-                segment.id === segmentId ? updatedSegment : segment
-            ));
-            
-            // Return the ID of the newly created utterance (last one in the updated segment)
-            const newUtterance = updatedSegment.utterances[updatedSegment.utterances.length - 1];
-            return newUtterance?.id || '';
-        },
-        extractSpeakerSegment: async (segmentId: string, startUtteranceId: string, endUtteranceId: string) => {
-            const newSegments = await extractSpeakerSegment(data.meeting.cityId, data.meeting.id, segmentId, startUtteranceId, endUtteranceId);
-            
-            // Replace the original segment with the new segments (Before, Middle, After)
-            setTranscript(prev => {
-                const originalIndex = prev.findIndex(s => s.id === segmentId);
-                if (originalIndex === -1) return prev;
-
-                const updatedTranscript = [...prev];
-                updatedTranscript.splice(originalIndex, 1, ...newSegments);
-                
-                return updatedTranscript;
-            });
-            
-            // Add any new speaker tags that were created
-            const newTags = newSegments.map(s => s.speakerTag);
-            setSpeakerTags(prev => {
-                 const prevIds = new Set(prev.map(t => t.id));
-                 const tagsToAdd = newTags.filter(t => !prevIds.has(t.id));
-                 return [...prev, ...tagsToAdd];
-            });
-        },
-        deleteUtterance: async (utteranceId: string) => {
-            console.log(`Deleting utterance ${utteranceId}`);
-            const { segmentId, remainingUtterances } = await deleteUtterance(utteranceId);
-            
-            // Update the segment to remove the utterance
-            setTranscript(prev => prev.map(segment => {
-                if (segment.id === segmentId) {
-                    const updatedUtterances = segment.utterances.filter(u => u.id !== utteranceId);
-                    
-                    // If no utterances remain, keep the segment but with empty utterances array
-                    if (remainingUtterances === 0) {
-                        return { ...segment, utterances: [] };
-                    }
-                    
-                    // Otherwise, recalculate timestamps based on remaining utterances
-                    const newTimestamps = recalculateSegmentTimestamps(updatedUtterances);
-                    return {
-                        ...segment,
-                        utterances: updatedUtterances,
-                        ...newTimestamps
-                    };
-                }
-                return segment;
-            }));
-        },
-        updateUtterance: (segmentId: string, utteranceId: string, updates: Partial<{ text: string; startTimestamp: number; endTimestamp: number; lastModifiedBy: LastModifiedBy | null }>) => {
-            setTranscript(prev => prev.map(segment => {
-                if (segment.id === segmentId) {
-                    // Update the utterance
-                    const updatedUtterances = segment.utterances.map(u =>
-                        u.id === utteranceId ? { ...u, ...updates } : u
-                    );
-                    
-                    // If timestamps changed, recalculate segment boundaries
-                    const timestampsChanged = 'startTimestamp' in updates || 'endTimestamp' in updates;
-                    if (timestampsChanged) {
-                        const newTimestamps = recalculateSegmentTimestamps(updatedUtterances);
-                        return {
-                            ...segment,
-                            utterances: updatedUtterances,
-                            ...newTimestamps
-                        };
-                    }
-                    
-                    return {
-                        ...segment,
-                        utterances: updatedUtterances
-                    };
-                }
-                return segment;
-            }));
-        }
-    }), [data, peopleMap, partiesMap, speakerTags, speakerTagsMap, speakerSegmentsMap, transcript, speakerTagSegmentCounts, highlights, addHighlight, updateHighlight, removeHighlight, getHighlight, recalculateSegmentTimestamps]);
+        extractSpeakerSegment: extractSpeakerSegmentFn,
+        // TEMPORARY backward compat — remove after all consumers migrate to useCouncilMeetingTranscript()
+        transcript,
+        getSpeakerSegmentById: (id: string) => speakerSegmentsMap.get(id),
+        getSpeakerSegmentCount: (tagId: string) => speakerTagSegmentCounts.get(tagId) || 0,
+    }), [
+        data, peopleMap, partiesMap,
+        speakerTags, speakerTagsMap,
+        highlights, highlightsMap,
+        // Stable callbacks (don't add volatility):
+        updateSpeakerTagPersonFn, updateSpeakerTagLabelFn,
+        createEmptySegmentAfterFn, createEmptySegmentBeforeFn,
+        moveUtterancesToPreviousFn, moveUtterancesToNextFn,
+        deleteEmptySegmentFn, updateSpeakerSegmentDataFn,
+        addUtteranceToSegmentFn, extractSpeakerSegmentFn,
+        deleteUtteranceFn, updateUtteranceFn,
+        addHighlight, updateHighlightFn, removeHighlight,
+        // TEMPORARY — these re-introduce transcript volatility until backward compat is removed
+        transcript, speakerSegmentsMap, speakerTagSegmentCounts,
+    ]);
 
     return (
         <CouncilMeetingDataContext.Provider value={contextValue}>
-            {children}
+            <CouncilMeetingTranscriptContext.Provider value={transcriptValue}>
+                {children}
+            </CouncilMeetingTranscriptContext.Provider>
         </CouncilMeetingDataContext.Provider>
     );
 }

--- a/src/components/meetings/EditingContext.tsx
+++ b/src/components/meetings/EditingContext.tsx
@@ -1,6 +1,6 @@
 "use client";
-import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
-import { useCouncilMeetingData } from './CouncilMeetingDataContext';
+import React, { createContext, useContext, useState, useCallback, useRef, ReactNode, useMemo } from 'react';
+import { useCouncilMeetingData, useCouncilMeetingTranscript } from './CouncilMeetingDataContext';
 import { ACTIONS, useKeyboardShortcut } from '@/contexts/KeyboardShortcutsContext';
 import { useToast } from '@/hooks/use-toast';
 import { useTranslations } from 'next-intl';
@@ -21,16 +21,19 @@ export function EditingProvider({ children }: { children: ReactNode }) {
     const [selectedUtteranceIds, setSelectedUtteranceIds] = useState<Set<string>>(new Set());
     const [lastClickedUtteranceId, setLastClickedUtteranceId] = useState<string | null>(null);
     const [isProcessing, setIsProcessing] = useState(false);
-    
-    const { transcript, extractSpeakerSegment, getSpeakerSegmentById } = useCouncilMeetingData();
+
+    // Subscribe to transcript context — EditingProvider re-renders on transcript changes (cheap,
+    // it's one component). We store transcript in a ref so callbacks can read the latest value
+    // without depending on it — this is the standard React pattern for stable event handlers.
+    const { transcript } = useCouncilMeetingTranscript();
+    const { extractSpeakerSegment } = useCouncilMeetingData();
     const { toast } = useToast();
     const t = useTranslations('editing.toasts');
 
-    // Flatten utterances for easy range index finding
-    // Memoizing this might be expensive if transcript changes often, but necessary for range selection
-    const allUtterances = React.useMemo(() => {
-        return transcript.flatMap(segment => segment.utterances);
-    }, [transcript]);
+    // Single internal ref: read latest transcript in callbacks without adding it as a dep.
+    // This prevents toggleSelection/extractSelectedSegment from changing on every transcript edit.
+    const transcriptRef = useRef(transcript);
+    transcriptRef.current = transcript;
 
     const clearSelection = useCallback(() => {
         setSelectedUtteranceIds(new Set());
@@ -42,11 +45,11 @@ export function EditingProvider({ children }: { children: ReactNode }) {
             const newSet = new Set(prev);
 
             if (modifiers.shift && lastClickedUtteranceId) {
-                // Range selection using shared utility
+                // Compute allUtterances lazily from ref
+                const allUtterances = transcriptRef.current.flatMap(segment => segment.utterances);
                 const rangeIds = calculateUtteranceRange(allUtterances, lastClickedUtteranceId, id);
                 rangeIds.forEach(rangeId => newSet.add(rangeId));
             } else if (modifiers.ctrl) {
-                // Toggle individual
                 if (newSet.has(id)) {
                     newSet.delete(id);
                 } else {
@@ -54,7 +57,6 @@ export function EditingProvider({ children }: { children: ReactNode }) {
                 }
                 setLastClickedUtteranceId(id);
             } else {
-                // Single select (clear others)
                 newSet.clear();
                 newSet.add(id);
                 setLastClickedUtteranceId(id);
@@ -62,20 +64,23 @@ export function EditingProvider({ children }: { children: ReactNode }) {
 
             return newSet;
         });
-    }, [allUtterances, lastClickedUtteranceId]);
+    // lastClickedUtteranceId changes on user clicks — that's fine because
+    // the context value already changes when lastClickedUtteranceId changes.
+    }, [lastClickedUtteranceId]);
 
     const extractSelectedSegment = useCallback(async () => {
-        if (selectedUtteranceIds.size === 0) return;
         if (isProcessing) return;
+        if (selectedUtteranceIds.size === 0) return;
 
         setIsProcessing(true);
         try {
+            const allUtterances = transcriptRef.current.flatMap(segment => segment.utterances);
             const selectedList = Array.from(selectedUtteranceIds);
             const firstUtterance = allUtterances.find(u => u.id === selectedList[0]);
             if (!firstUtterance) throw new Error("Selected utterance not found");
 
             const targetSegmentId = firstUtterance.speakerSegmentId;
-            
+
             // Validate all selected utterances belong to the same segment
             const allInSame = selectedList.every(id => {
                 const u = allUtterances.find(ut => ut.id === id);
@@ -95,12 +100,12 @@ export function EditingProvider({ children }: { children: ReactNode }) {
             const indices = selectedList
                 .map(id => allUtterances.findIndex(u => u.id === id))
                 .sort((a, b) => a - b);
-            
+
             const startUtteranceId = allUtterances[indices[0]].id;
             const endUtteranceId = allUtterances[indices[indices.length - 1]].id;
 
             // Validate extraction leaves utterances before and after (A-B-A pattern)
-            const originalSegment = getSpeakerSegmentById(targetSegmentId);
+            const originalSegment = transcriptRef.current.find(s => s.id === targetSegmentId);
             if (originalSegment) {
                 const totalUtterances = originalSegment.utterances.length;
                 const segmentStartIndex = originalSegment.utterances.findIndex(u => u.id === startUtteranceId);
@@ -127,7 +132,7 @@ export function EditingProvider({ children }: { children: ReactNode }) {
             }
 
             await extractSpeakerSegment(targetSegmentId, startUtteranceId, endUtteranceId);
-            
+
             clearSelection();
             toast({
                 description: t('extractionSuccess')
@@ -143,21 +148,25 @@ export function EditingProvider({ children }: { children: ReactNode }) {
         } finally {
             setIsProcessing(false);
         }
-    }, [selectedUtteranceIds, isProcessing, allUtterances, extractSpeakerSegment, getSpeakerSegmentById, clearSelection, toast, t]);
+    // These deps change on user actions (selection, processing) — not on transcript edits.
+    }, [selectedUtteranceIds, isProcessing, extractSpeakerSegment, clearSelection, toast, t]);
 
     // Register Shortcuts
     useKeyboardShortcut(ACTIONS.EXTRACT_SEGMENT.id, extractSelectedSegment, selectedUtteranceIds.size > 0);
     useKeyboardShortcut(ACTIONS.CLEAR_SELECTION.id, clearSelection, selectedUtteranceIds.size > 0);
 
+    // Memoize value — changes on user actions (selection, processing), NOT on transcript edits.
+    const value = useMemo(() => ({
+        selectedUtteranceIds,
+        lastClickedUtteranceId,
+        toggleSelection,
+        clearSelection,
+        extractSelectedSegment,
+        isProcessing,
+    }), [selectedUtteranceIds, lastClickedUtteranceId, toggleSelection, clearSelection, extractSelectedSegment, isProcessing]);
+
     return (
-        <EditingContext.Provider value={{
-            selectedUtteranceIds,
-            lastClickedUtteranceId,
-            toggleSelection,
-            clearSelection,
-            extractSelectedSegment,
-            isProcessing
-        }}>
+        <EditingContext.Provider value={value}>
             {children}
         </EditingContext.Provider>
     );

--- a/src/components/meetings/EditingModeBar.tsx
+++ b/src/components/meetings/EditingModeBar.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import { useTranscriptOptions } from './options/OptionsContext';
 import { useVideo } from './VideoProvider';
-import { useCouncilMeetingData } from './CouncilMeetingDataContext';
+import { useCouncilMeetingData, useCouncilMeetingTranscript } from './CouncilMeetingDataContext';
 import { useHighlight } from './HighlightContext';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -21,7 +21,8 @@ import { useRouter } from 'next/navigation';
 export function EditingModeBar() {
     const { options, updateOptions } = useTranscriptOptions();
     const { playbackSpeed, handleSpeedChange, seekTo, currentTime } = useVideo();
-    const { transcript: speakerSegments, getSpeakerTag, meeting } = useCouncilMeetingData();
+    const { transcript: speakerSegments } = useCouncilMeetingTranscript();
+    const { getSpeakerTag, meeting } = useCouncilMeetingData();
     const { editingHighlight } = useHighlight(); // To check for exclusivity
     const t = useTranslations('editing');
     const [showCompleteDialog, setShowCompleteDialog] = useState(false);

--- a/src/components/meetings/HighlightContext.tsx
+++ b/src/components/meetings/HighlightContext.tsx
@@ -3,7 +3,7 @@ import React, { createContext, useContext, useState, useEffect, useMemo, useCall
 import { useRouter, usePathname } from 'next/navigation';
 import type { HighlightWithUtterances } from '@/lib/db/highlights';
 import { useCouncilMeetingData, useCouncilMeetingTranscript } from './CouncilMeetingDataContext';
-import { useVideo } from './VideoProvider';
+import { useVideo, useVideoActions } from './VideoProvider';
 import { Utterance } from '@prisma/client';
 import { calculateUtteranceRange } from '@/lib/selection-utils';
 
@@ -82,9 +82,18 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
   // Store in ref so callbacks read latest value without depending on it.
   const { transcript } = useCouncilMeetingTranscript();
   const { getSpeakerTag, getPerson, meeting, addHighlight, updateHighlight } = useCouncilMeetingData();
-  const { currentTime, seekTo, isPlaying, setIsPlaying, seekToAndPlay } = useVideo();
+  const { seekTo, seekToWithoutScroll } = useVideoActions(); // stable refs — won't trigger re-renders
+  const { currentTime, isPlaying, setIsPlaying } = useVideo(); // reactive state — only for effects/conditions
   const router = useRouter();
   const pathname = usePathname();
+
+  // Stable seekToAndPlay built from stable actions — prevents cascading re-renders
+  // when VideoContext value changes (seekTo from useVideoActions is stable,
+  // setIsPlaying is a useState setter which React guarantees stable identity)
+  const seekToAndPlay = useCallback((time: number) => {
+      seekTo(time);
+      setIsPlaying(true);
+  }, [seekTo, setIsPlaying]);
 
   // Single internal ref for stable callback access to transcript
   const transcriptRef = useRef(transcript);

--- a/src/components/meetings/HighlightContext.tsx
+++ b/src/components/meetings/HighlightContext.tsx
@@ -2,7 +2,7 @@
 import React, { createContext, useContext, useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import type { HighlightWithUtterances } from '@/lib/db/highlights';
-import { useCouncilMeetingData } from './CouncilMeetingDataContext';
+import { useCouncilMeetingData, useCouncilMeetingTranscript } from './CouncilMeetingDataContext';
 import { useVideo } from './VideoProvider';
 import { Utterance } from '@prisma/client';
 import { calculateUtteranceRange } from '@/lib/selection-utils';
@@ -35,7 +35,6 @@ interface HighlightContextType {
   highlightUtterances: HighlightUtterance[] | null;
   currentHighlightIndex: number;
   totalHighlights: number;
-  utteranceMap: Map<string, Utterance>; // Pre-built utterance map for performance
   hasUnsavedChanges: boolean;
   isSaving: boolean;
   isCreating: boolean;
@@ -78,44 +77,47 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
   const [isCreating, setIsCreating] = useState(false);
   const [lastClickedUtteranceId, setLastClickedUtteranceId] = useState<string | null>(null);
   const [lastClickedAction, setLastClickedAction] = useState<'add' | 'remove' | null>(null);
-  
-  // Get transcript and speaker data from CouncilMeetingDataContext
-  const { transcript, getSpeakerTag, getPerson, getSpeakerSegmentById, meeting, addHighlight, updateHighlight } = useCouncilMeetingData();
+
+  // Subscribe to transcript context — provider re-renders on transcript changes (cheap).
+  // Store in ref so callbacks read latest value without depending on it.
+  const { transcript } = useCouncilMeetingTranscript();
+  const { getSpeakerTag, getPerson, meeting, addHighlight, updateHighlight } = useCouncilMeetingData();
   const { currentTime, seekTo, isPlaying, setIsPlaying, seekToAndPlay } = useVideo();
   const router = useRouter();
   const pathname = usePathname();
 
-  // Build utterance map once and memoize it - this eliminates the need to rebuild it in useHighlightCalculations
-  const utteranceMap = useMemo(() => {
+  // Single internal ref for stable callback access to transcript
+  const transcriptRef = useRef(transcript);
+  transcriptRef.current = transcript;
+
+  // Helper: build utterance map from transcript ref (lazily, not as a memo)
+  const buildUtteranceMap = useCallback(() => {
     const map = new Map<string, Utterance>();
-    transcript.forEach(segment => {
+    transcriptRef.current.forEach(segment => {
       segment.utterances.forEach(utterance => {
         map.set(utterance.id, utterance);
       });
     });
     return map;
-  }, [transcript]);
-
-  // Flatten utterances for range selection
-  const allUtterances = useMemo(() => {
-    return transcript.flatMap(segment => segment.utterances);
-  }, [transcript]);
+  }, []);
 
   const calculateHighlightData = useCallback((highlight: HighlightWithUtterances | null): HighlightCalculationResult | null => {
-      if (!highlight || !transcript) {
+      if (!highlight) {
         return null;
       }
+
+      const utteranceMap = buildUtteranceMap();
 
       // Extract highlight utterances with timestamps and speaker information
       const utterances: HighlightUtterance[] = [];
       highlight.highlightedUtterances.forEach(hu => {
         const utterance = utteranceMap.get(hu.utteranceId);
         if (utterance) {
-          const segment = getSpeakerSegmentById(utterance.speakerSegmentId);
+          const segment = transcriptRef.current.find(s => s.id === utterance.speakerSegmentId);
           const speakerTag = segment ? getSpeakerTag(segment.speakerTagId) : null;
           const person = speakerTag?.personId ? getPerson(speakerTag.personId) : undefined;
           const speakerName = person ? person.name_short : speakerTag?.label || 'Unknown';
-          
+
           utterances.push({
             id: utterance.id,
             text: utterance.text,
@@ -132,11 +134,11 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
 
       // Calculate statistics
       const utteranceCount = utterances.length;
-      
+
       const duration = utterances.reduce((total, utterance: HighlightUtterance) => {
         return total + (utterance.endTimestamp - utterance.startTimestamp);
       }, 0);
-      
+
       // Calculate speaker count
       const speakerNames = new Set<string>();
       utterances.forEach(utterance => {
@@ -151,7 +153,7 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
       };
 
       return { statistics, highlightUtterances: utterances };
-    }, [transcript, utteranceMap, getSpeakerSegmentById, getSpeakerTag, getPerson]);
+    }, [buildUtteranceMap, getSpeakerTag, getPerson]);
 
   // Calculate data for the currently editing highlight
   const editingHighlightData = useMemo(() => {
@@ -173,12 +175,12 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
       setCurrentHighlightIndex(0);
       return;
     }
-    
+
     // Find which highlighted utterance we're currently in
-    const currentIndex = highlightUtterances.findIndex(utterance => 
+    const currentIndex = highlightUtterances.findIndex(utterance =>
       currentTime >= utterance.startTimestamp && currentTime <= utterance.endTimestamp
     );
-    
+
     // Only update if we found a valid index and it's different from current
     if (currentIndex !== -1 && currentIndex !== currentHighlightIndex) {
       setCurrentHighlightIndex(currentIndex);
@@ -206,10 +208,10 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     if (isAutoAdvancingRef.current) {
       return;
     }
-    
+
     const currentUtterance = highlightUtterances[currentHighlightIndex];
     if (!currentUtterance) return;
-    
+
     if (currentTime >= currentUtterance.endTimestamp) {
       // Auto-advance to next highlight (wrap to start at the end)
       const nextIndex = (currentHighlightIndex + 1) % totalHighlights;
@@ -222,62 +224,55 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
   }, [currentTime, previewMode, highlightUtterances, currentHighlightIndex, isPlaying, totalHighlights, seekTo]);
 
   // Enhanced navigation functions
-  const goToPreviousHighlight = () => {
+  const goToPreviousHighlight = useCallback(() => {
     if (!highlightUtterances || highlightUtterances.length === 0) return;
-    
+
     let newIndex: number;
-    
+
     if (currentHighlightIndex > 0) {
       newIndex = currentHighlightIndex - 1;
     } else if (previewMode) {
-      // In preview mode, loop to last highlight
       newIndex = totalHighlights - 1;
     } else {
-      // In edit mode, stay at first highlight
       return;
     }
-    
+
     setIsPlaying(false);
     setCurrentHighlightIndex(newIndex);
     seekToAndPlay(highlightUtterances[newIndex].startTimestamp);
-  };
+  }, [highlightUtterances, currentHighlightIndex, previewMode, totalHighlights, setIsPlaying, seekToAndPlay]);
 
-  const goToNextHighlight = () => {
+  const goToNextHighlight = useCallback(() => {
     if (!highlightUtterances || highlightUtterances.length === 0) return;
-    
+
     let newIndex: number;
-    
+
     if (currentHighlightIndex < totalHighlights - 1) {
       newIndex = currentHighlightIndex + 1;
     } else if (previewMode) {
-      // In preview mode, loop back to first highlight
       newIndex = 0;
     } else {
-      // In edit mode, stay at last highlight
       return;
     }
-    
+
     setIsPlaying(false);
     setCurrentHighlightIndex(newIndex);
     seekToAndPlay(highlightUtterances[newIndex].startTimestamp);
-  };
+  }, [highlightUtterances, currentHighlightIndex, previewMode, totalHighlights, setIsPlaying, seekToAndPlay]);
 
-  const goToHighlightIndex = (index: number) => {
+  const goToHighlightIndex = useCallback((index: number) => {
     if (highlightUtterances && index >= 0 && index < highlightUtterances.length) {
       setCurrentHighlightIndex(index);
       seekTo(highlightUtterances[index].startTimestamp);
     }
-  };
+  }, [highlightUtterances, seekTo]);
 
-  // Enhanced preview mode toggle
-  const togglePreviewMode = () => {
+  const togglePreviewMode = useCallback(() => {
     if (isPreviewDialogOpen) {
-      // Close dialog and exit preview
       setIsPreviewDialogOpen(false);
       setPreviewMode(false);
       setIsPlaying(false);
     } else {
-      // Open dialog and enter preview
       setIsPreviewDialogOpen(true);
       setPreviewMode(true);
       if (highlightUtterances && highlightUtterances.length > 0) {
@@ -285,27 +280,26 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
         seekToAndPlay(highlightUtterances[0].startTimestamp);
       }
     }
-  };
+  }, [isPreviewDialogOpen, highlightUtterances, setIsPlaying, seekToAndPlay]);
 
-  const openPreviewDialog = () => {
+  const openPreviewDialog = useCallback(() => {
     if (isPreviewDialogOpen) return;
     setIsPreviewDialogOpen(true);
     setPreviewMode(true);
     if (highlightUtterances && highlightUtterances.length > 0) {
       setCurrentHighlightIndex(0);
-      // Small delay to ensure video element is ready before starting playback
       setTimeout(() => {
         seekToAndPlay(highlightUtterances[0].startTimestamp);
       }, 100);
     }
-  };
+  }, [isPreviewDialogOpen, highlightUtterances, seekToAndPlay]);
 
-  const closePreviewDialog = () => {
+  const closePreviewDialog = useCallback(() => {
     if (!isPreviewDialogOpen) return;
     setIsPreviewDialogOpen(false);
     setPreviewMode(false);
     setIsPlaying(false);
-  };
+  }, [isPreviewDialogOpen, setIsPlaying]);
 
   // Enter edit mode - called when switching to edit mode (from URL parameter)
   const enterEditMode = useCallback((highlight: HighlightWithUtterances) => {
@@ -316,11 +310,11 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     // Clear range selection anchor
     setLastClickedUtteranceId(null);
     setLastClickedAction(null);
-    
+
     // Auto-navigate to transcript page with highlight parameter if not already there
     const expectedPath = `/${highlight.cityId}/${highlight.meetingId}/transcript`;
     const expectedUrl = `${expectedPath}?highlight=${highlight.id}`;
-    
+
     // Check if we're already on the transcript page
     if (pathname === expectedPath) {
       // We're on transcript page, just add/update the highlight parameter
@@ -347,53 +341,50 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
   }, [pathname, editingHighlight, setIsPlaying]);
 
   // Check if editing should be disabled (e.g., during save operations)
-  // This prevents users from making changes while operations like saving are in progress
   const isEditingDisabled = isSaving;
 
-  // Update highlight utterances during editing - called when adding/removing utterances
+  // Update highlight utterances during editing
   const updateHighlightUtterances = useCallback((utteranceId: string, action: 'add' | 'remove', modifiers?: { shift: boolean }) => {
     if (!editingHighlight || isEditingDisabled) return;
-    
-    // Determine the effective action:
-    // - If Shift is pressed and we have an anchor, use the anchor's action
-    // - Otherwise, use the action passed in (and set it as the new anchor action)
-    const effectiveAction = (modifiers?.shift && lastClickedUtteranceId && lastClickedAction) 
-      ? lastClickedAction 
+
+    // Determine the effective action
+    const effectiveAction = (modifiers?.shift && lastClickedUtteranceId && lastClickedAction)
+      ? lastClickedAction
       : action;
-    
+
     // Determine which utterances to operate on
     let utteranceIds: string[];
     if (modifiers?.shift && lastClickedUtteranceId) {
-      // Range operation with Shift modifier - use the anchor action for the entire range
+      // Range operation with Shift modifier
+      const allUtterances = transcriptRef.current.flatMap(segment => segment.utterances);
       utteranceIds = calculateUtteranceRange(allUtterances, lastClickedUtteranceId, utteranceId);
     } else {
-      // Single operation - this becomes the new anchor
+      // Single operation
       utteranceIds = [utteranceId];
       setLastClickedUtteranceId(utteranceId);
       setLastClickedAction(action);
     }
-    
+
     if (effectiveAction === 'remove') {
-      // Remove utterances from highlight
       const updatedHighlight = {
         ...editingHighlight,
         highlightedUtterances: editingHighlight.highlightedUtterances.filter(
           hu => !utteranceIds.includes(hu.utteranceId)
         )
       };
-      
+
       setEditingHighlight(updatedHighlight);
       setIsDirty(true);
     } else {
       // Add utterances to highlight
-      // Filter out already highlighted utterances and create new highlighted utterance objects
+      const utteranceMap = buildUtteranceMap();
       const now = new Date();
       const newHighlightedUtterances = utteranceIds
         .filter(id => !editingHighlight.highlightedUtterances.some(hu => hu.utteranceId === id))
         .map(id => {
           const utterance = utteranceMap.get(id);
           if (!utterance) return null;
-          
+
           return {
             id: `temp-${Date.now()}-${Math.random()}`,
             utteranceId: id,
@@ -404,8 +395,7 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
           };
         })
         .filter((hu): hu is NonNullable<typeof hu> => hu !== null);
-      
-      // Only update if we have new utterances to add
+
       if (newHighlightedUtterances.length > 0) {
         const updatedHighlight = {
           ...editingHighlight,
@@ -419,18 +409,16 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
         setIsDirty(true);
       }
     }
-  }, [editingHighlight, utteranceMap, isEditingDisabled, setEditingHighlight, setIsDirty, lastClickedUtteranceId, lastClickedAction, allUtterances]);
+  }, [editingHighlight, buildUtteranceMap, isEditingDisabled, lastClickedUtteranceId, lastClickedAction]);
 
-  // Reset to original state - discard all changes
-  const resetToOriginal = () => {
+  const resetToOriginal = useCallback(() => {
     if (originalHighlight) {
       setEditingHighlight(originalHighlight);
       setIsDirty(false);
-      // Clear range selection anchor
       setLastClickedUtteranceId(null);
       setLastClickedAction(null);
     }
-  };
+  }, [originalHighlight]);
 
   // Exit edit mode - navigate away; state cleanup happens in the pathname effect above
   const exitEditMode = useCallback(() => {
@@ -457,17 +445,15 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
       return { success: false, error: 'No highlight to save' };
     }
 
-    // Check if we have changes to save (either dirty state or explicit updates)
     const hasChanges = isDirty || (options?.name !== undefined) || (options?.subjectId !== undefined);
-    
+
     if (!hasChanges) {
       return { success: false, error: 'No changes to save' };
     }
 
     try {
       setIsSaving(true);
-      
-      // Prepare the update data
+
       const updateData = {
         name: options?.name ?? editingHighlight.name,
         meetingId: editingHighlight.meetingId,
@@ -481,25 +467,22 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(updateData)
       });
-      
+
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
         throw new Error(err?.error || 'Failed to save');
       }
-      
-      // Always get the full updated highlight from the API response
+
       const updatedHighlight = await res.json();
-      
-      // Update the editing highlight with the full data from the server
+
       setEditingHighlight(updatedHighlight);
       setOriginalHighlight(updatedHighlight);
-      
-      // Update the highlight in the meeting data context with the full server data
+
       updateHighlight(editingHighlight.id, updatedHighlight);
-      
+
       setIsDirty(false);
       options?.onSuccess?.();
-      
+
       return { success: true };
     } catch (error) {
       console.error('Failed to save highlight:', error);
@@ -517,12 +500,12 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     onError?: (error: Error) => void;
   }) => {
     const { preSelectedUtteranceId, onSuccess, onError } = options;
-    
+
     try {
       setIsCreating(true);
-      
+
       const utteranceIds = preSelectedUtteranceId ? [preSelectedUtteranceId] : [];
-      
+
       const res = await fetch('/api/highlights', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -532,29 +515,24 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
           utteranceIds
         })
       });
-      
+
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
         throw new Error(err?.error || 'Failed to create highlight');
       }
-      
-      // Get the full highlight data from the API response
+
       const highlight = await res.json();
-      
-      // Update the meeting data context with the complete highlight data from the server
+
       addHighlight(highlight);
-      
-      // Immediately enter editing mode with the full server data
       enterEditMode(highlight);
 
-      // Set the anchor for shift-click range selection to the pre-selected utterance
       if (preSelectedUtteranceId) {
         setLastClickedUtteranceId(preSelectedUtteranceId);
         setLastClickedAction('add');
       }
 
       onSuccess?.(highlight);
-      
+
       return { success: true };
     } catch (error) {
       console.error('Failed to create highlight:', error);
@@ -565,7 +543,8 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     }
   }, [meeting, addHighlight, enterEditMode]);
 
-  const value = {
+  // Memoize value — changes on highlight-specific state, NOT on transcript edits.
+  const value = useMemo(() => ({
     editingHighlight,
     previewMode,
     isPreviewDialogOpen,
@@ -573,7 +552,6 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     highlightUtterances,
     currentHighlightIndex,
     totalHighlights,
-    utteranceMap,
     hasUnsavedChanges: isDirty,
     isSaving,
     isCreating,
@@ -592,7 +570,16 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     calculateHighlightData,
     saveHighlight,
     createHighlight,
-  };
+  }), [
+    editingHighlight, previewMode, isPreviewDialogOpen,
+    statistics, highlightUtterances, currentHighlightIndex, totalHighlights,
+    isDirty, isSaving, isCreating, isEditingDisabled,
+    enterEditMode, updateHighlightUtterances, exitEditMode,
+    exitEditModeAndRedirectToHighlight, calculateHighlightData,
+    saveHighlight, createHighlight, resetToOriginal,
+    goToPreviousHighlight, goToNextHighlight, goToHighlightIndex,
+    togglePreviewMode, openPreviewDialog, closePreviewDialog,
+  ]);
 
   return (
     <HighlightContext.Provider value={value}>
@@ -607,4 +594,4 @@ export function useHighlight() {
     throw new Error('useHighlight must be used within a HighlightProvider');
   }
   return context;
-} 
+}

--- a/src/components/meetings/KeyboardShortcuts.tsx
+++ b/src/components/meetings/KeyboardShortcuts.tsx
@@ -2,14 +2,14 @@
 
 import { useVideo, useVideoActions } from './VideoProvider';
 import { useTranscriptOptions } from './options/OptionsContext';
-import { useCouncilMeetingData } from './CouncilMeetingDataContext';
+import { useCouncilMeetingTranscript } from './CouncilMeetingDataContext';
 import { useKeyboardShortcut, ACTIONS } from '@/contexts/KeyboardShortcutsContext';
 
 export function KeyboardShortcuts() {
     const { seekTo, handleSpeedChange, togglePlayPause } = useVideo();
     const { currentTimeRef } = useVideoActions();
     const { options, updateOptions } = useTranscriptOptions();
-    const { transcript } = useCouncilMeetingData();
+    const { transcript } = useCouncilMeetingTranscript();
 
     // Play / Pause
     useKeyboardShortcut(ACTIONS.PLAY_PAUSE.id, () => {

--- a/src/components/meetings/Subjects.tsx
+++ b/src/components/meetings/Subjects.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { SubjectWithRelations } from "@/lib/db/subject";
-import { useCouncilMeetingData } from "./CouncilMeetingDataContext";
+import { useCouncilMeetingData, useCouncilMeetingTranscript } from "./CouncilMeetingDataContext";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ChevronDown, ChevronUp } from "lucide-react";
@@ -17,7 +17,8 @@ import { formatTimestamp } from "@/lib/utils";
 type AllocationOption = 'onlyMention' | 'skip' | 1 | 2 | 3 | 5;
 
 export default function Subjects() {
-    const { subjects, getSpeakerTag, getPerson, getParty, getSpeakerSegmentById } = useCouncilMeetingData();
+    const { subjects, getSpeakerTag, getPerson, getParty } = useCouncilMeetingData();
+    const { getSpeakerSegmentById } = useCouncilMeetingTranscript();
     const [expandedSubjects, setExpandedSubjects] = useState<string[]>([]);
     const { seekTo } = useVideo();
     const { options } = useTranscriptOptions();

--- a/src/components/meetings/TranscriptControls.tsx
+++ b/src/components/meetings/TranscriptControls.tsx
@@ -3,14 +3,14 @@ import { Play, Pause, Loader, ChevronLeft, ChevronRight, Youtube } from "lucide-
 import { useTranslations } from 'next-intl';
 import { useVideo } from "./VideoProvider"
 import { cn, formatTimestamp } from "@/lib/utils";
-import { useCouncilMeetingData } from "./CouncilMeetingDataContext";
+import { useCouncilMeetingData, useCouncilMeetingTranscript } from "./CouncilMeetingDataContext";
 import { useTranscriptOptions } from "./options/OptionsContext";
 import { useHighlight } from "./HighlightContext";
 import { useState, useRef, useEffect, useCallback } from "react";
 import { Video } from "./Video";
 
 export default function TranscriptControls({ className }: { className?: string }) {
-    const { transcript: speakerSegments } = useCouncilMeetingData();
+    const { transcript: speakerSegments } = useCouncilMeetingTranscript();
     const { isPlaying, togglePlayPause, currentTime, duration, seekTo, isSeeking, currentScrollInterval } = useVideo();
     const { options } = useTranscriptOptions();
     const { editingHighlight, highlightUtterances, previewMode, currentHighlightIndex, goToPreviousHighlight, goToNextHighlight, isPreviewDialogOpen } = useHighlight();

--- a/src/components/meetings/admin/Admin.tsx
+++ b/src/components/meetings/admin/Admin.tsx
@@ -14,7 +14,7 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import PodcastSpecs from './PodcastSpecs';
 import { toggleMeetingRelease } from '@/lib/db/meetings';
-import { useCouncilMeetingData } from '../CouncilMeetingDataContext';
+import { useCouncilMeetingData, useCouncilMeetingTranscript } from '../CouncilMeetingDataContext';
 import { requestProcessAgenda } from '@/lib/tasks/processAgenda';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import AddMeetingForm from '@/components/meetings/AddMeetingForm';
@@ -31,7 +31,8 @@ export default function AdminActions({
     }) {
     const { toast } = useToast();
     const t = useTranslations('admin.adminActions');
-    const { meeting, transcript, people, city, subjects } = useCouncilMeetingData();
+    const { transcript } = useCouncilMeetingTranscript();
+    const { meeting, people, city, subjects } = useCouncilMeetingData();
     const [isTranscribing, setIsTranscribing] = React.useState(false);
     const [isSummarizing, setIsSummarizing] = React.useState(false);
     const [isProcessingAgenda, setIsProcessingAgenda] = React.useState(false);

--- a/src/components/meetings/admin/PodcastSpecs.tsx
+++ b/src/components/meetings/admin/PodcastSpecs.tsx
@@ -3,14 +3,15 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { PersonBadge } from "@/components/persons/PersonBadge";
-import { useCouncilMeetingData } from "../CouncilMeetingDataContext";
+import { useCouncilMeetingData, useCouncilMeetingTranscript } from "../CouncilMeetingDataContext";
 import { getPodcastSpecsForMeeting, PodcastSpecWithRelations } from "@/lib/db/podcasts";
 import { requestSplitMediaFileForPodcast } from "@/lib/tasks/splitMediaFile";
 import { useToast } from '@/hooks/use-toast';
 import { getPartyFromRoles } from "@/lib/utils";
 
 export default function PodcastSpecs() {
-    const { meeting, getSpeakerTag, getPerson, getParty, getSpeakerSegmentById } = useCouncilMeetingData();
+    const { meeting, getSpeakerTag, getPerson, getParty } = useCouncilMeetingData();
+    const { getSpeakerSegmentById } = useCouncilMeetingTranscript();
     const [podcastSpecs, setPodcastSpecs] = useState<PodcastSpecWithRelations[]>([]);
     const [expandedSpecs, setExpandedSpecs] = useState<string[]>([]);
     const [isGeneratingAudio, setIsGeneratingAudio] = useState<{ [key: string]: boolean }>({});

--- a/src/components/meetings/options/OptionsContext.tsx
+++ b/src/components/meetings/options/OptionsContext.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
 import { SpeakerTag } from '@prisma/client';
 
 export interface TranscriptOptions {
@@ -34,9 +34,9 @@ const defaultOptions: TranscriptOptions = {
 function useTranscriptOptionsProvider(initialOptions: TranscriptOptions) {
     const [options, setOptions] = useState<TranscriptOptions>(initialOptions);
 
-    const updateOptions = (newOptions: Partial<TranscriptOptions>) => {
+    const updateOptions = useCallback((newOptions: Partial<TranscriptOptions>) => {
         setOptions(prev => ({ ...prev, ...newOptions }));
-    };
+    }, []);
 
     return { options, updateOptions };
 }
@@ -45,7 +45,7 @@ export function TranscriptOptionsProvider({ children, editable, canCreateHighlig
     const { options, updateOptions } = useTranscriptOptionsProvider({ ...defaultOptions, editsAllowed: editable, canCreateHighlights });
 
     return (
-        <TranscriptOptionsContext.Provider value={{ options, updateOptions }}>
+        <TranscriptOptionsContext.Provider value={useMemo(() => ({ options, updateOptions }), [options, updateOptions])}>
             {children}
         </TranscriptOptionsContext.Provider>
     );

--- a/src/components/meetings/subject/VotingSection.tsx
+++ b/src/components/meetings/subject/VotingSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
-import { useCouncilMeetingData } from '../CouncilMeetingDataContext';
+import { useCouncilMeetingData, useCouncilMeetingTranscript } from '../CouncilMeetingDataContext';
 import { UtteranceMiniTranscript } from './UtteranceMiniTranscript';
 
 interface VotingUtterance {
@@ -38,7 +38,8 @@ interface VotingSectionProps {
 export function VotingSection({ subjectId }: VotingSectionProps) {
     const [votingUtterances, setVotingUtterances] = useState<VotingUtterance[] | null>(null);
     const [loading, setLoading] = useState(true);
-    const { meeting, getSpeakerSegmentById } = useCouncilMeetingData();
+    const { meeting } = useCouncilMeetingData();
+    const { getSpeakerSegmentById } = useCouncilMeetingTranscript();
     const t = useTranslations('Subject');
 
     useEffect(() => {

--- a/src/components/meetings/transcript/SpeakerSegment.tsx
+++ b/src/components/meetings/transcript/SpeakerSegment.tsx
@@ -168,11 +168,12 @@ const AddUtteranceButton = ({ segmentId }: { segmentId: string }) => {
     );
 };
 
-const SpeakerSegment = React.memo(({ segment, isFirstSegment }: {
+const SpeakerSegment = React.memo(({ segment, isFirstSegment, segmentCount }: {
     segment: TranscriptType[number],
-    isFirstSegment?: boolean
+    isFirstSegment?: boolean,
+    segmentCount: number
 }) => {
-    const { getPerson, getSpeakerTag, getSpeakerSegmentCount, people, speakerTags, updateSpeakerTagPerson, updateSpeakerTagLabel, deleteEmptySegment } = useCouncilMeetingData();
+    const { getPerson, getSpeakerTag, people, speakerTags, updateSpeakerTagPerson, updateSpeakerTagLabel, deleteEmptySegment } = useCouncilMeetingData();
     const { options } = useTranscriptOptions();
     const { data: session } = useSession();
     const { toast } = useToast();
@@ -227,9 +228,8 @@ const SpeakerSegment = React.memo(({ segment, isFirstSegment }: {
         const party = person ? getPartyFromRoles(person.roles) : null;
         const borderColor = party?.colorHex || '#D3D3D3';
 
-        const segmentCount = speakerTag ? getSpeakerSegmentCount(speakerTag.id) : 0;
         return { speakerTag, person, party, borderColor, segmentCount };
-    }, [segment.speakerTagId, getPerson, getSpeakerTag, getSpeakerSegmentCount]);
+    }, [segment.speakerTagId, segmentCount, getPerson, getSpeakerTag]);
 
     const utterances = segment.utterances;
     if (!utterances) {

--- a/src/components/meetings/transcript/SpeakersOverviewSheet.tsx
+++ b/src/components/meetings/transcript/SpeakersOverviewSheet.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { useCouncilMeetingData } from '../CouncilMeetingDataContext';
+import { useCouncilMeetingData, useCouncilMeetingTranscript } from '../CouncilMeetingDataContext';
 import { useVideo } from '../VideoProvider';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
@@ -30,7 +30,8 @@ interface SpeakerStat {
 }
 
 function SpeakerStatsContent() {
-    const { transcript, getSpeakerTag, getPerson } = useCouncilMeetingData();
+    const { transcript } = useCouncilMeetingTranscript();
+    const { getSpeakerTag, getPerson } = useCouncilMeetingData();
     const { seekTo } = useVideo();
     const t = useTranslations('editing');
     const [expandedSpeakerId, setExpandedSpeakerId] = useState<string | null>(null);

--- a/src/components/meetings/transcript/Transcript.tsx
+++ b/src/components/meetings/transcript/Transcript.tsx
@@ -3,7 +3,7 @@ import SpeakerSegment from "./SpeakerSegment";
 import { useEffect, useRef, useMemo, useState } from 'react';
 import { useVideo } from "../VideoProvider";
 import { debounce, joinTranscriptSegments } from '@/lib/utils';
-import { useCouncilMeetingData } from "../CouncilMeetingDataContext";
+import { useCouncilMeetingData, useCouncilMeetingTranscript } from "../CouncilMeetingDataContext";
 import { Clock, ScrollText } from "lucide-react";
 import { useTranscriptOptions } from "../options/OptionsContext";
 import { useSearchParams } from "next/navigation";
@@ -27,7 +27,8 @@ const createSegmentId = (index: number): string => {
 };
 
 export default function Transcript() {
-    const { transcript: speakerSegments, getHighlight, taskStatus, transcriptHiddenForReview } = useCouncilMeetingData();
+    const { transcript: speakerSegments } = useCouncilMeetingTranscript();
+    const { getHighlight, taskStatus, transcriptHiddenForReview } = useCouncilMeetingData();
     const { options } = useTranscriptOptions();
     const tTranscript = useTranslations('transcript');
     const t = useTranslations('Common');
@@ -45,6 +46,18 @@ export default function Transcript() {
     const displayedSegments = useMemo(() => {
         return options.editable ? speakerSegments : joinTranscriptSegments(speakerSegments);
     }, [speakerSegments, options.editable]);
+
+    // Compute segment counts per speaker tag for passing as primitive props.
+    // The count is a number, so React.memo compares by value — unchanged counts
+    // don't trigger SpeakerSegment re-renders even when transcript changes.
+    const speakerTagSegmentCounts = useMemo(() => {
+        const counts = new Map<string, number>();
+        displayedSegments.forEach(segment => {
+            const count = counts.get(segment.speakerTag.id) || 0;
+            counts.set(segment.speakerTag.id, count + 1);
+        });
+        return counts;
+    }, [displayedSegments]);
 
     // Track scroll state for banner minimization via scroll container
     useEffect(() => {
@@ -175,6 +188,7 @@ export default function Transcript() {
                     <SpeakerSegment
                         segment={segment}
                         isFirstSegment={index === 0}
+                        segmentCount={speakerTagSegmentCounts.get(segment.speakerTag.id) || 0}
                     />
                 </div>
             ))}

--- a/src/components/meetings/transcript/Utterance.tsx
+++ b/src/components/meetings/transcript/Utterance.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Utterance } from "@prisma/client";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef, useCallback } from "react";
 import { useTranslations } from 'next-intl';
 import { useVideoActions } from "../VideoProvider";
 import { useTranscriptOptions } from "../options/OptionsContext";
@@ -39,7 +39,7 @@ const UtteranceC: React.FC<{
     
     const [isEditing, setIsEditing] = useState(false);
     const [localUtterance, setLocalUtterance] = useState(utterance);
-    const [editedText, setEditedText] = useState(utterance.text);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
     const [editedStartTime, setEditedStartTime] = useState(utterance.startTimestamp);
     const [editedEndTime, setEditedEndTime] = useState(utterance.endTimestamp);
     const [pendingShareAction, setPendingShareAction] = useState<number | null>(null);
@@ -57,7 +57,6 @@ const UtteranceC: React.FC<{
     // Update local state when prop changes
     useEffect(() => {
         setLocalUtterance(utterance);
-        setEditedText(utterance.text);
         setEditedStartTime(utterance.startTimestamp);
         setEditedEndTime(utterance.endTimestamp);
     }, [utterance]);
@@ -116,10 +115,11 @@ const UtteranceC: React.FC<{
 
     const handleEdit = async (e: React.FormEvent | React.MouseEvent) => {
         e.preventDefault();
+        const editedText = textareaRef.current?.value ?? localUtterance.text;
         const originalText = localUtterance.text;
         const originalStart = localUtterance.startTimestamp;
         const originalEnd = localUtterance.endTimestamp;
-        
+
         // Check what changed
         const textChanged = editedText !== originalText;
         const timestampsChanged = editedStartTime !== originalStart || editedEndTime !== originalEnd;
@@ -131,28 +131,28 @@ const UtteranceC: React.FC<{
         }
 
         // Optimistic update - immediate
-        setLocalUtterance({ 
-            ...localUtterance, 
+        setLocalUtterance({
+            ...localUtterance,
             text: editedText,
             startTimestamp: editedStartTime,
             endTimestamp: editedEndTime
         });
         setIsEditing(false);
-        
+
         // Background save
         try {
             // Update text first
             const updatedUtterance = await editUtterance(localUtterance.id, editedText);
-            
+
             // Then update timestamps if they changed
             if (timestampsChanged) {
                 const { utterance: finalUtterance } = await updateUtteranceTimestamps(
-                    localUtterance.id, 
-                    editedStartTime, 
+                    localUtterance.id,
+                    editedStartTime,
                     editedEndTime
                 );
                 setLocalUtterance(finalUtterance);
-                
+
                 // Update everything in context in one call
                 // This will automatically recalculate and update segment timestamps
                 updateUtterance(localUtterance.speakerSegmentId, localUtterance.id, {
@@ -161,28 +161,27 @@ const UtteranceC: React.FC<{
                     endTimestamp: editedEndTime,
                     lastModifiedBy: finalUtterance.lastModifiedBy
                 });
-                
+
                 // Call onUpdate if provided (for future extensibility)
                 onUpdate?.(finalUtterance);
             } else {
                 setLocalUtterance(updatedUtterance);
-                
+
                 // Update just the text in context
                 updateUtterance(localUtterance.speakerSegmentId, localUtterance.id, { text: editedText, lastModifiedBy: updatedUtterance.lastModifiedBy });
-                
+
                 // Call onUpdate if provided (for future extensibility)
                 onUpdate?.(updatedUtterance);
             }
         } catch (error) {
             console.error('Failed to edit utterance:', error);
             // Silent revert
-            setLocalUtterance({ 
-                ...localUtterance, 
+            setLocalUtterance({
+                ...localUtterance,
                 text: originalText,
                 startTimestamp: originalStart,
                 endTimestamp: originalEnd
             });
-            setEditedText(originalText);
             setEditedStartTime(originalStart);
             setEditedEndTime(originalEnd);
             toast({
@@ -195,7 +194,6 @@ const UtteranceC: React.FC<{
 
     const handleCancel = () => {
         setIsEditing(false);
-        setEditedText(localUtterance.text);
         setEditedStartTime(localUtterance.startTimestamp);
         setEditedEndTime(localUtterance.endTimestamp);
     };
@@ -305,6 +303,25 @@ const UtteranceC: React.FC<{
         }
     };
 
+    const handleContextMenuOpenChange = useCallback((open: boolean) => {
+        if (open) {
+            if (!isSelected) {
+                toggleSelection(localUtterance.id, { shift: false, ctrl: false });
+            }
+            if (pendingShareAction) {
+                setPendingShareAction(null);
+            }
+        } else {
+            if (pendingShareAction) {
+                openShareDropdownAndCopy(pendingShareAction);
+                setPendingShareAction(null);
+            }
+            if (selectedUtteranceIds.size === 1) {
+                clearSelection();
+            }
+        }
+    }, [isSelected, toggleSelection, localUtterance.id, pendingShareAction, openShareDropdownAndCopy, selectedUtteranceIds.size, clearSelection]);
+
     if (localUtterance.drift > options.maxUtteranceDrift) {
         return <span id={localUtterance.id} className="hover:bg-accent utterance transcript-text" />;
     }
@@ -315,10 +332,10 @@ const UtteranceC: React.FC<{
                 {/* Text Editor */}
                 <form onSubmit={handleEdit} className="relative">
                     <textarea
+                        ref={textareaRef}
                         spellCheck={true}
                         lang="el"
-                        value={editedText}
-                        onChange={(e) => setEditedText(e.target.value)}
+                        defaultValue={localUtterance.text}
                         onKeyDown={(e) => {
                             if (e.key === 'Enter' && !e.shiftKey) {
                                 e.preventDefault();
@@ -345,7 +362,7 @@ const UtteranceC: React.FC<{
                         }}
                         className="w-full resize-none border border-gray-300 rounded px-2 py-1 pr-16 text-sm min-h-[2.5em] transcript-text"
                         autoFocus
-                        rows={Math.max(1, editedText.split('\n').length)}
+                        rows={Math.max(1, localUtterance.text.split('\n').length)}
                         style={{
                             height: 'auto',
                             overflow: 'hidden'
@@ -488,31 +505,7 @@ const UtteranceC: React.FC<{
     }
 
     return (
-        <ContextMenu onOpenChange={(open) => {
-            if (open) {
-                // Context menu opened - select this utterance if not already selected
-                // This provides visual feedback for what will be operated on
-                if (!isSelected) {
-                    toggleSelection(localUtterance.id, { shift: false, ctrl: false });
-                }
-                // Clear any stale pending share action
-                if (pendingShareAction) {
-                    setPendingShareAction(null);
-                }
-            } else {
-                // Context menu closed
-                if (pendingShareAction) {
-                    // Execute pending share action first
-                    openShareDropdownAndCopy(pendingShareAction);
-                    setPendingShareAction(null);
-                }
-                // Only clear selection if there's just one selected (the temporary right-click selection)
-                // If multiple utterances are selected, preserve the user's deliberate selection
-                if (selectedUtteranceIds.size === 1) {
-                    clearSelection();
-                }
-            }
-        }}>
+        <ContextMenu onOpenChange={handleContextMenuOpenChange}>
             <ContextMenuTrigger>
                 <span className={cn(className, emptyUtteranceClass)} id={localUtterance.id} onClick={handleClick}>
                     {displayText}

--- a/src/contexts/KeyboardShortcutsContext.tsx
+++ b/src/contexts/KeyboardShortcutsContext.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { createContext, useContext, ReactNode, useCallback, useEffect } from 'react';
+import React, { createContext, useContext, ReactNode, useCallback, useEffect, useMemo } from 'react';
 
 export type KeyboardActionHandler = () => void;
 
@@ -133,8 +133,12 @@ export function KeyboardShortcutsProvider({ children }: { children: ReactNode })
         return () => window.removeEventListener('keydown', handleKeyDown);
     }, []);
 
+    const value = useMemo(() => ({
+        registerShortcut, unregisterShortcut, getShortcutLabel
+    }), [registerShortcut, unregisterShortcut, getShortcutLabel]);
+
     return (
-        <KeyboardShortcutsContext.Provider value={{ registerShortcut, unregisterShortcut, getShortcutLabel }}>
+        <KeyboardShortcutsContext.Provider value={value}>
             {children}
         </KeyboardShortcutsContext.Provider>
     );

--- a/src/contexts/ShareContext.tsx
+++ b/src/contexts/ShareContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useContext, useState, useCallback } from 'react';
+import React, { createContext, useContext, useState, useCallback, useMemo } from 'react';
 
 interface ShareContextValue {
     isOpen: boolean;
@@ -41,7 +41,7 @@ export function ShareProvider({ children }: { children: React.ReactNode }) {
         setShouldTriggerCopy(false);
     }, []);
 
-    const value: ShareContextValue = {
+    const value = useMemo(() => ({
         isOpen,
         targetTimestamp,
         shouldTriggerCopy,
@@ -49,7 +49,7 @@ export function ShareProvider({ children }: { children: React.ReactNode }) {
         openShareDropdownAndCopy,
         closeShareDropdown,
         resetCopyTrigger
-    };
+    }), [isOpen, targetTimestamp, shouldTriggerCopy, openShareDropdown, openShareDropdownAndCopy, closeShareDropdown, resetCopyTrigger]);
 
     return (
         <ShareContext.Provider value={value}>

--- a/src/hooks/useUtteranceData.ts
+++ b/src/hooks/useUtteranceData.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import { useCouncilMeetingData } from "@/components/meetings/CouncilMeetingDataContext";
+import { useCouncilMeetingTranscript } from "@/components/meetings/CouncilMeetingDataContext";
 import { Transcript } from "@/lib/db/transcript";
 import { Utterance } from "@prisma/client";
 
@@ -17,7 +17,7 @@ export interface UtteranceLookupResult {
  * Returns null if the utterance is not found.
  */
 export function useUtteranceData(utteranceId: string | null): UtteranceLookupResult | null {
-    const { transcript } = useCouncilMeetingData();
+    const { transcript } = useCouncilMeetingTranscript();
 
     return useMemo(() => {
         if (!utteranceId) return null;


### PR DESCRIPTION
## Summary

- Split `CouncilMeetingDataContext` into a stable main context (functions, lookups, rarely-changing state) and a volatile transcript context (transcript data)
- Stabilize `EditingContext` and `HighlightContext` values during transcript edits using internal refs for lazy transcript access
- Migrate all transcript consumers to `useCouncilMeetingTranscript()`

## Problem

After #289 (scrolling fix), reviewers reported lag in the editing interface — clicking utterances, typing corrections, and adding speakers all felt sluggish. The root cause: every utterance edit called `setTranscript()`, which invalidated the monolithic context value, re-rendering every SpeakerSegment and Utterance (~50-100 segments, hundreds of utterances). The old `renderMock` system had masked this by rendering off-screen segments as lightweight text-only elements.

## Approach

The main context's `useMemo` deps no longer include `transcript` or transcript-derived values. Editing an utterance now only re-renders `Transcript.tsx` + the one affected `SpeakerSegment` + the one affected `Utterance`.

## Test plan

- [ ] Open a large transcript in editing mode — verify lag is gone
- [ ] Edit utterance text and timestamps
- [ ] Move utterances between segments  
- [ ] Create/delete segments, change speaker person/label
- [ ] Shift-click range selection
- [ ] Highlight creation and editing
- [ ] Deep link with `?t=` parameter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core meeting/transcript React contexts and many consumers; behavior should be equivalent but there’s moderate risk of stale data or missed re-renders in editing/highlight flows due to the new memoization/ref patterns.
> 
> **Overview**
> **Fixes transcript editing lag** by splitting `CouncilMeetingDataContext` into a *stable* main context (meeting data, speaker tags/highlights, and mutation/lookup APIs) and a *volatile* `CouncilMeetingTranscriptContext` that only holds `transcript` and `getSpeakerSegmentById`.
> 
> Updates transcript-heavy consumers (`Transcript`, `TranscriptControls`, `KeyboardShortcuts`, `EditingContext`, `HighlightContext`, admin/subject views, etc.) to read transcript data via `useCouncilMeetingTranscript()`, and rewrites `EditingContext`/`HighlightContext` to use `useRef`-backed access so their callbacks/context values don’t change on every utterance edit.
> 
> Moves per-speaker segment count computation into `Transcript.tsx` and passes `segmentCount` as a primitive prop to `SpeakerSegment` to improve `React.memo` effectiveness, plus small related stabilizations (memoized provider values in `OptionsContext`, `KeyboardShortcutsContext`, and `ShareContext`, and an updated `Utterance` editor using a textarea ref and memoized context-menu open/close handler).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09007d351de13b09fd8323f1d9e2d0f41c8ba934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves transcript-editing lag by splitting `CouncilMeetingDataContext` into a stable main context (mutations, lookups) and a volatile `CouncilMeetingTranscriptContext`, then stabilising `EditingContext` and `HighlightContext` callbacks via internal `transcriptRef` refs, and finally switching `Utterance`'s textarea to uncontrolled to eliminate per-keystroke re-renders.

- `deleteEmptySegmentFn` calls `setSpeakerTags` as a side effect *inside* the `setTranscript` functional updater — impure updaters can be called multiple times in StrictMode/concurrent React, scheduling extra `speakerTags` state updates and triggering unnecessary `SpeakerSegment` re-renders; `extractSpeakerSegmentFn` already shows the correct pattern (separate sibling `setState` calls).
- Segment wrappers in `Transcript.tsx` use array index as React key, which causes `SpeakerSegment` local state (`isCollapsed`, `metadataDialogOpen`) to carry over to a different segment after any insert/delete/reorder operation.

<h3>Confidence Score: 4/5</h3>

Safe to merge with minor fixes — the two P2 findings are quality issues that won't cause data loss or runtime errors in production.

The overall approach is sound and well-executed. The two findings are P2: the impure updater in deleteEmptySegmentFn is a React anti-pattern that only has visible effects in development (StrictMode extra renders), and the index-key issue causes local UI state bleed on segment mutations (cosmetic). Neither is a data-corruption or crash bug. The PR solves a real performance problem cleanly.

src/components/meetings/CouncilMeetingDataContext.tsx (deleteEmptySegmentFn side-effect), src/components/meetings/transcript/Transcript.tsx (segment key strategy)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/meetings/CouncilMeetingDataContext.tsx | Core of the PR: splits a monolithic context into stable main + volatile transcript contexts; all mutations correctly use functional setTranscript(prev => ...); one anti-pattern where setSpeakerTags is called as a side effect inside a setTranscript updater in deleteEmptySegmentFn. |
| src/components/meetings/EditingContext.tsx | Correctly stabilised using a transcriptRef pattern; callbacks close over the ref instead of the live transcript state; useMemo value only invalidates on user actions (selection, processing). |
| src/components/meetings/HighlightContext.tsx | Migrated to use transcriptRef for stable callbacks; some useCallback functions (goToPreviousHighlight, goToNextHighlight, etc.) still capture highlightUtterances in deps and change whenever editing-highlight state changes — acceptable since those are highlight-specific state changes, not transcript edits. |
| src/components/meetings/transcript/Transcript.tsx | Migrated to transcript context; speakerTagSegmentCounts properly passes primitive segmentCount to SpeakerSegment; IntersectionObserver correctly depends on displayedSegments; wrapper div uses array-index as React key which can bleed local SpeakerSegment state during segment mutations. |
| src/components/meetings/transcript/Utterance.tsx | Switched from controlled textarea to uncontrolled (defaultValue + ref) to eliminate per-keystroke re-renders; handleContextMenuOpenChange wrapped in useCallback; edit flow reads text via textareaRef.current?.value correctly. |
| src/components/meetings/transcript/SpeakerSegment.tsx | Now receives segmentCount as a primitive prop (replaces context lookup); memoizedData correctly deps on segment.speakerTagId and segmentCount; local state for collapse/dialog is correct. |
| src/hooks/useUtteranceData.ts | New hook wrapping transcript context for utterance lookups; subscribes to volatile transcript context and is only used by UtteranceReferenceLink, which is appropriate. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as Utterance (uncontrolled)
    participant TC as CouncilMeetingTranscriptContext
    participant MC as CouncilMeetingDataContext (stable)
    participant EC as EditingContext
    participant HC as HighlightContext
    participant SS as SpeakerSegment
    participant T as Transcript

    Note over U: User types (no React state update)
    U->>U: textareaRef captures value
    U->>U: handleEdit on Enter/click
    U->>MC: updateUtterance(segId, uttId, updates)
    MC->>MC: setTranscript(prev => ...)
    MC->>TC: transcriptValue updates
    TC->>T: re-render (displayedSegments changes)
    T->>SS: new segment prop (only affected segment)
    SS->>U: new utterance prop
    Note over EC,HC: transcriptRef.current updated (no re-render cascade)
    TC-->>EC: re-render (cheap, 1 component)
    TC-->>HC: re-render (cheap, 1 component)
    EC->>EC: transcriptRef.current = transcript
    HC->>HC: transcriptRef.current = transcript
    Note over MC: Main context unchanged - no cascade to all consumers
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/components/meetings/CouncilMeetingDataContext.tsx
Line: 216-231

Comment:
**Side-effect inside functional state updater**

`setSpeakerTags` is called inside the `setTranscript` functional updater, making the updater impure. React's documentation explicitly requires that state updater functions be pure (no side effects). In React 18 StrictMode, updaters are intentionally invoked twice, scheduling `setSpeakerTags` twice and causing unnecessary re-renders of all `SpeakerSegment` components (which depend on `speakerTags` via `nextUnknownLabel`) — counterproductive for a PR focused on minimizing renders.

`extractSpeakerSegmentFn` (line 249) already does this correctly, calling `setTranscript(...)` and `setSpeakerTags(...)` as separate sibling statements that React 18 will batch automatically.

The simplest fix is to mirror `extractSpeakerSegmentFn`: call `setTranscript` first, then call `setSpeakerTags` after — React 18 will batch the two `setState` calls from the same synchronous frame.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/components/meetings/transcript/Transcript.tsx
Line: 181-194

Comment:
**Array-index key causes local state bleed across segments**

Using array index as React key means `SpeakerSegment`'s local state (`isCollapsed`, `userHasInteracted`, `metadataDialogOpen`) persists on the wrong component after segments are inserted, deleted, or reordered — for example, after `createEmptySegmentBefore` or `moveUtterancesToPrevious`. A segment that was collapsed at index 5 will remain collapsed after another segment is inserted before it, because React reuses the component at that position with the new `segment` prop.

Using `segment.id` as the map key would let React properly unmount/remount components when segment identity changes. The `id` attribute on the wrapper `<div>` (used by the IntersectionObserver) can stay index-based independently.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: eliminate typing lag with uncontrol..."](https://github.com/schemalabz/opencouncil/commit/09007d351de13b09fd8323f1d9e2d0f41c8ba934) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28471661)</sub>

<!-- /greptile_comment -->