### PR TITLE
feat: database role management scripts and access documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ Deep dives into specific features — architecture, data flow, and implementatio
 
 Procedures for working with the deployed environments.
 
-- **[guides/database-access.md](./guides/database-access.md)** — Database roles (readonly, readandwrite), copying production data with `scripts/copy_db.sh`, connecting locally to remote databases
+- **[guides/database-access.md](./guides/database-access.md)** — Database role management (`setup_db_role.sh`), copying production data with `copy_db.sh`, setting up remote dev databases for new team members
 - **[guides/preview-deployments.md](./guides/preview-deployments.md)** — Automated per-PR preview environments: GitHub Actions flow, NixOS droplet, port mapping, Caddy config
 - **[guides/cachix-setup.md](./guides/cachix-setup.md)** — Nix binary cache configuration for preview deployment builds
 - **[admin-alerts.md](./admin-alerts.md)** — Discord webhook setup for system event notifications

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ Deep dives into specific features — architecture, data flow, and implementatio
 
 Procedures for working with the deployed environments.
 
-- **[guides/database-access.md](./guides/database-access.md)** — Database roles (readonly, readandwrite), copying production data with `scripts/copy_db.sh`, connecting locally to remote databases
+- **[guides/database-access.md](./guides/database-access.md)** — Database role management (`setup_db_role.sh`), copying production data with `copy_db.sh`, setting up remote dev databases for new team members
 - **[guides/preview-deployments.md](./guides/preview-deployments.md)** — Automated per-PR preview environments: GitHub Actions flow, NixOS droplet, port mapping, Caddy config
 - **[guides/cachix-setup.md](./guides/cachix-setup.md)** — Nix binary cache configuration for preview deployment builds
 - **[admin-alerts.md](./admin-alerts.md)** — Discord webhook setup for system event notifications

--- a/docs/guides/database-access.md
+++ b/docs/guides/database-access.md
@@ -1,0 +1,176 @@
+# Database Access
+
+Procedures for accessing and working with the different OpenCouncil databases. For how the databases fit into the overall deployment topology, see [infrastructure.md](../infrastructure.md).
+
+## Overview
+
+All databases live in a single DigitalOcean Managed PostgreSQL cluster. Roles are **cluster-wide** (one password, shared across all databases in the cluster), but **grants are per-database** — a role's privileges on the production DB are independent from its privileges on staging.
+
+> **Important:** Always use port `25060` (direct connection) for scripts and role management. Port `25061` is the connection pool, which uses pool names (e.g., `stagpool`) instead of database names and may not work correctly with `COPY` operations.
+
+### Current roles
+
+| Role | Production DB | Staging DB | Dev DBs | Notes |
+|------|--------------|------------|---------|-------|
+| `doadmin` | Full access (admin) | Full access (owns tables) | Full access | DO auto-created. Used for role management only. |
+| `readandwrite` | Full access (owns tables) | No grants | No grants | Production app credential. Has default privileges for auto-grant on new tables. |
+| `app_staging` | No grants | Full CRUD | No grants | Staging app credential. Ready to replace `doadmin` on staging. |
+| `readonly` | SELECT on content tables | No grants | No grants | For `copy_db.sh` source. Cannot read User, Session, TaskStatus, etc. |
+
+### Target role matrix
+
+Where we're headed (see `scripts/setup_db_role.sh` header for full details):
+
+| Role | Production DB | Staging DB | Dev DBs |
+|------|--------------|------------|---------|
+| `app_production` | full CRUD | no connect | no connect |
+| `app_staging` | no connect | full CRUD | no connect |
+| `readonly` | SELECT (content) | no connect | no connect |
+| `<developer>` | no connect | full CRUD | full CRUD |
+| `doadmin` | admin only | admin only | admin only |
+
+Developer roles are per-person (e.g., `maria`, `andreas`). Each developer uses one credential for both staging and their personal dev database.
+
+## Managing Roles
+
+Use `scripts/setup_db_role.sh` to verify and set up role permissions. The script checks for common issues (doadmin inheritance, PUBLIC CONNECT defaults) and grants only the minimum privileges needed.
+
+```bash
+# Verify current grants for all roles on a database
+./scripts/setup_db_role.sh --db="postgresql://doadmin:<pw>@<host>:25060/<db>?sslmode=require" --verify
+
+# Verify a specific role
+./scripts/setup_db_role.sh --db="..." --role=readonly --verify
+
+# Set up a role (shows SQL and asks for confirmation)
+./scripts/setup_db_role.sh --db="..." --role=readonly
+```
+
+The script validates that roles are applied to the correct database:
+- `readonly` and `app_production` → only on `production`
+- `app_staging` → only on `staging`
+- Developer roles → only on `staging` or `*-devdb`
+
+### Creating new roles
+
+Create roles via the **DigitalOcean dashboard** (Databases > Users & Databases > Add User) so passwords are visible and manageable in the UI. Then run the setup script to apply the correct permissions:
+
+```bash
+# After creating the role in DO dashboard:
+./scripts/setup_db_role.sh --db="postgresql://doadmin:<pw>@<host>:25060/<db>" --role=<name>
+```
+
+### The `readonly` role
+
+Grants SELECT on content tables only (the same tables `copy_db.sh` operates on, defined in `scripts/content_tables.sh`). Sensitive tables (User, Session, Account, Notification, TaskStatus) are excluded — the role cannot read them at all.
+
+New tables are invisible to `readonly` by default. When you add a table to `scripts/content_tables.sh`, re-run the setup script to grant access.
+
+### Auditing access
+
+For a deep one-time audit of the full cluster state (all roles, memberships, ownership, default privileges, ACLs):
+
+```bash
+psql "postgresql://doadmin:<pw>@<host>:25060/<db>?sslmode=require" -f scripts/inspect_db_access.sql
+```
+
+## Copying Production Data
+
+The `scripts/copy_db.sh` script copies content table data from one database to another. This is how we keep staging and remote dev databases populated with real data from production.
+
+**The production database should never be accessed directly from development machines** — running `copy_db.sh` with the `readonly` role is the only sanctioned way to get production data out.
+
+### Usage
+
+```bash
+# Copy production → staging
+./scripts/copy_db.sh \
+  --source="postgresql://readonly:<pw>@<host>:25060/production?sslmode=require" \
+  --target="postgresql://app_staging:<pw>@<host>:25060/staging?sslmode=require" \
+  --clear
+
+# Copy production → remote dev database
+./scripts/copy_db.sh \
+  --source="postgresql://readonly:<pw>@<host>:25060/production?sslmode=require" \
+  --target="postgresql://maria:<pw>@<host>:25060/maria-devdb?sslmode=require" \
+  --clear
+```
+
+### What it does
+
+- Copies content tables (defined in `scripts/content_tables.sh`) — **not** user data or task statuses, to protect privacy and avoid stale task state
+- With `--clear`: deletes target data before copying (prompts for confirmation with a random code)
+- Without `--clear`: appends data (will fail on duplicate primary keys)
+
+### Safety checks
+
+The script validates several things before copying:
+
+1. **Migration parity**: verifies the target has all migrations present in the source — otherwise `COPY` would reference columns that don't exist
+2. **FK ordering**: validates the table copy order respects foreign key dependencies
+3. **Orphan FKs**: detects FK columns pointing to tables not in the copy list (e.g., user references) and NULLs them automatically to avoid constraint violations
+
+If any check fails, the script aborts before touching data.
+
+### Which role for which side?
+
+| Parameter | Role needed | Why |
+|-----------|-------------|-----|
+| `--source` | `readonly` | Only runs `SELECT` / `COPY TO STDOUT` on content tables |
+| `--target` | Developer role or `app_staging` | Needs `DELETE` (with `--clear`) and `INSERT` |
+
+## Setting Up a Remote Dev Database
+
+When a new team member joins (or you need a fresh dev environment), follow these steps to set up their own remote database with proper credentials.
+
+### 1. Create the database and role in DigitalOcean
+
+In the DO dashboard (**Databases > your-cluster**):
+- **Users & Databases > Add Database**: create a database named `<name>-devdb` (e.g., `maria-devdb`)
+- **Users & Databases > Add User**: create a role matching their name (e.g., `maria`). Creating via the dashboard ensures the password is visible and manageable in the UI.
+
+### 2. Grant permissions
+
+Run the setup script twice — once for their dev database, once for staging access:
+
+```bash
+# Grant full CRUD on their dev database
+./scripts/setup_db_role.sh \
+  --db="postgresql://doadmin:<pw>@<host>:25060/maria-devdb?sslmode=require" \
+  --role=maria \
+  --type=readwrite
+
+# Grant full CRUD on staging (shared environment)
+./scripts/setup_db_role.sh \
+  --db="postgresql://doadmin:<pw>@<host>:25060/staging?sslmode=require" \
+  --role=maria \
+  --type=readwrite
+```
+
+### 3. Populate with data
+
+Copy production content data into the new database:
+
+```bash
+./scripts/copy_db.sh \
+  --source="postgresql://readonly:<pw>@<host>:25060/production?sslmode=require" \
+  --target="postgresql://maria:<pw>@<host>:25060/maria-devdb?sslmode=require" \
+  --clear
+```
+
+### 4. Connect locally
+
+The developer adds the connection string to their `.env`:
+
+```
+DATABASE_URL="postgresql://maria:<pw>@<host>:25060/maria-devdb?sslmode=require"
+DIRECT_URL="postgresql://maria:<pw>@<host>:25060/maria-devdb?sslmode=require"
+```
+
+Then runs the dev server against it:
+
+```bash
+nix run .#dev -- --db=remote
+```
+
+The same `maria` credentials also work for connecting to staging when needed.

