### PR TITLE
feat: add PROCEDURAL_VOTE discussion status and subject withdrawal

### DIFF
--- a/prisma/migrations/20260416000003_add_procedural_vote_and_withdrawn/migration.sql
+++ b/prisma/migrations/20260416000003_add_procedural_vote_and_withdrawn/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+ALTER TYPE "DiscussionStatus" ADD VALUE 'PROCEDURAL_VOTE';
+
+-- AlterTable
+ALTER TABLE "Subject" ADD COLUMN "withdrawn" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -340,6 +340,7 @@ model Utterance {
 enum DiscussionStatus {
   ATTENDANCE
   SUBJECT_DISCUSSION
+  PROCEDURAL_VOTE
   VOTE
   OTHER
 }
@@ -423,6 +424,7 @@ model Subject {
 
   agendaItemIndex Int?
   nonAgendaReason NonAgendaReason?
+  withdrawn       Boolean          @default(false)
   topicId String?
   locationId String?
 

--- a/src/app/api/cities/[cityId]/meetings/[meetingId]/subjects/[subjectId]/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/[meetingId]/subjects/[subjectId]/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidatePath, revalidateTag } from 'next/cache';
+import { getCurrentUser } from '@/lib/auth';
+import prisma from '@/lib/db/prisma';
+import { handleApiError } from '@/lib/api/errors';
+import { z } from 'zod';
+
+const patchSchema = z.object({
+    nonAgendaReason: z.enum(['beforeAgenda', 'outOfAgenda']).nullable().optional(),
+    withdrawn: z.boolean().optional(),
+}).strict();
+
+export async function PATCH(
+    req: NextRequest,
+    { params }: { params: { cityId: string; meetingId: string; subjectId: string } }
+) {
+    try {
+        const user = await getCurrentUser();
+        if (!user?.isSuperAdmin) {
+            return NextResponse.json({ error: 'Superadmin access required' }, { status: 403 });
+        }
+
+        const body = await req.json();
+        const parsed = patchSchema.parse(body);
+
+        if (Object.keys(parsed).length === 0) {
+            return NextResponse.json({ error: 'No fields to update' }, { status: 400 });
+        }
+
+        const subject = await prisma.subject.findFirst({
+            where: {
+                id: params.subjectId,
+                cityId: params.cityId,
+                councilMeetingId: params.meetingId,
+            },
+        });
+
+        if (!subject) {
+            return NextResponse.json({ error: 'Subject not found' }, { status: 404 });
+        }
+
+        const updated = await prisma.subject.update({
+            where: { id: params.subjectId },
+            data: parsed,
+        });
+
+        revalidateTag(`city:${params.cityId}:meeting:${params.meetingId}`);
+        revalidatePath(`/${params.cityId}/${params.meetingId}`, 'layout');
+
+        return NextResponse.json({
+            id: updated.id,
+            nonAgendaReason: updated.nonAgendaReason,
+            withdrawn: updated.withdrawn,
+        });
+    } catch (error) {
+        return handleApiError(error, 'Failed to update subject');
+    }
+}

--- a/src/components/meetings/admin/DecisionsPanel.tsx
+++ b/src/components/meetings/admin/DecisionsPanel.tsx
@@ -16,6 +16,7 @@ import { DecisionWithSource, SubjectExtractedData } from '@/lib/db/decisions';
 import { LinkOrDrop } from '@/components/ui/link-or-drop';
 import { getPollingHistoryForMeeting, requestPollDecisions } from '@/lib/tasks/pollDecisions';
 import { calculateVoteResult } from '@/lib/utils/votes';
+import { getWithdrawnLabel } from '@/lib/utils/subjects';
 import ReactMarkdown from 'react-markdown';
 
 type FilterTab = 'all' | 'unlinked' | 'extracted';
@@ -297,7 +298,8 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
         .sort((a, b) => a.agendaItemIndex! - b.agendaItemIndex!);
     const outOfAgendaSubjects = subjects
         .filter(s => s.nonAgendaReason === 'outOfAgenda');
-    const eligibleSubjects = [...agendaSubjects, ...outOfAgendaSubjects];
+    const allDisplaySubjects = [...agendaSubjects, ...outOfAgendaSubjects];
+    const eligibleSubjects = allDisplaySubjects.filter(s => !s.withdrawn);
     const linkedCount = eligibleSubjects.filter(s => decisions[s.id]).length;
     const unlinkedSubjects = eligibleSubjects.filter(s => !decisions[s.id]);
     const extractedSubjects = eligibleSubjects.filter(s => {
@@ -310,7 +312,7 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
         ? unlinkedSubjects
         : filterTab === 'extracted'
             ? extractedSubjects
-            : eligibleSubjects;
+            : allDisplaySubjects;
 
     // Helper to get source info for a decision
     const getSourceInfo = (decision: DecisionWithSource) => {
@@ -438,7 +440,7 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
                                 : 'text-muted-foreground hover:text-foreground'
                         }`}
                     >
-                        {t('decisions.tabAll')} ({eligibleSubjects.length})
+                        {t('decisions.tabAll')} ({allDisplaySubjects.length})
                     </button>
                     <button
                         onClick={() => setFilterTab('unlinked')}
@@ -518,7 +520,7 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
                                                     <span className="w-4 shrink-0" />
                                                 )}
                                                 <div className="min-w-0">
-                                                    <div className="font-medium text-sm text-gray-900 break-words">
+                                                    <div className={`font-medium text-sm break-words ${subject.withdrawn ? 'text-muted-foreground' : 'text-gray-900'}`}>
                                                         {subject.agendaItemIndex != null && (
                                                             <span className="text-muted-foreground mr-1">#{subject.agendaItemIndex}</span>
                                                         )}
@@ -562,7 +564,11 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
                                             </div>
 
                                             <div className="flex items-center gap-2 shrink-0">
-                                                {decision ? (
+                                                {subject.withdrawn ? (
+                                                    <Badge variant="secondary" className="text-xs text-muted-foreground italic">
+                                                        {getWithdrawnLabel(subject)}
+                                                    </Badge>
+                                                ) : decision ? (
                                                     <>
                                                         {sourceInfo && (
                                                             <Tooltip>

--- a/src/components/meetings/admin/MinutesPreviewContent.tsx
+++ b/src/components/meetings/admin/MinutesPreviewContent.tsx
@@ -11,6 +11,7 @@ import {
     MinutesCouncilComposition,
     MinutesTranscriptEntry,
 } from '@/lib/minutes/types';
+import { getWithdrawnLabel } from '@/lib/utils/subjects';
 
 interface MinutesPreviewContentProps {
     data: MinutesData;
@@ -19,7 +20,9 @@ interface MinutesPreviewContentProps {
 export function MinutesPreviewContent({ data }: MinutesPreviewContentProps) {
     const meetingDate = new Date(data.meeting.dateTime);
 
-    const agendaSubjects = data.subjects.filter(s => s.nonAgendaReason !== 'outOfAgenda');
+    const agendaSubjects = data.subjects
+        .filter(s => s.nonAgendaReason !== 'outOfAgenda')
+        .sort((a, b) => (a.agendaItemIndex ?? 0) - (b.agendaItemIndex ?? 0));
     const outOfAgendaSubjects = data.subjects.filter(s => s.nonAgendaReason === 'outOfAgenda');
 
     return (
@@ -63,8 +66,8 @@ export function MinutesPreviewContent({ data }: MinutesPreviewContentProps) {
                 <TranscriptSection entries={data.preambleEntries} />
             )}
 
-            {/* All subjects in discussion order (linear, no section headings) */}
-            {data.subjects.map((subject) => (
+            {/* All subjects in discussion order (skip withdrawn — they appear in TOC only) */}
+            {data.subjects.filter(s => !s.withdrawn).map((subject) => (
                 <SubjectSection key={subject.subjectId} subject={subject} />
             ))}
 
@@ -156,17 +159,23 @@ function TOCTable({ subjects, useSequentialNumbers }: { subjects: MinutesSubject
             </thead>
             <tbody>
                 {subjects.map((subject, index) => (
-                    <tr key={subject.subjectId} className="border-b border-gray-200">
+                    <tr key={subject.subjectId} className={`border-b border-gray-200 ${subject.withdrawn ? 'text-gray-400 italic' : ''}`}>
                         <td className="py-1 pr-2 align-top">
                             {useSequentialNumbers ? index + 1 : subject.agendaItemIndex ?? ''}
                         </td>
                         <td className="py-1 pr-2">
-                            <a href={`#subject-${subject.subjectId}`} className="hover:underline text-blue-800">
-                                {subject.name}
-                            </a>
+                            {subject.withdrawn ? (
+                                <span>{subject.name}</span>
+                            ) : (
+                                <a href={`#subject-${subject.subjectId}`} className="hover:underline text-blue-800">
+                                    {subject.name}
+                                </a>
+                            )}
                         </td>
                         <td className="py-1 pr-2 text-gray-500">
-                            {subject.decision?.protocolNumber ?? ''}
+                            {subject.withdrawn
+                                ? getWithdrawnLabel(subject)
+                                : (subject.decision?.protocolNumber ?? '')}
                         </td>
                     </tr>
                 ))}

