### PR TITLE
Fix profile card description text overflow

### DIFF
--- a/src/components/persons/Person.tsx
+++ b/src/components/persons/Person.tsx
@@ -242,6 +242,7 @@ export default function PersonC({ city, person, parties, administrativeBodies, s
                                         layout="inline"
                                         showIcons
                                         borderless={true}
+                                        fullText
                                         className="items-start"
                                     />
 

--- a/src/components/persons/RoleDisplay.tsx
+++ b/src/components/persons/RoleDisplay.tsx
@@ -4,6 +4,11 @@ import { Badge } from '../ui/badge';
 import { cn, sortRolesByPriority, getPrimaryRole } from '@/lib/utils';
 import { Star, Building, Users } from 'lucide-react';
 import { RoleWithRelations } from '@/lib/db/types';
+const BADGE_MAX_CHARS_SMALL = 40;
+const BADGE_MAX_CHARS_LG = 70;
+
+const truncateWithEllipsis = (text: string, max: number) =>
+    text.length > max ? `${text.slice(0, max)}…` : text;
 
 interface RoleDisplayProps {
     roles: RoleWithRelations[];
@@ -12,6 +17,12 @@ interface RoleDisplayProps {
     maxDisplay?: number;
     showIcons?: boolean;
     borderless?: boolean;
+    /**
+     * When true, the badge shows the full role text (no char cap), wraps long text,
+     * and renders with rounded corners instead of the pill shape. Use on detail pages
+     * where there's room for the full label.
+     */
+    fullText?: boolean;
     className?: string;
 }
 
@@ -75,6 +86,7 @@ export function RoleDisplay({
     maxDisplay,
     showIcons = false,
     borderless = false,
+    fullText = false,
     className
 }: RoleDisplayProps) {
     if (!roles.length) return null;
@@ -152,6 +164,20 @@ export function RoleDisplay({
         <div className={cn(layoutClasses[layout], sizeClasses[size], className)}>
             {displayRoles.map((role, index) => {
                 const RoleIcon = showIcons ? getRoleIcon(role) : null;
+                const roleText = getRoleText(role);
+                const textSmall = truncateWithEllipsis(roleText, BADGE_MAX_CHARS_SMALL);
+                const textLg = truncateWithEllipsis(roleText, BADGE_MAX_CHARS_LG);
+                const displayText = fullText ? (
+                    roleText
+                ) : (
+                    <>
+                        <span className="lg:hidden" aria-hidden="true">{textSmall}</span>
+                        <span className="hidden lg:inline" aria-hidden="true">{textLg}</span>
+                    </>
+                );
+                const displayAsBox = fullText && roleText.length > BADGE_MAX_CHARS_LG;
+                const badgeShapeClass = displayAsBox ? "!rounded-md text-left" : "";
+                const textSpanClass = "break-words whitespace-normal";
 
                 return (
                     <React.Fragment key={role.id}>
@@ -192,20 +218,25 @@ export function RoleDisplay({
                         ) : (
                             <Badge
                                 variant={getRoleVariant(role)}
+                                title={roleText}
+                                aria-label={roleText}
                                 className={cn(
-                                    "flex items-center gap-1.5 text-muted-foreground relative overflow-hidden hover:bg-accent font-normal",
+                                    "flex items-center gap-1.5 text-muted-foreground relative overflow-hidden hover:bg-accent font-normal max-w-full",
                                     borderless && "border-0 bg-muted/50 hover:bg-muted",
-                                    (role.isHead || role.cityId) && "bg-gradient-to-r from-[#fc550a]/10 to-[#a4c0e1]/10"
+                                    (role.isHead || role.cityId) && "bg-gradient-to-r from-[#fc550a]/10 to-[#a4c0e1]/10",
+                                    badgeShapeClass
                                 )}
                             >
                                 {(role.isHead || role.cityId) && (
                                     <span className="absolute inset-0 bg-gradient-to-r from-[#fc550a]/5 to-[#a4c0e1]/5"></span>
                                 )}
-                                <span className="relative z-10 flex items-center gap-1.5">
-                                    <div className="w-3 h-3 flex items-center justify-center flex-shrink-0">
-                                        {RoleIcon && <RoleIcon className={cn("w-3 h-3", getRoleIconColor(role))} />}
-                                    </div>
-                                    {getRoleText(role)}
+                                <span className="relative z-10 flex items-center gap-1.5 min-w-0">
+                                    {!displayAsBox && (
+                                        <div className="w-3 h-3 flex items-center justify-center flex-shrink-0">
+                                            {RoleIcon && <RoleIcon className={cn("w-3 h-3", getRoleIconColor(role))} />}
+                                        </div>
+                                    )}
+                                    <span className={textSpanClass}>{displayText}</span>
                                 </span>
                             </Badge>
                         )}


### PR DESCRIPTION
## Proposed fix (maybe temp, better solutions to be examined)
- List pages (fullText unset): text truncated with …; below lg capped at 40 chars, at lg+ capped at 70. Pill badge with icon.
- Detail page (fullText passed): full text rendered.
- ≤70 chars → normal pill badge with icon. 70 chars → displayAsBox mode: !rounded-md, left-aligned, icon hidden, wraps; keeps the variant background color.
- Box/hide-icon applies only to the non-party (non-Link) badge. Party-linked badges stay as pills.
- Knobs: BADGE_MAX_CHARS_SMALL (40, <lg) and BADGE_MAX_CHARS_LG (70, lg+ and detail-page threshold).

## Screenshots for usecases

### In people list
<img width="901" height="510" alt="Screenshot 2026-04-22 at 16 59 45" src="https://github.com/user-attachments/assets/fc34a09a-d54f-402e-90bf-0a51a29b9b30" />

### In people page
- If the role text is smaller than BADGE_MAX_CHARS_LG, the badge will be displayed as expected

<img width="1039" height="216" alt="Screenshot 2026-04-22 at 16 57 33" src="https://github.com/user-attachments/assets/3b9ca0ff-cbf1-4bd1-8795-9fdb32117957" />
(mobile)
<img width="372" height="358" alt="Screenshot 2026-04-22 at 16 57 51" src="https://github.com/user-attachments/assets/d5793413-c01c-44a7-abba-210d7a1e129b" />

---

- If the role text is bigger than BADGE_MAX_CHARS_LG, the badge will be displayed as box (left alignment, without icon, not rounded)
<img width="1046" height="337" alt="Screenshot 2026-04-22 at 16 56 50" src="https://github.com/user-attachments/assets/b06c862e-428f-4c9c-b812-6ba00eb91328" />
(mobile)
<img width="370" height="418" alt="Screenshot 2026-04-22 at 16 56 58" src="https://github.com/user-attachments/assets/cabe0130-6096-4917-8c65-0371f60df8f5" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes profile card description text overflow by adding a `fullText` prop to `RoleDisplay` and implementing responsive truncation (40 chars `< lg`, 70 chars `lg+`) for list pages, plus a "box" display mode for very long strings on detail pages. Both previous thread concerns (dual-span screen-reader duplication and the ineffective `max-w-[190ch]`) have been addressed in this revision.

- The party-linked badge branch (line 214) still renders untruncated text via `getRoleText(role)` when `fullText=false`; the computed `displayText` variable is unused there, leaving long party-role strings potentially overflowing on list pages.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core overflow fix is correct and the only remaining gap is a P2 cosmetic edge case on party badges.

All findings are P2 or lower. The main fix (responsive truncation + box mode) works as described and both previous P2 thread concerns were addressed. The unresolved party-badge truncation gap is a pre-existing cosmetic issue that doesn't regress anything introduced in this PR.

src/components/persons/RoleDisplay.tsx — party badge branch at line 214 warrants a follow-up for consistency.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/persons/RoleDisplay.tsx | Adds `fullText` prop, responsive truncation constants, and box-display mode for long text; party-linked badge still renders untruncated text when `fullText=false` (pre-existing gap carried over). |
| src/components/persons/Person.tsx | Single-line addition of `fullText` prop to the detail-page `RoleDisplay` call; straightforward and correct. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[RoleDisplay renders a role] --> B{role.partyId && role.party?}
    B -- Yes --> C[Party-linked Badge via Link\nAlways renders full getRoleText\nAlways pill shape]
    B -- No --> D{fullText prop?}
    D -- false --> E[Responsive truncation\ntextSmall: 40 chars on < lg\ntextLg: 70 chars on lg+\nboth spans aria-hidden, Badge has aria-label]
    D -- true --> F{roleText.length > 70?}
    F -- No --> G[Full text as pill\nicon shown]
    F -- Yes --> H[Box mode: !rounded-md, text-left\nicon hidden, text wraps]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/persons/RoleDisplay.tsx`, line 195-198 ([link](https://github.com/schemalabz/opencouncil/blob/84a6af304de41e5036e1ffc8c0657bc2987723b5/src/components/persons/RoleDisplay.tsx#L195-L198)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Party badge text is not truncated on list pages**

   The `displayText` / truncation logic only applies to the non-party `<Badge>`. The party-linked badge (lines 195–218) still renders `{getRoleText(role)}` directly (line 216), so long party-role strings (e.g. `"Very Long Party Name - Very Long Role Name"`) can still overflow in list pages where `fullText=false`. If party names are guaranteed to be short in practice, this is fine — but it's worth a conscious decision.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/persons/RoleDisplay.tsx
   Line: 195-198

   Comment:
   **Party badge text is not truncated on list pages**

   The `displayText` / truncation logic only applies to the non-party `<Badge>`. The party-linked badge (lines 195–218) still renders `{getRoleText(role)}` directly (line 216), so long party-role strings (e.g. `"Very Long Party Name - Very Long Role Name"`) can still overflow in list pages where `fullText=false`. If party names are guaranteed to be short in practice, this is fine — but it's worth a conscious decision.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/components/persons/RoleDisplay.tsx
Line: 214

Comment:
**Party badge text not truncated on list pages**

The `displayText` / truncation logic is computed for every role but only used in the non-party branch. The party-linked badge still calls `getRoleText(role)` directly here, so long party-name strings (e.g. `"Very Long Party Name - Very Long Role Name"`) bypass the 40/70-char cap on list pages where `fullText=false`. Per the PR description party badges intentionally stay as pills, but applying the same `displayText` variable here would also give them responsive truncation without changing their visual shape.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(components/persons): handle text ove..."](https://github.com/schemalabz/opencouncil/commit/099755448ce905c0d9967c1cbb093ad54a3b97cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29432683)</sub>

<!-- /greptile_comment -->