### PR TITLE
fix(cache): flush Valkey on deploy to prevent stale HTML chunks

### DIFF
--- a/cache-handler.mjs
+++ b/cache-handler.mjs
@@ -3,7 +3,7 @@ import createRedisHandler from '@neshca/cache-handler/redis-strings';
 import createLruHandler from '@neshca/cache-handler/local-lru';
 import { createClient } from 'redis';
 
-CacheHandler.onCreation(async () => {
+CacheHandler.onCreation(async ({ buildId }) => {
   if (!process.env.CACHE_URL) {
     console.info('[cache-handler] CACHE_URL not set — using in-memory LRU cache');
     return {
@@ -42,6 +42,30 @@ CacheHandler.onCreation(async () => {
   }
 
   if (client?.isReady) {
+    // Flush stale cached pages when a new build is deployed.
+    // Compares the current Next.js build ID against a sentinel key in Valkey.
+    // First instance to boot after a deploy flushes; others find the updated sentinel and skip.
+    const SENTINEL_KEY = 'oc:__build_id__';
+    try {
+      if (!buildId) {
+        console.warn('[cache-handler] No build ID available — skipping deploy flush check');
+      } else {
+        const storedBuildId = await client.get(SENTINEL_KEY);
+
+        if (storedBuildId !== buildId) {
+          console.info(
+            `[cache-handler] Build ID changed: ${storedBuildId ?? '(none)'} → ${buildId} — flushing cache`,
+          );
+          await client.flushDb();
+          await client.set(SENTINEL_KEY, buildId);
+        } else {
+          console.info(`[cache-handler] Build ID unchanged (${buildId}) — skipping flush`);
+        }
+      }
+    } catch (error) {
+      console.warn('[cache-handler] Deploy flush check failed:', error.message);
+    }
+
     const handler = createRedisHandler({
       client,
       keyPrefix: 'oc:',


### PR DESCRIPTION
## Summary
- Flush the shared Valkey cache when a new build is deployed, preventing stale HTML from referencing old JS chunk hashes (ChunkLoadError)
- Compares Next.js build ID against a sentinel key (`oc:__build_id__`) at startup — flushes on mismatch, skips on restart
- First instance to boot after deploy flushes; subsequent instances find the updated sentinel and skip

## Context
Addresses the P0 action item from [INC-2026-04-14](../incidents/2026-04-14-stale-html-chunks.md) — deploy-time Valkey cache flush.

## Test plan
- [x] Verified locally with `nix run .#oc-dev-cache` + standalone server:
  - First boot: `Build ID changed: (none) → X — flushing cache`
  - Restart (same build): `Build ID unchanged (X) — skipping flush`
  - New build: `Build ID changed: X → Y — flushing cache`
- [ ] Monitor DO runtime logs on first production deploy for flush confirmation

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a deploy-time Valkey cache flush to prevent `ChunkLoadError` from stale HTML referencing old JS chunk hashes. On startup, the handler compares the current Next.js `buildId` against a sentinel key (`oc:__build_id__`) and calls `flushDb()` on mismatch. The approach is sound and the error handling is well structured, with two P2 concerns worth addressing before scaling.

<h3>Confidence Score: 4/5</h3>

Safe to merge — no stale HTML will be served; the two P2 findings (non-atomic sentinel update, unscoped flushDb) are low-impact in the current single-DB setup.

Only P2 findings present. The race condition causes redundant flushes under parallel boot but never serves stale content. The flushDb scope issue is benign as long as Valkey is dedicated to this cache, which appears to be the case today.

cache-handler.mjs — specifically the non-atomic check-and-flush-and-set sequence around lines 53–60.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cache-handler.mjs | Adds deploy-time Valkey cache flush by comparing Next.js buildId against a sentinel key; logic is correct but has a non-atomic check-and-set that allows parallel boots to each trigger a flush, and flushDb() is not scoped to the oc: prefix. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
cache-handler.mjs:58-60
**Race condition between `flushDb` and sentinel update**

Multiple instances starting simultaneously will all read the same (old/null) sentinel before any of them writes the new one. They'll each call `flushDb()`, meaning a second instance can flush the DB *after* the first instance has already flushed and begun populating fresh cache entries. The comment says "subsequent instances find the updated sentinel and skip," but that guarantee only holds if boots are serialized. Under parallel boot, the net result is still correct (no stale HTML), but newly-warmed cache entries can get wiped by a lagging instance, and the cache takes longer to warm up.

Consider replacing the get→flush→set sequence with a Lua script or `SET NX` pattern to make it atomic.

### Issue 2 of 2
cache-handler.mjs:59
**`flushDb()` wipes all keys, not just `oc:`-prefixed cache keys**

`client.flushDb()` deletes every key in the current Redis logical database — not just the keys managed by this handler under the `oc:` prefix. If the Valkey instance (or DB index) is ever shared with other data (sessions, queues, other services), they would all be silently wiped on every deploy. Using a `SCAN` + `DEL` loop scoped to the `oc:` prefix would be safer, though slower. At minimum, this assumption should be documented.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cache): flush Valkey on deploy to pr..."](https://github.com/schemalabz/opencouncil/commit/75f82f0bfdcf7575c3596f36e97896e8b515362e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30293951)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->