--- a/src/components/meetings/docx/MinutesDocx.ts
+++ b/src/components/meetings/docx/MinutesDocx.ts
@@ -8,6 +8,7 @@ import {
 import { formatTimestamp } from '@/lib/utils';
 import { formatGapDuration } from '@/lib/formatters/time';
 import { markdownToDocxParagraphs } from '@/lib/minutes/markdownToDocx';
+import { getWithdrawnLabel } from '@/lib/utils/subjects';
 import {
     MinutesData,
     MinutesSubject,
@@ -183,18 +184,24 @@ function createTOCTable(subjects: MinutesSubject[], useSequentialNumbers: boolea
 
     const dataRows = subjects.map((subject, index) => {
         const seqNum = useSequentialNumbers ? `${index + 1}` : `${subject.agendaItemIndex ?? ''}`;
+        const decisionText = subject.withdrawn
+            ? getWithdrawnLabel(subject)
+            : (subject.decision?.protocolNumber ?? '');
 
         return new TableRow({
             children: [
                 tocCell(seqNum, false),
                 tocCell(subject.name, false),
-                tocCell(subject.decision?.protocolNumber ?? '', false),
-                new TableCell({
-                    children: [new Paragraph({
-                        spacing: { before: 40, after: 40 },
-                        children: [new PageReference(subjectBookmarkId(subject))],
-                    })],
-                }),
+                tocCell(decisionText, false),
+                // No page reference for withdrawn subjects (no subject block to link to)
+                subject.withdrawn
+                    ? tocCell('', false)
+                    : new TableCell({
+                        children: [new Paragraph({
+                            spacing: { before: 40, after: 40 },
+                            children: [new PageReference(subjectBookmarkId(subject))],
+                        })],
+                    }),
             ],
         });
     });
@@ -208,7 +215,9 @@ function createTOCTable(subjects: MinutesSubject[], useSequentialNumbers: boolea
 function createTOCSections(subjects: MinutesSubject[]): (Paragraph | Table)[] {
     const elements: (Paragraph | Table)[] = [];
 
-    const agenda = subjects.filter(s => s.nonAgendaReason !== 'outOfAgenda');
+    const agenda = subjects
+        .filter(s => s.nonAgendaReason !== 'outOfAgenda')
+        .sort((a, b) => (a.agendaItemIndex ?? 0) - (b.agendaItemIndex ?? 0));
     const outOfAgenda = subjects.filter(s => s.nonAgendaReason === 'outOfAgenda');
 
     if (agenda.length > 0) {
@@ -417,8 +426,9 @@ export async function renderMinutesDocx(data: MinutesData): Promise<Blob> {
         children.push(...createTranscriptParagraphs(data.preambleEntries));
     }
 
-    // All subjects in discussion order (linear, no section headings)
+    // All subjects in discussion order (skip withdrawn — they appear in TOC only)
     for (const subject of data.subjects) {
+        if (subject.withdrawn) continue;
         children.push(...createSubjectSection(subject));
     }
 

--- a/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
+++ b/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
@@ -28,6 +28,7 @@ function makeSubject(overrides: Partial<MinutesSubject> = {}): MinutesSubject {
         subjectId: 'subject-1',
         agendaItemIndex: 1,
         nonAgendaReason: null,
+        withdrawn: false,
         name: 'Έγκριση προϋπολογισμού',
         discussedWith: null,
         decision: null,

--- a/src/components/meetings/subject/DebugUtterances.tsx
+++ b/src/components/meetings/subject/DebugUtterances.tsx
@@ -12,7 +12,7 @@ type DebugUtterance = {
     text: string;
     startTimestamp: number;
     endTimestamp: number;
-    discussionStatus: 'SUBJECT_DISCUSSION' | 'VOTE' | null;
+    discussionStatus: 'SUBJECT_DISCUSSION' | 'PROCEDURAL_VOTE' | 'VOTE' | null;
     speakerSegment: {
         speakerTag: {
             label: string;
@@ -64,12 +64,14 @@ export function DebugUtterances({ subjectId }: DebugUtterancesProps) {
 
     // Calculate statistics (memoized to avoid redundant filtering)
     const statistics = useMemo(() => {
-        if (!utterances) return { discussionCount: 0, voteCount: 0, discussionTime: 0, voteTime: 0 };
+        if (!utterances) return { discussionCount: 0, voteCount: 0, proceduralCount: 0, discussionTime: 0, voteTime: 0, proceduralTime: 0 };
 
         let discussionCount = 0;
         let voteCount = 0;
+        let proceduralCount = 0;
         let discussionTime = 0;
         let voteTime = 0;
+        let proceduralTime = 0;
 
         for (const utterance of utterances) {
             const duration = utterance.endTimestamp - utterance.startTimestamp;
@@ -79,10 +81,13 @@ export function DebugUtterances({ subjectId }: DebugUtterancesProps) {
             } else if (utterance.discussionStatus === 'VOTE') {
                 voteCount++;
                 voteTime += duration;
+            } else if (utterance.discussionStatus === 'PROCEDURAL_VOTE') {
+                proceduralCount++;
+                proceduralTime += duration;
             }
         }
 
-        return { discussionCount, voteCount, discussionTime, voteTime };
+        return { discussionCount, voteCount, proceduralCount, discussionTime, voteTime, proceduralTime };
     }, [utterances]);
 
     // Don't render until authorization is checked or if user is not authorized
@@ -138,6 +143,14 @@ export function DebugUtterances({ subjectId }: DebugUtterancesProps) {
                                         {statistics.voteCount} ({(statistics.voteTime / 60).toFixed(1)}m)
                                     </Badge>
                                 </div>
+                                {statistics.proceduralCount > 0 && (
+                                    <div className="flex items-center gap-2">
+                                        <span className="text-muted-foreground">Procedural:</span>
+                                        <Badge variant="outline">
+                                            {statistics.proceduralCount} ({(statistics.proceduralTime / 60).toFixed(1)}m)
+                                        </Badge>
+                                    </div>
+                                )}
                             </div>
 
                             {/* Utterance list */}
@@ -163,7 +176,7 @@ export function DebugUtterances({ subjectId }: DebugUtterancesProps) {
                                                     variant={utterance.discussionStatus === 'SUBJECT_DISCUSSION' ? 'default' : 'outline'}
                                                     className="shrink-0"
                                                 >
-                                                    {utterance.discussionStatus === 'SUBJECT_DISCUSSION' ? 'DISCUSSION' : 'VOTE'}
+                                                    {utterance.discussionStatus === 'SUBJECT_DISCUSSION' ? 'DISCUSSION' : utterance.discussionStatus === 'PROCEDURAL_VOTE' ? 'PROCEDURAL' : 'VOTE'}
                                                 </Badge>
                                             </div>
                                             <div className="flex items-center gap-2 text-muted-foreground mb-2">

--- a/src/components/meetings/subject/SubjectAdminControls.tsx
+++ b/src/components/meetings/subject/SubjectAdminControls.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { JsonMetadataDialog } from "@/components/ui/json-metadata-dialog";
+import { getWithdrawnLabel } from "@/lib/utils/subjects";
+import { FileJson } from "lucide-react";
+
+interface SubjectAdminControlsProps {
+    subject: {
+        id: string;
+        nonAgendaReason: string | null;
+        withdrawn: boolean;
+        [key: string]: unknown;
+    };
+    cityId: string;
+    meetingId: string;
+}
+
+export function SubjectAdminControls({ subject, cityId, meetingId }: SubjectAdminControlsProps) {
+    const [open, setOpen] = useState(false);
+    const [isUpdating, setIsUpdating] = useState(false);
+
+    const updateSubject = useCallback(async (fields: { nonAgendaReason?: string | null; withdrawn?: boolean }) => {
+        setIsUpdating(true);
+        try {
+            const res = await fetch(
+                `/api/cities/${cityId}/meetings/${meetingId}/subjects/${subject.id}`,
+                { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(fields) }
+            );
+            if (!res.ok) {
+                const err = await res.json();
+                console.error('Failed to update subject:', err.error);
+                return;
+            }
+            setOpen(false);
+            window.location.reload();
+        } finally {
+            setIsUpdating(false);
+        }
+    }, [cityId, meetingId, subject.id]);
+
+    return (
+        <>
+            <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 text-muted-foreground hover:text-primary hover:bg-primary/10"
+                onClick={(e) => { e.stopPropagation(); setOpen(true); }}
+            >
+                <FileJson className="h-4 w-4" />
+            </Button>
+
+            <JsonMetadataDialog
+                open={open}
+                onOpenChange={setOpen}
+                title="Subject Metadata"
+                data={subject}
+                footerActions={
+                    <div className="flex items-center gap-4 mr-auto">
+                        <div className="flex items-center gap-2">
+                            <Label htmlFor="nonAgendaReason" className="text-xs text-muted-foreground whitespace-nowrap">Category</Label>
+                            <Select
+                                value={subject.nonAgendaReason ?? 'agenda'}
+                                onValueChange={(value) => updateSubject({
+                                    nonAgendaReason: value === 'agenda' ? null : value,
+                                })}
+                                disabled={isUpdating}
+                            >
+                                <SelectTrigger id="nonAgendaReason" className="h-7 w-[160px] text-xs">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="agenda">Ημερησίας</SelectItem>
+                                    <SelectItem value="beforeAgenda">Προ ημερησίας</SelectItem>
+                                    <SelectItem value="outOfAgenda">Εκτός ημερησίας</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <Label htmlFor="withdrawn" className="text-xs text-muted-foreground">{getWithdrawnLabel(subject)}</Label>
+                            <Switch
+                                id="withdrawn"
+                                checked={subject.withdrawn}
+                                onCheckedChange={(checked) => updateSubject({ withdrawn: checked })}
+                                disabled={isUpdating}
+                            />
+                        </div>
+                    </div>
+                }
+            />
+        </>
+    );
+}

--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -26,6 +26,7 @@ import { requestPollDecisionForSubject, getLastPollTimeForMeeting, getDecisionFo
 import { useSubjectHeader } from "@/contexts/SubjectHeaderContext";
 import { useSession } from "next-auth/react";
 import { DebugMetadataButton } from "@/components/ui/debug-metadata-button";
+import { getWithdrawnLabel } from "@/lib/utils/subjects";
 
 export default function Subject({ subjectId }: { subjectId?: string }) {
     const { subjects, getSpeakerTag, getPerson, getParty, meeting } = useCouncilMeetingData();
@@ -106,10 +107,10 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
 
     // Fetch last poll time on mount when there's no decision
     useEffect(() => {
-        if (agendaItemIndex != null && !subject.decision) {
+        if (agendaItemIndex != null && !subject.decision && !subject.withdrawn) {
             getLastPollTimeForMeeting(meeting.id, meeting.cityId).then(setLastSearchedAt);
         }
-    }, [agendaItemIndex, subject.decision, meeting.id, meeting.cityId]);
+    }, [agendaItemIndex, subject.decision, subject.withdrawn, meeting.id, meeting.cityId]);
 
     const handleFetchDecision = useCallback(async () => {
         setIsFetchingDecision(true);
@@ -160,6 +161,13 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                         />
                     </div>
                 )}
+                {/* Withdrawn notice */}
+                {subject.withdrawn && (
+                    <div className="rounded-lg border border-muted bg-muted/30 px-4 py-3 text-sm text-muted-foreground italic">
+                        {getWithdrawnLabel(subject, 'long')}
+                    </div>
+                )}
+
                 {/* Quick Stats Section */}
                 <div className="flex flex-col md:flex-row gap-3 md:gap-4">
                     {/* Parties Card */}
@@ -377,8 +385,8 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                     )}
                 </CollapsibleCard>
 
-                {/* Voting Section */}
-                <CollapsibleCard
+                {/* Voting Section (skip for withdrawn subjects) */}
+                {!subject.withdrawn && <CollapsibleCard
                     icon={<CheckSquare className="w-4 h-4" />}
                     title={
                         voteResult && voteResult.totalVotes > 0 ? (
@@ -399,10 +407,10 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                     defaultOpen={false}
                 >
                     <VotingSection subjectId={subject.id} votes={subject.votes} />
-                </CollapsibleCard>
+                </CollapsibleCard>}
 
-                {/* Decision Section */}
-                {agendaItemIndex != null && (
+                {/* Decision Section (skip for withdrawn subjects) */}
+                {agendaItemIndex != null && !subject.withdrawn && (
                     <CollapsibleCard
                         id="decision"
                         icon={<Landmark className="w-4 h-4" />}

--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -25,8 +25,8 @@ import { useTranslations, useLocale } from "next-intl";
 import { requestPollDecisionForSubject, getLastPollTimeForMeeting, getDecisionForSubject } from "@/lib/tasks/pollDecisions";
 import { useSubjectHeader } from "@/contexts/SubjectHeaderContext";
 import { useSession } from "next-auth/react";
-import { DebugMetadataButton } from "@/components/ui/debug-metadata-button";
 import { getWithdrawnLabel } from "@/lib/utils/subjects";
+import { SubjectAdminControls } from "./SubjectAdminControls";
 
 export default function Subject({ subjectId }: { subjectId?: string }) {
     const { subjects, getSpeakerTag, getPerson, getParty, meeting } = useCouncilMeetingData();
@@ -154,10 +154,10 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
             <div className="max-w-4xl mx-auto px-3 py-4 md:px-4 md:py-6 space-y-6">
                 {isSuperAdmin && (
                     <div className="flex justify-end">
-                        <DebugMetadataButton
-                            data={subject}
-                            title="Subject Metadata"
-                            tooltip="View subject metadata"
+                        <SubjectAdminControls
+                            subject={subject}
+                            cityId={meeting.cityId}
+                            meetingId={meeting.id}
                         />
                     </div>
                 )}

--- a/src/components/meetings/transcript/SpeakerSegmentMetadataDialog.tsx
+++ b/src/components/meetings/transcript/SpeakerSegmentMetadataDialog.tsx
@@ -232,7 +232,7 @@ export default function SpeakerSegmentMetadataDialog({
                         <div className="flex items-center justify-between">
                             <div className="text-sm text-muted-foreground space-y-1">
                                 <div>Edit utterances and summary data. Remove utterances by deleting them from the array.</div>
-                                <div>discussionStatus: ATTENDANCE | SUBJECT_DISCUSSION | VOTE | OTHER | null.</div>
+                                <div>discussionStatus: ATTENDANCE | SUBJECT_DISCUSSION | PROCEDURAL_VOTE | VOTE | OTHER | null.</div>
                                 <div>Set discussionSubjectId to a subject ID or null.</div>
                             </div>
                             <Button

--- a/src/components/subject-card.tsx
+++ b/src/components/subject-card.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "./ui/card"
 import Icon from "./icon";
 import { MapPin, ScrollText, Calendar, Loader2, Clock, MessageSquare } from "lucide-react";
 import { cn, getPartyFromRoles } from "@/lib/utils";
-import { getNonAgendaLabel } from "@/lib/utils/subjects";
+import { getNonAgendaLabel, getWithdrawnLabel } from "@/lib/utils/subjects";
 import { Link, useRouter } from "@/i18n/routing";
 import { PersonAvatarList } from "./persons/PersonAvatarList";
 import { PersonWithRelations } from '@/lib/db/people';
@@ -88,7 +88,8 @@ export function SubjectCard({ subject, city, meeting, parties, persons, fullWidt
         <Link {...linkProps} onClick={handleClick} onMouseEnter={() => setIsCardHovered(true)} onMouseLeave={() => setIsCardHovered(false)}>
             <Card disableHover={disableHover} className={cn(
                 "relative group/card hover:shadow-md transition-all duration-300 w-full h-full",
-                disableHover ? "hover:shadow-none" : ""
+                disableHover ? "hover:shadow-none" : "",
+                subject.withdrawn ? "opacity-60" : ""
             )}>
                 {isLoading && (
                     <div className="absolute inset-0 flex items-center justify-center bg-background/90 backdrop-blur-sm z-20 rounded-lg">
@@ -179,14 +180,20 @@ export function SubjectCard({ subject, city, meeting, parties, persons, fullWidt
                             )}
                         </div>
                     )}
-                    {/* Speaker avatars */}
-                    <div onClick={(e) => e.stopPropagation()} className="w-full">
-                        <PersonAvatarList
-                            users={fullDisplayedSpeakers}
-                            autoScroll
-                            isHovered={isCardHovered}
-                        />
-                    </div>
+                    {/* Speaker avatars or withdrawn label */}
+                    {subject.withdrawn ? (
+                        <div className="w-full text-xs text-muted-foreground/70 italic">
+                            {getWithdrawnLabel(subject)}
+                        </div>
+                    ) : (
+                        <div onClick={(e) => e.stopPropagation()} className="w-full">
+                            <PersonAvatarList
+                                users={fullDisplayedSpeakers}
+                                autoScroll
+                                isHovered={isCardHovered}
+                            />
+                        </div>
+                    )}
                     {showContext && (
                         <div className="flex justify-end w-full mt-auto">
                             <span className="text-[10px] text-muted-foreground/70 flex items-center gap-1">

--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -143,6 +143,7 @@ export interface SpeakerContribution {
 export enum DiscussionStatus {
     ATTENDANCE = "ATTENDANCE",
     SUBJECT_DISCUSSION = "SUBJECT_DISCUSSION",
+    PROCEDURAL_VOTE = "PROCEDURAL_VOTE",
     VOTE = "VOTE",
     OTHER = "OTHER"
 }
@@ -176,6 +177,9 @@ export interface Subject {
 
     topicLabel: string | null;
     context: SubjectContext | null;
+
+    // Set to true when subject won't be discussed: withdrawal/postponement or rejected κατεπείγον
+    withdrawn?: boolean;
 
     // Reference to primary subject ID (API identifier, not DB ID)
     discussedIn?: string;

--- a/src/lib/db/subject.ts
+++ b/src/lib/db/subject.ts
@@ -264,7 +264,7 @@ export async function getUtterancesForSubject(subjectId: string) {
         where: {
             discussionSubjectId: subjectId,
             discussionStatus: {
-                in: ['SUBJECT_DISCUSSION', 'VOTE']
+                in: ['SUBJECT_DISCUSSION', 'PROCEDURAL_VOTE', 'VOTE']
             }
         },
         select: {

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -361,6 +361,7 @@ export async function saveSubjectsForMeeting(
                     proximityImportance: incoming.proximityImportance,
                     context: incoming.context?.text ?? null,
                     contextCitationUrls: incoming.context?.citationUrls ?? [],
+                    withdrawn: incoming.withdrawn ?? false,
                     // Clear discussedIn — will be re-established in pass 2
                     discussedInId: null,
                 }
@@ -433,6 +434,7 @@ export async function saveSubjectsForMeeting(
                         : subject.agendaItemIndex === 'OUT_OF_AGENDA'
                             ? 'outOfAgenda'
                             : undefined,
+                    withdrawn: subject.withdrawn ?? false,
                     introducedBy: validIntroducedBy
                         ? { connect: { id: validIntroducedBy } }
                         : undefined,

--- a/src/lib/minutes/getMinutesData.ts
+++ b/src/lib/minutes/getMinutesData.ts
@@ -5,7 +5,6 @@ import { getPeopleForCity } from '@/lib/db/people';
 import { getCity } from '@/lib/db/cities';
 import { getSpeakerDisplayInfo, isRoleActiveAt, isMayorRole, simplifyRoleName } from '@/lib/utils/roles';
 import { PersonWithRelations } from '@/lib/db/people';
-import { filterSubjectsForMinutes } from '@/lib/utils/subjects';
 import prisma from '@/lib/db/prisma';
 import {
     MinutesData,
@@ -51,10 +50,13 @@ export async function getMinutesData(
     );
 
     // Filter to agenda + outOfAgenda subjects (exclude beforeAgenda)
-    const filteredSubjects = filterSubjectsForMinutes(subjects);
+    // Includes withdrawn subjects — they appear in the TOC but get empty transcript entries
+    const filteredSubjects = subjects.filter(
+        s => s.agendaItemIndex || s.nonAgendaReason === 'outOfAgenda'
+    );
 
-    // Get transcript entries grouped by subject
-    const subjectIds = filteredSubjects.map(s => s.id);
+    // Get transcript entries grouped by non-withdrawn subjects only
+    const subjectIds = filteredSubjects.filter(s => !s.withdrawn).map(s => s.id);
     const utteranceSelect = {
         id: true,
         text: true,
@@ -233,11 +235,14 @@ export async function getMinutesData(
 
     const sortedSubjects = sortSubjectsByDiscussionOrder(filteredSubjects, firstUtteranceBySubject);
 
-    // --- Orphaned utterances (discussionSubjectId = null) ---
+    // --- Orphaned utterances (no subject, or PROCEDURAL_VOTE which flows into preamble/gaps) ---
     const orphanedUtterances = await prisma.utterance.findMany({
         where: {
             speakerSegment: { meetingId: meeting.id, cityId },
-            discussionSubjectId: null,
+            OR: [
+                { discussionSubjectId: null },
+                { discussionStatus: 'PROCEDURAL_VOTE' },
+            ],
         },
         select: utteranceSelect,
         orderBy: { startTimestamp: 'asc' },
@@ -338,6 +343,7 @@ export async function getMinutesData(
             subjectId: s.id,
             agendaItemIndex: s.agendaItemIndex,
             nonAgendaReason: s.nonAgendaReason as 'beforeAgenda' | 'outOfAgenda' | null,
+            withdrawn: s.withdrawn,
             name: s.name,
             discussedWith: s.discussedIn ? {
                 id: s.discussedIn.id,

--- a/src/lib/minutes/types.ts
+++ b/src/lib/minutes/types.ts
@@ -58,6 +58,7 @@ export interface MinutesSubject {
     subjectId: string;
     agendaItemIndex: number | null;
     nonAgendaReason: 'beforeAgenda' | 'outOfAgenda' | null;
+    withdrawn: boolean;
     name: string;
 
     discussedWith: { id: string; name: string; agendaItemIndex: number | null } | null;

--- a/src/lib/tasks/__tests__/summarizeForceCleanup.test.ts
+++ b/src/lib/tasks/__tests__/summarizeForceCleanup.test.ts
@@ -1,51 +1,70 @@
 /** @jest-environment node */
 
 /**
- * Tests for the force-summarize cleanup logic in requestSummarize.
+ * Tests for the summarize cleanup and force semantics.
  *
- * WHY cleanup is needed:
+ * The `force` flag on requestSummarize controls ONLY idempotency — whether
+ * the task is allowed to run again if it already succeeded. It does NOT
+ * control cleanup.
  *
- * handleSummarizeResult uses upserts to save data, but upserts only
- * create/update — they never delete. This creates stale data problems
- * on re-runs:
- *
- * - TopicLabels are upserted with composite key `${speakerSegmentId}_${topicId}`.
- *   If run 1 tags segment-A with ["economy", "environment"] and run 2 tags it
- *   with ["health"], the upsert creates the "health" label but the old "economy"
- *   and "environment" labels remain in the database.
- *
- * - Utterance discussion statuses are set via individual updates for each
- *   utterance in the response. If run 1 sets a status on utterance-X but run 2's
- *   response doesn't include utterance-X, its old status persists.
- *
- * - Summaries are upserted with a unique key on speakerSegmentId (1:1), so
- *   the old value is always overwritten. No cleanup needed.
- *
- * The force path in requestSummarize explicitly deletes topic labels and resets
- * utterance statuses before dispatching the task to ensure a clean slate.
+ * Cleanup of stale data (topic labels, utterance discussion statuses) always
+ * happens in handleSummarizeResult when a successful callback is received.
+ * This ensures the DB stays consistent: old data is only removed when we
+ * have new data to replace it with. If the task fails, old data is preserved.
  */
+
+const CITY_ID = 'city-1';
+const MEETING_ID = 'meeting-1';
+const TASK_ID = 'task-1';
 
 const mockTopicLabelDeleteMany = jest.fn().mockResolvedValue({ count: 0 });
 const mockUtteranceUpdateMany = jest.fn().mockResolvedValue({ count: 0 });
+const mockTransaction = jest.fn().mockResolvedValue([]);
+const mockTaskStatusFindUnique = jest.fn().mockResolvedValue({
+  id: TASK_ID,
+  councilMeeting: {
+    id: MEETING_ID,
+    cityId: CITY_ID,
+    city: { name_en: 'TestCity' },
+    name: 'Test Meeting',
+    administrativeBody: null,
+  },
+});
+const mockTopicFindMany = jest.fn().mockResolvedValue([]);
+const mockUtteranceFindMany = jest.fn().mockResolvedValue([]);
+const mockUtteranceUpdate = jest.fn().mockResolvedValue({});
 
 jest.mock('../../db/prisma', () => ({
   __esModule: true,
   default: {
+    taskStatus: {
+      findUnique: (...args: unknown[]) => mockTaskStatusFindUnique(...args),
+    },
     topicLabel: {
       deleteMany: (...args: unknown[]) => mockTopicLabelDeleteMany(...args),
     },
     utterance: {
       updateMany: (...args: unknown[]) => mockUtteranceUpdateMany(...args),
+      findMany: (...args: unknown[]) => mockUtteranceFindMany(...args),
+      update: (...args: unknown[]) => mockUtteranceUpdate(...args),
     },
+    topic: {
+      findMany: (...args: unknown[]) => mockTopicFindMany(...args),
+    },
+    $transaction: (...args: unknown[]) => mockTransaction(...args),
   },
 }));
 
+const mockGetAvailableSpeakerSegmentIds = jest.fn().mockResolvedValue([]);
+const mockSaveSubjectsForMeeting = jest.fn().mockResolvedValue(new Map());
 const mockGetSummarizeRequestBody = jest.fn().mockResolvedValue({ transcript: [] });
 jest.mock('../../db/utils', () => ({
+  getAvailableSpeakerSegmentIds: (...args: unknown[]) => mockGetAvailableSpeakerSegmentIds(...args),
+  saveSubjectsForMeeting: (...args: unknown[]) => mockSaveSubjectsForMeeting(...args),
   getSummarizeRequestBody: (...args: unknown[]) => mockGetSummarizeRequestBody(...args),
 }));
 
-const mockStartTask = jest.fn().mockResolvedValue({ id: 'task-1' });
+const mockStartTask = jest.fn().mockResolvedValue({ id: TASK_ID });
 jest.mock('../tasks', () => ({
   startTask: (...args: unknown[]) => mockStartTask(...args),
 }));
@@ -54,24 +73,21 @@ jest.mock('../../auth', () => ({
   withUserAuthorizedToEdit: jest.fn().mockResolvedValue(undefined),
 }));
 
-import { requestSummarize } from '../summarize';
+import { requestSummarize, handleSummarizeResult } from '../summarize';
+import { SummarizeResult } from '../../apiTypes';
 
-const CITY_ID = 'city-1';
-const MEETING_ID = 'meeting-1';
+const EMPTY_RESPONSE: SummarizeResult = {
+  speakerSegmentSummaries: [],
+  subjects: [],
+  utteranceDiscussionStatuses: [],
+};
 
-describe('requestSummarize — force cleanup', () => {
+describe('requestSummarize — force controls idempotency only', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('does NOT delete topic labels or reset utterance statuses when force is false', async () => {
-    await requestSummarize(CITY_ID, MEETING_ID);
-
-    expect(mockTopicLabelDeleteMany).not.toHaveBeenCalled();
-    expect(mockUtteranceUpdateMany).not.toHaveBeenCalled();
-  });
-
-  it('does NOT pass force to startTask when force is false', async () => {
+  it('passes force:false to startTask by default (idempotency enforced)', async () => {
     await requestSummarize(CITY_ID, MEETING_ID);
 
     expect(mockStartTask).toHaveBeenCalledWith(
@@ -83,8 +99,33 @@ describe('requestSummarize — force cleanup', () => {
     );
   });
 
-  it('deletes topic labels scoped to the meeting when force is true', async () => {
+  it('passes force:true to startTask when requested (idempotency bypassed)', async () => {
     await requestSummarize(CITY_ID, MEETING_ID, [], undefined, { force: true });
+
+    expect(mockStartTask).toHaveBeenCalledWith(
+      'summarize',
+      expect.anything(),
+      MEETING_ID,
+      CITY_ID,
+      { force: true },
+    );
+  });
+
+  it('never does cleanup, even with force:true', async () => {
+    await requestSummarize(CITY_ID, MEETING_ID, [], undefined, { force: true });
+
+    expect(mockTopicLabelDeleteMany).not.toHaveBeenCalled();
+    expect(mockUtteranceUpdateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleSummarizeResult — always cleans up stale data on success', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('deletes topic labels scoped to the meeting', async () => {
+    await handleSummarizeResult(TASK_ID, EMPTY_RESPONSE);
 
     expect(mockTopicLabelDeleteMany).toHaveBeenCalledWith({
       where: {
@@ -93,8 +134,8 @@ describe('requestSummarize — force cleanup', () => {
     });
   });
 
-  it('resets utterance discussion statuses scoped to the meeting when force is true', async () => {
-    await requestSummarize(CITY_ID, MEETING_ID, [], undefined, { force: true });
+  it('resets utterance discussion statuses scoped to the meeting', async () => {
+    await handleSummarizeResult(TASK_ID, EMPTY_RESPONSE);
 
     expect(mockUtteranceUpdateMany).toHaveBeenCalledWith({
       where: {
@@ -107,27 +148,18 @@ describe('requestSummarize — force cleanup', () => {
     });
   });
 
-  it('passes force:true to startTask to bypass idempotency', async () => {
-    await requestSummarize(CITY_ID, MEETING_ID, [], undefined, { force: true });
-
-    expect(mockStartTask).toHaveBeenCalledWith(
-      'summarize',
-      expect.anything(),
-      MEETING_ID,
-      CITY_ID,
-      { force: true },
-    );
-  });
-
-  it('cleans up before building the request body', async () => {
+  it('cleans up before saving new data', async () => {
     const callOrder: string[] = [];
     mockTopicLabelDeleteMany.mockImplementation(() => { callOrder.push('deleteTopicLabels'); return Promise.resolve({ count: 0 }); });
     mockUtteranceUpdateMany.mockImplementation(() => { callOrder.push('resetUtterances'); return Promise.resolve({ count: 0 }); });
-    mockGetSummarizeRequestBody.mockImplementation(() => { callOrder.push('getRequestBody'); return Promise.resolve({ transcript: [] }); });
+    mockTransaction.mockImplementation(() => { callOrder.push('saveTransaction'); return Promise.resolve([]); });
+    mockSaveSubjectsForMeeting.mockImplementation(() => { callOrder.push('saveSubjects'); return Promise.resolve(new Map()); });
 
-    await requestSummarize(CITY_ID, MEETING_ID, [], undefined, { force: true });
+    await handleSummarizeResult(TASK_ID, EMPTY_RESPONSE);
 
-    expect(callOrder.indexOf('deleteTopicLabels')).toBeLessThan(callOrder.indexOf('getRequestBody'));
-    expect(callOrder.indexOf('resetUtterances')).toBeLessThan(callOrder.indexOf('getRequestBody'));
+    expect(callOrder.indexOf('deleteTopicLabels')).toBeLessThan(callOrder.indexOf('saveTransaction'));
+    expect(callOrder.indexOf('resetUtterances')).toBeLessThan(callOrder.indexOf('saveTransaction'));
+    expect(callOrder.indexOf('deleteTopicLabels')).toBeLessThan(callOrder.indexOf('saveSubjects'));
+    expect(callOrder.indexOf('resetUtterances')).toBeLessThan(callOrder.indexOf('saveSubjects'));
   });
 });

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -3,7 +3,16 @@
 import { PollDecisionsRequest, PollDecisionsResult, ExtractedDecisionData } from "../apiTypes";
 import { startTask } from "./tasks";
 import prisma from "../db/prisma";
-import { AttendanceStatus, DataSource, VoteType } from "@prisma/client";
+import { AttendanceStatus, DataSource, Prisma, VoteType } from "@prisma/client";
+
+/** Subjects eligible for decision polling: agenda + out-of-agenda, excluding withdrawn */
+const POLL_ELIGIBLE_SUBJECT_WHERE = {
+    withdrawn: false,
+    OR: [
+        { agendaItemIndex: { not: null } },
+        { nonAgendaReason: 'outOfAgenda' },
+    ],
+} satisfies Prisma.SubjectWhereInput;
 import { upsertDecision, deleteDecision, getDecisionForSubject } from "../db/decisions";
 export { getDecisionForSubject };
 import { withUserAuthorizedToEdit } from "../auth";
@@ -61,12 +70,7 @@ export async function pollDecisionsForMeeting(
                     nonAgendaReason: true,
                     decision: { select: { ada: true, title: true, pdfUrl: true, excerpt: true } },
                 },
-                where: {
-                    OR: [
-                        { agendaItemIndex: { not: null } },
-                        { nonAgendaReason: 'outOfAgenda' },
-                    ],
-                },
+                where: POLL_ELIGIBLE_SUBJECT_WHERE,
             },
         },
     });
@@ -150,7 +154,7 @@ export async function pollDecisionsForRecentMeetings() {
             },
             subjects: {
                 some: {
-                    agendaItemIndex: { not: null },
+                    ...POLL_ELIGIBLE_SUBJECT_WHERE,
                     decision: null,
                 },
             },

--- a/src/lib/tasks/summarize.ts
+++ b/src/lib/tasks/summarize.ts
@@ -17,34 +17,6 @@ export async function requestSummarize(cityId: string, councilMeetingId: string,
 } = {}) {
     await withUserAuthorizedToEdit({ cityId });
 
-    if (force) {
-        console.log(`Force summarize: deleting stale summarize data for meeting ${councilMeetingId}`);
-
-        // Summaries use upsert (keyed on speakerSegmentId) so they're overwritten naturally.
-        // TopicLabels and utterance discussion statuses need explicit cleanup because:
-        // - TopicLabels: upsert only creates/updates matching pairs; old labels for topics
-        //   no longer assigned to a segment remain as stale data.
-        // - Utterance statuses: only utterances present in the new response get updated;
-        //   utterances that had statuses from the previous run but aren't in the new
-        //   response keep their old (now stale) values.
-
-        await prisma.topicLabel.deleteMany({
-            where: {
-                speakerSegment: { meetingId: councilMeetingId, cityId }
-            }
-        });
-
-        await prisma.utterance.updateMany({
-            where: {
-                speakerSegment: { meetingId: councilMeetingId, cityId }
-            },
-            data: {
-                discussionStatus: null,
-                discussionSubjectId: null
-            }
-        });
-    }
-
     const body = await getSummarizeRequestBody(councilMeetingId, cityId, requestedSubjects, additionalInstructions);
 
     return startTask('summarize', body, councilMeetingId, cityId, { force });
@@ -70,6 +42,34 @@ export async function handleSummarizeResult(taskId: string, response: SummarizeR
     }
 
     const { councilMeeting } = task;
+
+    // Clean up stale data before saving new results.
+    // This runs on every successful callback (not just force), ensuring the DB
+    // is consistent even if a previous run left partial data.
+    // Summaries use upsert (keyed on speakerSegmentId) so they're overwritten naturally.
+    // TopicLabels and utterance discussion statuses need explicit cleanup because:
+    // - TopicLabels: upsert only creates/updates matching pairs; old labels for topics
+    //   no longer assigned to a segment remain as stale data.
+    // - Utterance statuses: only utterances present in the new response get updated;
+    //   utterances that had statuses from the previous run but aren't in the new
+    //   response keep their old (now stale) values.
+    console.log(`Cleaning up stale summarize data for meeting ${councilMeeting.id}`);
+
+    await prisma.topicLabel.deleteMany({
+        where: {
+            speakerSegment: { meetingId: councilMeeting.id, cityId: councilMeeting.cityId }
+        }
+    });
+
+    await prisma.utterance.updateMany({
+        where: {
+            speakerSegment: { meetingId: councilMeeting.id, cityId: councilMeeting.cityId }
+        },
+        data: {
+            discussionStatus: null,
+            discussionSubjectId: null
+        }
+    });
 
     const availableSpeakerSegmentIds = await getAvailableSpeakerSegmentIds(councilMeeting.id, councilMeeting.cityId);
 

--- a/src/lib/utils/__tests__/subjects.test.ts
+++ b/src/lib/utils/__tests__/subjects.test.ts
@@ -1,10 +1,11 @@
-import { categorizeSubjects, getNonAgendaLabel, SUBJECT_CATEGORIES, filterSubjectsForMinutes } from '../subjects';
+import { categorizeSubjects, getNonAgendaLabel, getWithdrawnLabel, SUBJECT_CATEGORIES } from '../subjects';
 
 function makeSubject(overrides: Partial<{
     id: string;
     name: string;
     nonAgendaReason: string | null;
     agendaItemIndex: number | null;
+    withdrawn: boolean;
     statistics: { speakingSeconds: number };
 }> = {}) {
     return {
@@ -12,6 +13,7 @@ function makeSubject(overrides: Partial<{
         name: 'Test subject',
         nonAgendaReason: null as string | null,
         agendaItemIndex: null as number | null,
+        withdrawn: false,
         statistics: { speakingSeconds: 0 },
         speakerSegments: [],
         ...overrides,
@@ -119,59 +121,20 @@ describe('SUBJECT_CATEGORIES', () => {
     });
 });
 
-describe('filterSubjectsForMinutes', () => {
-    it('keeps agenda items', () => {
-        const subjects = [
-            makeSubject({ id: 's1', agendaItemIndex: 1 }),
-            makeSubject({ id: 's2', agendaItemIndex: 2 }),
-        ];
-        expect(filterSubjectsForMinutes(subjects).map(s => s.id)).toEqual(['s1', 's2']);
+describe('getWithdrawnLabel', () => {
+    it('returns "Αποσύρθηκε" for IN_AGENDA withdrawn (short)', () => {
+        expect(getWithdrawnLabel({ nonAgendaReason: null })).toBe('Αποσύρθηκε');
     });
 
-    it('keeps outOfAgenda subjects', () => {
-        const subjects = [
-            makeSubject({ id: 's1', agendaItemIndex: null, nonAgendaReason: 'outOfAgenda' }),
-        ];
-        expect(filterSubjectsForMinutes(subjects)).toHaveLength(1);
+    it('returns "Δεν εγκρίθηκε" for OUT_OF_AGENDA withdrawn (short)', () => {
+        expect(getWithdrawnLabel({ nonAgendaReason: 'outOfAgenda' })).toBe('Δεν εγκρίθηκε');
     });
 
-    it('excludes beforeAgenda subjects', () => {
-        const subjects = [
-            makeSubject({ id: 's1', agendaItemIndex: null, nonAgendaReason: 'beforeAgenda' }),
-        ];
-        expect(filterSubjectsForMinutes(subjects)).toHaveLength(0);
+    it('returns long label for IN_AGENDA withdrawn', () => {
+        expect(getWithdrawnLabel({ nonAgendaReason: null }, 'long')).toBe('Το θέμα αποσύρθηκε και δεν συζητήθηκε.');
     });
 
-    it('excludes subjects with no agendaItemIndex and no nonAgendaReason', () => {
-        const subjects = [
-            makeSubject({ id: 's1' }),
-        ];
-        expect(filterSubjectsForMinutes(subjects)).toHaveLength(0);
-    });
-
-    it('handles mixed subjects correctly', () => {
-        const subjects = [
-            makeSubject({ id: 'agenda-1', agendaItemIndex: 1 }),
-            makeSubject({ id: 'before', agendaItemIndex: null, nonAgendaReason: 'beforeAgenda' }),
-            makeSubject({ id: 'out', agendaItemIndex: null, nonAgendaReason: 'outOfAgenda' }),
-            makeSubject({ id: 'agenda-2', agendaItemIndex: 3 }),
-            makeSubject({ id: 'orphan' }),
-        ];
-        expect(filterSubjectsForMinutes(subjects).map(s => s.id)).toEqual(['agenda-1', 'out', 'agenda-2']);
-    });
-
-    it('returns empty array for empty input', () => {
-        expect(filterSubjectsForMinutes([])).toEqual([]);
-    });
-
-    // agendaItemIndex is always 1-indexed in practice, so 0 never occurs.
-    // This test documents the current behavior; if 0-indexing is ever needed,
-    // the filter should use `s.agendaItemIndex !== null` instead of truthiness.
-    it('treats agendaItemIndex 0 as falsy (excluded unless outOfAgenda)', () => {
-        const subjects = [
-            makeSubject({ id: 'zero', agendaItemIndex: 0 }),
-        ];
-        // Currently excluded because 0 is falsy — this is a known limitation
-        expect(filterSubjectsForMinutes(subjects)).toHaveLength(0);
+    it('returns long label for OUT_OF_AGENDA withdrawn', () => {
+        expect(getWithdrawnLabel({ nonAgendaReason: 'outOfAgenda' }, 'long')).toBe('Το θέμα δεν εγκρίθηκε ως έκτακτο.');
     });
 });

--- a/src/lib/utils/subjects.ts
+++ b/src/lib/utils/subjects.ts
@@ -49,17 +49,14 @@ export function getNonAgendaLabel(reason: 'beforeAgenda' | 'outOfAgenda'): strin
 }
 
 /**
- * Filter subjects to only those included in meeting minutes:
- * agenda items (have agendaItemIndex) + outOfAgenda subjects.
- * Excludes beforeAgenda subjects (pre-agenda announcements without decisions).
- *
- * Used by the minutes data gatherer (getMinutesData) to ensure
- * consistent filtering.
+ * Returns the withdrawn label for a subject based on whether it's an IN_AGENDA
+ * item that was withdrawn/postponed, or an OUT_OF_AGENDA item that was rejected.
+ * "short" for compact UI (cards, TOC), "long" for detail pages with full sentence.
  */
-export function filterSubjectsForMinutes<T extends { agendaItemIndex: number | null; nonAgendaReason: string | null }>(
-    subjects: T[],
-): T[] {
-    return subjects.filter(
-        s => s.agendaItemIndex || s.nonAgendaReason === 'outOfAgenda'
-    );
+export function getWithdrawnLabel(subject: { nonAgendaReason: string | null }, mode: 'short' | 'long' = 'short'): string {
+    if (subject.nonAgendaReason === 'outOfAgenda') {
+        return mode === 'short' ? 'Δεν εγκρίθηκε' : 'Το θέμα δεν εγκρίθηκε ως έκτακτο.';
+    }
+    return mode === 'short' ? 'Αποσύρθηκε' : 'Το θέμα αποσύρθηκε και δεν συζητήθηκε.';
 }
+


### PR DESCRIPTION
<!-- preview-link: tasks=37 -->

## Summary

Companion to schemalabz/opencouncil-tasks#37. Adds DB schema, UI handling, and minutes generation for the new `PROCEDURAL_VOTE` utterance status and `withdrawn` subject field.

### What are procedural votes?

Municipal council meetings have procedural phases where the council votes on **whether to discuss or withdraw** a subject, before any substantive discussion. Two cases:

- **Urgency vote (κατεπείγον)**: Council votes to accept an out-of-agenda item. If rejected, the subject is created with `withdrawn: true`.
- **Item withdrawal (απόσυρση/αναβολή)**: President announces removing/postponing an agenda item. Subject gets `withdrawn: true`.

### Withdrawn subject handling

`withdrawn: true` means "this subject won't be discussed in this meeting". The UI differentiates between IN_AGENDA and OUT_OF_AGENDA withdrawn items using a shared `getWithdrawnLabel()` utility:
- IN_AGENDA: "Αποσύρθηκε" / "Το θέμα αποσύρθηκε και δεν συζητήθηκε."
- OUT_OF_AGENDA: "Δεν εγκρίθηκε" / "Το θέμα δεν εγκρίθηκε ως έκτακτο."

### UI changes

**Meeting minutes (DOCX + HTML preview):**
- Withdrawn subjects appear in the TOC (sorted by agenda index) with the withdrawn label in the decision column
- No subject block is rendered — `PROCEDURAL_VOTE` utterances flow into preamble/gaps

**Subject card:**
- Reduced opacity, withdrawn label replaces speaker avatars in footer

**Subject detail page:**
- Withdrawn notice banner, voting and decision sections hidden

**Admin decisions panel:**
- Withdrawn subjects shown with badge, excluded from linked/unlinked counts

**Decision polling:**
- Withdrawn subjects excluded from polling queries

## Testing

Tested locally on `zografou/jan29_2_2026` with `withdrawn: true` set on both an IN_AGENDA subject (θέμα 3) and an OUT_OF_AGENDA subject, verifying all surfaces: meeting page, subject page, minutes preview, DOCX generation, and admin decisions panel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches DB schema and multiple data pipelines (minutes generation, decision polling, summarize result handling), so regressions could affect meeting rendering and task results despite relatively straightforward logic changes.
> 
> **Overview**
> Adds support for a new `DiscussionStatus.PROCEDURAL_VOTE` and a `Subject.withdrawn` flag end-to-end (DB migration + Prisma schema + API types).
> 
> Introduces a superadmin-only `PATCH /api/cities/:cityId/meetings/:meetingId/subjects/:subjectId` endpoint and UI controls to update `nonAgendaReason` and `withdrawn`, and updates meeting/admin UI to visually mark withdrawn subjects and exclude them from decision polling/decision-linking workflows.
> 
> Updates minutes generation (HTML preview + DOCX + data builder) to keep withdrawn subjects in the TOC with a withdrawn label but skip rendering their transcript sections, and routes `PROCEDURAL_VOTE` utterances into the orphaned/preamble flow rather than subject discussions.
> 
> Moves summarize-task cleanup of stale topic labels and utterance discussion statuses from the request-time `force` path to always run on successful `handleSummarizeResult` callbacks, and adjusts/extends tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 987f8b416d9aa959877f300c15f30345782e82d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `PROCEDURAL_VOTE` as a new `DiscussionStatus` enum value and a `withdrawn` boolean flag on `Subject`, wiring up DB migration, a superadmin PATCH endpoint, minutes generation (DOCX + HTML), and multiple UI surfaces (subject card, subject detail, decisions panel). The summarize cleanup refactor — moving stale-data deletion from `requestSummarize`'s `force` path to every successful `handleSummarizeResult` callback — is the most behaviorally significant change and has an open discussion thread about partial-summarize scope.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style/UX suggestions that do not block correctness.

The P1 cron-picker issue (withdrawn subjects triggering spurious poll errors) is fixed via POLL_ELIGIBLE_SUBJECT_WHERE. The schema migration is backward-compatible (default false). All UI surfaces consistently handle the new flag. The two open items (import ordering in pollDecisions.ts, silent error in SubjectAdminControls) are P2 cleanup. The partial-summarize scope concern from the previous review remains open by author intent.

src/lib/tasks/pollDecisions.ts — stats queries (stillPollingMeetings, eligibleCounts) still lack withdrawn:false filter (carry-over from prior review). src/components/meetings/subject/SubjectAdminControls.tsx — no user-visible error feedback on PATCH failure.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/api/cities/[cityId]/meetings/[meetingId]/subjects/[subjectId]/route.ts | New superadmin-only PATCH endpoint for nonAgendaReason/withdrawn; uses zod strict schema, verifies subject ownership before update, revalidates cache correctly. |
| src/lib/tasks/pollDecisions.ts | Introduces POLL_ELIGIBLE_SUBJECT_WHERE constant (withdrawn:false) used in pollDecisionsForMeeting and pollDecisionsForRecentMeetings; cron picker P1 is fixed. Constant is placed between import blocks (style). The stillPollingMeetings stats query and eligibleCounts groupBy still lack withdrawn:false filter. |
| src/lib/minutes/getMinutesData.ts | Inline filter keeps withdrawn subjects for TOC; transcript subject IDs exclude withdrawn; PROCEDURAL_VOTE utterances added to orphaned query. The agendaItemIndex falsy-check (index 0 edge case) is unchanged. |
| src/lib/tasks/summarize.ts | Cleanup moved from requestSummarize (force path) to handleSummarizeResult (every success); semantics are intentional per PR description. Partial-summarize scope concern flagged in prior review remains open. |
| src/lib/utils/subjects.ts | Replaces filterSubjectsForMinutes with getWithdrawnLabel; all former callers updated; docstring corrected. |
| src/components/meetings/subject/SubjectAdminControls.tsx | New superadmin control widget; PATCH integration works but silently swallows errors — no visual feedback shown to the user on failure. |
| src/components/meetings/docx/MinutesDocx.ts | Withdrawn subjects get empty page-ref cell and withdrawn label in decision column; agenda TOC now sorted by agendaItemIndex; subject block skipped for withdrawn subjects. |
| src/components/meetings/admin/MinutesPreviewContent.tsx | HTML preview mirrors DOCX: withdrawn subjects shown in TOC (dimmed/italic, no link) but excluded from transcript rendering; TOC now sorted by agendaItemIndex. |
| src/components/meetings/admin/DecisionsPanel.tsx | Withdrawn subjects shown in 'All' tab with badge but excluded from linked/unlinked counts and polling eligibility; logic looks correct. |
| src/components/meetings/subject/subject.tsx | Withdrawn notice banner added, voting and decision sections hidden for withdrawn subjects; poll fetch skips withdrawn subjects; SubjectAdminControls replaces DebugMetadataButton. |
| src/lib/db/subject.ts | getUtterancesForSubject now includes PROCEDURAL_VOTE in allowed discussionStatus values, consistent with new enum entry. |
| prisma/schema.prisma | Adds PROCEDURAL_VOTE enum value and withdrawn boolean field (default false) to Subject model; consistent with migration. |
| prisma/migrations/20260416000003_add_procedural_vote_and_withdrawn/migration.sql | Adds PROCEDURAL_VOTE to DiscussionStatus enum and withdrawn BOOLEAN column (default false) to Subject table; safe and straightforward. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Subject created / updated] --> B{withdrawn?}
    B -- false --> C[Normal flow]
    B -- true --> D[Withdrawn flow]

    C --> C1[Subject block in minutes DOCX/HTML]
    C --> C2[Decision section shown on subject page]
    C --> C3[Eligible for pollDecisions]
    C --> C4[Counted in linked/unlinked in DecisionsPanel]

    D --> D1[TOC entry only — no subject block]
    D --> D2[Withdrawn banner shown on subject page]
    D --> D3[Excluded from pollDecisions queries]
    D --> D4[Badge shown in DecisionsPanel, excluded from counts]

    E[PROCEDURAL_VOTE utterances] --> F[Orphaned utterances pool]
    F --> G[Flow into preamble/gap entries in minutes]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/lib/tasks/pollDecisions.ts`, line 152-155 ([link](https://github.com/schemalabz/opencouncil/blob/eb2764a128f27bb2bb2c0dcfadac9d27901315dc/src/lib/tasks/pollDecisions.ts#L152-L155)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Cron picker includes withdrawn subjects, causing spurious errors**

   `pollDecisionsForRecentMeetings` finds meetings to poll using `agendaItemIndex: { not: null }, decision: null`, but does not exclude `withdrawn: true` subjects. If a meeting's only unlinked agenda subjects are all withdrawn, the cron dispatches a `pollDecisions` task, which then calls `pollDecisionsForMeeting`. There, subjects are re-queried with `withdrawn: false`; if none survive that filter, `councilMeeting.subjects.length === 0` and the task throws `"No eligible subjects to poll"` — caught and logged as a cron error even though the meeting state is valid.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/tasks/pollDecisions.ts
   Line: 152-155

   Comment:
   **Cron picker includes withdrawn subjects, causing spurious errors**

   `pollDecisionsForRecentMeetings` finds meetings to poll using `agendaItemIndex: { not: null }, decision: null`, but does not exclude `withdrawn: true` subjects. If a meeting's only unlinked agenda subjects are all withdrawn, the cron dispatches a `pollDecisions` task, which then calls `pollDecisionsForMeeting`. There, subjects are re-queried with `withdrawn: false`; if none survive that filter, `councilMeeting.subjects.length === 0` and the task throws `"No eligible subjects to poll"` — caught and logged as a cron error even though the meeting state is valid.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/lib/minutes/getMinutesData.ts`, line 8 ([link](https://github.com/schemalabz/opencouncil/blob/eb2764a128f27bb2bb2c0dcfadac9d27901315dc/src/lib/minutes/getMinutesData.ts#L8)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unused import and misleading docstring**

   `filterSubjectsForMinutes` is imported here but never called in this file. The inline filter at line 55–57 intentionally diverges (it keeps withdrawn subjects for TOC rendering), so `filterSubjectsForMinutes` cannot simply replace it. The docstring in `src/lib/utils/subjects.ts` currently says _"Used by the minutes data gatherer (getMinutesData)"_, which is incorrect and should be updated or removed.

   Remove the unused import, and update the `filterSubjectsForMinutes` docstring to reflect that it is used by other callers, not `getMinutesData`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/minutes/getMinutesData.ts
   Line: 8

   Comment:
   **Unused import and misleading docstring**

   `filterSubjectsForMinutes` is imported here but never called in this file. The inline filter at line 55–57 intentionally diverges (it keeps withdrawn subjects for TOC rendering), so `filterSubjectsForMinutes` cannot simply replace it. The docstring in `src/lib/utils/subjects.ts` currently says _"Used by the minutes data gatherer (getMinutesData)"_, which is incorrect and should be updated or removed.

   Remove the unused import, and update the `filterSubjectsForMinutes` docstring to reflect that it is used by other callers, not `getMinutesData`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `src/lib/tasks/pollDecisions.ts`, line 362-372 ([link](https://github.com/schemalabz/opencouncil/blob/eb2764a128f27bb2bb2c0dcfadac9d27901315dc/src/lib/tasks/pollDecisions.ts#L362-L372)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stats query includes withdrawn subjects in "still polling" list**

   Both the `stillPollingMeetings` filter (`subjects.some { agendaItemIndex: { not: null }, decision: null }`) and the `eligibleCounts` groupBy query do not exclude `withdrawn: true` subjects. A meeting whose only decision-less agenda subjects are all withdrawn will appear in the "still polling" list and show an inflated "total eligible subjects" count, even though future polling will not touch those subjects. Adding `withdrawn: false` to both filters would keep the stats accurate.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/tasks/pollDecisions.ts
   Line: 362-372

   Comment:
   **Stats query includes withdrawn subjects in "still polling" list**

   Both the `stillPollingMeetings` filter (`subjects.some { agendaItemIndex: { not: null }, decision: null }`) and the `eligibleCounts` groupBy query do not exclude `withdrawn: true` subjects. A meeting whose only decision-less agenda subjects are all withdrawn will appear in the "still polling" list and show an inflated "total eligible subjects" count, even though future polling will not touch those subjects. Adding `withdrawn: false` to both filters would keep the stats accurate.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/lib/tasks/pollDecisions.ts
Line: 8-18

Comment:
**Import declarations after executable code**

`POLL_ELIGIBLE_SUBJECT_WHERE` is declared at lines 8–15, which places executable code between the import at line 6 and the imports at lines 16–22. While TypeScript hoists static imports at runtime, this violates the `import/first` convention and will be flagged by ESLint.

Move the constant below all import statements to follow the file's existing style.

```suggestion
import { AttendanceStatus, DataSource, Prisma, VoteType } from "@prisma/client";
import { upsertDecision, deleteDecision, getDecisionForSubject } from "../db/decisions";
export { getDecisionForSubject };
import { withUserAuthorizedToEdit } from "../auth";

/** Subjects eligible for decision polling: agenda + out-of-agenda, excluding withdrawn */
const POLL_ELIGIBLE_SUBJECT_WHERE = {
    withdrawn: false,
    OR: [
        { agendaItemIndex: { not: null } },
        { nonAgendaReason: 'outOfAgenda' },
    ],
} satisfies Prisma.SubjectWhereInput;
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/components/meetings/subject/SubjectAdminControls.tsx
Line: 35-42

Comment:
**No user-facing error feedback on failed update**

When the PATCH request returns a non-OK response the code logs to the console and returns early — the dialog stays open with `isUpdating` reset to `false` but no error is shown. A super admin who triggers this will see the dialog freeze and release with no indication of what went wrong.

Consider surfacing the error with a local error state rendered in the dialog or a toast notification.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (7): Last reviewed commit: ["feat(admin): add subject category and wi..."](https://github.com/schemalabz/opencouncil/commit/987f8b416d9aa959877f300c15f30345782e82d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28875153)</sub>

<!-- /greptile_comment -->