--- a/docs/guides/database-access.md
+++ b/docs/guides/database-access.md
@@ -1,0 +1,176 @@
+# Database Access
+
+Procedures for accessing and working with the different OpenCouncil databases. For how the databases fit into the overall deployment topology, see [infrastructure.md](../infrastructure.md).
+
+## Overview
+
+All databases live in a single DigitalOcean Managed PostgreSQL cluster. Roles are **cluster-wide** (one password, shared across all databases in the cluster), but **grants are per-database** — a role's privileges on the production DB are independent from its privileges on staging.
+
+> **Important:** Always use port `25060` (direct connection) for scripts and role management. Port `25061` is the connection pool, which uses pool names (e.g., `stagpool`) instead of database names and may not work correctly with `COPY` operations.
+
+### Roles
+
+| Role | Production DB | Staging DB | Dev DBs | Notes |
+|------|--------------|------------|---------|-------|
+| `readandwrite` | Full CRUD, owns tables | No grants | No grants | Production app credential. It also runs the migrations, so it owns the tables and the Elasticsearch views. |
+| `app_staging` | No grants | Full CRUD | No grants | Staging app credential. Ready to replace `doadmin` on staging. |
+| `readonly` | SELECT on content tables | No grants | No grants | Source credential for `copy_db.sh`, and the credential for read-only analysis of production. Cannot read `User`, `Session`, `Account` or `Notification`. |
+| `<developer>` | No grants | Full CRUD | Full CRUD | Per-person (e.g. `maria`, `andreas`). One credential for both staging and the personal dev database. |
+| `doadmin` | Admin | Admin | Admin | DO auto-created. Used for role management only. |
+
+`setup_db_role.sh` manages the five roles above. Two more roles exist that it does not manage:
+
+| Role | What it is | Why it matters here |
+|------|-----------|---------------------|
+| `pgsync` | Replicates PostgreSQL into Elasticsearch. | It is a **member of `readandwrite`**, because bootstrap drops triggers and that needs table ownership. Membership gives it `readandwrite`'s privileges, so count it when you audit who can read production. See the `es-deploy` skill. |
+| `notis_reader` | `NOLOGIN` role with SELECT on the five `notis_*` views and nothing else. | `prisma/migrations` creates it, not the DO dashboard. Each environment adds a login user with `IN ROLE notis_reader`. The migration **fails** if `notis_reader` inherits from any role, so never grant it membership. |
+
+Ownership of the production tables and views sits with `readandwrite`. Do not move it without reading the `es-deploy` skill first: a view owned by another role blocks `views.sql` and every later migration.
+
+## Managing Roles
+
+Use `scripts/setup_db_role.sh` to verify and set up role permissions. The script checks for common issues (doadmin inheritance, PUBLIC CONNECT defaults) and grants only the minimum privileges needed.
+
+```bash
+# Verify current grants for all roles on a database
+./scripts/setup_db_role.sh --db="postgresql://doadmin:<pw>@<host>:25060/<db>?sslmode=require" --verify
+
+# Verify a specific role
+./scripts/setup_db_role.sh --db="..." --role=readonly --verify
+
+# Set up a role (shows SQL and asks for confirmation)
+./scripts/setup_db_role.sh --db="..." --role=readonly
+```
+
+The script validates that roles are applied to the correct database:
+- `readonly` and `readandwrite` → only on `production`
+- `app_staging` → only on `staging`
+- Developer roles → only on `staging` or `*-devdb`
+
+### Creating new roles
+
+Create roles via the **DigitalOcean dashboard** (Databases > Users & Databases > Add User) so passwords are visible and manageable in the UI. Then run the setup script to apply the correct permissions:
+
+```bash
+# After creating the role in DO dashboard:
+./scripts/setup_db_role.sh --db="postgresql://doadmin:<pw>@<host>:25060/<db>" --role=<name>
+```
+
+### The `readonly` role
+
+Grants SELECT on the content tables (defined in `scripts/content_tables.sh`, the same tables `copy_db.sh` operates on), plus the extra tables in `READONLY_EXTRA_TABLES`: `_prisma_migrations` and `TaskStatus`. `copy_db.sh` does not copy these two tables, but the role needs read access to them. Sensitive tables (User, Session, Account, Notification) are excluded — the role cannot read them at all.
+
+New tables are invisible to `readonly` by default. When you add a table to `scripts/content_tables.sh` or to `READONLY_EXTRA_TABLES`, re-run the setup script to grant access.
+
+The grant names every table, so PostgreSQL rejects the whole statement if one of them does not exist, and applies nothing. The script checks first and stops with the cause: either the database is behind on migrations, or `content_tables.sh` lists a table that no longer exists. `--verify` reports the same two conditions separately, because only the first one is a grant the setup script can add.
+
+### Auditing access
+
+For a deep one-time audit of the full cluster state (all roles, memberships, ownership, default privileges, ACLs):
+
+```bash
+psql "postgresql://doadmin:<pw>@<host>:25060/<db>?sslmode=require" -f scripts/inspect_db_access.sql
+```
+
+## Copying Production Data
+
+The `scripts/copy_db.sh` script copies content table data from one database to another. This is how we keep staging and remote dev databases populated with real data from production.
+
+**The production database should never be accessed directly from development machines** — running `copy_db.sh` with the `readonly` role is the only sanctioned way to get production data out.
+
+### Usage
+
+```bash
+# Copy production → staging
+./scripts/copy_db.sh \
+  --source="postgresql://readonly:<pw>@<host>:25060/production?sslmode=require" \
+  --target="postgresql://app_staging:<pw>@<host>:25060/staging?sslmode=require" \
+  --clear
+
+# Copy production → remote dev database
+./scripts/copy_db.sh \
+  --source="postgresql://readonly:<pw>@<host>:25060/production?sslmode=require" \
+  --target="postgresql://maria:<pw>@<host>:25060/maria-devdb?sslmode=require" \
+  --clear
+```
+
+### What it does
+
+- Copies content tables (defined in `scripts/content_tables.sh`) — **not** user data or task statuses, to protect privacy and avoid stale task state
+- NULLs each nullable foreign key that points at an excluded table. `UtteranceEdit.userId` is the current case: the target keeps the edit, and loses the reviewer identity. The review tracking in `src/lib/db/reviews.ts` selects reviewers through that column, so it reports no reviewer for a copied edit. It still counts the edits, because it filters on `editedBy`.
+- With `--clear`: deletes target data before copying (prompts for confirmation with a random code)
+- Without `--clear`: appends data (will fail on duplicate primary keys)
+
+### Safety checks
+
+The script validates several things before copying:
+
+1. **Migration parity**: verifies the target has all migrations present in the source — otherwise `COPY` would reference columns that don't exist
+2. **FK ordering**: validates the table copy order respects foreign key dependencies
+3. **Column compatibility**: verifies every column of every copied table in the source also exists in the target. Migration parity compares migration *names* only, so a target that is ahead of the source passes it even if the extra migration dropped a column. This check compares column names, not types or enum labels
+4. **Orphan FKs**: detects FK columns pointing to tables not in the copy list (e.g., user references) and NULLs them automatically to avoid constraint violations
+
+If any check fails, the script aborts before touching data.
+
+### Which role for which side?
+
+| Parameter | Role needed | Why |
+|-----------|-------------|-----|
+| `--source` | `readonly` | Only runs `SELECT` / `COPY TO STDOUT` on content tables |
+| `--target` | Developer role or `app_staging` | Needs `DELETE` (with `--clear`) and `INSERT` |
+
+## Setting Up a Remote Dev Database
+
+When a new team member joins (or you need a fresh dev environment), follow these steps to set up their own remote database with proper credentials.
+
+### 1. Create the database and role in DigitalOcean
+
+In the DO dashboard (**Databases > your-cluster**):
+- **Users & Databases > Add Database**: create a database named `<name>-devdb` (e.g., `maria-devdb`)
+- **Users & Databases > Add User**: create a role matching their name (e.g., `maria`). Creating via the dashboard ensures the password is visible and manageable in the UI.
+
+### 2. Grant permissions
+
+Run the setup script twice — once for their dev database, once for staging access:
+
+```bash
+# Grant full CRUD on their dev database
+./scripts/setup_db_role.sh \
+  --db="postgresql://doadmin:<pw>@<host>:25060/maria-devdb?sslmode=require" \
+  --role=maria \
+  --type=readwrite
+
+# Grant full CRUD on staging (shared environment)
+./scripts/setup_db_role.sh \
+  --db="postgresql://doadmin:<pw>@<host>:25060/staging?sslmode=require" \
+  --role=maria \
+  --type=readwrite
+```
+
+### 3. Populate with data
+
+Copy production content data into the new database:
+
+```bash
+./scripts/copy_db.sh \
+  --source="postgresql://readonly:<pw>@<host>:25060/production?sslmode=require" \
+  --target="postgresql://maria:<pw>@<host>:25060/maria-devdb?sslmode=require" \
+  --clear
+```
+
+### 4. Connect locally
+
+The developer adds the connection string to their `.env`:
+
+```
+DATABASE_URL="postgresql://maria:<pw>@<host>:25060/maria-devdb?sslmode=require"
+DIRECT_URL="postgresql://maria:<pw>@<host>:25060/maria-devdb?sslmode=require"
+```
+
+Then runs the dev server against it:
+
+```bash
+nix run .#dev -- --db=remote
+```
+
+The same `maria` credentials also work for connecting to staging when needed.

