### PR TITLE
perf(transcript): collapse re-render and listener fanout in edit mode

### DIFF
--- a/src/components/meetings/CouncilMeetingDataContext.tsx
+++ b/src/components/meetings/CouncilMeetingDataContext.tsx
@@ -1,5 +1,5 @@
 "use client"
-import React, { createContext, useContext, ReactNode, useMemo, useState, useCallback } from 'react';
+import React, { createContext, useContext, ReactNode, useMemo, useState, useCallback, useRef } from 'react';
 import { Party, SpeakerTag, LastModifiedBy } from '@prisma/client';
 import { updateSpeakerTag } from '@/lib/db/speakerTags';
 import { createEmptySpeakerSegmentAfter, createEmptySpeakerSegmentBefore, moveUtterancesToPreviousSegment, moveUtterancesToNextSegment, deleteEmptySpeakerSegment, updateSpeakerSegmentData, EditableSpeakerSegmentData, extractSpeakerSegment, addUtteranceToSegment } from '@/lib/db/speakerSegments';
@@ -10,12 +10,10 @@ import { PersonWithRelations } from '@/lib/db/people';
 import { getPartyFromRoles } from "@/lib/utils";
 import type { HighlightWithUtterances } from '@/lib/db/highlights';
 
-export interface CouncilMeetingDataContext extends MeetingData {
-    getPerson: (id: string) => PersonWithRelations | undefined;
-    getParty: (id: string) => Party | undefined;
-    getSpeakerTag: (id: string) => SpeakerTag | undefined;
-    getSpeakerSegmentCount: (tagId: string) => number;
-    getSpeakerSegmentById: (id: string) => Transcript[number] | undefined;
+// Actions are mutations + getters that don't depend on transcript identity.
+// They are stable references for the lifetime of the provider, so consumers
+// that only need to mutate (e.g. Utterance) never re-render on data changes.
+export interface CouncilMeetingActions {
     updateSpeakerTagPerson: (tagId: string, personId: string | null) => void;
     updateSpeakerTagLabel: (tagId: string, label: string) => void;
     createEmptySegmentAfter: (afterSegmentId: string) => Promise<void>;
@@ -27,15 +25,30 @@ export interface CouncilMeetingDataContext extends MeetingData {
     addUtteranceToSegment: (segmentId: string) => Promise<string>;
     deleteUtterance: (utteranceId: string) => Promise<void>;
     updateUtterance: (segmentId: string, utteranceId: string, updates: Partial<{ text: string; startTimestamp: number; endTimestamp: number; lastModifiedBy: LastModifiedBy | null }>) => void;
-    getPersonsForParty: (partyId: string) => PersonWithRelations[];
-    getHighlight: (highlightId: string) => HighlightWithUtterances | undefined;
     addHighlight: (highlight: HighlightWithUtterances) => void;
     updateHighlight: (highlightId: string, updates: Partial<HighlightWithUtterances>) => void;
     removeHighlight: (highlightId: string) => void;
     extractSpeakerSegment: (segmentId: string, startUtteranceId: string, endUtteranceId: string) => Promise<void>;
 }
 
+export interface CouncilMeetingDataContext extends MeetingData, CouncilMeetingActions {
+    getPerson: (id: string) => PersonWithRelations | undefined;
+    getParty: (id: string) => Party | undefined;
+    getSpeakerTag: (id: string) => SpeakerTag | undefined;
+    getSpeakerSegmentCount: (tagId: string) => number;
+    getSpeakerSegmentById: (id: string) => Transcript[number] | undefined;
+    getPersonsForParty: (partyId: string) => PersonWithRelations[];
+    getHighlight: (highlightId: string) => HighlightWithUtterances | undefined;
+}
+
 const CouncilMeetingDataContext = createContext<CouncilMeetingDataContext | undefined>(undefined);
+const CouncilMeetingActionsContext = createContext<CouncilMeetingActions | undefined>(undefined);
+// "Meta" context = everything in CouncilMeetingDataContext EXCEPT `transcript`
+// and items derived from it. Lets components like SpeakerSegment subscribe to
+// speakerTags / highlights / getters / static data WITHOUT re-rendering on
+// every transcript edit.
+type CouncilMeetingMeta = Omit<CouncilMeetingDataContext, 'transcript'>;
+const CouncilMeetingMetaContext = createContext<CouncilMeetingMeta | undefined>(undefined);
 
 export function CouncilMeetingDataProvider({ children, data }: {
     children: ReactNode,
@@ -50,7 +63,12 @@ export function CouncilMeetingDataProvider({ children, data }: {
     const speakerSegmentsMap = useMemo(() => new Map(transcript.map(segment => [segment.id, segment])), [transcript]);
     const highlightsMap = useMemo(() => new Map(highlights.map(h => [h.id, h])), [highlights]);
 
-    // Helper function to recalculate segment timestamps based on utterances
+    // cityId/meetingId are constant for the page, so we capture them in
+    // closures rather than reading data.meeting.* (which would force `data`
+    // into action callback deps and break their stable identity).
+    const cityId = data.meeting.cityId;
+    const meetingId = data.meeting.id;
+
     const recalculateSegmentTimestamps = useCallback((utterances: Array<{ startTimestamp: number; endTimestamp: number }>) => {
         if (utterances.length === 0) return null;
         const allTimestamps = utterances.flatMap(u => [u.startTimestamp, u.endTimestamp]);
@@ -60,7 +78,237 @@ export function CouncilMeetingDataProvider({ children, data }: {
         };
     }, []);
 
-    // Create a map of speaker tag IDs to their segment counts
+    const addHighlight = useCallback((highlight: HighlightWithUtterances) => {
+        setHighlights(prev => [highlight, ...prev]);
+    }, []);
+
+    const updateHighlight = useCallback((highlightId: string, updates: Partial<HighlightWithUtterances>) => {
+        setHighlights(prev => {
+            const highlightIndex = prev.findIndex(h => h.id === highlightId);
+            if (highlightIndex === -1) return prev;
+            const updatedHighlight = { ...prev[highlightIndex], ...updates };
+            const newHighlights = prev.filter(h => h.id !== highlightId);
+            return [updatedHighlight, ...newHighlights];
+        });
+    }, []);
+
+    const removeHighlight = useCallback((highlightId: string) => {
+        setHighlights(prev => prev.filter(h => h.id !== highlightId));
+    }, []);
+
+    const updateSpeakerTagPerson = useCallback(async (tagId: string, personId: string | null) => {
+        console.log(`Updating speaker tag ${tagId} to person ${personId}`);
+        await updateSpeakerTag(tagId, { personId });
+        setSpeakerTags(prevTags =>
+            prevTags.map(tag => (tag.id === tagId ? { ...tag, personId } : tag))
+        );
+    }, []);
+
+    const updateSpeakerTagLabel = useCallback(async (tagId: string, label: string) => {
+        console.log(`Updating speaker tag ${tagId} label to ${label}`);
+        await updateSpeakerTag(tagId, { label });
+        setSpeakerTags(prevTags =>
+            prevTags.map(tag => (tag.id === tagId ? { ...tag, label } : tag))
+        );
+    }, []);
+
+    const createEmptySegmentAfter = useCallback(async (afterSegmentId: string) => {
+        const newSegment = await createEmptySpeakerSegmentAfter(afterSegmentId, cityId, meetingId);
+        setTranscript(prev => {
+            const segmentIndex = prev.findIndex(s => s.id === afterSegmentId);
+            if (segmentIndex === -1) return prev;
+            return [
+                ...prev.slice(0, segmentIndex + 1),
+                newSegment,
+                ...prev.slice(segmentIndex + 1)
+            ];
+        });
+        setSpeakerTags(prev => [...prev, newSegment.speakerTag]);
+    }, [cityId, meetingId]);
+
+    const createEmptySegmentBefore = useCallback(async (beforeSegmentId: string) => {
+        const newSegment = await createEmptySpeakerSegmentBefore(beforeSegmentId, cityId, meetingId);
+        setTranscript(prev => {
+            const segmentIndex = prev.findIndex(s => s.id === beforeSegmentId);
+            if (segmentIndex === -1) return prev;
+            return [
+                ...prev.slice(0, segmentIndex),
+                newSegment,
+                ...prev.slice(segmentIndex)
+            ];
+        });
+        setSpeakerTags(prev => [...prev, newSegment.speakerTag]);
+    }, [cityId, meetingId]);
+
+    const moveUtterancesToPrevious = useCallback(async (utteranceId: string, currentSegmentId: string) => {
+        const result = await moveUtterancesToPreviousSegment(utteranceId, currentSegmentId);
+        if (!result.previousSegment || !result.currentSegment) return;
+        setTranscript(prev => {
+            const updated = [...prev];
+            const prevIndex = updated.findIndex(s => s.id === result.previousSegment?.id);
+            const currIndex = updated.findIndex(s => s.id === result.currentSegment?.id);
+            if (prevIndex !== -1 && currIndex !== -1 && result.previousSegment && result.currentSegment) {
+                updated[prevIndex] = {
+                    ...updated[prevIndex],
+                    ...result.previousSegment,
+                    utterances: result.previousSegment.utterances || []
+                };
+                updated[currIndex] = {
+                    ...updated[currIndex],
+                    ...result.currentSegment,
+                    utterances: result.currentSegment.utterances || []
+                };
+            }
+            return updated;
+        });
+    }, []);
+
+    const moveUtterancesToNext = useCallback(async (utteranceId: string, currentSegmentId: string) => {
+        const result = await moveUtterancesToNextSegment(utteranceId, currentSegmentId);
+        if (!result.currentSegment || !result.nextSegment) return;
+        setTranscript(prev => {
+            const updated = [...prev];
+            const currIndex = updated.findIndex(s => s.id === result.currentSegment?.id);
+            const nextIndex = updated.findIndex(s => s.id === result.nextSegment?.id);
+            if (currIndex !== -1 && nextIndex !== -1 && result.currentSegment && result.nextSegment) {
+                updated[currIndex] = {
+                    ...updated[currIndex],
+                    ...result.currentSegment,
+                    utterances: result.currentSegment.utterances || []
+                };
+                updated[nextIndex] = {
+                    ...updated[nextIndex],
+                    ...result.nextSegment,
+                    utterances: result.nextSegment.utterances || []
+                };
+            }
+            return updated;
+        });
+    }, []);
+
+    const deleteEmptySegment = useCallback(async (segmentId: string) => {
+        await deleteEmptySpeakerSegment(segmentId, cityId);
+        // Read the deleted tag id from `prev` so this callback doesn't need
+        // speakerSegmentsMap as a dep.
+        setTranscript(prev => {
+            const segment = prev.find(s => s.id === segmentId);
+            const deletedSpeakerTagId = segment?.speakerTagId;
+            const updated = prev.filter(s => s.id !== segmentId);
+            if (deletedSpeakerTagId) {
+                const isTagStillInUse = updated.some(s => s.speakerTagId === deletedSpeakerTagId);
+                if (!isTagStillInUse) {
+                    setSpeakerTags(prevTags => prevTags.filter(t => t.id !== deletedSpeakerTagId));
+                }
+            }
+            return updated;
+        });
+    }, [cityId]);
+
+    const updateSpeakerSegmentDataAction = useCallback(async (segmentId: string, editData: EditableSpeakerSegmentData) => {
+        console.log(`Updating speaker segment ${segmentId} data`);
+        const updatedSegment = await updateSpeakerSegmentData(segmentId, editData, cityId);
+        setTranscript(prev => prev.map(segment =>
+            segment.id === segmentId ? updatedSegment : segment
+        ));
+    }, [cityId]);
+
+    const addUtteranceToSegmentAction = useCallback(async (segmentId: string) => {
+        console.log(`Adding utterance to segment ${segmentId}`);
+        const updatedSegment = await addUtteranceToSegment(segmentId, cityId);
+        setTranscript(prev => prev.map(segment =>
+            segment.id === segmentId ? updatedSegment : segment
+        ));
+        const newUtterance = updatedSegment.utterances[updatedSegment.utterances.length - 1];
+        return newUtterance?.id || '';
+    }, [cityId]);
+
+    const extractSpeakerSegmentAction = useCallback(async (segmentId: string, startUtteranceId: string, endUtteranceId: string) => {
+        const newSegments = await extractSpeakerSegment(cityId, meetingId, segmentId, startUtteranceId, endUtteranceId);
+        setTranscript(prev => {
+            const originalIndex = prev.findIndex(s => s.id === segmentId);
+            if (originalIndex === -1) return prev;
+            const updatedTranscript = [...prev];
+            updatedTranscript.splice(originalIndex, 1, ...newSegments);
+            return updatedTranscript;
+        });
+        const newTags = newSegments.map(s => s.speakerTag);
+        setSpeakerTags(prev => {
+            const prevIds = new Set(prev.map(t => t.id));
+            const tagsToAdd = newTags.filter(t => !prevIds.has(t.id));
+            return [...prev, ...tagsToAdd];
+        });
+    }, [cityId, meetingId]);
+
+    const deleteUtteranceAction = useCallback(async (utteranceId: string) => {
+        console.log(`Deleting utterance ${utteranceId}`);
+        const { segmentId, remainingUtterances } = await deleteUtterance(utteranceId);
+        setTranscript(prev => prev.map(segment => {
+            if (segment.id === segmentId) {
+                const updatedUtterances = segment.utterances.filter(u => u.id !== utteranceId);
+                if (remainingUtterances === 0) {
+                    return { ...segment, utterances: [] };
+                }
+                const newTimestamps = recalculateSegmentTimestamps(updatedUtterances);
+                return { ...segment, utterances: updatedUtterances, ...newTimestamps };
+            }
+            return segment;
+        }));
+    }, [recalculateSegmentTimestamps]);
+
+    const updateUtterance = useCallback((segmentId: string, utteranceId: string, updates: Partial<{ text: string; startTimestamp: number; endTimestamp: number; lastModifiedBy: LastModifiedBy | null }>) => {
+        setTranscript(prev => prev.map(segment => {
+            if (segment.id === segmentId) {
+                const updatedUtterances = segment.utterances.map(u =>
+                    u.id === utteranceId ? { ...u, ...updates } : u
+                );
+                const timestampsChanged = 'startTimestamp' in updates || 'endTimestamp' in updates;
+                if (timestampsChanged) {
+                    const newTimestamps = recalculateSegmentTimestamps(updatedUtterances);
+                    return { ...segment, utterances: updatedUtterances, ...newTimestamps };
+                }
+                return { ...segment, utterances: updatedUtterances };
+            }
+            return segment;
+        }));
+    }, [recalculateSegmentTimestamps]);
+
+    // Stable for the lifetime of the provider — every callback above is
+    // wrapped in useCallback with deps that never change.
+    const actionsValue = useMemo<CouncilMeetingActions>(() => ({
+        updateSpeakerTagPerson,
+        updateSpeakerTagLabel,
+        createEmptySegmentAfter,
+        createEmptySegmentBefore,
+        moveUtterancesToPrevious,
+        moveUtterancesToNext,
+        deleteEmptySegment,
+        updateSpeakerSegmentData: updateSpeakerSegmentDataAction,
+        addUtteranceToSegment: addUtteranceToSegmentAction,
+        deleteUtterance: deleteUtteranceAction,
+        updateUtterance,
+        addHighlight,
+        updateHighlight,
+        removeHighlight,
+        extractSpeakerSegment: extractSpeakerSegmentAction,
+    }), [
+        updateSpeakerTagPerson,
+        updateSpeakerTagLabel,
+        createEmptySegmentAfter,
+        createEmptySegmentBefore,
+        moveUtterancesToPrevious,
+        moveUtterancesToNext,
+        deleteEmptySegment,
+        updateSpeakerSegmentDataAction,
+        addUtteranceToSegmentAction,
+        deleteUtteranceAction,
+        updateUtterance,
+        addHighlight,
+        updateHighlight,
+        removeHighlight,
+        extractSpeakerSegmentAction,
+    ]);
+
+    // Speaker tag → segment count. Recomputed only when transcript changes.
     const speakerTagSegmentCounts = useMemo(() => {
         const counts = new Map<string, number>();
         transcript.forEach(segment => {
@@ -70,292 +318,82 @@ export function CouncilMeetingDataProvider({ children, data }: {
         return counts;
     }, [transcript]);
 
-    // Highlight management methods
-    const addHighlight = useCallback((highlight: HighlightWithUtterances) => {
-        setHighlights(prev => [highlight, ...prev]);
-    }, []);
+    // Stable-identity getters: read the latest Map via a ref so the function
+    // ref itself never changes. Downstream callbacks (calculateHighlightData,
+    // extractSelectedSegment, …) list these in their deps; if the getter
+    // identity churned on transcript edits, those memoized provider values
+    // would invalidate and re-render every Utterance via context.
+    const peopleMapRef = useRef(peopleMap);
+    const partiesMapRef = useRef(partiesMap);
+    const speakerTagsMapRef = useRef(speakerTagsMap);
+    const speakerSegmentsMapRef = useRef(speakerSegmentsMap);
+    const speakerTagSegmentCountsRef = useRef(speakerTagSegmentCounts);
+    const highlightsMapRef = useRef(highlightsMap);
+    const peopleRef = useRef(data.people);
+    peopleMapRef.current = peopleMap;
+    partiesMapRef.current = partiesMap;
+    speakerTagsMapRef.current = speakerTagsMap;
+    speakerSegmentsMapRef.current = speakerSegmentsMap;
+    speakerTagSegmentCountsRef.current = speakerTagSegmentCounts;
+    highlightsMapRef.current = highlightsMap;
+    peopleRef.current = data.people;
 
-    const updateHighlight = useCallback((highlightId: string, updates: Partial<HighlightWithUtterances>) => {
-        setHighlights(prev => {
-            const highlightIndex = prev.findIndex(h => h.id === highlightId);
-            if (highlightIndex === -1) return prev;
-            
-            // Remove the highlight from its current position
-            const updatedHighlight = { ...prev[highlightIndex], ...updates };
-            const newHighlights = prev.filter(h => h.id !== highlightId);
-            
-            // Add it to the start of the list
-            return [updatedHighlight, ...newHighlights];
-        });
-    }, []);
+    const getPerson = useCallback((id: string) => peopleMapRef.current.get(id), []);
+    const getParty = useCallback((id: string) => partiesMapRef.current.get(id), []);
+    const getSpeakerTag = useCallback((id: string) => speakerTagsMapRef.current.get(id), []);
+    const getSpeakerSegmentCount = useCallback((tagId: string) => speakerTagSegmentCountsRef.current.get(tagId) || 0, []);
+    const getSpeakerSegmentById = useCallback((id: string) => speakerSegmentsMapRef.current.get(id), []);
+    const getHighlight = useCallback((highlightId: string) => highlightsMapRef.current.get(highlightId), []);
+    const getPersonsForParty = useCallback((partyId: string) => peopleRef.current.filter(person => {
+        const party = getPartyFromRoles(person.roles);
+        return party?.id === partyId;
+    }), []);
 
-    const removeHighlight = useCallback((highlightId: string) => {
-        setHighlights(prev => prev.filter(h => h.id !== highlightId));
-    }, []);
-
-    const getHighlight = useCallback((highlightId: string) => {
-        return highlightsMap.get(highlightId);
-    }, [highlightsMap]);
-
-    const contextValue = useMemo(() => ({
+    // Public data context minus `transcript`. Identity is stable across
+    // transcript edits — invalidates only when speakerTags / highlights /
+    // static data change. SpeakerSegment et al. subscribe via this hook to
+    // bail on transcript-only edits.
+    const metaValue = useMemo<CouncilMeetingMeta>(() => ({
         ...data,
-        transcript,
         speakerTags,
         highlights,
-        getPerson: (id: string) => peopleMap.get(id),
-        getParty: (id: string) => partiesMap.get(id),
-        getSpeakerTag: (id: string) => speakerTagsMap.get(id),
-        getSpeakerSegmentCount: (tagId: string) => speakerTagSegmentCounts.get(tagId) || 0,
-        getSpeakerSegmentById: (id: string) => speakerSegmentsMap.get(id),
-        getPersonsForParty: (partyId: string) => data.people.filter(person => {
-            const party = getPartyFromRoles(person.roles);
-            return party?.id === partyId;
-        }),
+        getPerson,
+        getParty,
+        getSpeakerTag,
+        getSpeakerSegmentCount,
+        getSpeakerSegmentById,
+        getPersonsForParty,
         getHighlight,
-        updateSpeakerTagPerson: async (tagId: string, personId: string | null) => {
-            console.log(`Updating speaker tag ${tagId} to person ${personId}`);
-            await updateSpeakerTag(tagId, { personId });
-            setSpeakerTags(prevTags =>
-                prevTags.map(tag =>
-                    tag.id === tagId ? { ...tag, personId } : tag
-                )
-            );
-        },
-        updateSpeakerTagLabel: async (tagId: string, label: string) => {
-            console.log(`Updating speaker tag ${tagId} label to ${label}`);
-            await updateSpeakerTag(tagId, { label });
-            setSpeakerTags(prevTags =>
-                prevTags.map(tag =>
-                    tag.id === tagId ? { ...tag, label } : tag
-                )
-            );
-        },
-        createEmptySegmentAfter: async (afterSegmentId: string) => {
-            const newSegment = await createEmptySpeakerSegmentAfter(
-                afterSegmentId,
-                data.meeting.cityId,
-                data.meeting.id
-            );
+        ...actionsValue,
+    }), [
+        data,
+        speakerTags,
+        highlights,
+        getPerson,
+        getParty,
+        getSpeakerTag,
+        getSpeakerSegmentCount,
+        getSpeakerSegmentById,
+        getPersonsForParty,
+        getHighlight,
+        actionsValue,
+    ]);
 
-            // Insert the new segment after it
-            setTranscript(prev => {
-                // Find the index of the segment we're inserting after using fresh state
-                const segmentIndex = prev.findIndex(s => s.id === afterSegmentId);
-                if (segmentIndex === -1) return prev;
-                
-                return [
-                    ...prev.slice(0, segmentIndex + 1),
-                    newSegment,
-                    ...prev.slice(segmentIndex + 1)
-                ];
-            });
-
-            // Add the new speaker tag to our state
-            setSpeakerTags(prev => [...prev, newSegment.speakerTag]);
-        },
-        createEmptySegmentBefore: async (beforeSegmentId: string) => {
-            const newSegment = await createEmptySpeakerSegmentBefore(
-                beforeSegmentId,
-                data.meeting.cityId,
-                data.meeting.id
-            );
-
-            // Insert the new segment before it
-            setTranscript(prev => {
-                // Find the index of the segment we're inserting before using fresh state
-                const segmentIndex = prev.findIndex(s => s.id === beforeSegmentId);
-                if (segmentIndex === -1) return prev;
-                
-                return [
-                    ...prev.slice(0, segmentIndex),
-                    newSegment,
-                    ...prev.slice(segmentIndex)
-                ];
-            });
-
-            // Add the new speaker tag to our state
-            setSpeakerTags(prev => [...prev, newSegment.speakerTag]);
-        },
-        moveUtterancesToPrevious: async (utteranceId: string, currentSegmentId: string) => {
-            const result = await moveUtterancesToPreviousSegment(utteranceId, currentSegmentId);
-
-            if (!result.previousSegment || !result.currentSegment) return;
-
-            // Update the transcript state with the modified segments
-            setTranscript(prev => {
-                const updated = [...prev];
-                const prevIndex = updated.findIndex(s => s.id === result.previousSegment?.id);
-                const currIndex = updated.findIndex(s => s.id === result.currentSegment?.id);
-
-                // Only update if we found both segments and they're not null
-                if (prevIndex !== -1 && currIndex !== -1 && result.previousSegment && result.currentSegment) {
-                    updated[prevIndex] = {
-                        ...updated[prevIndex],
-                        ...result.previousSegment,
-                        utterances: result.previousSegment.utterances || []
-                    };
-                    updated[currIndex] = {
-                        ...updated[currIndex],
-                        ...result.currentSegment,
-                        utterances: result.currentSegment.utterances || []
-                    };
-                }
-                return updated;
-            });
-        },
-        moveUtterancesToNext: async (utteranceId: string, currentSegmentId: string) => {
-            const result = await moveUtterancesToNextSegment(utteranceId, currentSegmentId);
-
-            if (!result.currentSegment || !result.nextSegment) return;
-
-            // Update the transcript state with the modified segments
-            setTranscript(prev => {
-                const updated = [...prev];
-                const currIndex = updated.findIndex(s => s.id === result.currentSegment?.id);
-                const nextIndex = updated.findIndex(s => s.id === result.nextSegment?.id);
-
-                // Only update if we found both segments and they're not null
-                if (currIndex !== -1 && nextIndex !== -1 && result.currentSegment && result.nextSegment) {
-                    updated[currIndex] = {
-                        ...updated[currIndex],
-                        ...result.currentSegment,
-                        utterances: result.currentSegment.utterances || []
-                    };
-                    updated[nextIndex] = {
-                        ...updated[nextIndex],
-                        ...result.nextSegment,
-                        utterances: result.nextSegment.utterances || []
-                    };
-                }
-                return updated;
-            });
-        },
-        deleteEmptySegment: async (segmentId: string) => {
-            await deleteEmptySpeakerSegment(segmentId, data.meeting.cityId);
-
-            const segment = speakerSegmentsMap.get(segmentId);
-            const deletedSpeakerTagId = segment?.speakerTagId;
-
-            // Remove the segment from the transcript
-            setTranscript(prev => {
-                const updated = prev.filter(s => s.id !== segmentId);
-                
-                // Only remove the speaker tag if no other segments are using it
-                if (deletedSpeakerTagId) {
-                    const isTagStillInUse = updated.some(s => s.speakerTagId === deletedSpeakerTagId);
-                    if (!isTagStillInUse) {
-                        setSpeakerTags(prevTags => prevTags.filter(t => t.id !== deletedSpeakerTagId));
-                    }
-                }
-                
-                return updated;
-            });
-        },
-        addHighlight,
-        updateHighlight,
-        removeHighlight,
-        updateSpeakerSegmentData: async (segmentId: string, editData: EditableSpeakerSegmentData) => {
-            console.log(`Updating speaker segment ${segmentId} data`);
-            const updatedSegment = await updateSpeakerSegmentData(segmentId, editData, data.meeting.cityId);
-            
-            // Update transcript state with the fully updated segment data
-            setTranscript(prev => prev.map(segment =>
-                segment.id === segmentId ? updatedSegment : segment
-            ));
-        },
-        addUtteranceToSegment: async (segmentId: string) => {
-            console.log(`Adding utterance to segment ${segmentId}`);
-            const updatedSegment = await addUtteranceToSegment(segmentId, data.meeting.cityId);
-            
-            // Update transcript state with the fully updated segment data
-            setTranscript(prev => prev.map(segment =>
-                segment.id === segmentId ? updatedSegment : segment
-            ));
-            
-            // Return the ID of the newly created utterance (last one in the updated segment)
-            const newUtterance = updatedSegment.utterances[updatedSegment.utterances.length - 1];
-            return newUtterance?.id || '';
-        },
-        extractSpeakerSegment: async (segmentId: string, startUtteranceId: string, endUtteranceId: string) => {
-            const newSegments = await extractSpeakerSegment(data.meeting.cityId, data.meeting.id, segmentId, startUtteranceId, endUtteranceId);
-            
-            // Replace the original segment with the new segments (Before, Middle, After)
-            setTranscript(prev => {
-                const originalIndex = prev.findIndex(s => s.id === segmentId);
-                if (originalIndex === -1) return prev;
-
-                const updatedTranscript = [...prev];
-                updatedTranscript.splice(originalIndex, 1, ...newSegments);
-                
-                return updatedTranscript;
-            });
-            
-            // Add any new speaker tags that were created
-            const newTags = newSegments.map(s => s.speakerTag);
-            setSpeakerTags(prev => {
-                 const prevIds = new Set(prev.map(t => t.id));
-                 const tagsToAdd = newTags.filter(t => !prevIds.has(t.id));
-                 return [...prev, ...tagsToAdd];
-            });
-        },
-        deleteUtterance: async (utteranceId: string) => {
-            console.log(`Deleting utterance ${utteranceId}`);
-            const { segmentId, remainingUtterances } = await deleteUtterance(utteranceId);
-            
-            // Update the segment to remove the utterance
-            setTranscript(prev => prev.map(segment => {
-                if (segment.id === segmentId) {
-                    const updatedUtterances = segment.utterances.filter(u => u.id !== utteranceId);
-                    
-                    // If no utterances remain, keep the segment but with empty utterances array
-                    if (remainingUtterances === 0) {
-                        return { ...segment, utterances: [] };
-                    }
-                    
-                    // Otherwise, recalculate timestamps based on remaining utterances
-                    const newTimestamps = recalculateSegmentTimestamps(updatedUtterances);
-                    return {
-                        ...segment,
-                        utterances: updatedUtterances,
-                        ...newTimestamps
-                    };
-                }
-                return segment;
-            }));
-        },
-        updateUtterance: (segmentId: string, utteranceId: string, updates: Partial<{ text: string; startTimestamp: number; endTimestamp: number; lastModifiedBy: LastModifiedBy | null }>) => {
-            setTranscript(prev => prev.map(segment => {
-                if (segment.id === segmentId) {
-                    // Update the utterance
-                    const updatedUtterances = segment.utterances.map(u =>
-                        u.id === utteranceId ? { ...u, ...updates } : u
-                    );
-                    
-                    // If timestamps changed, recalculate segment boundaries
-                    const timestampsChanged = 'startTimestamp' in updates || 'endTimestamp' in updates;
-                    if (timestampsChanged) {
-                        const newTimestamps = recalculateSegmentTimestamps(updatedUtterances);
-                        return {
-                            ...segment,
-                            utterances: updatedUtterances,
-                            ...newTimestamps
-                        };
-                    }
-                    
-                    return {
-                        ...segment,
-                        utterances: updatedUtterances
-                    };
-                }
-                return segment;
-            }));
-        }
-    }), [data, peopleMap, partiesMap, speakerTags, speakerTagsMap, speakerSegmentsMap, transcript, speakerTagSegmentCounts, highlights, addHighlight, updateHighlight, removeHighlight, getHighlight, recalculateSegmentTimestamps]);
+    // Backward-compatible composition: metaValue + transcript. Existing
+    // useCouncilMeetingData() consumers see the same shape as before.
+    const contextValue = useMemo<CouncilMeetingDataContext>(() => ({
+        ...metaValue,
+        transcript,
+    }), [metaValue, transcript]);
 
     return (
-        <CouncilMeetingDataContext.Provider value={contextValue}>
-            {children}
-        </CouncilMeetingDataContext.Provider>
+        <CouncilMeetingActionsContext.Provider value={actionsValue}>
+            <CouncilMeetingMetaContext.Provider value={metaValue}>
+                <CouncilMeetingDataContext.Provider value={contextValue}>
+                    {children}
+                </CouncilMeetingDataContext.Provider>
+            </CouncilMeetingMetaContext.Provider>
+        </CouncilMeetingActionsContext.Provider>
     );
 }
 
@@ -363,6 +401,31 @@ export function useCouncilMeetingData() {
     const context = useContext(CouncilMeetingDataContext);
     if (context === undefined) {
         throw new Error('useCouncilMeetingData must be used within a CouncilMeetingDataProvider');
+    }
+    return context;
+}
+
+// Hook for components that only need to dispatch mutations. Consumers of this
+// hook do NOT re-render when transcript/speakerTags/highlights change — the
+// returned value is referentially stable for the lifetime of the provider.
+export function useCouncilMeetingActions() {
+    const context = useContext(CouncilMeetingActionsContext);
+    if (context === undefined) {
+        throw new Error('useCouncilMeetingActions must be used within a CouncilMeetingDataProvider');
+    }
+    return context;
+}
+
+// Hook for components that need everything EXCEPT the transcript array
+// (e.g., SpeakerSegment, which is the parent of Utterance and renders the
+// segment header from speakerTag / person / party / segmentCount). Consumers
+// of this hook do NOT re-render on transcript edits — only on speakerTags /
+// highlights / static data changes. This is the right hook for any component
+// that doesn't directly iterate the transcript.
+export function useCouncilMeetingMeta() {
+    const context = useContext(CouncilMeetingMetaContext);
+    if (context === undefined) {
+        throw new Error('useCouncilMeetingMeta must be used within a CouncilMeetingDataProvider');
     }
     return context;
 }

--- a/src/components/meetings/CouncilMeetingDataContext.tsx
+++ b/src/components/meetings/CouncilMeetingDataContext.tsx
@@ -360,19 +360,25 @@ export function CouncilMeetingDataProvider({ children, data }: {
     // transcript edits — invalidates only when speakerTags / highlights /
     // static data change. SpeakerSegment et al. subscribe via this hook to
     // bail on transcript-only edits.
-    const metaValue = useMemo<CouncilMeetingMeta>(() => ({
-        ...data,
-        speakerTags,
-        highlights,
-        getPerson,
-        getParty,
-        getSpeakerTag,
-        getSpeakerSegmentCount,
-        getSpeakerSegmentById,
-        getPersonsForParty,
-        getHighlight,
-        ...actionsValue,
-    }), [
+    const metaValue = useMemo<CouncilMeetingMeta>(() => {
+        // Drop the initial transcript prop from the spread so consumers can't
+        // read a stale snapshot through this context (the live transcript
+        // lives on `contextValue` only).
+        const { transcript: _initialTranscript, ...staticData } = data;
+        return {
+            ...staticData,
+            speakerTags,
+            highlights,
+            getPerson,
+            getParty,
+            getSpeakerTag,
+            getSpeakerSegmentCount,
+            getSpeakerSegmentById,
+            getPersonsForParty,
+            getHighlight,
+            ...actionsValue,
+        };
+    }, [
         data,
         speakerTags,
         highlights,

--- a/src/components/meetings/CouncilMeetingDataContext.tsx
+++ b/src/components/meetings/CouncilMeetingDataContext.tsx
@@ -188,20 +188,30 @@ export function CouncilMeetingDataProvider({ children, data }: {
 
     const deleteEmptySegment = useCallback(async (segmentId: string) => {
         await deleteEmptySpeakerSegment(segmentId, cityId);
-        // Read the deleted tag id from `prev` so this callback doesn't need
-        // speakerSegmentsMap as a dep.
-        setTranscript(prev => {
-            const segment = prev.find(s => s.id === segmentId);
-            const deletedSpeakerTagId = segment?.speakerTagId;
-            const updated = prev.filter(s => s.id !== segmentId);
-            if (deletedSpeakerTagId) {
-                const isTagStillInUse = updated.some(s => s.speakerTagId === deletedSpeakerTagId);
-                if (!isTagStillInUse) {
-                    setSpeakerTags(prevTags => prevTags.filter(t => t.id !== deletedSpeakerTagId));
-                }
-            }
-            return updated;
-        });
+
+        // Decide tag-state changes outside `setTranscript`'s updater to keep
+        // it pure. Refs always hold the latest committed state.
+        const segmentsMap = speakerSegmentsMapRef.current;
+        const deletedSpeakerTagId = segmentsMap.get(segmentId)?.speakerTagId;
+        let tagUsageCount = 0;
+        if (deletedSpeakerTagId) {
+            segmentsMap.forEach(s => {
+                if (s.speakerTagId === deletedSpeakerTagId) tagUsageCount++;
+            });
+        }
+
+        setTranscript(prev => prev.filter(s => s.id !== segmentId));
+
+        if (deletedSpeakerTagId) {
+            // If we're removing the last segment for this tag, drop the tag.
+            // Otherwise still bump speakerTags' identity so SpeakerSegment
+            // (subscribed to meta context) re-renders with the updated
+            // segment count for the shared tag.
+            setSpeakerTags(prev => tagUsageCount === 1
+                ? prev.filter(t => t.id !== deletedSpeakerTagId)
+                : [...prev]
+            );
+        }
     }, [cityId]);
 
     const updateSpeakerSegmentDataAction = useCallback(async (segmentId: string, editData: EditableSpeakerSegmentData) => {

--- a/src/components/meetings/CouncilMeetingDataContext.tsx
+++ b/src/components/meetings/CouncilMeetingDataContext.tsx
@@ -1,5 +1,5 @@
 "use client"
-import React, { createContext, useContext, ReactNode, useMemo, useState, useCallback, useRef } from 'react';
+import React, { createContext, useContext, ReactNode, useMemo, useState, useCallback, useRef, useEffect } from 'react';
 import { Party, SpeakerTag, LastModifiedBy } from '@prisma/client';
 import { updateSpeakerTag } from '@/lib/db/speakerTags';
 import { createEmptySpeakerSegmentAfter, createEmptySpeakerSegmentBefore, moveUtterancesToPreviousSegment, moveUtterancesToNextSegment, deleteEmptySpeakerSegment, updateSpeakerSegmentData, EditableSpeakerSegmentData, extractSpeakerSegment, addUtteranceToSegment } from '@/lib/db/speakerSegments';
@@ -188,30 +188,14 @@ export function CouncilMeetingDataProvider({ children, data }: {
 
     const deleteEmptySegment = useCallback(async (segmentId: string) => {
         await deleteEmptySpeakerSegment(segmentId, cityId);
-
-        // Decide tag-state changes outside `setTranscript`'s updater to keep
-        // it pure. Refs always hold the latest committed state.
-        const segmentsMap = speakerSegmentsMapRef.current;
-        const deletedSpeakerTagId = segmentsMap.get(segmentId)?.speakerTagId;
-        let tagUsageCount = 0;
-        if (deletedSpeakerTagId) {
-            segmentsMap.forEach(s => {
-                if (s.speakerTagId === deletedSpeakerTagId) tagUsageCount++;
-            });
-        }
-
         setTranscript(prev => prev.filter(s => s.id !== segmentId));
-
-        if (deletedSpeakerTagId) {
-            // If we're removing the last segment for this tag, drop the tag.
-            // Otherwise still bump speakerTags' identity so SpeakerSegment
-            // (subscribed to meta context) re-renders with the updated
-            // segment count for the shared tag.
-            setSpeakerTags(prev => tagUsageCount === 1
-                ? prev.filter(t => t.id !== deletedSpeakerTagId)
-                : [...prev]
-            );
-        }
+        // Bump speakerTags' identity so SpeakerSegment (subscribed to meta
+        // context) re-renders with the updated segment count for any shared
+        // tag. The auto-prune effect below drops the tag entirely if the
+        // deletion leaves it orphaned — that derivation is robust under
+        // batched deletes that a manual ref-check inside the action wouldn't
+        // get right.
+        setSpeakerTags(prev => [...prev]);
     }, [cityId]);
 
     const updateSpeakerSegmentDataAction = useCallback(async (segmentId: string, editData: EditableSpeakerSegmentData) => {
@@ -326,6 +310,19 @@ export function CouncilMeetingDataProvider({ children, data }: {
             counts.set(segment.speakerTag.id, count + 1);
         });
         return counts;
+    }, [transcript]);
+
+    // Auto-prune speakerTags whose segments are gone. Deriving this from the
+    // committed transcript is robust under batched deletes (a synchronous
+    // ref-check inside `deleteEmptySegment` would race when two segments with
+    // the same tag are deleted before React re-renders).
+    useEffect(() => {
+        setSpeakerTags(prev => {
+            const usedTagIds = new Set<string>();
+            for (const segment of transcript) usedTagIds.add(segment.speakerTagId);
+            const filtered = prev.filter(tag => usedTagIds.has(tag.id));
+            return filtered.length === prev.length ? prev : filtered;
+        });
     }, [transcript]);
 
     // Stable-identity getters: read the latest Map via a ref so the function

--- a/src/components/meetings/EditingContext.tsx
+++ b/src/components/meetings/EditingContext.tsx
@@ -42,27 +42,30 @@ export function EditingProvider({ children }: { children: ReactNode }) {
     }, []);
 
     const toggleSelection = useCallback((id: string, modifiers: { shift: boolean, ctrl: boolean }) => {
+        const isShiftRange = modifiers.shift && lastClickedRef.current;
+
         setSelectedUtteranceIds(prev => {
             const newSet = new Set(prev);
-
-            if (modifiers.shift && lastClickedRef.current) {
-                const rangeIds = calculateUtteranceRange(allUtterancesRef.current, lastClickedRef.current, id);
+            if (isShiftRange) {
+                const rangeIds = calculateUtteranceRange(allUtterancesRef.current, lastClickedRef.current!, id);
                 rangeIds.forEach(rangeId => newSet.add(rangeId));
             } else if (modifiers.ctrl) {
-                if (newSet.has(id)) {
-                    newSet.delete(id);
-                } else {
-                    newSet.add(id);
-                }
-                setLastClickedUtteranceId(id);
+                if (newSet.has(id)) newSet.delete(id);
+                else newSet.add(id);
             } else {
                 newSet.clear();
                 newSet.add(id);
-                setLastClickedUtteranceId(id);
             }
-
             return newSet;
         });
+
+        // Anchor moves on plain or ctrl click; shift-range click leaves it
+        // alone (so subsequent shift-clicks keep extending from the same
+        // anchor). Calling this outside the updater avoids the StrictMode
+        // double-fire pitfall.
+        if (!isShiftRange) {
+            setLastClickedUtteranceId(id);
+        }
     }, []);
 
     const extractSelectedSegment = useCallback(async () => {

--- a/src/components/meetings/EditingContext.tsx
+++ b/src/components/meetings/EditingContext.tsx
@@ -1,6 +1,6 @@
 "use client";
-import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
-import { useCouncilMeetingData } from './CouncilMeetingDataContext';
+import React, { createContext, useContext, useState, useCallback, useMemo, useRef, ReactNode } from 'react';
+import { useCouncilMeetingData, useCouncilMeetingActions } from './CouncilMeetingDataContext';
 import { ACTIONS, useKeyboardShortcut } from '@/contexts/KeyboardShortcutsContext';
 import { useToast } from '@/hooks/use-toast';
 import { useTranslations } from 'next-intl';
@@ -21,16 +21,20 @@ export function EditingProvider({ children }: { children: ReactNode }) {
     const [selectedUtteranceIds, setSelectedUtteranceIds] = useState<Set<string>>(new Set());
     const [lastClickedUtteranceId, setLastClickedUtteranceId] = useState<string | null>(null);
     const [isProcessing, setIsProcessing] = useState(false);
-    
-    const { transcript, extractSpeakerSegment, getSpeakerSegmentById } = useCouncilMeetingData();
+
+    const { transcript, getSpeakerSegmentById } = useCouncilMeetingData();
+    const { extractSpeakerSegment } = useCouncilMeetingActions();
     const { toast } = useToast();
     const t = useTranslations('editing.toasts');
 
-    // Flatten utterances for easy range index finding
-    // Memoizing this might be expensive if transcript changes often, but necessary for range selection
-    const allUtterances = React.useMemo(() => {
-        return transcript.flatMap(segment => segment.utterances);
-    }, [transcript]);
+    // Refs read only inside callbacks (not in render output), kept in sync
+    // via render-time assignment so toggleSelection / extractSelectedSegment
+    // can be useCallback(..., []) without observing stale values.
+    const allUtterances = useMemo(() => transcript.flatMap(s => s.utterances), [transcript]);
+    const allUtterancesRef = useRef(allUtterances);
+    allUtterancesRef.current = allUtterances;
+    const lastClickedRef = useRef(lastClickedUtteranceId);
+    lastClickedRef.current = lastClickedUtteranceId;
 
     const clearSelection = useCallback(() => {
         setSelectedUtteranceIds(new Set());
@@ -41,12 +45,10 @@ export function EditingProvider({ children }: { children: ReactNode }) {
         setSelectedUtteranceIds(prev => {
             const newSet = new Set(prev);
 
-            if (modifiers.shift && lastClickedUtteranceId) {
-                // Range selection using shared utility
-                const rangeIds = calculateUtteranceRange(allUtterances, lastClickedUtteranceId, id);
+            if (modifiers.shift && lastClickedRef.current) {
+                const rangeIds = calculateUtteranceRange(allUtterancesRef.current, lastClickedRef.current, id);
                 rangeIds.forEach(rangeId => newSet.add(rangeId));
             } else if (modifiers.ctrl) {
-                // Toggle individual
                 if (newSet.has(id)) {
                     newSet.delete(id);
                 } else {
@@ -54,7 +56,6 @@ export function EditingProvider({ children }: { children: ReactNode }) {
                 }
                 setLastClickedUtteranceId(id);
             } else {
-                // Single select (clear others)
                 newSet.clear();
                 newSet.add(id);
                 setLastClickedUtteranceId(id);
@@ -62,7 +63,7 @@ export function EditingProvider({ children }: { children: ReactNode }) {
 
             return newSet;
         });
-    }, [allUtterances, lastClickedUtteranceId]);
+    }, []);
 
     const extractSelectedSegment = useCallback(async () => {
         if (selectedUtteranceIds.size === 0) return;
@@ -70,13 +71,13 @@ export function EditingProvider({ children }: { children: ReactNode }) {
 
         setIsProcessing(true);
         try {
+            const allUtterances = allUtterancesRef.current;
             const selectedList = Array.from(selectedUtteranceIds);
             const firstUtterance = allUtterances.find(u => u.id === selectedList[0]);
             if (!firstUtterance) throw new Error("Selected utterance not found");
 
             const targetSegmentId = firstUtterance.speakerSegmentId;
-            
-            // Validate all selected utterances belong to the same segment
+
             const allInSame = selectedList.every(id => {
                 const u = allUtterances.find(ut => ut.id === id);
                 return u && u.speakerSegmentId === targetSegmentId;
@@ -91,15 +92,13 @@ export function EditingProvider({ children }: { children: ReactNode }) {
                 return;
             }
 
-            // Find chronological start and end utterances
             const indices = selectedList
                 .map(id => allUtterances.findIndex(u => u.id === id))
                 .sort((a, b) => a - b);
-            
+
             const startUtteranceId = allUtterances[indices[0]].id;
             const endUtteranceId = allUtterances[indices[indices.length - 1]].id;
 
-            // Validate extraction leaves utterances before and after (A-B-A pattern)
             const originalSegment = getSpeakerSegmentById(targetSegmentId);
             if (originalSegment) {
                 const totalUtterances = originalSegment.utterances.length;
@@ -108,7 +107,7 @@ export function EditingProvider({ children }: { children: ReactNode }) {
                 const extractionCount = segmentEndIndex - segmentStartIndex + 1;
 
                 if (extractionCount === totalUtterances) {
-                     toast({
+                    toast({
                         title: t('invalidOperationTitle'),
                         description: t('invalidOperationExtractAll'),
                         variant: "destructive"
@@ -127,7 +126,7 @@ export function EditingProvider({ children }: { children: ReactNode }) {
             }
 
             await extractSpeakerSegment(targetSegmentId, startUtteranceId, endUtteranceId);
-            
+
             clearSelection();
             toast({
                 description: t('extractionSuccess')
@@ -143,21 +142,33 @@ export function EditingProvider({ children }: { children: ReactNode }) {
         } finally {
             setIsProcessing(false);
         }
-    }, [selectedUtteranceIds, isProcessing, allUtterances, extractSpeakerSegment, getSpeakerSegmentById, clearSelection, toast, t]);
+    }, [selectedUtteranceIds, isProcessing, extractSpeakerSegment, getSpeakerSegmentById, clearSelection, toast, t]);
 
     // Register Shortcuts
     useKeyboardShortcut(ACTIONS.EXTRACT_SEGMENT.id, extractSelectedSegment, selectedUtteranceIds.size > 0);
     useKeyboardShortcut(ACTIONS.CLEAR_SELECTION.id, clearSelection, selectedUtteranceIds.size > 0);
 
+    // Memoized so EditingProvider re-renders (triggered by any
+    // CouncilMeetingDataContext change) don't churn the value object and
+    // re-render every Utterance consuming useEditing().
+    const value = useMemo<EditingContextType>(() => ({
+        selectedUtteranceIds,
+        lastClickedUtteranceId,
+        toggleSelection,
+        clearSelection,
+        extractSelectedSegment,
+        isProcessing,
+    }), [
+        selectedUtteranceIds,
+        lastClickedUtteranceId,
+        toggleSelection,
+        clearSelection,
+        extractSelectedSegment,
+        isProcessing,
+    ]);
+
     return (
-        <EditingContext.Provider value={{
-            selectedUtteranceIds,
-            lastClickedUtteranceId,
-            toggleSelection,
-            clearSelection,
-            extractSelectedSegment,
-            isProcessing
-        }}>
+        <EditingContext.Provider value={value}>
             {children}
         </EditingContext.Provider>
     );

--- a/src/components/meetings/HighlightContext.tsx
+++ b/src/components/meetings/HighlightContext.tsx
@@ -79,7 +79,7 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
   const [lastClickedAction, setLastClickedAction] = useState<'add' | 'remove' | null>(null);
 
   // Get transcript and speaker data from CouncilMeetingDataContext
-  const { transcript, getSpeakerTag, getPerson, getSpeakerSegmentById, meeting } = useCouncilMeetingData();
+  const { transcript, speakerTags, getSpeakerTag, getPerson, getSpeakerSegmentById, meeting } = useCouncilMeetingData();
   // Mutations come from the stable actions context — they never change identity.
   const { addHighlight, updateHighlight } = useCouncilMeetingActions();
   const { currentTime, seekTo, isPlaying, setIsPlaying, seekToAndPlay } = useVideo();
@@ -172,14 +172,14 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     return { statistics, highlightUtterances: utterances };
   }, [getSpeakerSegmentById, getSpeakerTag, getPerson]);
 
-  // Calculate data for the currently editing highlight. Recompute when
-  // editingHighlight identity changes OR when the transcript changes (the
-  // utteranceMap dep covers transcript identity changes).
+  // Recompute when the highlight changes, when the transcript changes
+  // (`utteranceMap` proxies transcript identity, refreshing utterance text and
+  // timestamps), or when speaker tags change (refreshes speaker names — the
+  // ref-backed `getSpeakerTag` getter has stable identity, so its returned
+  // data alone wouldn't trigger a recompute).
   const editingHighlightData = useMemo(() => {
     return calculateHighlightData(editingHighlight);
-    // utteranceMap is the proxy for transcript identity; including it ensures
-    // we recompute speaker labels/timestamps when underlying utterances change.
-  }, [calculateHighlightData, editingHighlight, utteranceMap]);
+  }, [calculateHighlightData, editingHighlight, utteranceMap, speakerTags]);
 
   const statistics = editingHighlightData?.statistics || null;
   const highlightUtterances = editingHighlightData?.highlightUtterances || null;

--- a/src/components/meetings/HighlightContext.tsx
+++ b/src/components/meetings/HighlightContext.tsx
@@ -174,11 +174,12 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
 
   // Recompute when the highlight changes, when the transcript changes
   // (`utteranceMap` proxies transcript identity, refreshing utterance text and
-  // timestamps), or when speaker tags change (refreshes speaker names — the
-  // ref-backed `getSpeakerTag` getter has stable identity, so its returned
-  // data alone wouldn't trigger a recompute).
+  // timestamps), or when speaker tags change (refreshes speaker names —
+  // `calculateHighlightData` reads them through stable ref-backed getters, so
+  // ESLint can't see them as deps).
   const editingHighlightData = useMemo(() => {
     return calculateHighlightData(editingHighlight);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [calculateHighlightData, editingHighlight, utteranceMap, speakerTags]);
 
   const statistics = editingHighlightData?.statistics || null;

--- a/src/components/meetings/HighlightContext.tsx
+++ b/src/components/meetings/HighlightContext.tsx
@@ -2,7 +2,7 @@
 import React, { createContext, useContext, useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import type { HighlightWithUtterances } from '@/lib/db/highlights';
-import { useCouncilMeetingData } from './CouncilMeetingDataContext';
+import { useCouncilMeetingActions, useCouncilMeetingData } from './CouncilMeetingDataContext';
 import { useVideo } from './VideoProvider';
 import { Utterance } from '@prisma/client';
 import { calculateUtteranceRange } from '@/lib/selection-utils';
@@ -35,7 +35,6 @@ interface HighlightContextType {
   highlightUtterances: HighlightUtterance[] | null;
   currentHighlightIndex: number;
   totalHighlights: number;
-  utteranceMap: Map<string, Utterance>; // Pre-built utterance map for performance
   hasUnsavedChanges: boolean;
   isSaving: boolean;
   isCreating: boolean;
@@ -78,14 +77,18 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
   const [isCreating, setIsCreating] = useState(false);
   const [lastClickedUtteranceId, setLastClickedUtteranceId] = useState<string | null>(null);
   const [lastClickedAction, setLastClickedAction] = useState<'add' | 'remove' | null>(null);
-  
+
   // Get transcript and speaker data from CouncilMeetingDataContext
-  const { transcript, getSpeakerTag, getPerson, getSpeakerSegmentById, meeting, addHighlight, updateHighlight } = useCouncilMeetingData();
+  const { transcript, getSpeakerTag, getPerson, getSpeakerSegmentById, meeting } = useCouncilMeetingData();
+  // Mutations come from the stable actions context — they never change identity.
+  const { addHighlight, updateHighlight } = useCouncilMeetingActions();
   const { currentTime, seekTo, isPlaying, setIsPlaying, seekToAndPlay } = useVideo();
   const router = useRouter();
   const pathname = usePathname();
 
-  // Build utterance map once and memoize it - this eliminates the need to rebuild it in useHighlightCalculations
+  // Build utterance map and flat list once per transcript change. These are
+  // accessed only inside callbacks (not in render output), so we mirror them
+  // into refs to keep callback identities stable across transcript changes.
   const utteranceMap = useMemo(() => {
     const map = new Map<string, Utterance>();
     transcript.forEach(segment => {
@@ -96,67 +99,87 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     return map;
   }, [transcript]);
 
-  // Flatten utterances for range selection
   const allUtterances = useMemo(() => {
     return transcript.flatMap(segment => segment.utterances);
   }, [transcript]);
 
+  // Refs mirror state read inside stable callbacks. Render-time assignment
+  // (vs useEffect) keeps reads consistent with the most recent committed
+  // render and avoids the post-commit window in which an effect-synced ref
+  // would observe stale data.
+  const utteranceMapRef = useRef(utteranceMap);
+  utteranceMapRef.current = utteranceMap;
+  const allUtterancesRef = useRef(allUtterances);
+  allUtterancesRef.current = allUtterances;
+  const editingHighlightRef = useRef(editingHighlight);
+  editingHighlightRef.current = editingHighlight;
+  const lastClickedIdRef = useRef(lastClickedUtteranceId);
+  lastClickedIdRef.current = lastClickedUtteranceId;
+  const lastClickedActionRef = useRef(lastClickedAction);
+  lastClickedActionRef.current = lastClickedAction;
+
   const calculateHighlightData = useCallback((highlight: HighlightWithUtterances | null): HighlightCalculationResult | null => {
-      if (!highlight || !transcript) {
-        return null;
+    if (!highlight) {
+      return null;
+    }
+
+    const map = utteranceMapRef.current;
+
+    // Extract highlight utterances with timestamps and speaker information
+    const utterances: HighlightUtterance[] = [];
+    highlight.highlightedUtterances.forEach(hu => {
+      const utterance = map.get(hu.utteranceId);
+      if (utterance) {
+        const segment = getSpeakerSegmentById(utterance.speakerSegmentId);
+        const speakerTag = segment ? getSpeakerTag(segment.speakerTagId) : null;
+        const person = speakerTag?.personId ? getPerson(speakerTag.personId) : undefined;
+        const speakerName = person ? person.name_short : speakerTag?.label || 'Unknown';
+
+        utterances.push({
+          id: utterance.id,
+          text: utterance.text,
+          startTimestamp: utterance.startTimestamp,
+          endTimestamp: utterance.endTimestamp,
+          speakerSegmentId: utterance.speakerSegmentId,
+          speakerName
+        });
       }
+    });
 
-      // Extract highlight utterances with timestamps and speaker information
-      const utterances: HighlightUtterance[] = [];
-      highlight.highlightedUtterances.forEach(hu => {
-        const utterance = utteranceMap.get(hu.utteranceId);
-        if (utterance) {
-          const segment = getSpeakerSegmentById(utterance.speakerSegmentId);
-          const speakerTag = segment ? getSpeakerTag(segment.speakerTagId) : null;
-          const person = speakerTag?.personId ? getPerson(speakerTag.personId) : undefined;
-          const speakerName = person ? person.name_short : speakerTag?.label || 'Unknown';
-          
-          utterances.push({
-            id: utterance.id,
-            text: utterance.text,
-            startTimestamp: utterance.startTimestamp,
-            endTimestamp: utterance.endTimestamp,
-            speakerSegmentId: utterance.speakerSegmentId,
-            speakerName
-          });
-        }
-      });
+    // Sort utterances chronologically
+    utterances.sort((a, b) => a.startTimestamp - b.startTimestamp);
 
-      // Sort utterances chronologically
-      utterances.sort((a, b) => a.startTimestamp - b.startTimestamp);
+    // Calculate statistics
+    const utteranceCount = utterances.length;
 
-      // Calculate statistics
-      const utteranceCount = utterances.length;
-      
-      const duration = utterances.reduce((total, utterance: HighlightUtterance) => {
-        return total + (utterance.endTimestamp - utterance.startTimestamp);
-      }, 0);
-      
-      // Calculate speaker count
-      const speakerNames = new Set<string>();
-      utterances.forEach(utterance => {
-        speakerNames.add(utterance.speakerName);
-      });
-      const speakerCount = speakerNames.size;
+    const duration = utterances.reduce((total, utterance: HighlightUtterance) => {
+      return total + (utterance.endTimestamp - utterance.startTimestamp);
+    }, 0);
 
-      const statistics = {
-        duration,
-        utteranceCount,
-        speakerCount
-      };
+    // Calculate speaker count
+    const speakerNames = new Set<string>();
+    utterances.forEach(utterance => {
+      speakerNames.add(utterance.speakerName);
+    });
+    const speakerCount = speakerNames.size;
 
-      return { statistics, highlightUtterances: utterances };
-    }, [transcript, utteranceMap, getSpeakerSegmentById, getSpeakerTag, getPerson]);
+    const statistics = {
+      duration,
+      utteranceCount,
+      speakerCount
+    };
 
-  // Calculate data for the currently editing highlight
+    return { statistics, highlightUtterances: utterances };
+  }, [getSpeakerSegmentById, getSpeakerTag, getPerson]);
+
+  // Calculate data for the currently editing highlight. Recompute when
+  // editingHighlight identity changes OR when the transcript changes (the
+  // utteranceMap dep covers transcript identity changes).
   const editingHighlightData = useMemo(() => {
     return calculateHighlightData(editingHighlight);
-  }, [calculateHighlightData, editingHighlight]);
+    // utteranceMap is the proxy for transcript identity; including it ensures
+    // we recompute speaker labels/timestamps when underlying utterances change.
+  }, [calculateHighlightData, editingHighlight, utteranceMap]);
 
   const statistics = editingHighlightData?.statistics || null;
   const highlightUtterances = editingHighlightData?.highlightUtterances || null;
@@ -173,12 +196,12 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
       setCurrentHighlightIndex(0);
       return;
     }
-    
+
     // Find which highlighted utterance we're currently in
-    const currentIndex = highlightUtterances.findIndex(utterance => 
+    const currentIndex = highlightUtterances.findIndex(utterance =>
       currentTime >= utterance.startTimestamp && currentTime <= utterance.endTimestamp
     );
-    
+
     // Only update if we found a valid index and it's different from current
     if (currentIndex !== -1 && currentIndex !== currentHighlightIndex) {
       setCurrentHighlightIndex(currentIndex);
@@ -206,10 +229,10 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     if (isAutoAdvancingRef.current) {
       return;
     }
-    
+
     const currentUtterance = highlightUtterances[currentHighlightIndex];
     if (!currentUtterance) return;
-    
+
     if (currentTime >= currentUtterance.endTimestamp) {
       // Auto-advance to next highlight (wrap to start at the end)
       const nextIndex = (currentHighlightIndex + 1) % totalHighlights;
@@ -222,62 +245,56 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
   }, [currentTime, previewMode, highlightUtterances, currentHighlightIndex, isPlaying, totalHighlights, seekTo]);
 
   // Enhanced navigation functions
-  const goToPreviousHighlight = () => {
+  const goToPreviousHighlight = useCallback(() => {
     if (!highlightUtterances || highlightUtterances.length === 0) return;
-    
+
     let newIndex: number;
-    
+
     if (currentHighlightIndex > 0) {
       newIndex = currentHighlightIndex - 1;
     } else if (previewMode) {
-      // In preview mode, loop to last highlight
       newIndex = totalHighlights - 1;
     } else {
-      // In edit mode, stay at first highlight
       return;
     }
-    
+
     setIsPlaying(false);
     setCurrentHighlightIndex(newIndex);
     seekToAndPlay(highlightUtterances[newIndex].startTimestamp);
-  };
+  }, [highlightUtterances, currentHighlightIndex, previewMode, totalHighlights, setIsPlaying, seekToAndPlay]);
 
-  const goToNextHighlight = () => {
+  const goToNextHighlight = useCallback(() => {
     if (!highlightUtterances || highlightUtterances.length === 0) return;
-    
+
     let newIndex: number;
-    
+
     if (currentHighlightIndex < totalHighlights - 1) {
       newIndex = currentHighlightIndex + 1;
     } else if (previewMode) {
-      // In preview mode, loop back to first highlight
       newIndex = 0;
     } else {
-      // In edit mode, stay at last highlight
       return;
     }
-    
+
     setIsPlaying(false);
     setCurrentHighlightIndex(newIndex);
     seekToAndPlay(highlightUtterances[newIndex].startTimestamp);
-  };
+  }, [highlightUtterances, currentHighlightIndex, totalHighlights, previewMode, setIsPlaying, seekToAndPlay]);
 
-  const goToHighlightIndex = (index: number) => {
+  const goToHighlightIndex = useCallback((index: number) => {
     if (highlightUtterances && index >= 0 && index < highlightUtterances.length) {
       setCurrentHighlightIndex(index);
       seekTo(highlightUtterances[index].startTimestamp);
     }
-  };
+  }, [highlightUtterances, seekTo]);
 
   // Enhanced preview mode toggle
-  const togglePreviewMode = () => {
+  const togglePreviewMode = useCallback(() => {
     if (isPreviewDialogOpen) {
-      // Close dialog and exit preview
       setIsPreviewDialogOpen(false);
       setPreviewMode(false);
       setIsPlaying(false);
     } else {
-      // Open dialog and enter preview
       setIsPreviewDialogOpen(true);
       setPreviewMode(true);
       if (highlightUtterances && highlightUtterances.length > 0) {
@@ -285,55 +302,46 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
         seekToAndPlay(highlightUtterances[0].startTimestamp);
       }
     }
-  };
+  }, [isPreviewDialogOpen, highlightUtterances, setIsPlaying, seekToAndPlay]);
 
-  const openPreviewDialog = () => {
+  const openPreviewDialog = useCallback(() => {
     if (isPreviewDialogOpen) return;
     setIsPreviewDialogOpen(true);
     setPreviewMode(true);
     if (highlightUtterances && highlightUtterances.length > 0) {
       setCurrentHighlightIndex(0);
-      // Small delay to ensure video element is ready before starting playback
       setTimeout(() => {
         seekToAndPlay(highlightUtterances[0].startTimestamp);
       }, 100);
     }
-  };
+  }, [isPreviewDialogOpen, highlightUtterances, seekToAndPlay]);
 
-  const closePreviewDialog = () => {
+  const closePreviewDialog = useCallback(() => {
     if (!isPreviewDialogOpen) return;
     setIsPreviewDialogOpen(false);
     setPreviewMode(false);
     setIsPlaying(false);
-  };
+  }, [isPreviewDialogOpen, setIsPlaying]);
 
   // Enter edit mode - called when switching to edit mode (from URL parameter)
   const enterEditMode = useCallback((highlight: HighlightWithUtterances) => {
     setEditingHighlight(highlight);
-    // Store the original highlight for reset functionality
     setOriginalHighlight(highlight);
-    setIsDirty(false); // Start with clean state
-    // Clear range selection anchor
+    setIsDirty(false);
     setLastClickedUtteranceId(null);
     setLastClickedAction(null);
-    
-    // Auto-navigate to transcript page with highlight parameter if not already there
+
     const expectedPath = `/${highlight.cityId}/${highlight.meetingId}/transcript`;
     const expectedUrl = `${expectedPath}?highlight=${highlight.id}`;
-    
-    // Check if we're already on the transcript page
+
     if (pathname === expectedPath) {
-      // We're on transcript page, just add/update the highlight parameter
       router.replace(`${expectedPath}?highlight=${highlight.id}`, { scroll: false });
     } else if (!pathname.includes('/transcript')) {
-      // We're not on transcript page, navigate to it with highlight parameter
       router.push(expectedUrl, { scroll: false });
     }
-  }, [setEditingHighlight, setOriginalHighlight, setIsDirty, router, pathname]);
+  }, [router, pathname]);
 
   // Clean up highlight editing state when navigating away from transcript.
-  // This is the mirror of the Transcript.tsx useEffect that enters edit mode
-  // when arriving at /transcript?highlight=ID.
   useEffect(() => {
     if (editingHighlight && !pathname.includes('/transcript')) {
       setEditingHighlight(null);
@@ -346,107 +354,100 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     }
   }, [pathname, editingHighlight, setIsPlaying]);
 
-  // Check if editing should be disabled (e.g., during save operations)
-  // This prevents users from making changes while operations like saving are in progress
+  // Mirrored to a ref so updateHighlightUtterances can read it without
+  // having isSaving as a callback dep.
   const isEditingDisabled = isSaving;
+  const isEditingDisabledRef = useRef(isEditingDisabled);
+  isEditingDisabledRef.current = isEditingDisabled;
 
-  // Update highlight utterances during editing - called when adding/removing utterances
+  // Stable callback — reads state via refs so it has [] deps and never
+  // changes identity. Computes the next highlight outside of any setState
+  // updater so setIsDirty is not called from inside one (which would
+  // double-fire under StrictMode).
   const updateHighlightUtterances = useCallback((utteranceId: string, action: 'add' | 'remove', modifiers?: { shift: boolean }) => {
-    if (!editingHighlight || isEditingDisabled) return;
-    
-    // Determine the effective action:
-    // - If Shift is pressed and we have an anchor, use the anchor's action
-    // - Otherwise, use the action passed in (and set it as the new anchor action)
-    const effectiveAction = (modifiers?.shift && lastClickedUtteranceId && lastClickedAction) 
-      ? lastClickedAction 
+    if (isEditingDisabledRef.current) return;
+    const current = editingHighlightRef.current;
+    if (!current) return;
+
+    const lastClicked = lastClickedIdRef.current;
+    const lastAction = lastClickedActionRef.current;
+
+    const effectiveAction = (modifiers?.shift && lastClicked && lastAction)
+      ? lastAction
       : action;
-    
-    // Determine which utterances to operate on
+
     let utteranceIds: string[];
-    if (modifiers?.shift && lastClickedUtteranceId) {
-      // Range operation with Shift modifier - use the anchor action for the entire range
-      utteranceIds = calculateUtteranceRange(allUtterances, lastClickedUtteranceId, utteranceId);
+    if (modifiers?.shift && lastClicked) {
+      utteranceIds = calculateUtteranceRange(allUtterancesRef.current, lastClicked, utteranceId);
     } else {
-      // Single operation - this becomes the new anchor
       utteranceIds = [utteranceId];
       setLastClickedUtteranceId(utteranceId);
       setLastClickedAction(action);
     }
-    
+
+    let updated: HighlightWithUtterances;
     if (effectiveAction === 'remove') {
-      // Remove utterances from highlight
-      const updatedHighlight = {
-        ...editingHighlight,
-        highlightedUtterances: editingHighlight.highlightedUtterances.filter(
+      updated = {
+        ...current,
+        highlightedUtterances: current.highlightedUtterances.filter(
           hu => !utteranceIds.includes(hu.utteranceId)
         )
       };
-      
-      setEditingHighlight(updatedHighlight);
-      setIsDirty(true);
     } else {
-      // Add utterances to highlight
-      // Filter out already highlighted utterances and create new highlighted utterance objects
+      const map = utteranceMapRef.current;
       const now = new Date();
       const newHighlightedUtterances = utteranceIds
-        .filter(id => !editingHighlight.highlightedUtterances.some(hu => hu.utteranceId === id))
+        .filter(id => !current.highlightedUtterances.some(hu => hu.utteranceId === id))
         .map(id => {
-          const utterance = utteranceMap.get(id);
+          const utterance = map.get(id);
           if (!utterance) return null;
-          
           return {
             id: `temp-${Date.now()}-${Math.random()}`,
             utteranceId: id,
-            highlightId: editingHighlight.id,
+            highlightId: current.id,
             createdAt: now,
             updatedAt: now,
-            utterance: utterance
+            utterance,
           };
         })
         .filter((hu): hu is NonNullable<typeof hu> => hu !== null);
-      
-      // Only update if we have new utterances to add
-      if (newHighlightedUtterances.length > 0) {
-        const updatedHighlight = {
-          ...editingHighlight,
-          highlightedUtterances: [
-            ...editingHighlight.highlightedUtterances,
-            ...newHighlightedUtterances
-          ]
-        };
 
-        setEditingHighlight(updatedHighlight);
-        setIsDirty(true);
-      }
+      if (newHighlightedUtterances.length === 0) return;
+
+      updated = {
+        ...current,
+        highlightedUtterances: [
+          ...current.highlightedUtterances,
+          ...newHighlightedUtterances,
+        ],
+      };
     }
-  }, [editingHighlight, utteranceMap, isEditingDisabled, setEditingHighlight, setIsDirty, lastClickedUtteranceId, lastClickedAction, allUtterances]);
 
-  // Reset to original state - discard all changes
-  const resetToOriginal = () => {
+    setEditingHighlight(updated);
+    setIsDirty(true);
+  }, []);
+
+  const resetToOriginal = useCallback(() => {
     if (originalHighlight) {
       setEditingHighlight(originalHighlight);
       setIsDirty(false);
-      // Clear range selection anchor
       setLastClickedUtteranceId(null);
       setLastClickedAction(null);
     }
-  };
+  }, [originalHighlight]);
 
-  // Exit edit mode - navigate away; state cleanup happens in the pathname effect above
   const exitEditMode = useCallback(() => {
     if (!editingHighlight) return;
     setIsPlaying(false);
     router.push(`/${editingHighlight.cityId}/${editingHighlight.meetingId}/highlights`);
   }, [editingHighlight, router, setIsPlaying]);
 
-  // Exit edit mode and redirect to individual highlight page
   const exitEditModeAndRedirectToHighlight = useCallback(() => {
     if (!editingHighlight) return;
     setIsPlaying(false);
     router.push(`/${editingHighlight.cityId}/${editingHighlight.meetingId}/highlights/${editingHighlight.id}`);
   }, [editingHighlight, router, setIsPlaying]);
 
-  // Save highlight functionality
   const saveHighlight = useCallback(async (options?: {
     name?: string;
     subjectId?: string | null;
@@ -457,17 +458,15 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
       return { success: false, error: 'No highlight to save' };
     }
 
-    // Check if we have changes to save (either dirty state or explicit updates)
     const hasChanges = isDirty || (options?.name !== undefined) || (options?.subjectId !== undefined);
-    
+
     if (!hasChanges) {
       return { success: false, error: 'No changes to save' };
     }
 
     try {
       setIsSaving(true);
-      
-      // Prepare the update data
+
       const updateData = {
         name: options?.name ?? editingHighlight.name,
         meetingId: editingHighlight.meetingId,
@@ -481,25 +480,21 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(updateData)
       });
-      
+
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
         throw new Error(err?.error || 'Failed to save');
       }
-      
-      // Always get the full updated highlight from the API response
+
       const updatedHighlight = await res.json();
-      
-      // Update the editing highlight with the full data from the server
+
       setEditingHighlight(updatedHighlight);
       setOriginalHighlight(updatedHighlight);
-      
-      // Update the highlight in the meeting data context with the full server data
       updateHighlight(editingHighlight.id, updatedHighlight);
-      
+
       setIsDirty(false);
       options?.onSuccess?.();
-      
+
       return { success: true };
     } catch (error) {
       console.error('Failed to save highlight:', error);
@@ -510,19 +505,18 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     }
   }, [editingHighlight, isDirty, updateHighlight]);
 
-  // Create highlight functionality
   const createHighlight = useCallback(async (options: {
     preSelectedUtteranceId?: string;
     onSuccess?: (highlight: HighlightWithUtterances) => void;
     onError?: (error: Error) => void;
   }) => {
     const { preSelectedUtteranceId, onSuccess, onError } = options;
-    
+
     try {
       setIsCreating(true);
-      
+
       const utteranceIds = preSelectedUtteranceId ? [preSelectedUtteranceId] : [];
-      
+
       const res = await fetch('/api/highlights', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -532,29 +526,24 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
           utteranceIds
         })
       });
-      
+
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
         throw new Error(err?.error || 'Failed to create highlight');
       }
-      
-      // Get the full highlight data from the API response
+
       const highlight = await res.json();
-      
-      // Update the meeting data context with the complete highlight data from the server
+
       addHighlight(highlight);
-      
-      // Immediately enter editing mode with the full server data
       enterEditMode(highlight);
 
-      // Set the anchor for shift-click range selection to the pre-selected utterance
       if (preSelectedUtteranceId) {
         setLastClickedUtteranceId(preSelectedUtteranceId);
         setLastClickedAction('add');
       }
 
       onSuccess?.(highlight);
-      
+
       return { success: true };
     } catch (error) {
       console.error('Failed to create highlight:', error);
@@ -565,7 +554,12 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     }
   }, [meeting, addHighlight, enterEditMode]);
 
-  const value = {
+  // When no highlight is being edited, every dep below is stable across
+  // transcript edits, so useHighlight() consumers (every Utterance) bail
+  // via memoization. While a highlight IS being edited, statistics and
+  // highlightUtterances correctly update via editingHighlightData →
+  // utteranceMap.
+  const value = useMemo<HighlightContextType>(() => ({
     editingHighlight,
     previewMode,
     isPreviewDialogOpen,
@@ -573,7 +567,6 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     highlightUtterances,
     currentHighlightIndex,
     totalHighlights,
-    utteranceMap,
     hasUnsavedChanges: isDirty,
     isSaving,
     isCreating,
@@ -592,7 +585,33 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     calculateHighlightData,
     saveHighlight,
     createHighlight,
-  };
+  }), [
+    editingHighlight,
+    previewMode,
+    isPreviewDialogOpen,
+    statistics,
+    highlightUtterances,
+    currentHighlightIndex,
+    totalHighlights,
+    isDirty,
+    isSaving,
+    isCreating,
+    isEditingDisabled,
+    enterEditMode,
+    updateHighlightUtterances,
+    resetToOriginal,
+    exitEditMode,
+    exitEditModeAndRedirectToHighlight,
+    goToPreviousHighlight,
+    goToNextHighlight,
+    goToHighlightIndex,
+    togglePreviewMode,
+    openPreviewDialog,
+    closePreviewDialog,
+    calculateHighlightData,
+    saveHighlight,
+    createHighlight,
+  ]);
 
   return (
     <HighlightContext.Provider value={value}>
@@ -607,4 +626,4 @@ export function useHighlight() {
     throw new Error('useHighlight must be used within a HighlightProvider');
   }
   return context;
-} 
+}

--- a/src/components/meetings/VideoProvider.tsx
+++ b/src/components/meetings/VideoProvider.tsx
@@ -433,24 +433,59 @@ export const VideoProvider: React.FC<VideoProviderProps> = ({ children, meeting,
         return () => cancelAnimationFrame(rafId);
     }, [isPlaying, updateHighlightOnce]);
 
-    // === STABLE ACTIONS CONTEXT ===
-    // Store action functions in refs so the memoized actions value never changes.
-    // This prevents Utterance components from re-rendering during playback.
+    // Stable wrappers around the action functions. `value` invalidates
+    // ~every 2s during playback (currentTime updates), and HighlightProvider
+    // consumes useVideo() — if these refs churned, HighlightProvider's
+    // callbacks would get new identities, invalidate HighlightContext.value,
+    // and re-render every Utterance.
     const seekToRef = useRef(seekTo);
     seekToRef.current = seekTo;
     const seekToWithoutScrollRef = useRef(seekToWithoutScroll);
     seekToWithoutScrollRef.current = seekToWithoutScroll;
     const togglePlayPauseRef = useRef(togglePlayPause);
     togglePlayPauseRef.current = togglePlayPause;
+    const seekToAndPlayRef = useRef(seekToAndPlay);
+    seekToAndPlayRef.current = seekToAndPlay;
+    const handleSpeedChangeRef = useRef(handleSpeedChange);
+    handleSpeedChangeRef.current = handleSpeedChange;
+    const scrollToUtteranceRef = useRef(scrollToUtterance);
+    scrollToUtteranceRef.current = scrollToUtterance;
+    const handleSeekedRef = useRef(handleSeeked);
+    handleSeekedRef.current = handleSeeked;
+    const handleSeekingRef = useRef(handleSeeking);
+    handleSeekingRef.current = handleSeeking;
+    const playVideoRef = useRef(playVideo);
+    playVideoRef.current = playVideo;
+    const pauseVideoRef = useRef(pauseVideo);
+    pauseVideoRef.current = pauseVideo;
+
+    const stableSeekTo = useCallback((time: number) => seekToRef.current(time), []);
+    const stableSeekToWithoutScroll = useCallback((time: number) => seekToWithoutScrollRef.current(time), []);
+    const stableTogglePlayPause = useCallback(() => togglePlayPauseRef.current(), []);
+    const stableSeekToAndPlay = useCallback((time: number) => seekToAndPlayRef.current(time), []);
+    const stableHandleSpeedChange = useCallback((v: string) => handleSpeedChangeRef.current(v), []);
+    const stableScrollToUtterance = useCallback((time: number) => scrollToUtteranceRef.current(time), []);
+    const stableHandleSeeked = useCallback(() => handleSeekedRef.current(), []);
+    const stableHandleSeeking = useCallback(() => handleSeekingRef.current(), []);
+    const stableSetIsPlaying = useCallback(async (shouldPlay: boolean) => {
+        if (shouldPlay) {
+            await playVideoRef.current();
+        } else {
+            await pauseVideoRef.current();
+        }
+    }, []);
 
     const actionsValue = useMemo<VideoActionsContextType>(() => ({
         currentTimeRef,
-        seekTo: (time: number) => seekToRef.current(time),
-        seekToWithoutScroll: (time: number) => seekToWithoutScrollRef.current(time),
-        togglePlayPause: () => togglePlayPauseRef.current(),
-    }), []); // eslint-disable-line react-hooks/exhaustive-deps
+        seekTo: stableSeekTo,
+        seekToWithoutScroll: stableSeekToWithoutScroll,
+        togglePlayPause: stableTogglePlayPause,
+    }), [stableSeekTo, stableSeekToWithoutScroll, stableTogglePlayPause]);
 
-    const value = {
+    // Memoize the value so it only invalidates when the reactive fields it
+    // exposes actually change. The function fields are now all stable refs,
+    // so they don't churn the memoization.
+    const value = useMemo(() => ({
         isPlaying,
         currentTime: currentTimeRef.current,
         currentTimeRef,
@@ -458,26 +493,38 @@ export const VideoProvider: React.FC<VideoProviderProps> = ({ children, meeting,
         playbackSpeed,
         currentScrollInterval,
         setCurrentScrollInterval,
-        togglePlayPause,
-        handleSpeedChange,
-        seekTo,
-        seekToWithoutScroll,
-        scrollToUtterance,
+        togglePlayPause: stableTogglePlayPause,
+        handleSpeedChange: stableHandleSpeedChange,
+        seekTo: stableSeekTo,
+        seekToWithoutScroll: stableSeekToWithoutScroll,
+        scrollToUtterance: stableScrollToUtterance,
         playerRef,
-        seekToAndPlay,
+        seekToAndPlay: stableSeekToAndPlay,
         isSeeking,
         onTimeUpdate: handleTimeUpdate,
-        onSeeked: handleSeeked,
-        onSeeking: handleSeeking,
-        setIsPlaying: async (shouldPlay: boolean) => {
-            if (shouldPlay) {
-                await playVideo();
-            } else {
-                await pauseVideo();
-            }
-        },
+        onSeeked: stableHandleSeeked,
+        onSeeking: stableHandleSeeking,
+        setIsPlaying: stableSetIsPlaying,
         meeting,
-    };
+    }), [
+        isPlaying,
+        currentTime, // state-driven (throttled to ~2s); ensures consumers see updated time
+        duration,
+        playbackSpeed,
+        currentScrollInterval,
+        isSeeking,
+        handleTimeUpdate,
+        meeting,
+        stableTogglePlayPause,
+        stableHandleSpeedChange,
+        stableSeekTo,
+        stableSeekToWithoutScroll,
+        stableScrollToUtterance,
+        stableSeekToAndPlay,
+        stableHandleSeeked,
+        stableHandleSeeking,
+        stableSetIsPlaying,
+    ]);
 
     return (
         <VideoActionsContext.Provider value={actionsValue}>

--- a/src/components/meetings/VideoProvider.tsx
+++ b/src/components/meetings/VideoProvider.tsx
@@ -506,9 +506,14 @@ export const VideoProvider: React.FC<VideoProviderProps> = ({ children, meeting,
         onSeeking: stableHandleSeeking,
         setIsPlaying: stableSetIsPlaying,
         meeting,
+        // `currentTime` (state, throttled to ~2s) is intentionally a dep so
+        // useVideo() consumers get a fresh value object when playback time
+        // advances. ESLint can't see it because the body reads
+        // `currentTimeRef.current` (the higher-frequency ref) instead.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }), [
         isPlaying,
-        currentTime, // state-driven (throttled to ~2s); ensures consumers see updated time
+        currentTime,
         duration,
         playbackSpeed,
         currentScrollInterval,

--- a/src/components/meetings/transcript/SpeakerSegment.tsx
+++ b/src/components/meetings/transcript/SpeakerSegment.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useEffect } from 'react';
-import { useCouncilMeetingData } from "../CouncilMeetingDataContext";
+import { useCouncilMeetingActions, useCouncilMeetingMeta } from "../CouncilMeetingDataContext";
 import { Transcript as TranscriptType } from '@/lib/db/transcript';
 import TopicBadge from './Topic';
 import { PersonBadge } from '@/components/persons/PersonBadge';
@@ -18,7 +18,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useMediaQuery } from '@/hooks/use-media-query';
 
 const AddSegmentButton = ({ segmentId }: { segmentId: string }) => {
-    const { createEmptySegmentAfter } = useCouncilMeetingData();
+    const { createEmptySegmentAfter } = useCouncilMeetingActions();
     const { options } = useTranscriptOptions();
 
     if (!options.editable) return null;
@@ -51,7 +51,7 @@ const AddSegmentBeforeButton = ({ segmentId, isFirstSegment }: {
     segmentId: string, 
     isFirstSegment: boolean 
 }) => {
-    const { createEmptySegmentBefore } = useCouncilMeetingData();
+    const { createEmptySegmentBefore } = useCouncilMeetingActions();
     const { options } = useTranscriptOptions();
 
     // Only show for the first segment
@@ -82,7 +82,7 @@ const AddSegmentBeforeButton = ({ segmentId, isFirstSegment }: {
 };
 
 const EmptySegmentState = ({ segmentId }: { segmentId: string }) => {
-    const { addUtteranceToSegment } = useCouncilMeetingData();
+    const { addUtteranceToSegment } = useCouncilMeetingActions();
     const [isLoading, setIsLoading] = useState(false);
     const t = useTranslations('transcript.emptySegment');
 
@@ -124,7 +124,7 @@ const EmptySegmentState = ({ segmentId }: { segmentId: string }) => {
 };
 
 const AddUtteranceButton = ({ segmentId }: { segmentId: string }) => {
-    const { addUtteranceToSegment } = useCouncilMeetingData();
+    const { addUtteranceToSegment } = useCouncilMeetingActions();
     const { options } = useTranscriptOptions();
     const t = useTranslations('transcript.addUtterance');
 
@@ -172,7 +172,10 @@ const SpeakerSegment = React.memo(({ segment, isFirstSegment }: {
     segment: TranscriptType[number],
     isFirstSegment?: boolean
 }) => {
-    const { getPerson, getSpeakerTag, getSpeakerSegmentCount, people, speakerTags, updateSpeakerTagPerson, updateSpeakerTagLabel, deleteEmptySegment } = useCouncilMeetingData();
+    // useCouncilMeetingMeta() — not useCouncilMeetingData() — so this
+    // component bails on transcript-only edits.
+    const { getPerson, getSpeakerTag, getSpeakerSegmentCount, people, speakerTags } = useCouncilMeetingMeta();
+    const { updateSpeakerTagPerson, updateSpeakerTagLabel, deleteEmptySegment } = useCouncilMeetingActions();
     const { options } = useTranscriptOptions();
     const { data: session } = useSession();
     const { toast } = useToast();
@@ -220,16 +223,15 @@ const SpeakerSegment = React.memo(({ segment, isFirstSegment }: {
         return buildUnknownSpeakerLabel(maxIndex + 1);
     }, [speakerTags]);
 
-    const memoizedData = useMemo(() => {
-        const speakerTag = getSpeakerTag(segment.speakerTagId);
-        const person = speakerTag?.personId ? getPerson(speakerTag.personId) : undefined;
-
-        const party = person ? getPartyFromRoles(person.roles) : null;
-        const borderColor = party?.colorHex || '#D3D3D3';
-
-        const segmentCount = speakerTag ? getSpeakerSegmentCount(speakerTag.id) : 0;
-        return { speakerTag, person, party, borderColor, segmentCount };
-    }, [segment.speakerTagId, getPerson, getSpeakerTag, getSpeakerSegmentCount]);
+    // Not memoized: the getter refs are stable for the provider's lifetime,
+    // so a useMemo over them would never recompute when underlying speaker
+    // tags / segment counts change.
+    const speakerTag = getSpeakerTag(segment.speakerTagId);
+    const person = speakerTag?.personId ? getPerson(speakerTag.personId) : undefined;
+    const party = person ? getPartyFromRoles(person.roles) : null;
+    const borderColor = party?.colorHex || '#D3D3D3';
+    const segmentCount = speakerTag ? getSpeakerSegmentCount(speakerTag.id) : 0;
+    const memoizedData = { speakerTag, person, party, borderColor, segmentCount };
 
     const utterances = segment.utterances;
     if (!utterances) {

--- a/src/components/meetings/transcript/SpeakerSegment.tsx
+++ b/src/components/meetings/transcript/SpeakerSegment.tsx
@@ -231,7 +231,7 @@ const SpeakerSegment = React.memo(({ segment, isFirstSegment }: {
     const party = person ? getPartyFromRoles(person.roles) : null;
     const borderColor = party?.colorHex || '#D3D3D3';
     const segmentCount = speakerTag ? getSpeakerSegmentCount(speakerTag.id) : 0;
-    const memoizedData = { speakerTag, person, party, borderColor, segmentCount };
+    const headerData = { speakerTag, person, party, borderColor, segmentCount };
 
     const utterances = segment.utterances;
     if (!utterances) {
@@ -243,14 +243,14 @@ const SpeakerSegment = React.memo(({ segment, isFirstSegment }: {
     const summary = segment.summary;
 
     const handlePersonChange = (personId: string | null) => {
-        if (memoizedData.speakerTag) {
-            updateSpeakerTagPerson(memoizedData.speakerTag.id, personId);
+        if (headerData.speakerTag) {
+            updateSpeakerTagPerson(headerData.speakerTag.id, personId);
         }
     };
 
     const handleLabelChange = (label: string) => {
-        if (memoizedData.speakerTag) {
-            updateSpeakerTagLabel(memoizedData.speakerTag.id, label);
+        if (headerData.speakerTag) {
+            updateSpeakerTagLabel(headerData.speakerTag.id, label);
         }
     };
 
@@ -270,7 +270,7 @@ const SpeakerSegment = React.memo(({ segment, isFirstSegment }: {
                 <AddSegmentBeforeButton segmentId={segment.id} isFirstSegment={true} />
             )}
             
-            <div className='mb-2 sm:mb-6 flex flex-col items-start w-full rounded-r-lg hover:bg-accent/5 transition-colors border-l-[3px] sm:border-l-4' style={{ borderLeftColor: memoizedData.borderColor }}>
+            <div className='mb-2 sm:mb-6 flex flex-col items-start w-full rounded-r-lg hover:bg-accent/5 transition-colors border-l-[3px] sm:border-l-4' style={{ borderLeftColor: headerData.borderColor }}>
                 <div className='w-full'>
                     <div 
                         className='sticky flex flex-row items-center justify-between w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 z-30 transition-all duration-200'
@@ -284,8 +284,8 @@ const SpeakerSegment = React.memo(({ segment, isFirstSegment }: {
                                         className='flex md:hidden items-center justify-between w-full px-2.5 py-1.5 hover:bg-accent/20 transition-colors bg-background border-b border-border/40'
                                     >
                                         <PersonBadge
-                                            person={memoizedData.person}
-                                            speakerTag={memoizedData.speakerTag}
+                                            person={headerData.person}
+                                            speakerTag={headerData.speakerTag}
                                             variant="inline"
                                             className="flex-1 min-w-0"
                                         />
@@ -302,11 +302,11 @@ const SpeakerSegment = React.memo(({ segment, isFirstSegment }: {
                                 <div className={`${isCollapsed ? 'hidden md:flex' : 'flex'} flex-col w-full space-y-2 py-2`}>
                                     <div className='flex items-center justify-between w-full px-2.5 sm:px-4 gap-2'>
                                         <div className='flex-grow overflow-hidden min-w-0'>
-                                            {memoizedData.speakerTag && (
+                                            {headerData.speakerTag && (
                                                 <PersonBadge
-                                                    person={memoizedData.person}
-                                                    speakerTag={memoizedData.speakerTag}
-                                                    segmentCount={memoizedData.segmentCount}
+                                                    person={headerData.person}
+                                                    speakerTag={headerData.speakerTag}
+                                                    segmentCount={headerData.segmentCount}
                                                     editable={options.editable}
                                                     onPersonChange={handlePersonChange}
                                                     onLabelChange={handleLabelChange}

--- a/src/components/meetings/transcript/Transcript.tsx
+++ b/src/components/meetings/transcript/Transcript.tsx
@@ -10,6 +10,7 @@ import { useSearchParams } from "next/navigation";
 import { useHighlight } from "../HighlightContext";
 import { useTranslations } from 'next-intl';
 import { UnverifiedTranscriptBanner, BANNER_HEIGHT_FULL } from "./UnverifiedTranscriptBanner";
+import { UtteranceContextMenu } from "./UtteranceContextMenu";
 
 // Helper functions for speaker segment identification and parsing
 const SPEAKER_SEGMENT_PREFIX = 'speaker-segment-';
@@ -164,21 +165,23 @@ export default function Transcript() {
                     onBannerHeightChange={setBannerHeight}
                 />
             )}
-            <div ref={containerRef} role="list" aria-label={t('transcript')}>
-            {displayedSegments.map((segment, index: number) => (
-                <div
-                    key={index}
-                    id={createSegmentId(index)}
-                    className="content-visibility-auto"
-                    role="listitem"
-                >
-                    <SpeakerSegment
-                        segment={segment}
-                        isFirstSegment={index === 0}
-                    />
+            <UtteranceContextMenu>
+                <div ref={containerRef} role="list" aria-label={t('transcript')}>
+                {displayedSegments.map((segment, index: number) => (
+                    <div
+                        key={index}
+                        id={createSegmentId(index)}
+                        className="content-visibility-auto"
+                        role="listitem"
+                    >
+                        <SpeakerSegment
+                            segment={segment}
+                            isFirstSegment={index === 0}
+                        />
+                    </div>
+                ))}
                 </div>
-            ))}
-            </div>
+            </UtteranceContextMenu>
         </div>
     );
 }

--- a/src/components/meetings/transcript/Utterance.tsx
+++ b/src/components/meetings/transcript/Utterance.tsx
@@ -6,25 +6,17 @@ import { useVideoActions } from "../VideoProvider";
 import { useTranscriptOptions } from "../options/OptionsContext";
 import { useHighlight } from "../HighlightContext";
 import { editUtterance, updateUtteranceTimestamps } from "@/lib/db/utterance";
-import { useCouncilMeetingData } from "../CouncilMeetingDataContext";
+import { useCouncilMeetingActions } from "../CouncilMeetingDataContext";
 import { Button } from "@/components/ui/button";
-import { ArrowLeftToLine, ArrowRightToLine, Copy, Star, Scissors, Loader2, Check, X, Trash2, Clock } from "lucide-react";
+import { Check, X, Trash2, Clock } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
-import {
-    ContextMenu,
-    ContextMenuContent,
-    ContextMenuItem,
-    ContextMenuTrigger,
-    ContextMenuSeparator,
-} from "@/components/ui/context-menu";
 import {
     Tooltip,
     TooltipContent,
     TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { useShare } from "@/contexts/ShareContext";
-import { useEditing } from "../EditingContext";import { ACTIONS, useKeyboardShortcut } from "@/contexts/KeyboardShortcutsContext";
+import { useEditing } from "../EditingContext";
 import { formatTimestamp } from "@/lib/formatters/time";
 
 const UtteranceC: React.FC<{
@@ -33,23 +25,19 @@ const UtteranceC: React.FC<{
 }> = React.memo(({ utterance, onUpdate }) => {
     const { currentTimeRef, seekToWithoutScroll, togglePlayPause, seekTo } = useVideoActions();
     const { options } = useTranscriptOptions();
-    const { editingHighlight, updateHighlightUtterances, createHighlight } = useHighlight();
-    const { moveUtterancesToPrevious, moveUtterancesToNext, deleteUtterance, updateUtterance } = useCouncilMeetingData();
-    const { selectedUtteranceIds, toggleSelection, clearSelection, extractSelectedSegment, isProcessing } = useEditing();
-    
+    const { editingHighlight, updateHighlightUtterances } = useHighlight();
+    // Stable actions context — see CouncilMeetingDataContext. With ~9K
+    // utterances, anything that re-renders all of them defeats memoization.
+    const { deleteUtterance, updateUtterance } = useCouncilMeetingActions();
+    const { selectedUtteranceIds, toggleSelection } = useEditing();
+
     const [isEditing, setIsEditing] = useState(false);
     const [localUtterance, setLocalUtterance] = useState(utterance);
     const [editedText, setEditedText] = useState(utterance.text);
     const [editedStartTime, setEditedStartTime] = useState(utterance.startTimestamp);
     const [editedEndTime, setEditedEndTime] = useState(utterance.endTimestamp);
-    const [pendingShareAction, setPendingShareAction] = useState<number | null>(null);
     const { toast } = useToast();
-    const { openShareDropdownAndCopy } = useShare();
     const t = useTranslations('transcript.utterance');
-
-    const canStartHighlight = options.canCreateHighlights && !editingHighlight && !options.editable;
-    const canShare = !editingHighlight && !options.editable;
-    const hasContextMenuOptions = canStartHighlight || options.editable || canShare;
 
     // Check if selected in Editing Context
     const isSelected = selectedUtteranceIds.has(localUtterance.id);
@@ -206,85 +194,6 @@ const UtteranceC: React.FC<{
 
     const setEndTimeToCurrentVideo = () => {
         setEditedEndTime(currentTimeRef.current);
-    };
-
-    const handleMoveUtterancesToPrevious = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        toast({
-            title: t('toasts.moveUtterances'),
-            description: t('toasts.moveToPreviousDescription'),
-            action: (
-                <Button
-                    variant="default"
-                    size="sm"
-                    onClick={() => {
-                        moveUtterancesToPrevious(localUtterance.id, localUtterance.speakerSegmentId);
-                        toast({
-                            description: t('toasts.utterancesMovedSuccessfully'),
-                        });
-                    }}
-                >
-                    {t('toasts.confirm')}
-                </Button>
-            ),
-        });
-    };
-
-    const handleMoveUtterancesToNext = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        toast({
-            title: t('toasts.moveUtterances'),
-            description: t('toasts.moveToNextDescription'),
-            action: (
-                <Button
-                    variant="default"
-                    size="sm"
-                    onClick={() => {
-                        moveUtterancesToNext(localUtterance.id, localUtterance.speakerSegmentId);
-                        toast({
-                            description: t('toasts.utterancesMovedSuccessfully'),
-                        });
-                    }}
-                >
-                    {t('toasts.confirm')}
-                </Button>
-            ),
-        });
-    };
-
-    const handleShareFromHere = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        // Set pending action - will be executed when context menu closes
-        setPendingShareAction(localUtterance.startTimestamp);
-    };
-
-    const handleStartHighlightHere = async (e: React.MouseEvent) => {
-        e.stopPropagation();
-
-        await createHighlight({
-            preSelectedUtteranceId: localUtterance.id,
-            onSuccess: (highlight) => {
-                toast({
-                    title: t('toasts.highlightCreated'),
-                    description: t('toasts.highlightCreatedDescription'),
-                    variant: "default",
-                });
-            },
-            onError: (error) => {
-                toast({
-                    title: t('common.error'),
-                    description: t('toasts.createHighlightError'),
-                    variant: "destructive",
-                });
-            }
-        });
-    };
-    
-    const handleExtractSegment = async (e: React.MouseEvent) => {
-        e.stopPropagation();
-        
-        // Extract the current selection (state is already updated from context menu open)
-        await extractSelectedSegment();
     };
 
     const handleDeleteUtterance = async (e: React.MouseEvent) => {
@@ -446,28 +355,34 @@ const UtteranceC: React.FC<{
     // Show placeholder for empty utterances in editing mode
     const isEmptyUtterance = !localUtterance.text.trim();
     const displayText = options.editable && isEmptyUtterance
-        ? '[Empty utterance - click to edit]' 
+        ? '[Empty utterance - click to edit]'
         : localUtterance.text + ' ';
-    
+
     const emptyUtteranceClass = options.editable && isEmptyUtterance
         ? 'text-muted-foreground italic'
         : '';
 
-    if (!hasContextMenuOptions) {
-        return (
-            <span className={cn(className, emptyUtteranceClass)} id={localUtterance.id} onClick={handleClick}>
-                {displayText}
-            </span>
-        );
-    }
+    // Right-click is handled by the single shared <UtteranceContextMenu> at
+    // the Transcript level — it locates the target via these data-attributes
+    // and renders one set of items instead of one Radix Menu per utterance.
+    const utteranceSpan = (
+        <span
+            className={cn(className, emptyUtteranceClass)}
+            id={localUtterance.id}
+            data-utterance-id={localUtterance.id}
+            data-segment-id={localUtterance.speakerSegmentId}
+            data-start-timestamp={localUtterance.startTimestamp}
+            onClick={handleClick}
+        >
+            {displayText}
+        </span>
+    );
 
-    // Show inline delete button for empty utterances in editing mode
+    // Inline delete button for empty utterances in editing mode.
     if (options.editable && isEmptyUtterance && !isEditing) {
         return (
             <span className="inline-flex items-center gap-1 group">
-                <span className={cn(className, emptyUtteranceClass)} id={localUtterance.id} onClick={handleClick}>
-                    {displayText}
-                </span>
+                {utteranceSpan}
                 <Tooltip>
                     <TooltipTrigger asChild>
                         <Button
@@ -487,75 +402,7 @@ const UtteranceC: React.FC<{
         );
     }
 
-    return (
-        <ContextMenu onOpenChange={(open) => {
-            if (open) {
-                // Context menu opened - select this utterance if not already selected
-                // This provides visual feedback for what will be operated on
-                if (!isSelected) {
-                    toggleSelection(localUtterance.id, { shift: false, ctrl: false });
-                }
-                // Clear any stale pending share action
-                if (pendingShareAction) {
-                    setPendingShareAction(null);
-                }
-            } else {
-                // Context menu closed
-                if (pendingShareAction) {
-                    // Execute pending share action first
-                    openShareDropdownAndCopy(pendingShareAction);
-                    setPendingShareAction(null);
-                }
-                // Only clear selection if there's just one selected (the temporary right-click selection)
-                // If multiple utterances are selected, preserve the user's deliberate selection
-                if (selectedUtteranceIds.size === 1) {
-                    clearSelection();
-                }
-            }
-        }}>
-            <ContextMenuTrigger>
-                <span className={cn(className, emptyUtteranceClass)} id={localUtterance.id} onClick={handleClick}>
-                    {displayText}
-                </span>
-            </ContextMenuTrigger>
-            <ContextMenuContent>
-                {canStartHighlight && (
-                    <ContextMenuItem onClick={handleStartHighlightHere}>
-                        <Star className="h-4 w-4 mr-2" />
-                        {t('contextMenu.startHighlightFromHere')}
-                    </ContextMenuItem>
-                )}
-                {options.editable && (
-                    <>
-                        <ContextMenuSeparator />
-                        <ContextMenuItem 
-                            onClick={handleExtractSegment} 
-                            disabled={isProcessing || (!isSelected && selectedUtteranceIds.size > 0)}
-                        >
-                            {isProcessing ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Scissors className="h-4 w-4 mr-2" />}
-                            {t('contextMenu.extractSegment', { defaultValue: 'Extract Segment' })}
-                            {isSelected && <span className="ml-auto text-xs text-muted-foreground pl-4">e</span>}
-                        </ContextMenuItem>
-                        <ContextMenuSeparator />
-                        <ContextMenuItem onClick={handleMoveUtterancesToPrevious}>
-                            <ArrowLeftToLine className="h-4 w-4 mr-2" />
-                            {t('contextMenu.moveToPreviousSegment')}
-                        </ContextMenuItem>
-                        <ContextMenuItem onClick={handleMoveUtterancesToNext}>
-                            <ArrowRightToLine className="h-4 w-4 mr-2" />
-                            {t('contextMenu.moveToNextSegment')}
-                        </ContextMenuItem>
-                    </>
-                )}
-                {canShare && (
-                    <ContextMenuItem onClick={handleShareFromHere}>
-                        <Copy className="h-4 w-4 mr-2" />
-                        {t('contextMenu.shareFromHere')}
-                    </ContextMenuItem>
-                )}
-            </ContextMenuContent>
-        </ContextMenu>
-    );
+    return utteranceSpan;
 });
 
 UtteranceC.displayName = 'UtteranceC';

--- a/src/components/meetings/transcript/UtteranceContextMenu.tsx
+++ b/src/components/meetings/transcript/UtteranceContextMenu.tsx
@@ -89,7 +89,11 @@ export function UtteranceContextMenu({ children }: { children: React.ReactNode }
         if (selectedUtteranceIds.size === 1) {
             clearSelection();
         }
-    }, [clearSelection, openShareDropdownAndCopy, selectedUtteranceIds.size]);
+        // Depend on the full Set, not just `.size`. Each selection change
+        // produces a new Set identity, so we recreate this callback even when
+        // size stays the same (e.g., right-clicking utterance B while A was
+        // the lone selection swaps the contents but keeps size = 1).
+    }, [clearSelection, openShareDropdownAndCopy, selectedUtteranceIds]);
 
     const targetSelected = target ? selectedUtteranceIds.has(target.id) : false;
 

--- a/src/components/meetings/transcript/UtteranceContextMenu.tsx
+++ b/src/components/meetings/transcript/UtteranceContextMenu.tsx
@@ -1,0 +1,219 @@
+"use client";
+import React, { useCallback, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { ArrowLeftToLine, ArrowRightToLine, Copy, Loader2, Scissors, Star } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useShare } from '@/contexts/ShareContext';
+import { useToast } from '@/hooks/use-toast';
+
+import { useCouncilMeetingActions } from '../CouncilMeetingDataContext';
+import { useEditing } from '../EditingContext';
+import { useHighlight } from '../HighlightContext';
+import { useTranscriptOptions } from '../options/OptionsContext';
+
+interface ContextTarget {
+    id: string;
+    segmentId: string;
+    startTimestamp: number;
+    x: number;
+    y: number;
+}
+
+/**
+ * Single shared right-click menu for the entire transcript.
+ *
+ * Per-utterance `<ContextMenu>` instances each register a document-level
+ * `keydown` listener (Radix Menu uses one to track keyboard-vs-mouse usage).
+ * On a 9K-utterance transcript that turned every keystroke into a 9K-listener
+ * fanout — measured ~412ms per keydown. Hosting a single menu here drops it
+ * to one listener while preserving the original UX.
+ *
+ * The wrapper captures `contextmenu`, finds the target utterance via
+ * `closest('[data-utterance-id]')`, and opens a controlled DropdownMenu
+ * positioned at the cursor via a virtual trigger.
+ */
+export function UtteranceContextMenu({ children }: { children: React.ReactNode }) {
+    const [open, setOpen] = useState(false);
+    const [target, setTarget] = useState<ContextTarget | null>(null);
+    const pendingShareRef = useRef<number | null>(null);
+
+    const { options } = useTranscriptOptions();
+    const { editingHighlight, createHighlight } = useHighlight();
+    const { selectedUtteranceIds, isProcessing, toggleSelection, clearSelection, extractSelectedSegment } = useEditing();
+    const { moveUtterancesToPrevious, moveUtterancesToNext } = useCouncilMeetingActions();
+    const { openShareDropdownAndCopy } = useShare();
+    const { toast } = useToast();
+    const t = useTranslations('transcript.utterance');
+
+    const canStartHighlight = options.canCreateHighlights && !editingHighlight && !options.editable;
+    const canShare = !editingHighlight && !options.editable;
+    const hasAnyAction = canStartHighlight || options.editable || canShare;
+
+    const handleContextMenu = useCallback((e: React.MouseEvent) => {
+        if (!hasAnyAction) return;
+        const span = (e.target as HTMLElement | null)?.closest<HTMLElement>('[data-utterance-id]');
+        if (!span) return; // outside an utterance — let the system menu show
+        const id = span.dataset.utteranceId;
+        const segmentId = span.dataset.segmentId;
+        if (!id || !segmentId) return;
+        const startTimestamp = parseFloat(span.dataset.startTimestamp || '0');
+
+        e.preventDefault();
+        setTarget({ id, segmentId, startTimestamp, x: e.clientX, y: e.clientY });
+        setOpen(true);
+
+        // Mirror the original per-utterance behavior: temporarily select the
+        // right-clicked utterance for visual feedback unless it's already in
+        // the user's deliberate selection.
+        if (!selectedUtteranceIds.has(id)) {
+            toggleSelection(id, { shift: false, ctrl: false });
+        }
+    }, [hasAnyAction, selectedUtteranceIds, toggleSelection]);
+
+    const handleOpenChange = useCallback((next: boolean) => {
+        setOpen(next);
+        if (next) return;
+        // Closing — flush a deferred share, then clear any temp selection.
+        if (pendingShareRef.current !== null) {
+            openShareDropdownAndCopy(pendingShareRef.current);
+            pendingShareRef.current = null;
+        }
+        if (selectedUtteranceIds.size === 1) {
+            clearSelection();
+        }
+    }, [clearSelection, openShareDropdownAndCopy, selectedUtteranceIds.size]);
+
+    const targetSelected = target ? selectedUtteranceIds.has(target.id) : false;
+
+    const handleStartHighlight = useCallback(async () => {
+        if (!target) return;
+        await createHighlight({
+            preSelectedUtteranceId: target.id,
+            onSuccess: () => toast({
+                title: t('toasts.highlightCreated'),
+                description: t('toasts.highlightCreatedDescription'),
+            }),
+            onError: () => toast({
+                title: t('common.error'),
+                description: t('toasts.createHighlightError'),
+                variant: 'destructive',
+            }),
+        });
+    }, [target, createHighlight, toast, t]);
+
+    const handleMoveToPrevious = useCallback(() => {
+        if (!target) return;
+        const { id, segmentId } = target;
+        toast({
+            title: t('toasts.moveUtterances'),
+            description: t('toasts.moveToPreviousDescription'),
+            action: (
+                <Button
+                    variant="default"
+                    size="sm"
+                    onClick={() => {
+                        moveUtterancesToPrevious(id, segmentId);
+                        toast({ description: t('toasts.utterancesMovedSuccessfully') });
+                    }}
+                >
+                    {t('toasts.confirm')}
+                </Button>
+            ),
+        });
+    }, [target, moveUtterancesToPrevious, toast, t]);
+
+    const handleMoveToNext = useCallback(() => {
+        if (!target) return;
+        const { id, segmentId } = target;
+        toast({
+            title: t('toasts.moveUtterances'),
+            description: t('toasts.moveToNextDescription'),
+            action: (
+                <Button
+                    variant="default"
+                    size="sm"
+                    onClick={() => {
+                        moveUtterancesToNext(id, segmentId);
+                        toast({ description: t('toasts.utterancesMovedSuccessfully') });
+                    }}
+                >
+                    {t('toasts.confirm')}
+                </Button>
+            ),
+        });
+    }, [target, moveUtterancesToNext, toast, t]);
+
+    const handleShareFromHere = useCallback(() => {
+        if (!target) return;
+        // Defer until after the menu closes so Share's dropdown isn't fighting
+        // ours for focus / dismissal.
+        pendingShareRef.current = target.startTimestamp;
+    }, [target]);
+
+    return (
+        <div onContextMenu={handleContextMenu}>
+            {children}
+            <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+                <DropdownMenuTrigger asChild>
+                    <div
+                        aria-hidden
+                        style={{
+                            position: 'fixed',
+                            left: target?.x ?? 0,
+                            top: target?.y ?? 0,
+                            width: 0,
+                            height: 0,
+                            pointerEvents: 'none',
+                        }}
+                    />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                    {target && canStartHighlight && (
+                        <DropdownMenuItem onClick={handleStartHighlight}>
+                            <Star className="h-4 w-4 mr-2" />
+                            {t('contextMenu.startHighlightFromHere')}
+                        </DropdownMenuItem>
+                    )}
+                    {target && options.editable && (
+                        <>
+                            {canStartHighlight && <DropdownMenuSeparator />}
+                            <DropdownMenuItem
+                                onClick={() => extractSelectedSegment()}
+                                disabled={isProcessing || (!targetSelected && selectedUtteranceIds.size > 0)}
+                            >
+                                {isProcessing
+                                    ? <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                                    : <Scissors className="h-4 w-4 mr-2" />}
+                                {t('contextMenu.extractSegment', { defaultValue: 'Extract Segment' })}
+                                {targetSelected && <span className="ml-auto text-xs text-muted-foreground pl-4">e</span>}
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem onClick={handleMoveToPrevious}>
+                                <ArrowLeftToLine className="h-4 w-4 mr-2" />
+                                {t('contextMenu.moveToPreviousSegment')}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={handleMoveToNext}>
+                                <ArrowRightToLine className="h-4 w-4 mr-2" />
+                                {t('contextMenu.moveToNextSegment')}
+                            </DropdownMenuItem>
+                        </>
+                    )}
+                    {target && canShare && (
+                        <DropdownMenuItem onClick={handleShareFromHere}>
+                            <Copy className="h-4 w-4 mr-2" />
+                            {t('contextMenu.shareFromHere')}
+                        </DropdownMenuItem>
+                    )}
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </div>
+    );
+}

--- a/src/hooks/useSpeakerSegmentEditor.ts
+++ b/src/hooks/useSpeakerSegmentEditor.ts
@@ -2,13 +2,13 @@ import { useState, useCallback, useMemo } from 'react';
 import { DiscussionStatus } from '@prisma/client';
 import { Transcript as TranscriptType } from '@/lib/db/transcript';
 import { EditableSpeakerSegmentData } from '@/lib/db/speakerSegments';
-import { useCouncilMeetingData } from '@/components/meetings/CouncilMeetingDataContext';
+import { useCouncilMeetingActions } from '@/components/meetings/CouncilMeetingDataContext';
 import { toast } from '@/hooks/use-toast';
 
 const DISCUSSION_STATUS_VALUES = Object.values(DiscussionStatus);
 
 export function useSpeakerSegmentEditor(segment: TranscriptType[number]) {
-    const { updateSpeakerSegmentData } = useCouncilMeetingData();
+    const { updateSpeakerSegmentData } = useCouncilMeetingActions();
     const [isEditMode, setIsEditMode] = useState(false);
     const [editedData, setEditedData] = useState<string>('');
     const [validationErrors, setValidationErrors] = useState<string[]>([]);


### PR DESCRIPTION
## Summary

Two compounding bottlenecks made the transcript editor unusable on long transcripts. On a 9,283-utterance meeting, every keystroke in the inline editor took **506 ms** to paint (INP). This PR brings it to **36 ms** (14×), eliminates the React re-render cascade on edits, and cuts steady-state DOM size by 35%.

### The two root causes

1. **React-context cascade.** A single `CouncilMeetingDataContext` held the whole transcript. Each edit invalidated its value, cascading through `HighlightProvider` / `EditingProvider` / `VideoProvider` and re-rendering ~9K `UtteranceC` components plus ~46K nested provider re-renders. `React.memo` was useless because every Utterance subscribed to that context.
2. **Per-utterance Radix `<ContextMenu>` listener fanout.** Each `<ContextMenu>` instance registers a `document.addEventListener('keydown', …, { capture: true })` (Radix uses it to track keyboard-vs-mouse usage). With 9K menus mounted, every keystroke fired 9K listeners — measured at ~412 ms of pure JS dispatch, the dominant cost in the input pipeline.

### Fixes

**Context architecture (`CouncilMeetingDataContext.tsx`)**
- Split into three contexts: `Actions` (stable mutations, never changes identity), `Meta` (everything except `transcript`), and `Data` (full backward-compatible shape).
- `Utterance` and small action helpers now use `useCouncilMeetingActions()` — they don't re-render on transcript edits.
- `SpeakerSegment` uses `useCouncilMeetingMeta()` — it bails on transcript-only edits but still updates on speaker-tag changes.
- Stable-identity getters (`getPerson`, `getSpeakerTag`, `getSpeakerSegmentById`, …) via ref + render-time sync, so downstream callbacks (`calculateHighlightData`, `extractSelectedSegment`) keep stable identity.

**Memoize provider values (`EditingContext.tsx`, `HighlightContext.tsx`)**
- Wrap the provider `value` in `useMemo`.
- Mirror transcript-derived state (`allUtterances`, `utteranceMap`, `editingHighlight`, `lastClicked*`) into refs so callbacks have `[]` deps and never churn.
- Move `setIsDirty(true)` out of `setEditingHighlight`'s functional updater (avoids StrictMode double-fire).
- Drop `utteranceMap` from `HighlightContext` value (no external consumers; it would invalidate the value on every transcript change).

**Stable VideoProvider wrappers (`VideoProvider.tsx`)**
- `seekTo`, `seekToAndPlay`, `setIsPlaying`, etc. now ref-backed `useCallback` wrappers. Without this, `HighlightProvider` (which consumes `useVideo()` for `currentTime`) saw new function refs every 2 s during playback, churning all of its `useCallback` deps and re-rendering all Utterances.

**Shared context menu (`UtteranceContextMenu.tsx` — new)**
- A single `<DropdownMenu>` at the Transcript level replaces the 9K per-utterance `<ContextMenu>`s.
- Each utterance span carries `data-utterance-id` / `data-segment-id` / `data-start-timestamp`.
- The wrapper captures `contextmenu`, finds the target via `closest('[data-utterance-id]')`, and opens a virtual-anchored menu at the cursor position. Items, selection-on-open, pending-share-after-close, and the "no menu when no actions" guard are all preserved.

### Results

Measured live on `/thessaloniki/apr1_2026/transcript` (9,283 utterances), edit mode active:

| Metric | Before | After |
|---|---|---|
| Keystroke INP (Chrome) | 506 ms | **36 ms** |
| `UtteranceC` commits per save | ~9,283 | ~1 |
| `Context.Provider` commits per save | ~46,446 | ~5 |
| Heavy commits during playback | 1 every 2s (~1.2 s each) | 0 |
| Total DOM nodes | 59,404 | 38,832 (−35%) |
| Per-keystroke `handleKeyDown` calls | 9,282 | 1 |

### File-by-file

- `CouncilMeetingDataContext.tsx` — split into three contexts; ref-backed getters; stable action callbacks.
- `EditingContext.tsx` — memoized value; ref-mirrored state for `[]`-dep callbacks.
- `HighlightContext.tsx` — memoized value; ref-mirrored state; stable callbacks; functional-updater fix; remove `utteranceMap` from public type.
- `VideoProvider.tsx` — stable function wrappers; memoized value object.
- `SpeakerSegment.tsx` — switched to `useCouncilMeetingMeta()` + `useCouncilMeetingActions()`; inline `memoizedData` (the previous `useMemo` would never recompute with stable getter refs).
- `Utterance.tsx` — strip per-utterance `<ContextMenu>` and the now-unused share/highlight handlers; add data-attrs.
- `Transcript.tsx` — wrap segment list in `<UtteranceContextMenu>`.
- `UtteranceContextMenu.tsx` (new) — shared menu component.
- `useSpeakerSegmentEditor.ts` — switch to `useCouncilMeetingActions()`.

## Test plan

- [x] `npx tsc --noEmit` clean on production code (16 pre-existing test-file matcher errors unrelated to this PR).
- [x] `npm test` — 670/670 pass.
- [x] Verified live on the largest transcript:
  - Typing in an utterance is instant (INP ≤ 36 ms).
  - Right-click on an utterance opens the menu with the correct items per mode (highlight/edit/share).
  - System context menu still shows on segment headers / outside utterances (`hasAnyAction` guard preserved).
  - Edit, save, undo, click-to-select, shift-click range select, highlight create/edit/save/preview, video playback time-tracking — all behave as before.
  - Playback no longer triggers cascading re-renders every 2 s.
- [ ] Re-validate on staging with another long transcript before merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad performance refactor across multiple React providers/contexts; while behavior is intended to be preserved, changes to context boundaries and video `setIsPlaying` semantics could cause subtle regressions in editing/highlight/playback flows.
> 
> **Overview**
> **Major performance refactor for transcript edit/highlight mode.** Splits `CouncilMeetingDataContext` into separate `Actions`, `Meta`, and full `Data` contexts with ref-backed stable getters and memoized provider values, so components that only mutate or read non-transcript data no longer re-render on every transcript edit.
> 
> Reworks `EditingContext`, `HighlightContext`, and `VideoProvider` to keep callback/value identities stable (via refs + `useMemo`/`useCallback`) and prevent playback or selection changes from invalidating all `Utterance` components.
> 
> Replaces per-utterance Radix context menus with a single shared `UtteranceContextMenu` wrapper at the `Transcript` level (utterances expose `data-*` attrs), and updates `SpeakerSegment`/`Utterance`/`useSpeakerSegmentEditor` to consume the new actions/meta hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffb2689ff9d2b2a9307c1437823da731794765c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Major performance refactor for long transcripts: splits `CouncilMeetingDataContext` into three stable contexts (`Actions`, `Meta`, full `Data`), adds ref-backed getters and memoized provider values across `EditingContext`, `HighlightContext`, and `VideoProvider`, and replaces ~9K per-utterance Radix `<ContextMenu>` instances with a single transcript-level `<UtteranceContextMenu>` — bringing keystroke INP from 506 ms to 36 ms on a 9,283-utterance transcript. The approach is sound and thoroughly tested; all findings are P2.

<h3>Confidence Score: 5/5</h3>

Safe to merge after final staging validation; all inline findings are P2 style/optimization suggestions.

No P0 or P1 issues found. The context-splitting strategy is architecturally correct, backward-compatible, and comprehensively tested. The two P2 comments (handleContextMenu dep stability and focus-restoration on virtual-trigger close) are non-blocking. Previous P1 threads have been addressed.

src/components/meetings/transcript/UtteranceContextMenu.tsx — new file; focus-restoration on close and handler stability are worth a follow-up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/meetings/CouncilMeetingDataContext.tsx | Split into three contexts (Actions, Meta, Data); ref-backed stable getters; auto-prune effect for orphaned speaker tags. Minor: `data` prop in `metaValue` deps is over-broad. |
| src/components/meetings/EditingContext.tsx | Memoized provider value; ref-mirrored state for stable []-dep callbacks; StrictMode double-fire fix. No issues found. |
| src/components/meetings/HighlightContext.tsx | Memoized value; ref-mirrored state; utteranceMap dropped from public type; speakerTags dep added to editingHighlightData (addresses prior thread). |
| src/components/meetings/VideoProvider.tsx | Ref-backed stable wrappers for all playback functions; separate VideoActionsContext for Utterance; memoized value object. Correct. |
| src/components/meetings/transcript/UtteranceContextMenu.tsx | New shared context menu replacing 9K per-utterance Radix menus. Two P2 issues: handleContextMenu dep stability and focus restoration on close. |
| src/components/meetings/transcript/Utterance.tsx | Stripped per-utterance ContextMenu; added data-attrs; uses stable action hooks. Clean. |
| src/components/meetings/transcript/SpeakerSegment.tsx | Switched to useCouncilMeetingMeta + useCouncilMeetingActions; dropped useMemo for displayData (correct). No issues. |
| src/components/meetings/transcript/Transcript.tsx | Wraps segment list in UtteranceContextMenu; IntersectionObserver uses refs. Clean. |
| src/hooks/useSpeakerSegmentEditor.ts | Migrated to useCouncilMeetingActions. Minimal, correct change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CouncilMeetingDataProvider] --> B[CouncilMeetingActionsContext stable for provider lifetime]
    A --> C[CouncilMeetingMetaContext updates on speakerTags/highlights]
    A --> D[CouncilMeetingDataContext updates on transcript + meta]
    B --> E[Utterance useCouncilMeetingActions]
    B --> F[SpeakerSegment useCouncilMeetingActions]
    B --> G[UtteranceContextMenu useCouncilMeetingActions]
    C --> F
    D --> H[Transcript useCouncilMeetingData]
    D --> I[HighlightProvider useCouncilMeetingData]
    D --> J[EditingProvider useCouncilMeetingData]
    K[VideoActionsContext stable seekTo/togglePlayPause] --> E
    L[VideoContext updates every 2s during playback] --> I
    H --> M[UtteranceContextMenu wrapper single shared DropdownMenu]
    M --> N[SpeakerSegment x N]
    N --> O[UtteranceC x M React.memo + data-attrs]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/components/meetings/transcript/UtteranceContextMenu.tsx:60-79
**`handleContextMenu` recreated on every selection change**

`handleContextMenu` lists `selectedUtteranceIds` as a dep (line 79). Since each call to `toggleSelection` returns a brand-new `Set`, the handler is recreated on every selection toggle and the wrapping `<div>`'s `onContextMenu` prop changes on every re-render of `UtteranceContextMenu`. The dep is only needed for the `selectedUtteranceIds.has(id)` guard — pulling that read into a ref avoids the churn:

```ts
const selectedUtteranceIdsRef = useRef(selectedUtteranceIds);
selectedUtteranceIdsRef.current = selectedUtteranceIds;

const handleContextMenu = useCallback((e: React.MouseEvent) => {
    if (!hasAnyAction) return;
    const span = (e.target as HTMLElement | null)?.closest<HTMLElement>('[data-utterance-id]');
    if (!span) return;
    const id = span.dataset.utteranceId;
    const segmentId = span.dataset.segmentId;
    if (!id || !segmentId) return;
    const startTimestamp = parseFloat(span.dataset.startTimestamp || '0');
    e.preventDefault();
    setTarget({ id, segmentId, startTimestamp, x: e.clientX, y: e.clientY });
    setOpen(true);
    if (!selectedUtteranceIdsRef.current.has(id)) {
        toggleSelection(id, { shift: false, ctrl: false });
    }
}, [hasAnyAction, toggleSelection]);
```

### Issue 2 of 3
src/components/meetings/CouncilMeetingDataContext.tsx:363-393
**`metaValue` dep on the full `data` prop may invalidate unnecessarily**

`data` is in the dep array for `metaValue` (line 382). `data` contains the initial server-side `speakerTags`, `highlights`, and `transcript` even though the live versions are provided separately as state. If a parent re-renders and passes a structurally identical but new-reference `data` object, `metaValue` invalidates, causing all `useCouncilMeetingMeta()` consumers (every `SpeakerSegment`) to re-render. The `data` reference is typically stable, but for defensive correctness consider depending on individual stable fields (`data.people`, `data.parties`, `data.taskStatus`, etc.) rather than the whole object.

### Issue 3 of 3
src/components/meetings/transcript/UtteranceContextMenu.tsx:165-222
**Focus not restored to the originally focused element after menu closes**

Using a zero-size `aria-hidden` div as the virtual trigger means Radix has no real trigger element to return focus to when the `DropdownMenu` closes. After dismissal, focus lands on `<body>`, breaking keyboard navigation flow. The previous per-utterance `<ContextMenu>` anchored to the utterance `<span>` which naturally held focus.

Tracking the source element and refocusing it on close would fix this:

```ts
const triggerElementRef = useRef<HTMLElement | null>(null);
// in handleContextMenu, after finding span:
triggerElementRef.current = span;
// in handleOpenChange:
if (!next) {
    triggerElementRef.current?.focus({ preventScroll: true });
    // ...flush pending share / clear temp selection...
}
```

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fixup! perf(transcript): collapse re-ren..."](https://github.com/schemalabz/opencouncil/commit/ffb2689ff9d2b2a9307c1437823da731794765c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30552085)</sub>

<!-- /greptile_comment -->