--- a/scripts/content_tables.sh
+++ b/scripts/content_tables.sh
@@ -1,0 +1,33 @@
+# Shared list of content tables — sourced by copy_db.sh and setup_db_role.sh.
+# These are public content tables (no user data, no auth, no task state).
+# When adding a new content table, add it here and both scripts pick it up.
+CONTENT_TABLES=(
+    "City"
+    "Topic"
+    "Location"
+    "Party"
+    "AdministrativeBody"
+    "Person"
+    "Role"
+    "CouncilMeeting"
+    "SpeakerTag"
+    "Subject"
+    "Decision"
+    "SpeakerSegment"
+    "SubjectSpeakerSegment"
+    "SpeakerContribution"
+    "Utterance"
+    "Word"
+    "TopicLabel"
+    "Summary"
+    "Highlight"
+    "HighlightedUtterance"
+    "PodcastSpec"
+    "PodcastPart"
+    "PodcastPartAudioUtterance"
+    "Offer"
+    "VoicePrint"
+    "CityMessage"
+    "Consultation"
+    "QrCampaign"
+)

--- a/scripts/content_tables.sh
+++ b/scripts/content_tables.sh
@@ -1,0 +1,37 @@
+# Shared list of content tables — sourced by copy_db.sh and setup_db_role.sh.
+# These are public content tables (no auth data, no task state). A content table
+# can hold a nullable foreign key to an excluded table, for example
+# UtteranceEdit.userId — copy_db.sh sets those columns to NULL as it copies.
+# When adding a new content table, add it here and both scripts pick it up.
+# Order matters: copy_db.sh copies in this order, so a table must appear after
+# every table it references by foreign key.
+CONTENT_TABLES=(
+    "City"
+    "Topic"
+    "Location"
+    "Party"
+    "AdministrativeBody"
+    "Person"
+    "Role"
+    "CouncilMeeting"
+    "SpeakerTag"
+    "Subject"
+    "Decision"
+    "SubjectAttendance"
+    "SubjectVote"
+    "MeetingAttendance"
+    "SpeakerSegment"
+    "SpeakerContribution"
+    "Utterance"
+    "UtteranceEdit"
+    "Word"
+    "TopicLabel"
+    "Summary"
+    "Highlight"
+    "HighlightedUtterance"
+    "Offer"
+    "VoicePrint"
+    "CityMessage"
+    "Consultation"
+    "QrCampaign"
+)

--- a/scripts/content_tables.sh
+++ b/scripts/content_tables.sh
@@ -17,6 +17,7 @@ CONTENT_TABLES=(
     "SpeakerTag"
     "Subject"
     "Decision"
+    "DecisionCandidate"
     "SubjectAttendance"
     "SubjectVote"
     "MeetingAttendance"

--- a/scripts/copy_db.sh
+++ b/scripts/copy_db.sh
@@ -41,37 +41,10 @@ if [ "$CONFIRMATION" != "$CONFIRMATION_CODE" ]; then
     exit 1
 fi
 
-# Array of tables -- we only copy tables that don't have user data or tasks.
-TABLES=(
-    "City"
-    "Topic"
-    "Location"
-    "Party"
-    "AdministrativeBody"
-    "Person"
-    "Role"
-    "CouncilMeeting"
-    "SpeakerTag"
-    "Subject"
-    "Decision"
-    "SpeakerSegment"
-    "SubjectSpeakerSegment"
-    "SpeakerContribution"
-    "Utterance"
-    "Word"
-    "TopicLabel"
-    "Summary"
-    "Highlight"
-    "HighlightedUtterance"
-    "PodcastSpec"
-    "PodcastPart"
-    "PodcastPartAudioUtterance"
-    "Offer"
-    "VoicePrint"
-    "CityMessage"
-    "Consultation"
-    "QrCampaign"
-)
+# Source the shared content tables list (also used by setup_db_role.sh)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/content_tables.sh"
+TABLES=("${CONTENT_TABLES[@]}")
 
 # Verify the target database has all migrations that the source has.
 # The target may have extra migrations (e.g. feature branch), but must not be

--- a/scripts/copy_db.sh
+++ b/scripts/copy_db.sh
@@ -41,36 +41,10 @@ if [ "$CONFIRMATION" != "$CONFIRMATION_CODE" ]; then
     exit 1
 fi
 
-# Array of tables -- we only copy tables that don't have user data or tasks.
-TABLES=(
-    "City"
-    "Topic"
-    "Location"
-    "Party"
-    "AdministrativeBody"
-    "Person"
-    "Role"
-    "CouncilMeeting"
-    "SpeakerTag"
-    "Subject"
-    "Decision"
-    "SubjectAttendance"
-    "SubjectVote"
-    "MeetingAttendance"
-    "SpeakerSegment"
-    "SpeakerContribution"
-    "Utterance"
-    "Word"
-    "TopicLabel"
-    "Summary"
-    "Highlight"
-    "HighlightedUtterance"
-    "Offer"
-    "VoicePrint"
-    "CityMessage"
-    "Consultation"
-    "QrCampaign"
-)
+# Source the shared content tables list (also used by setup_db_role.sh)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/content_tables.sh"
+TABLES=("${CONTENT_TABLES[@]}")
 
 # Verify the target database has all migrations that the source has.
 # The target may have extra migrations (e.g. feature branch), but must not be

--- a/scripts/inspect_db_access.sql
+++ b/scripts/inspect_db_access.sql
@@ -1,0 +1,71 @@
+-- Full database access audit. Run as doadmin against each database:
+-- psql "postgresql://doadmin:<pw>@<host>:25060/<db>?sslmode=require" -f scripts/inspect_db_access.sql
+
+\echo '========================================'
+\echo '  DATABASE ACCESS AUDIT'
+\echo '========================================'
+SELECT current_database() AS database, current_user AS connected_as;
+
+\echo ''
+\echo '=== 1. All roles in the cluster ==='
+\echo '    (cluster-wide — same output regardless of which DB you connect to)'
+SELECT rolname, rolcanlogin AS can_login, rolsuper AS superuser,
+       rolcreaterole AS can_create_roles, rolcreatedb AS can_create_db
+FROM pg_roles
+WHERE rolname NOT LIKE 'pg_%'
+ORDER BY rolname;
+
+\echo ''
+\echo '=== 2. Role membership (who inherits from whom) ==='
+\echo '    Shows: "member" inherits all privileges of "member_of"'
+\echo '    NOTE: In DO Managed PostgreSQL, doadmin is a member OF user roles'
+\echo '    (so admin can manage them). This does NOT give user roles admin access.'
+SELECT m.rolname AS member, r.rolname AS member_of
+FROM pg_auth_members am
+JOIN pg_roles r ON r.oid = am.roleid
+JOIN pg_roles m ON m.oid = am.member
+WHERE m.rolname NOT LIKE 'pg_%'
+ORDER BY m.rolname, r.rolname;
+
+\echo ''
+\echo '=== 3. Database-level privileges ==='
+\echo '    datacl format: grantee=privileges/grantor (C=connect, T=temp, c=create)'
+SELECT datname, datacl
+FROM pg_database
+WHERE datname NOT LIKE 'template%' AND datname != '_dodb'
+ORDER BY datname;
+
+\echo ''
+\echo '=== 4. Table ownership (this database) ==='
+SELECT tableowner, count(*) AS tables_owned
+FROM pg_tables
+WHERE schemaname = 'public'
+GROUP BY tableowner
+ORDER BY tableowner;
+
+\echo ''
+\echo '=== 5. Explicit table grants (this database) ==='
+\echo '    Only shows explicitly granted privileges, not inherited ones.'
+SELECT grantee, table_name, string_agg(privilege_type, ', ' ORDER BY privilege_type) AS privileges
+FROM information_schema.role_table_grants
+WHERE table_schema = 'public'
+  AND grantee NOT IN ('doadmin', 'PUBLIC')
+  AND grantee NOT LIKE 'pg_%'
+GROUP BY grantee, table_name
+ORDER BY grantee, table_name;
+
+\echo ''
+\echo '=== 6. Default privileges (ALTER DEFAULT PRIVILEGES) ==='
+\echo '    Rules that auto-grant on future objects.'
+SELECT pg_get_userbyid(defaclrole) AS granting_role,
+       defaclnamespace::regnamespace AS schema,
+       defaclobjtype AS object_type,
+       defaclacl AS default_acl
+FROM pg_default_acl;
+
+\echo ''
+\echo '=== 7. Schema privileges ==='
+SELECT nspname AS schema,
+       nspacl AS acl
+FROM pg_namespace
+WHERE nspname = 'public';

--- a/scripts/setup_db_role.sh
+++ b/scripts/setup_db_role.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+set -o pipefail
+
+#
+# Manage database roles for OpenCouncil.
+#
+# All OpenCouncil databases live in a single DigitalOcean Managed PostgreSQL
+# cluster. Roles are cluster-wide (one password, shared across databases),
+# but GRANTS are per-database — a role's privileges in the production DB
+# are independent from its privileges in staging.
+#
+# We use this to enforce isolation: each role can only CONNECT to the
+# databases it needs, and only has the privileges required for its purpose.
+#
+# ┌─────────────────────┬──────────────────┬────────────────────┬──────────────┐
+# │ Role                │ Production DB    │ Staging DB         │ Dev DBs      │
+# ├─────────────────────┼──────────────────┼────────────────────┼──────────────┤
+# │ app_production      │ full CRUD        │ no connect         │ no connect   │
+# │ app_staging         │ no connect       │ full CRUD          │ no connect   │
+# │ readonly            │ SELECT (content) │ no connect         │ no connect   │
+# │ <developer>         │ no connect       │ full CRUD          │ full CRUD    │
+# ├─────────────────────┼──────────────────┼────────────────────┼──────────────┤
+# │ doadmin             │ admin            │ admin              │ admin        │
+# └─────────────────────┴──────────────────┴────────────────────┴──────────────┘
+#
+# app_production  — Used by the production Next.js app. Can only touch production.
+# app_staging     — Used by the staging Next.js app and PR previews.
+# readonly        — Used by copy_db.sh to read production data. SELECT only on
+#                   content tables (no user/auth/task data). See content_tables.sh.
+# <developer>      — Per-developer roles (e.g., maria, andreas). Used for staging
+#                   access, copy_db.sh targets, and remote dev DBs. One credential
+#                   per developer for both staging and their personal dev DB.
+# doadmin         — DigitalOcean auto-created superuser. Used only to manage roles.
+#
+# NOTE: In DO Managed PostgreSQL, doadmin is a member OF user roles (not the
+# other way around). This lets the admin manage all roles but does NOT give
+# user roles admin privileges. Explicit grants are the real source of truth.
+#
+# IMPORTANT: Roles are cluster-wide but CONNECT is per-database. After creating
+# a role, you must REVOKE CONNECT ON DATABASE ... FROM PUBLIC and explicitly
+# GRANT CONNECT only to the roles that need it. Otherwise any role can connect
+# to any database by default.
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/content_tables.sh"
+
+# Extra tables the readonly role needs beyond content tables.
+# These are not copied by copy_db.sh but are needed for read access.
+READONLY_EXTRA_TABLES=("_prisma_migrations" "TaskStatus")
+
+usage() {
+    cat <<'EOF'
+Usage: setup_db_role.sh --db=<connection-string> [--role=<name>] [--type=<type>] [--verify]
+
+Manage database roles for OpenCouncil. Connect as doadmin (or equivalent admin).
+
+Options:
+  --db=<url>       PostgreSQL connection string
+  --role=<name>    Role name to set up or verify
+  --type=<type>    Privilege type: "readonly" or "readwrite" (default: inferred from role name)
+  --verify         Show current grants instead of applying changes.
+                   If --role is omitted, shows all known roles.
+
+Privilege types:
+  readonly    — SELECT on content tables + _prisma_migrations only
+  readwrite   — Full CRUD on all tables + auto-grant on future tables
+
+Type is inferred from the role name for known roles:
+  readonly             → readonly
+  app_production       → readwrite
+  app_staging          → readwrite
+Any other role name requires --type to be specified explicitly.
+
+Examples:
+  # See current grants for all known roles
+  ./scripts/setup_db_role.sh --db="postgresql://doadmin:.../<db>" --verify
+
+  # See grants for a specific developer
+  ./scripts/setup_db_role.sh --db="postgresql://doadmin:.../<db>" --role=maria --verify
+
+  # Set up known roles (type inferred)
+  ./scripts/setup_db_role.sh --db="postgresql://doadmin:.../<prod-db>" --role=readonly
+  ./scripts/setup_db_role.sh --db="postgresql://doadmin:.../<prod-db>" --role=app_production
+
+  # Set up a developer's personal role on their dev DB
+  ./scripts/setup_db_role.sh --db="postgresql://doadmin:.../<maria-devdb>" --role=maria --type=readwrite
+EOF
+    exit 1
+}
+
+# Parse arguments
+VERIFY=false
+ROLE_TYPE=""
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --db=*) DB_URL="${1#*=}" ;;
+        --role=*) ROLE_NAME="${1#*=}" ;;
+        --type=*) ROLE_TYPE="${1#*=}" ;;
+        --verify) VERIFY=true ;;
+        *) echo "Unknown parameter: $1"; usage ;;
+    esac
+    shift
+done
+
+[ -z "$DB_URL" ] && usage
+
+DB_NAME=$(echo "$DB_URL" | sed -n 's#.*/\([^/?]*\).*#\1#p')
+
+# --- Precondition checks ---
+
+# Check if a role inherits from doadmin (making explicit grants meaningless).
+# In pg_auth_members, "member" inherits privileges of "roleid".
+# DO Managed Databases inverts this: doadmin is a member OF user roles (so admin
+# can manage them). We check the dangerous direction: role inheriting FROM doadmin.
+check_doadmin_membership() {
+    local role="$1"
+    local is_member
+    is_member=$(psql "$DB_URL" -t -A -c "
+        SELECT 1 FROM pg_auth_members am
+        JOIN pg_roles granted ON granted.oid = am.roleid
+        JOIN pg_roles member ON member.oid = am.member
+        WHERE member.rolname = '$role' AND granted.rolname = 'doadmin';
+    " 2>/dev/null)
+    [ "$is_member" = "1" ]
+}
+
+# Check if PUBLIC has CONNECT on the current database.
+# Empty datacl means defaults apply (PUBLIC can connect).
+# Non-empty datacl with "=...C..." means PUBLIC has explicit CONNECT.
+check_public_connect() {
+    local acl
+    acl=$(psql "$DB_URL" -t -A -c "
+        SELECT datacl FROM pg_database WHERE datname = current_database();
+    " 2>/dev/null)
+    # Empty ACL = default = PUBLIC can connect
+    if [ -z "$acl" ]; then
+        return 0
+    fi
+    # Non-empty: check for PUBLIC entry (empty grantee before =, e.g. {=CTc/doadmin} or ,=CTc/doadmin)
+    echo "$acl" | grep -qE '(^\{|,)=[^/]*C'
+}
+
+# --- Verify ---
+
+verify_role() {
+    local role="$1"
+    echo ""
+    echo "=== $role on $DB_NAME ==="
+
+    local exists
+    exists=$(psql "$DB_URL" -t -A -c "SELECT 1 FROM pg_roles WHERE rolname = '$role';" 2>/dev/null)
+    if [ "$exists" != "1" ]; then
+        echo "  Role does not exist."
+        return
+    fi
+
+    # Precondition warnings
+    if check_doadmin_membership "$role"; then
+        echo "  WARNING: inherits from doadmin — has full admin access regardless of grants below"
+    fi
+
+    # Check CONNECT privilege
+    local has_connect
+    has_connect=$(psql "$DB_URL" -t -A -c "SELECT has_database_privilege('$role', current_database(), 'CONNECT');" 2>/dev/null)
+    echo "  CONNECT: $has_connect"
+    if [ "$has_connect" = "t" ] && check_public_connect; then
+        echo "  (via PUBLIC default — not explicitly granted)"
+    fi
+
+    # Table grants
+    local grants
+    grants=$(psql "$DB_URL" -t -A -F $'\t' -c "
+        SELECT table_name, string_agg(privilege_type, ', ' ORDER BY privilege_type)
+        FROM information_schema.role_table_grants
+        WHERE grantee = '$role'
+        GROUP BY table_name
+        ORDER BY table_name;
+    " 2>/dev/null)
+
+    if [ -z "$grants" ]; then
+        echo "  No table grants."
+    else
+        echo ""
+        printf "  %-35s %s\n" "TABLE" "PRIVILEGES"
+        printf "  %-35s %s\n" "---" "---"
+        while IFS=$'\t' read -r table privs; do
+            printf "  %-35s %s\n" "$table" "$privs"
+        done <<< "$grants"
+    fi
+
+    # Check for missing expected grants based on role type
+    local expected_type=""
+    case "$role" in
+        readonly)             expected_type="readonly" ;;
+        app_production|app_staging) expected_type="readwrite" ;;
+    esac
+
+    if [ -n "$expected_type" ]; then
+        if [ "$expected_type" = "readonly" ]; then
+            local missing=()
+            for t in "${CONTENT_TABLES[@]}" "${READONLY_EXTRA_TABLES[@]}"; do
+                echo "$grants" | grep -q "^${t}	" || missing+=("$t")
+            done
+
+            if [ ${#missing[@]} -gt 0 ]; then
+                echo ""
+                echo "  MISSING ${#missing[@]} expected table(s):"
+                for t in "${missing[@]}"; do
+                    echo "    - $t"
+                done
+                echo "  Run: ./scripts/setup_db_role.sh --db=... --role=$role"
+            fi
+        elif [ "$expected_type" = "readwrite" ]; then
+            # Check all public tables have the expected CRUD grants
+            local all_tables
+            all_tables=$(psql "$DB_URL" -t -A -c "
+                SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY tablename;
+            " 2>/dev/null)
+            local missing=()
+            while IFS= read -r t; do
+                [ -z "$t" ] && continue
+                echo "$grants" | grep -q "^${t}	.*DELETE.*INSERT.*SELECT.*UPDATE" || missing+=("$t")
+            done <<< "$all_tables"
+
+            if [ ${#missing[@]} -gt 0 ]; then
+                echo ""
+                echo "  MISSING full CRUD on ${#missing[@]} table(s):"
+                for t in "${missing[@]}"; do
+                    echo "    - $t"
+                done
+                echo "  Run: ./scripts/setup_db_role.sh --db=... --role=$role"
+            fi
+        fi
+    fi
+}
+
+if [ "$VERIFY" = true ]; then
+    if [ -n "$ROLE_NAME" ]; then
+        verify_role "$ROLE_NAME"
+    else
+        verify_role "app_production"
+        verify_role "app_staging"
+        verify_role "readonly"
+        verify_role "readandwrite"
+    fi
+    echo ""
+    exit 0
+fi
+
+# --- Setup ---
+
+[ -z "$ROLE_NAME" ] && usage
+
+# Infer type from known role names, or require --type
+if [ -z "$ROLE_TYPE" ]; then
+    case "$ROLE_NAME" in
+        readonly)                          ROLE_TYPE="readonly" ;;
+        app_production|app_staging)        ROLE_TYPE="readwrite" ;;
+        *)
+            echo "Error: unknown role '$ROLE_NAME'. Specify --type=readonly or --type=readwrite."
+            exit 1
+            ;;
+    esac
+fi
+
+if [ "$ROLE_TYPE" != "readonly" ] && [ "$ROLE_TYPE" != "readwrite" ]; then
+    echo "Error: --type must be 'readonly' or 'readwrite'"
+    exit 1
+fi
+
+# Validate role is being applied to the correct database to prevent mistakes.
+# Known roles have strict database requirements:
+#   readonly        → production only
+#   app_production  → production only
+#   app_staging     → staging only
+# Developer roles (--type=readwrite with custom name) can target staging or *-devdb databases.
+# They are never allowed on production.
+validate_db_error=""
+case "$ROLE_NAME" in
+    readonly|app_production)
+        if [ "$DB_NAME" != "production" ]; then
+            validate_db_error="'$ROLE_NAME' should only be set up on the 'production' database, not '$DB_NAME'."
+        fi
+        ;;
+    app_staging)
+        if [ "$DB_NAME" != "staging" ]; then
+            validate_db_error="'app_staging' should only be set up on the 'staging' database, not '$DB_NAME'."
+        fi
+        ;;
+    *)
+        # Custom role names (developers) can target staging or *-devdb databases
+        if [ -n "$ROLE_TYPE" ] && [ "$DB_NAME" != "staging" ] && [[ "$DB_NAME" != *-devdb ]]; then
+            validate_db_error="Developer role '$ROLE_NAME' can only target 'staging' or '*-devdb' databases, not '$DB_NAME'."
+        fi
+        ;;
+esac
+
+if [ -n "$validate_db_error" ]; then
+    echo "ERROR: $validate_db_error"
+    echo ""
+    echo "This check prevents accidentally granting privileges on the wrong database."
+    echo "If you're sure this is correct, file a bug — the validation may need updating."
+    exit 1
+fi
+
+# Check if role exists
+ROLE_EXISTS=$(psql "$DB_URL" -t -A -c "SELECT 1 FROM pg_roles WHERE rolname = '$ROLE_NAME';" 2>/dev/null)
+if [ "$ROLE_EXISTS" != "1" ]; then
+    echo "Role '$ROLE_NAME' does not exist yet."
+    echo ""
+    echo "Create it first (as doadmin):"
+    echo "  CREATE ROLE $ROLE_NAME WITH LOGIN PASSWORD '<password>';"
+    echo ""
+    echo "Or create it via the DigitalOcean dashboard, then re-run this script."
+    exit 1
+fi
+
+# Precondition checks
+if check_doadmin_membership "$ROLE_NAME"; then
+    echo "WARNING: '$ROLE_NAME' is a member of doadmin and inherits full admin access."
+    echo "Explicit grants will have no practical effect until membership is revoked:"
+    echo ""
+    echo "  REVOKE doadmin FROM $ROLE_NAME;"
+    echo ""
+    read -p "Continue anyway? [y/N] " CONFIRM_INHERIT
+    [ "$CONFIRM_INHERIT" != "y" ] && [ "$CONFIRM_INHERIT" != "Y" ] && echo "Aborted." && exit 0
+    echo ""
+fi
+
+if check_public_connect; then
+    echo "NOTE: PUBLIC has CONNECT on '$DB_NAME'. Any role can connect to this database."
+    echo "To enforce CONNECT isolation, revoke PUBLIC access:"
+    echo ""
+    echo "  REVOKE CONNECT ON DATABASE \"$DB_NAME\" FROM PUBLIC;"
+    echo ""
+fi
+
+# Build quoted table lists
+CONTENT_TABLE_LIST=""
+for t in "${CONTENT_TABLES[@]}"; do
+    [ -n "$CONTENT_TABLE_LIST" ] && CONTENT_TABLE_LIST+=", "
+    CONTENT_TABLE_LIST+="\"$t\""
+done
+
+EXTRA_TABLE_LIST=""
+for t in "${READONLY_EXTRA_TABLES[@]}"; do
+    EXTRA_TABLE_LIST+=", \"$t\""
+done
+
+case "$ROLE_TYPE" in
+    readonly)
+        SQL="GRANT CONNECT ON DATABASE \"$DB_NAME\" TO $ROLE_NAME;
+GRANT USAGE ON SCHEMA public TO $ROLE_NAME;
+GRANT SELECT ON $CONTENT_TABLE_LIST$EXTRA_TABLE_LIST TO $ROLE_NAME;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO $ROLE_NAME;"
+        ;;
+    readwrite)
+        SQL="GRANT CONNECT ON DATABASE \"$DB_NAME\" TO $ROLE_NAME;
+GRANT USAGE ON SCHEMA public TO $ROLE_NAME;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO $ROLE_NAME;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO $ROLE_NAME;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO $ROLE_NAME;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO $ROLE_NAME;"
+        ;;
+esac
+
+echo "Will run on $DB_NAME:"
+echo ""
+echo "$SQL"
+echo ""
+read -p "Continue? [y/N] " CONFIRM
+[ "$CONFIRM" != "y" ] && [ "$CONFIRM" != "Y" ] && echo "Aborted." && exit 0
+
+psql "$DB_URL" -c "$SQL"
+if [ $? -ne 0 ]; then
+    echo "Failed to apply grants."
+    exit 1
+fi
+
+echo ""
+echo "Done. Verifying:"
+verify_role "$ROLE_NAME"
+echo ""

--- a/scripts/setup_db_role.sh
+++ b/scripts/setup_db_role.sh
@@ -1,0 +1,571 @@
+#!/usr/bin/env bash
+set -o pipefail
+
+#
+# Manage database roles for OpenCouncil.
+#
+# All OpenCouncil databases live in a single DigitalOcean Managed PostgreSQL
+# cluster. Roles are cluster-wide (one password, shared across databases),
+# but GRANTS are per-database — a role's privileges in the production DB
+# are independent from its privileges in staging.
+#
+# We use this to enforce isolation: each role can only CONNECT to the
+# databases it needs, and only has the privileges required for its purpose.
+#
+# ┌─────────────────────┬──────────────────┬────────────────────┬──────────────┐
+# │ Role                │ Production DB    │ Staging DB         │ Dev DBs      │
+# ├─────────────────────┼──────────────────┼────────────────────┼──────────────┤
+# │ readandwrite        │ full CRUD, owner │ no connect         │ no connect   │
+# │ app_staging         │ no connect       │ full CRUD          │ no connect   │
+# │ readonly            │ SELECT (content) │ no connect         │ no connect   │
+# │ <developer>         │ no connect       │ full CRUD          │ full CRUD    │
+# ├─────────────────────┼──────────────────┼────────────────────┼──────────────┤
+# │ doadmin             │ admin            │ admin              │ admin        │
+# └─────────────────────┴──────────────────┴────────────────────┴──────────────┘
+#
+# readandwrite    — Used by the production Next.js app. Can only touch production.
+#                   It also runs the migrations, so it owns the production tables
+#                   and the Elasticsearch views. Do not move that ownership without
+#                   reading the es-deploy skill: a view owned by another role blocks
+#                   views.sql and every later migration.
+# app_staging     — Used by the staging Next.js app and PR previews.
+# readonly        — Used by copy_db.sh to read production data, and for read-only
+#                   analysis of it. SELECT only, on the content tables plus the
+#                   extra tables below. No auth or notification data. See
+#                   content_tables.sh and READONLY_EXTRA_TABLES.
+# <developer>      — Per-developer roles (e.g., maria, andreas). Used for staging
+#                   access, copy_db.sh targets, and remote dev DBs. One credential
+#                   per developer for both staging and their personal dev DB.
+# doadmin         — DigitalOcean auto-created superuser. Used only to manage roles.
+#
+# Two roles exist that this script does not manage:
+#   pgsync       — Replicates PostgreSQL into Elasticsearch. A member OF
+#                  readandwrite, because bootstrap drops triggers and that needs
+#                  table ownership. Membership means it holds readandwrite's
+#                  privileges — account for it when you audit production access.
+#   notis_reader — Created by prisma/migrations, not in the DO dashboard. NOLOGIN,
+#                  with SELECT on five notis views and nothing else. Each
+#                  environment adds a login user with IN ROLE notis_reader. The
+#                  migration refuses to run if notis_reader inherits from any role,
+#                  so never grant it membership.
+#
+# NOTE: In DO Managed PostgreSQL, doadmin is a member OF user roles (not the
+# other way around). This lets the admin manage all roles but does NOT give
+# user roles admin privileges. Explicit grants are the real source of truth.
+#
+# IMPORTANT: Roles are cluster-wide but CONNECT is per-database. After creating
+# a role, you must REVOKE CONNECT ON DATABASE ... FROM PUBLIC and explicitly
+# GRANT CONNECT only to the roles that need it. Otherwise any role can connect
+# to any database by default.
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/content_tables.sh"
+
+# Extra tables the readonly role needs beyond content tables.
+# These are not copied by copy_db.sh but are needed for read access.
+READONLY_EXTRA_TABLES=("_prisma_migrations" "TaskStatus")
+
+usage() {
+    cat <<'EOF'
+Usage: setup_db_role.sh --db=<connection-string> [--role=<name>] [--type=<type>] [--verify]
+
+Manage database roles for OpenCouncil. Connect as doadmin (or equivalent admin).
+
+Options:
+  --db=<url>       PostgreSQL connection string
+  --role=<name>    Role name to set up or verify
+  --type=<type>    Privilege type: "readonly" or "readwrite" (default: inferred from role name)
+  --verify         Show current grants instead of applying changes.
+                   If --role is omitted, shows all known roles.
+
+Privilege types:
+  readonly    — SELECT on the content tables, plus _prisma_migrations and
+                TaskStatus.
+                New tables are NOT granted automatically. This is deliberate:
+                a new table can hold personal data, so a person decides each
+                time. Re-run this script after you add one.
+  readwrite   — Full CRUD on all tables. Also sets a default privilege for
+                tables that doadmin creates later. A role that creates a table
+                owns it, so it needs no grant for its own tables. A different
+                readwrite role does: re-run this script for that role after a
+                migration adds a table.
+
+Type is inferred from the role name for known roles:
+  readonly             → readonly
+  readandwrite         → readwrite
+  app_staging          → readwrite
+Any other role name requires --type to be specified explicitly.
+
+Examples:
+  # See current grants for all known roles
+  ./scripts/setup_db_role.sh --db="postgresql://doadmin:.../<db>" --verify
+
+  # See grants for a specific developer
+  ./scripts/setup_db_role.sh --db="postgresql://doadmin:.../<db>" --role=maria --verify
+
+  # Set up known roles (type inferred)
+  ./scripts/setup_db_role.sh --db="postgresql://doadmin:.../<prod-db>" --role=readonly
+  ./scripts/setup_db_role.sh --db="postgresql://doadmin:.../<prod-db>" --role=readandwrite
+
+  # Set up a developer's personal role on their dev DB
+  ./scripts/setup_db_role.sh --db="postgresql://doadmin:.../<maria-devdb>" --role=maria --type=readwrite
+EOF
+    exit 1
+}
+
+# Parse arguments
+VERIFY=false
+ROLE_TYPE=""
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --db=*) DB_URL="${1#*=}" ;;
+        --role=*) ROLE_NAME="${1#*=}" ;;
+        --type=*) ROLE_TYPE="${1#*=}" ;;
+        --verify) VERIFY=true ;;
+        *) echo "Unknown parameter: $1"; usage ;;
+    esac
+    shift
+done
+
+[ -z "$DB_URL" ] && usage
+
+# The role name is interpolated into SQL string literals and into GRANT as an
+# identifier. Restrict it so the value cannot break out of either.
+if [ -n "$ROLE_NAME" ] && ! [[ "$ROLE_NAME" =~ ^[A-Za-z0-9_-]+$ ]]; then
+    echo "Error: role name may contain only letters, digits, underscore and hyphen."
+    exit 1
+fi
+
+DB_NAME=$(echo "$DB_URL" | sed -n 's#.*/\([^/?]*\).*#\1#p')
+
+# Every check below reads psql's stdout and discards its stderr, so a refused
+# connection would otherwise surface as "role does not exist" or "no grants".
+# Prove the connection works once, and let psql report the real reason.
+if ! psql "$DB_URL" -c 'SELECT 1' > /dev/null; then
+    echo "Cannot connect to '$DB_NAME' with the given --db connection string."
+    exit 1
+fi
+
+# --- Precondition checks ---
+
+# Check if a role inherits from doadmin (making explicit grants meaningless).
+# In pg_auth_members, "member" inherits privileges of "roleid".
+# DO Managed Databases inverts this: doadmin is a member OF user roles (so admin
+# can manage them). We check the dangerous direction: role inheriting FROM doadmin.
+check_doadmin_membership() {
+    local role="$1"
+    local is_member
+    is_member=$(psql "$DB_URL" -t -A -c "
+        SELECT 1 FROM pg_auth_members am
+        JOIN pg_roles granted ON granted.oid = am.roleid
+        JOIN pg_roles member ON member.oid = am.member
+        WHERE member.rolname = '$role' AND granted.rolname = 'doadmin';
+    " 2>/dev/null)
+    [ "$is_member" = "1" ]
+}
+
+# Check if PUBLIC has CONNECT on the current database.
+# Empty datacl means defaults apply (PUBLIC can connect).
+# Non-empty datacl with "=...C..." means PUBLIC has explicit CONNECT.
+check_public_connect() {
+    local acl
+    acl=$(psql "$DB_URL" -t -A -c "
+        SELECT datacl FROM pg_database WHERE datname = current_database();
+    " 2>/dev/null)
+    # Empty ACL = default = PUBLIC can connect
+    if [ -z "$acl" ]; then
+        return 0
+    fi
+    # Non-empty: check for PUBLIC entry (empty grantee before =, e.g. {=CTc/doadmin} or ,=CTc/doadmin)
+    echo "$acl" | grep -qE '(^\{|,)=[^/]*C'
+}
+
+# Print the tables from the argument list that this database does not have.
+# A GRANT that names a relation which does not exist fails as a whole statement,
+# so the caller must know before it builds one. Uses pg_class rather than
+# information_schema, which hides objects the connected role cannot see.
+absent_tables() {
+    local in_list="" t
+    for t in "$@"; do
+        [ -n "$in_list" ] && in_list+=", "
+        in_list+="'$t'"
+    done
+    # Callers run this in a command substitution, so exiting here would only end
+    # the subshell. Return non-zero and let the caller decide.
+    psql "$DB_URL" -t -A -c "
+        SELECT x.name FROM unnest(ARRAY[$in_list]) AS x(name)
+        WHERE NOT EXISTS (
+            SELECT 1 FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'public' AND c.relname = x.name
+              AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+        )
+        ORDER BY x.name;
+    " || return 1
+}
+
+# Which databases a role is meant to reach. Roles are cluster-wide but grants
+# are per-database, so the same role is correct in one database and a mistake
+# in another.
+role_expected_here() {
+    case "$1" in
+        readonly|readandwrite) [ "$DB_NAME" = "production" ] ;;
+        app_staging)           [ "$DB_NAME" = "staging" ] ;;
+        *)                     [ "$DB_NAME" = "staging" ] || [[ "$DB_NAME" == *-devdb ]] ;;
+    esac
+}
+
+role_expected_databases() {
+    case "$1" in
+        readonly|readandwrite) echo "the 'production' database" ;;
+        app_staging)           echo "the 'staging' database" ;;
+        *)                     echo "'staging' or a '*-devdb' database" ;;
+    esac
+}
+
+# Tables this script has an opinion about: ordinary tables in public that an
+# extension does not own. PostGIS brings its own (spatial_ref_sys), which no
+# application role needs to write.
+APP_TABLES_SQL="FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND c.relkind IN ('r', 'p')
+      AND NOT EXISTS (
+          SELECT 1 FROM pg_depend d
+          WHERE d.objid = c.oid AND d.deptype = 'e'
+      )"
+
+# --- Verify ---
+
+verify_role() {
+    local role="$1"
+    echo ""
+    echo "=== $role on $DB_NAME ==="
+
+    local exists
+    exists=$(psql "$DB_URL" -t -A -c "SELECT 1 FROM pg_roles WHERE rolname = '$role';" 2>/dev/null)
+    if [ "$exists" != "1" ]; then
+        echo "  Role does not exist."
+        return
+    fi
+
+    # Precondition warnings
+    if check_doadmin_membership "$role"; then
+        echo "  WARNING: inherits from doadmin — has full admin access regardless of grants below"
+    fi
+
+    # Check CONNECT privilege
+    local has_connect
+    has_connect=$(psql "$DB_URL" -t -A -c "SELECT has_database_privilege('$role', current_database(), 'CONNECT');" 2>/dev/null)
+    echo "  CONNECT: $has_connect"
+    if [ "$has_connect" = "t" ] && check_public_connect; then
+        echo "  (via PUBLIC default — not explicitly granted)"
+    fi
+
+    # Table grants
+    local grants
+    grants=$(psql "$DB_URL" -t -A -F $'\t' -c "
+        SELECT table_name, string_agg(privilege_type, ', ' ORDER BY privilege_type)
+        FROM information_schema.role_table_grants
+        WHERE grantee = '$role'
+        GROUP BY table_name
+        ORDER BY table_name;
+    " 2>/dev/null)
+
+    echo ""
+    if [ -z "$grants" ]; then
+        echo "  No grants made directly to $role."
+    else
+        echo "  Granted directly to $role (what this script manages):"
+        echo ""
+        printf "  %-35s %s\n" "TABLE" "PRIVILEGES"
+        printf "  %-35s %s\n" "---" "---"
+        while IFS=$'\t' read -r table privs; do
+            printf "  %-35s %s\n" "$table" "$privs"
+        done <<< "$grants"
+    fi
+    echo ""
+    echo "  The checks below use effective access, which also counts privileges"
+    echo "  held through PUBLIC or through membership of another role."
+
+    # Default privileges are keyed to the role that CREATES the object, so a rule
+    # registered for doadmin never fires for a table a migration creates. Show
+    # which rules exist rather than leaving the operator to guess.
+    local defaults
+    defaults=$(psql "$DB_URL" -t -A -F $'\t' -c "
+        SELECT pg_get_userbyid(defaclrole),
+               CASE defaclobjtype
+                   WHEN 'r' THEN 'tables' WHEN 'S' THEN 'sequences'
+                   WHEN 'f' THEN 'functions' WHEN 'T' THEN 'types'
+                   ELSE defaclobjtype::text END,
+               array_to_string(defaclacl, ' ')
+        FROM pg_default_acl
+        WHERE strpos(array_to_string(defaclacl, ' '), '$role=') > 0;
+    ")
+    if [ -n "$defaults" ]; then
+        echo ""
+        echo "  Default privileges (apply only to objects that the creator makes):"
+        while IFS=$'\t' read -r creator objtype acl; do
+            [ -z "$creator" ] && continue
+            echo "    when $creator creates $objtype: $acl"
+        done <<< "$defaults"
+    fi
+
+    # Check for missing expected grants based on role type
+    local expected_type=""
+    case "$role" in
+        readonly)                   expected_type="readonly" ;;
+        readandwrite|app_staging)   expected_type="readwrite" ;;
+    esac
+
+    if [ -n "$expected_type" ] && ! role_expected_here "$role"; then
+        # Listing every table as "missing" here would be noise: the role is not
+        # supposed to reach this database at all. Report the exception instead.
+        local reachable
+        reachable=$(psql "$DB_URL" -t -A -c "
+            SELECT count(*) $APP_TABLES_SQL
+              AND (has_table_privilege('$role', c.oid, 'SELECT')
+                OR has_table_privilege('$role', c.oid, 'INSERT')
+                OR has_table_privilege('$role', c.oid, 'UPDATE')
+                OR has_table_privilege('$role', c.oid, 'DELETE'));
+        ")
+        echo ""
+        echo "  $role is not meant to reach '$DB_NAME'. It belongs on $(role_expected_databases "$role")."
+        if [ "$reachable" = "0" ]; then
+            echo "    Holds no table privileges here. Correct."
+        else
+            echo "    WARNING: it can reach $reachable table(s) here. Revoke them."
+        fi
+        if [ "$has_connect" = "t" ]; then
+            echo "    WARNING: it can CONNECT to '$DB_NAME'. Revoke with:"
+            echo "      REVOKE CONNECT ON DATABASE \"$DB_NAME\" FROM \"$role\";"
+        fi
+    elif [ -n "$expected_type" ]; then
+        if [ "$expected_type" = "readonly" ]; then
+            # Two different conditions hide behind one missing row: the table is
+            # here but ungranted (setup fixes it), or the table is not in this
+            # database at all (setup cannot fix it, and would fail outright).
+            local expected=("${CONTENT_TABLES[@]}" "${READONLY_EXTRA_TABLES[@]}")
+            local absent
+            if ! absent=$(absent_tables "${expected[@]}"); then
+                echo "  Could not read the table list from $DB_NAME."
+                return
+            fi
+            local not_here=()
+            for t in "${expected[@]}"; do
+                if [ -n "$absent" ] && grep -qxF "$t" <<< "$absent"; then
+                    not_here+=("$t")
+                fi
+            done
+
+            # has_table_privilege answers what the role can do, counting
+            # privileges held through PUBLIC or through role membership. The
+            # listing above shows only direct grants, so it can look emptier.
+            local expected_list="" t_
+            for t_ in "${expected[@]}"; do
+                [ -n "$expected_list" ] && expected_list+=", "
+                expected_list+="'$t_'"
+            done
+            local unreadable
+            unreadable=$(psql "$DB_URL" -t -A -c "
+                SELECT c.relname
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'public'
+                  AND c.relname = ANY(ARRAY[$expected_list])
+                  AND NOT has_table_privilege('$role', c.oid, 'SELECT')
+                ORDER BY c.relname;
+            ")
+
+            if [ -n "$unreadable" ]; then
+                echo ""
+                echo "  $(wc -l <<< "$unreadable") table(s) the role cannot read:"
+                sed 's/^/    - /' <<< "$unreadable"
+                echo "  Run: ./scripts/setup_db_role.sh --db=... --role=$role"
+            fi
+
+            if [ ${#not_here[@]} -gt 0 ]; then
+                echo ""
+                echo "  ${#not_here[@]} table(s) listed in content_tables.sh but not in $DB_NAME:"
+                for t in "${not_here[@]}"; do
+                    echo "    - $t"
+                done
+                echo "  The setup script cannot grant these. Either $DB_NAME is behind on"
+                echo "  migrations, or content_tables.sh lists a table that no longer exists."
+            fi
+        elif [ "$expected_type" = "readwrite" ]; then
+            # Report the privileges the role actually lacks, per table. Reading
+            # the direct grants instead would report a table as missing SELECT
+            # when PostGIS granted that SELECT to PUBLIC, or report every table
+            # as missing for a role that holds them through membership.
+            local incomplete
+            incomplete=$(psql "$DB_URL" -t -A -F $'\t' -c "
+                SELECT relname, missing FROM (
+                    SELECT c.relname, array_to_string(ARRAY(
+                        SELECT p FROM unnest(ARRAY['SELECT','INSERT','UPDATE','DELETE']) AS p
+                        WHERE NOT has_table_privilege('$role', c.oid, p)
+                    ), ', ') AS missing
+                    $APP_TABLES_SQL
+                ) t WHERE missing <> '' ORDER BY relname;
+            ")
+
+            if [ -n "$incomplete" ]; then
+                echo ""
+                echo "  $(wc -l <<< "$incomplete") table(s) without full read and write access:"
+                while IFS=$'\t' read -r table missing; do
+                    [ -z "$table" ] && continue
+                    echo "    - $table (missing $missing)"
+                done <<< "$incomplete"
+                echo "  Run: ./scripts/setup_db_role.sh --db=... --role=$role"
+            fi
+        fi
+    fi
+}
+
+if [ "$VERIFY" = true ]; then
+    if [ -n "$ROLE_NAME" ]; then
+        verify_role "$ROLE_NAME"
+    else
+        verify_role "readandwrite"
+        verify_role "app_staging"
+        verify_role "readonly"
+    fi
+    echo ""
+    exit 0
+fi
+
+# --- Setup ---
+
+[ -z "$ROLE_NAME" ] && usage
+
+# Infer type from known role names, or require --type
+if [ -z "$ROLE_TYPE" ]; then
+    case "$ROLE_NAME" in
+        readonly)                          ROLE_TYPE="readonly" ;;
+        readandwrite|app_staging)          ROLE_TYPE="readwrite" ;;
+        *)
+            echo "Error: unknown role '$ROLE_NAME'. Specify --type=readonly or --type=readwrite."
+            exit 1
+            ;;
+    esac
+fi
+
+if [ "$ROLE_TYPE" != "readonly" ] && [ "$ROLE_TYPE" != "readwrite" ]; then
+    echo "Error: --type must be 'readonly' or 'readwrite'"
+    exit 1
+fi
+
+# Validate role is being applied to the correct database to prevent mistakes.
+# Known roles have strict database requirements:
+#   readonly        → production only
+#   readandwrite    → production only
+#   app_staging     → staging only
+# Developer roles (--type=readwrite with custom name) can target staging or *-devdb databases.
+# They are never allowed on production.
+if ! role_expected_here "$ROLE_NAME"; then
+    echo "ERROR: '$ROLE_NAME' should only be set up on $(role_expected_databases "$ROLE_NAME"), not '$DB_NAME'."
+    echo ""
+    echo "This check prevents accidentally granting privileges on the wrong database."
+    echo "If you're sure this is correct, file a bug — the validation may need updating."
+    exit 1
+fi
+
+# Check if role exists
+ROLE_EXISTS=$(psql "$DB_URL" -t -A -c "SELECT 1 FROM pg_roles WHERE rolname = '$ROLE_NAME';" 2>/dev/null)
+if [ "$ROLE_EXISTS" != "1" ]; then
+    echo "Role '$ROLE_NAME' does not exist yet."
+    echo ""
+    echo "Create it first (as doadmin):"
+    echo "  CREATE ROLE \"$ROLE_NAME\" WITH LOGIN PASSWORD '<password>';"
+    echo ""
+    echo "Or create it via the DigitalOcean dashboard, then re-run this script."
+    exit 1
+fi
+
+# Precondition checks
+if check_doadmin_membership "$ROLE_NAME"; then
+    echo "WARNING: '$ROLE_NAME' is a member of doadmin and inherits full admin access."
+    echo "Explicit grants will have no practical effect until membership is revoked:"
+    echo ""
+    echo "  REVOKE doadmin FROM \"$ROLE_NAME\";"
+    echo ""
+    read -p "Continue anyway? [y/N] " CONFIRM_INHERIT
+    [ "$CONFIRM_INHERIT" != "y" ] && [ "$CONFIRM_INHERIT" != "Y" ] && echo "Aborted." && exit 0
+    echo ""
+fi
+
+if check_public_connect; then
+    echo "NOTE: PUBLIC has CONNECT on '$DB_NAME'. Any role can connect to this database."
+    echo "To enforce CONNECT isolation, revoke PUBLIC access:"
+    echo ""
+    echo "  REVOKE CONNECT ON DATABASE \"$DB_NAME\" FROM PUBLIC;"
+    echo ""
+fi
+
+# The readonly grant names every table, so one absent relation makes PostgreSQL
+# reject the whole statement and apply nothing. Fail here, with the cause, rather
+# than after the operator has confirmed.
+if [ "$ROLE_TYPE" = "readonly" ]; then
+    if ! ABSENT=$(absent_tables "${CONTENT_TABLES[@]}" "${READONLY_EXTRA_TABLES[@]}"); then
+        echo "Failed to read the table list from $DB_NAME."
+        exit 1
+    fi
+    if [ -n "$ABSENT" ]; then
+        echo "ERROR: $DB_NAME does not have $(wc -l <<< "$ABSENT") table(s) that the grant names:"
+        sed 's/^/  - /' <<< "$ABSENT"
+        echo ""
+        echo "The GRANT names each table, so PostgreSQL rejects the whole statement and"
+        echo "applies nothing. One of two things is true:"
+        echo "  - $DB_NAME is behind on migrations. Deploy them, then re-run this script."
+        echo "  - scripts/content_tables.sh lists a table that no longer exists. Remove it"
+        echo "    there — copy_db.sh reads the same list and would fail on it too."
+        exit 1
+    fi
+fi
+
+# Build quoted table lists
+CONTENT_TABLE_LIST=""
+for t in "${CONTENT_TABLES[@]}"; do
+    [ -n "$CONTENT_TABLE_LIST" ] && CONTENT_TABLE_LIST+=", "
+    CONTENT_TABLE_LIST+="\"$t\""
+done
+
+EXTRA_TABLE_LIST=""
+for t in "${READONLY_EXTRA_TABLES[@]}"; do
+    EXTRA_TABLE_LIST+=", \"$t\""
+done
+
+case "$ROLE_TYPE" in
+    readonly)
+        SQL="GRANT CONNECT ON DATABASE \"$DB_NAME\" TO \"$ROLE_NAME\";
+GRANT USAGE ON SCHEMA public TO \"$ROLE_NAME\";
+GRANT SELECT ON $CONTENT_TABLE_LIST$EXTRA_TABLE_LIST TO \"$ROLE_NAME\";
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO \"$ROLE_NAME\";"
+        ;;
+    readwrite)
+        SQL="GRANT CONNECT ON DATABASE \"$DB_NAME\" TO \"$ROLE_NAME\";
+GRANT USAGE ON SCHEMA public TO \"$ROLE_NAME\";
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO \"$ROLE_NAME\";
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO \"$ROLE_NAME\";
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO \"$ROLE_NAME\";
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO \"$ROLE_NAME\";"
+        ;;
+esac
+
+echo "Will run on $DB_NAME:"
+echo ""
+echo "$SQL"
+echo ""
+read -p "Continue? [y/N] " CONFIRM
+[ "$CONFIRM" != "y" ] && [ "$CONFIRM" != "Y" ] && echo "Aborted." && exit 0
+
+psql "$DB_URL" -c "$SQL"
+if [ $? -ne 0 ]; then
+    echo "Failed to apply grants."
+    exit 1
+fi
+
+echo ""
+echo "Done. Verifying:"
+verify_role "$ROLE_NAME"
+echo ""

--- a/src/lib/__tests__/contentTables.test.ts
+++ b/src/lib/__tests__/contentTables.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "fs";
+import path from "path";
+
+/**
+ * scripts/content_tables.sh drives two destructive-adjacent operations:
+ * copy_db.sh deletes every listed table from the target before it copies, and
+ * setup_db_role.sh names every listed table in a single GRANT. A list that has
+ * drifted from the schema therefore fails late — copy_db.sh aborts after the
+ * delete loop has already emptied the target.
+ *
+ * These invariants are derived from prisma/schema.prisma, so they need no
+ * hand-maintained copy of the model list.
+ */
+
+const ROOT = path.join(__dirname, "..", "..", "..");
+
+type Relation = { target: string; optional: boolean };
+
+function parseSchema(schema: string): Map<string, Relation[]> {
+    const models = new Map<string, Relation[]>();
+    const modelPattern = /^model (\w+) \{([\s\S]*?)^\}/gm;
+
+    for (const model of schema.matchAll(modelPattern)) {
+        const [, name, body] = model;
+        const relations: Relation[] = [];
+
+        for (const line of body.split("\n")) {
+            // Only the side that holds the foreign key declares `fields:`.
+            // The back-relation on the other side implies no dependency.
+            const relation = line.match(/^\s*\w+\s+(\w+)(\?|\[\])?\s+@relation\(.*fields:\s*\[/);
+            if (relation) {
+                relations.push({ target: relation[1], optional: relation[2] === "?" });
+            }
+        }
+
+        models.set(name, relations);
+    }
+
+    return models;
+}
+
+function parseContentTables(script: string): string[] {
+    const body = script.match(/CONTENT_TABLES=\(([\s\S]*?)\)/);
+    if (!body) throw new Error("CONTENT_TABLES array not found in content_tables.sh");
+    return [...body[1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1]);
+}
+
+const models = parseSchema(readFileSync(path.join(ROOT, "prisma", "schema.prisma"), "utf8"));
+const contentTables = parseContentTables(readFileSync(path.join(ROOT, "scripts", "content_tables.sh"), "utf8"));
+const contentSet = new Set(contentTables);
+const position = new Map(contentTables.map((table, index) => [table, index]));
+
+describe("content_tables.sh", () => {
+    it("parses a non-empty list", () => {
+        expect(contentTables.length).toBeGreaterThan(0);
+        expect(models.size).toBeGreaterThan(0);
+    });
+
+    it("lists no table that the schema does not define", () => {
+        // A dropped model left in the list makes copy_db.sh delete every table
+        // before it, then abort on the missing relation, restoring nothing.
+        const undefinedTables = contentTables.filter((table) => !models.has(table));
+        expect(undefinedTables).toEqual([]);
+    });
+
+    it("places every table after the content tables it references", () => {
+        // copy_db.sh inserts in list order, so a referenced table must exist first.
+        const violations: string[] = [];
+
+        for (const table of contentTables) {
+            for (const relation of models.get(table) ?? []) {
+                const target = position.get(relation.target);
+                const self = position.get(table);
+                if (target === undefined || self === undefined) continue;
+                if (relation.target !== table && target > self) {
+                    violations.push(`${table} references ${relation.target}, which is listed later`);
+                }
+            }
+        }
+
+        expect(violations).toEqual([]);
+    });
+
+    it("keeps every required foreign key inside the copy set", () => {
+        // copy_db.sh NULLs foreign keys that point outside the set. It cannot do
+        // that for a non-nullable column, so it aborts — after --clear has run.
+        const violations: string[] = [];
+
+        for (const table of contentTables) {
+            for (const relation of models.get(table) ?? []) {
+                if (!relation.optional && !contentSet.has(relation.target)) {
+                    violations.push(`${table} requires ${relation.target}, which is not copied`);
+                }
+            }
+        }
+
+        expect(violations).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

Introduces tooling and documentation for managing database roles across our DigitalOcean Managed PostgreSQL cluster. Moves from ad-hoc credentials to a structured, auditable access model.

- `scripts/setup_db_role.sh` — create and verify database role permissions, with precondition checks (doadmin inheritance, PUBLIC CONNECT) and database name validation to prevent mistakes
- `scripts/content_tables.sh` — shared table list sourced by both `setup_db_role.sh` and `copy_db.sh` (single source of truth)
- `scripts/inspect_db_access.sql` — one-time audit script for understanding cluster state
- `docs/guides/database-access.md` — documents the role model, setup procedures, `copy_db.sh` usage, and remote dev DB onboarding
- `scripts/copy_db.sh` — updated to source the shared table list

## Context: Current state of database access

We audited all databases in our DO cluster using `scripts/inspect_db_access.sql`. Key findings:

**Production:** `readandwrite` owns all 47 tables with default privileges configured — when `doadmin` creates new tables via migrations, `readandwrite` automatically gets full access.

**Staging:** `doadmin` owns all tables and is currently used as the app credential (overprivileged — it has full admin access).

**Cluster-wide:** All databases live in a single DO Managed PostgreSQL cluster. Roles are cluster-wide (shared across databases) but grants are per-database. `doadmin` is a member OF user roles (DO's convention for admin management — user roles do NOT inherit admin privileges). PUBLIC has CONNECT on all databases by default, meaning any role can connect anywhere — only table-level grants prevent unauthorized access.

## What the setup script does

```bash
# Verify current state — shows grants, warnings, and missing permissions
./scripts/setup_db_role.sh --db="postgresql://doadmin:.../<db>" --verify

# Set up known roles (type inferred, database validated)
./scripts/setup_db_role.sh --db=".../<prod-db>" --role=readonly
./scripts/setup_db_role.sh --db=".../<staging-db>" --role=app_staging

# Set up a developer's personal role (on both their dev DB and staging)
./scripts/setup_db_role.sh --db=".../<maria-devdb>" --role=maria --type=readwrite
./scripts/setup_db_role.sh --db=".../<staging-db>" --role=maria --type=readwrite
```

Safety features:
- **Database validation**: `readonly` and `app_production` only on `production`, `app_staging` only on `staging`, developer roles only on `staging` or `*-devdb` — never on production
- **Precondition checks**: warns if role inherits from doadmin (grants meaningless) or PUBLIC has CONNECT (isolation not enforced)
- **Missing grant detection**: `--verify` compares current grants against expected and flags gaps
- **Shows SQL and confirms** before applying any changes

## Target role matrix

Where we're headed. "no connect" requires revoking PUBLIC CONNECT — until then, any role can connect but table-level grants prevent unauthorized access.

```
┌─────────────────────┬──────────────────┬────────────────────┬──────────────┐
│ Role                │ Production DB    │ Staging DB         │ Dev DBs      │
├─────────────────────┼──────────────────┼────────────────────┼──────────────┤
│ app_production      │ full CRUD        │ no connect         │ no connect   │
│ app_staging         │ no connect       │ full CRUD          │ no connect   │
│ readonly            │ SELECT (content) │ no connect         │ no connect   │
│ <developer>         │ no connect       │ full CRUD          │ full CRUD    │
├─────────────────────┼──────────────────┼────────────────────┼──────────────┤
│ doadmin             │ admin only       │ admin only         │ admin only   │
└─────────────────────┴──────────────────┴────────────────────┴──────────────┘
```

Developer roles are per-person (e.g., `maria`, `andreas`). Each developer uses one credential for both staging and their personal dev database.

## Before merging

- [ ] Create `app_production` role in DO dashboard, run `setup_db_role.sh --role=app_production` on production
- [ ] Switch production app's `DATABASE_URL` from `readandwrite` to `app_production`
- [ ] Switch staging app's `DATABASE_URL` from `doadmin` to `app_staging`
- [ ] Update `prodpool` connection pool to use `app_production`
- [ ] Update `stagpool` connection pool to use `app_staging`
- [ ] Set up per-developer roles on staging and their dev databases
- [ ] Revoke PUBLIC CONNECT on production database
- [ ] Retire `readandwrite` and `doadmin` as app credentials

## Test plan

- [x] `setup_db_role.sh --verify` reports grants, PUBLIC CONNECT warnings, and missing grant detection
- [x] `setup_db_role.sh --role=readonly` applies correct per-table SELECT grants on production
- [x] `setup_db_role.sh --role=app_staging` applies full CRUD on staging
- [x] Database validation prevents running roles on wrong database (e.g., developer roles blocked on production)
- [x] `readonly` can SELECT content tables and TaskStatus, cannot SELECT User/Session/Account
- [x] `copy_db.sh` end-to-end: production (`readonly`) → staging (`app_staging`) with `--clear`











<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=29853221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/schema-labs/-/pull-requests/schemalabz/opencouncil/334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no outstanding or newly introduced actionable defects identified.

<details><summary><h3>Summary</h3></summary>

- Adds tooling to configure and inspect database roles and privileges.
- Centralizes the content-table list shared by role setup and database-copy operations.
- Extends copied content to include transcript edits while removing excluded user references.
- Documents role management, production-data copying, and developer database onboarding.
- Adds schema-derived tests for table existence, dependency ordering, and required foreign keys.
</details>

<!-- /greptile_comment -->