### PR TITLE
Enable inbound messaging for unsusbribe by reply

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,21 @@ GOOGLE_CALENDAR_ID=
 GOOGLE_CALENDAR_ENABLED=
 
 # ---------------------------------
+# Bird (WhatsApp / SMS notifications)
+# ---------------------------------
+# Full setup walkthrough in docs/bird-setup.md.
+BIRD_WORKSPACE_ID=
+BIRD_API_KEY=
+BIRD_WHATSAPP_CHANNEL_ID=
+BIRD_SMS_CHANNEL_ID=
+BIRD_WHATSAPP_TEMPLATE_WELCOME=
+BIRD_WHATSAPP_TEMPLATE_BEFORE_MEETING=
+BIRD_WHATSAPP_TEMPLATE_AFTER_MEETING=
+# Shared secret for HMAC verification of inbound Bird webhook events.
+# Generate with: openssl rand -base64 32
+BIRD_WEBHOOK_SECRET=
+
+# ---------------------------------
 # Storage (e.g., Digital Ocean Spaces)
 # ---------------------------------
 DO_SPACES_ENDPOINT=https://fra1.digitaloceanspaces.com

--- a/docs/bird-setup.md
+++ b/docs/bird-setup.md
@@ -1,0 +1,178 @@
+# Bird Messaging Setup (WhatsApp + SMS)
+
+This guide walks you through configuring [Bird](https://bird.com) for OpenCouncil's notification system: **outbound** WhatsApp/SMS (meeting reminders, welcome messages) and **inbound** WhatsApp replies (the unsubscribe-by-reply flow). By the end you'll have all the `BIRD_*` environment variables filled in and a local ngrok tunnel that lets Bird POST inbound events back to your machine.
+
+For the canonical list of variables and their default values, see [`.env.example`](../.env.example) and [`environment-variables.md`](./environment-variables.md).
+
+## Prerequisites
+
+- A Bird account — sign up at [app.bird.com](https://app.bird.com/sign-up).
+- A WhatsApp Business account (Bird's onboarding flow walks you through linking one). For local development, Bird's sandbox WhatsApp number is enough.
+- [`openssl`](https://www.openssl.org/) on your machine (for generating the webhook secret).
+- [`ngrok`](https://ngrok.com/download) (only needed for testing inbound locally).
+
+## Step 1: Create a Bird workspace
+
+1. Sign in at [app.bird.com](https://app.bird.com). On first sign-in Bird creates a workspace for you; otherwise create one from the workspace switcher in the top-left.
+2. Once inside the workspace, copy the **workspace UUID** from the URL — it's the segment after `/workspaces/`:
+
+   ```
+   https://app.bird.com/workspaces/<workspace-uuid>/...
+                                    ^^^^^^^^^^^^^^^^
+                                    BIRD_WORKSPACE_ID
+   ```
+
+   See [Bird — How to find a workspace ID](https://docs.bird.com/applications/settings/account/organization-settings/how-to-find-a-workspace-id) if you need help locating it.
+
+## Step 2: Set up the WhatsApp channel
+
+The channel is what Bird uses to deliver WhatsApp messages and receive inbound replies.
+
+1. In the workspace sidebar go to **Channels** → **Add channel** → choose **WhatsApp**. (Bird's [supported channels](https://docs.bird.com/api/channels-api/supported-channels) page lists every option.)
+2. Follow the WhatsApp Business onboarding (link a phone number, verify ownership). For a local-only setup, use Bird's sandbox WhatsApp number — no business verification required.
+3. Once the channel is active, open it from **Channels** and copy the **channel ID** from the URL — it's the UUID at the end:
+
+   ```
+   https://app.bird.com/workspaces/.../channels/whatsapp/<channel-uuid>
+                                                          ^^^^^^^^^^^^^^
+                                                          BIRD_WHATSAPP_CHANNEL_ID
+   ```
+
+## Step 3 (optional): Set up the SMS channel
+
+Repeat Step 2 picking **SMS** instead. Only needed if you want SMS fallback for users without WhatsApp.
+
+> ⚠️ **Inbound SMS is not supported by OpenCouncil.** Bird does support it, but it requires extra account setup (see [Receiving inbound SMS](https://docs.bird.com/connectivity-platform/receiving-sms/setting-your-account-up-to-receive-inbound-sms)) and OpenCouncil's webhook handler currently only routes inbound WhatsApp through the unsubscribe flow. SMS in OpenCouncil is outbound-only.
+
+Copy the channel ID into `BIRD_SMS_CHANNEL_ID`.
+
+## Step 4: Create the WhatsApp templates
+
+WhatsApp Business restricts outbound messages outside a 24-hour reply window to **pre-approved templates**. OpenCouncil uses three:
+
+| Env var | Used for | Variables it must accept |
+|---|---|---|
+| `BIRD_WHATSAPP_TEMPLATE_WELCOME` | First message after a user signs up | user name, city name |
+| `BIRD_WHATSAPP_TEMPLATE_BEFORE_MEETING` | Notification sent before a meeting | meeting title, date, link |
+| `BIRD_WHATSAPP_TEMPLATE_AFTER_MEETING` | Notification sent after a meeting | meeting title, link |
+
+For each template:
+
+1. Open **Bird Studio** (sidebar → **Studio**) and create a new WhatsApp template. See [Bird — WhatsApp templates](https://docs.bird.com/api/channels-api/supported-channels/programmable-whatsapp) for syntax and approval requirements.
+2. Submit it for WhatsApp approval (usually a few minutes).
+3. Once approved, copy the **template project ID (UUID)** from the URL or the template detail panel.
+4. Map each UUID into its env var (`BIRD_WHATSAPP_TEMPLATE_*`).
+
+> The actual template wording is yours to write — but match the variable list above so the substitution code in `src/lib/notifications/bird.ts` doesn't break.
+
+## Step 5: Generate an API key
+
+1. In the workspace sidebar go to **Settings** → **Developers** → **API access** (or **Access keys**, depending on Bird's UI version).
+2. Click **Create access key**, give it a descriptive name (e.g. `opencouncil-local`), and grant it the **Conversations** and **Channels** scopes.
+3. **Copy the key value immediately** — Bird only shows it once. Save it as `BIRD_API_KEY` in `.env`.
+
+## Step 6: Generate the webhook signing secret
+
+This is the shared secret Bird uses to sign inbound webhook events, so the `/api/webhooks/bird` handler can verify they actually came from Bird (not a forged request to your public URL).
+
+Generate 32 random bytes, base64-encoded:
+
+```sh
+openssl rand -base64 32
+```
+
+Save the **same value** in two places:
+
+- Locally as `BIRD_WEBHOOK_SECRET` in `.env`.
+- On Bird's side as the `signingKey` of the webhook subscription you'll create in [Step 8](#step-8-register-the-webhook-in-bird).
+
+> **Treat it like a password.** Anyone with this value can forge requests that look like they came from Bird. Don't commit it; generate a different one per environment (dev, staging, prod) so a leaked dev key doesn't compromise prod. The HMAC scheme itself (HMAC-SHA256 over `timestamp \n url \n sha256(body)`, base64-encoded) is documented in [Bird — Verifying a webhook subscription](https://docs.bird.com/api/notifications-api/api-reference/webhook-subscriptions/verifying-a-webhook-subscription).
+
+## Step 7: Fill in `.env`
+
+After Steps 1–6 you should have all eight variables. Add them to your `.env`:
+
+```bash
+# Bird API for WhatsApp/SMS notifications
+BIRD_WORKSPACE_ID=<workspace-uuid>
+BIRD_API_KEY=<your-api-key>
+BIRD_WHATSAPP_CHANNEL_ID=<whatsapp-channel-uuid>
+BIRD_SMS_CHANNEL_ID=<optional>
+BIRD_WHATSAPP_TEMPLATE_WELCOME=<uuid>
+BIRD_WHATSAPP_TEMPLATE_BEFORE_MEETING=<uuid>
+BIRD_WHATSAPP_TEMPLATE_AFTER_MEETING=<uuid>
+BIRD_WEBHOOK_SECRET=<openssl-output-from-step-6>
+```
+
+At this point **outbound** sends will work — you can use the admin `/conversations` page to fire test WhatsApp messages and they'll reach a real phone. **Inbound** still requires the next two steps.
+
+## Step 8: Expose the webhook locally with ngrok
+
+Bird needs a publicly reachable URL to POST inbound events to. In production that's `https://opencouncil.gr/api/webhooks/bird`; locally we tunnel with ngrok.
+
+1. Start the dev server:
+
+   ```sh
+   npm run dev
+   ```
+
+2. In a separate terminal, start an ngrok tunnel pointing at your local Next.js port (default `3000`):
+
+   ```sh
+   ngrok http 3000
+   ```
+
+3. ngrok prints a forwarding URL like:
+
+   ```
+   Forwarding  <ngrok-url> -> http://localhost:3000
+   ```
+
+   Your webhook URL is that forwarding URL plus `/api/webhooks/bird`:
+
+   ```
+   <ngrok-url>/api/webhooks/bird
+   ```
+
+> Free ngrok URLs change every restart. If you restart ngrok, update the webhook subscription URL in Bird (Step 9) — otherwise Bird will keep POSTing to a dead tunnel.
+
+## Step 9: Register the webhook in Bird
+
+1. In the workspace sidebar go to **Developers** → **Webhooks** → **New webhook subscription** (Bird's UI may also call this "Event subscription").
+2. Fill in:
+
+   | Field | Value |
+   |---|---|
+   | **URL** | The ngrok URL from Step 8, e.g. `<ngrok-url>/api/webhooks/bird` |
+   | **Signing key** | The same string you put in `BIRD_WEBHOOK_SECRET` (Step 6) |
+   | **Service** | `Conversations` |
+   | **Events** | `conversation.created`, `conversation.updated` |
+
+3. Save. Bird will start POSTing matching events to your tunnel.
+
+> The two events together cover the inbound path: `conversation.created` fires when a contact replies to one of your messages for the first time, `conversation.updated` fires for every subsequent message in that thread (which is where the inbound WhatsApp body and unsubscribe-detection logic actually run).
+
+## Step 10: Verify the full inbound path
+
+1. Open `http://localhost:3000/admin/conversations` (you need to be logged in as an admin).
+2. Click **Send test message** and pick one of the templates (e.g. welcome). Send it to a phone number you control that has WhatsApp installed.
+3. On that phone, reply to the message — try `STOP` to exercise the unsubscribe flow.
+4. Watch your dev server logs. A successful inbound looks like:
+
+   ```
+   Bird webhook: disabled phone notifications for user <id> across all cities (delivery <id>)
+   ```
+
+   Refresh `/admin/conversations` and the inbound message row should appear in the thread.
+
+If signature verification fails you'll see a warning like:
+
+```
+Bird webhook: signature verification failed — signature mismatch
+```
+
+The most common causes are:
+
+- The signing key in Bird's webhook subscription doesn't match `BIRD_WEBHOOK_SECRET` in `.env` (re-paste both).
+- ngrok was restarted and the URL on the Bird subscription is stale (update it).
+- Your `.env` was loaded before you set `BIRD_WEBHOOK_SECRET` — restart `npm run dev`.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -85,14 +85,9 @@ These variables are used by the flake runner (`nix run .#dev`) to configure **lo
 | `BIRD_WHATSAPP_TEMPLATE_BEFORE_MEETING` | Template project ID (UUID) from Bird Studio for before meeting notifications. | No | - |
 | `BIRD_WHATSAPP_TEMPLATE_AFTER_MEETING` | Template project ID (UUID) from Bird Studio for after meeting notifications. | No | - |
 | `BIRD_WHATSAPP_TEMPLATE_WELCOME` | Template project ID (UUID) from Bird Studio for welcome messages when users sign up. | No | - |
+| `BIRD_WEBHOOK_SECRET` | Shared secret for verifying HMAC signatures on inbound Bird webhook events. | No | - |
 
-**Note**: Bird API variables are optional. If not configured, message notifications (WhatsApp/SMS) will be skipped, but email notifications will still work. You need separate channel IDs because WhatsApp and SMS typically use different phone numbers/senders in Bird.
-
-**Getting Template Project IDs**: In Bird Studio, go to your approved WhatsApp templates and copy the project ID (UUID format like `ce6a2fd6-b2fa-4f5a-a2cd-f3bd15883318`). We use the latest version of each template project.
-
-**Required template parameters:**
-- Before/After Meeting templates: `date`, `cityName`, `subjectsSummary`, `adminBody`, `notificationId`
-- Welcome template: `userName`, `cityName`
+For full setup instructions (workspace, channels, templates, API key, webhook subscription), see [bird-setup.md](./bird-setup.md).
 
 #### NEXTAUTH_SECRET
 You can quickly create a good value on the command line via this openssl command:

--- a/prisma/migrations/20260504120000_add_message_table/migration.sql
+++ b/prisma/migrations/20260504120000_add_message_table/migration.sql
@@ -1,0 +1,39 @@
+-- CreateEnum
+CREATE TYPE "MessageChannel" AS ENUM ('whatsapp', 'sms');
+
+-- CreateEnum
+CREATE TYPE "MessageDirection" AS ENUM ('inbound', 'outbound');
+
+-- CreateEnum
+CREATE TYPE "MessageStatus" AS ENUM ('pending', 'sent', 'delivered', 'failed');
+
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" TEXT NOT NULL,
+    "channel" "MessageChannel" NOT NULL,
+    "direction" "MessageDirection" NOT NULL,
+    "birdMessageId" TEXT,
+    "conversationId" TEXT,
+    "phone" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "status" "MessageStatus" NOT NULL DEFAULT 'pending',
+    "notificationDeliveryId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Message_birdMessageId_key" ON "Message"("birdMessageId");
+
+-- CreateIndex
+CREATE INDEX "Message_phone_idx" ON "Message"("phone");
+
+-- CreateIndex
+CREATE INDEX "Message_conversationId_createdAt_idx" ON "Message"("conversationId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Message_createdAt_idx" ON "Message"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_notificationDeliveryId_fkey" FOREIGN KEY ("notificationDeliveryId") REFERENCES "NotificationDelivery"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260508120000_add_message_failure_reason_and_updated_at/migration.sql
+++ b/prisma/migrations/20260508120000_add_message_failure_reason_and_updated_at/migration.sql
@@ -1,0 +1,9 @@
+-- Add Bird's failure description (populated when status transitions to `failed`)
+-- and an `updatedAt` column so we can see when each row last changed (initial
+-- send, polled status, webhook update).
+
+ALTER TABLE "Message" ADD COLUMN "failureReason" TEXT;
+
+-- Backfill existing rows to `now()` so the NOT NULL column has a value, then
+-- let Prisma's @updatedAt take over for future writes.
+ALTER TABLE "Message" ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1150,6 +1150,11 @@ model NotificationDelivery {
   messageSentVia NotificationMessageType? // only filled in if status is sent
   sentAt DateTime?
 
+  // Both outbound (test sends, real notification messages) and inbound replies
+  // are recorded in Message; this back-relation lets us trace a delivery to
+  // the message rows it produced (or the user reply that came back).
+  messages Message[]
+
   @@index([status])
   @@index([createdAt])
   @@unique([notificationId, medium])
@@ -1168,6 +1173,49 @@ enum NotificationMessageType {
 enum NotificationDeliveryStatus {
   pending
   sent
+  failed
+}
+
+model Message {
+  id                     String   @id @default(cuid())
+  channel                MessageChannel
+  direction              MessageDirection
+  birdMessageId          String?  @unique
+  conversationId         String?
+  phone                  String
+  body                   String   @db.Text
+  status                 MessageStatus @default(pending)
+  // Bird's failure description when status transitions to `failed`. Null on
+  // success and on rows still in flight.
+  failureReason          String?  @db.Text
+
+  // Set when the message is the inbound reply to (or outbound delivery of)
+  // an existing notification. Null for free-form admin test sends.
+  notificationDeliveryId String?
+  notificationDelivery   NotificationDelivery? @relation(fields: [notificationDeliveryId], references: [id])
+
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
+
+  @@index([phone])
+  @@index([conversationId, createdAt])
+  @@index([createdAt])
+}
+
+enum MessageChannel {
+  whatsapp
+  sms
+}
+
+enum MessageDirection {
+  inbound
+  outbound
+}
+
+enum MessageStatus {
+  pending
+  sent
+  delivered
   failed
 }
 

--- a/src/app/[locale]/(other)/admin/conversations/actions.ts
+++ b/src/app/[locale]/(other)/admin/conversations/actions.ts
@@ -1,0 +1,260 @@
+"use server";
+
+import { withUserAuthorizedToEdit } from '@/lib/auth';
+import prisma from '@/lib/db/prisma';
+import {
+    sendConversationMessage,
+    createOrUpdateConversation,
+    sendSMSMessage,
+} from '@/lib/notifications/bird';
+import { sendAndPersistOutbound } from '@/lib/notifications/outbound';
+import { generateSmsContent, generateWelcomeSmsContent } from '@/lib/notifications/content';
+import { releaseNotifications } from '@/lib/notifications/deliver';
+import type { OutboundSendResult } from '@/lib/notifications/types';
+import type { MessageChannel } from '@prisma/client';
+
+export type SendReplyResult = Pick<OutboundSendResult, 'success' | 'error'>;
+
+/**
+ * Send a free-form text reply into an existing Bird conversation via the
+ * Conversations API, persisting the local Message row through the lifecycle
+ * (pending → sent / failed → polled terminal status).
+ */
+export async function sendTestReply(input: {
+    conversationId: string;
+    phone: string;
+    text: string;
+    channel: MessageChannel;
+}): Promise<SendReplyResult> {
+    await withUserAuthorizedToEdit({});
+
+    const text = input.text.trim();
+    if (!text) return { success: false, error: 'Message body is required' };
+    if (!input.conversationId) return { success: false, error: 'Conversation ID is required' };
+    if (!input.phone) return { success: false, error: 'Phone number is required' };
+
+    const result = await sendAndPersistOutbound({
+        channel: input.channel,
+        phone: input.phone,
+        body: text,
+        conversationId: input.conversationId,
+        send: () => sendConversationMessage({
+            conversationId: input.conversationId,
+            channel: input.channel,
+            text,
+            recipientPhone: input.phone,
+        }),
+    });
+
+    if (result.success && result.finalStatus !== 'failed') {
+        return { success: true };
+    }
+    return { success: false, error: result.finalReason ?? result.error };
+}
+
+/**
+ * Send a free-form SMS test to a phone via the Messaging API.
+ * Persists an outbound Message row in the same shape as `sendTestTemplate`.
+ */
+export async function sendTestSms(input: {
+    phone: string;
+    body: string;
+}): Promise<SendReplyResult> {
+    await withUserAuthorizedToEdit({});
+
+    const phone = input.phone.trim();
+    const body = input.body.trim();
+    if (!phone) return { success: false, error: 'Phone number is required' };
+    if (!body) return { success: false, error: 'Message body is required' };
+
+    const result = await sendAndPersistOutbound({
+        channel: 'sms',
+        phone,
+        body,
+        send: () => sendSMSMessage(phone, body),
+    });
+
+    if (result.success && result.finalStatus !== 'failed') {
+        return { success: true };
+    }
+    return { success: false, error: result.finalReason ?? result.error };
+}
+
+/**
+ * Send a WhatsApp welcome template to a phone via the Messaging API. Used by
+ * the admin "Send test message" dialog on `/admin/conversations` to seed a
+ * conversation for testing — kicks off a thread the user can reply to.
+ */
+export async function sendTestTemplate(input: {
+    phone: string;
+    userName?: string;
+    cityName?: string;
+}): Promise<SendReplyResult> {
+    await withUserAuthorizedToEdit({});
+
+    const phone = input.phone.trim();
+    if (!phone) return { success: false, error: 'Phone number is required' };
+    const userName = input.userName?.trim() || 'Friend';
+    const cityName = input.cityName?.trim() || 'Athens';
+
+    // Route through createOrUpdateConversation so the welcome message lands in
+    // the same Bird thread we reuse for later notifications.
+    const result = await sendAndPersistOutbound({
+        channel: 'whatsapp',
+        phone,
+        body: '[welcome template]',
+        send: () => createOrUpdateConversation({
+            phone,
+            notificationType: 'welcome',
+            params: { userName, cityName },
+        }),
+    });
+    if (result.success && result.finalStatus !== 'failed') {
+        return { success: true };
+    }
+
+    // WhatsApp failed — fall back to SMS. Either the send failed, or
+    // reconciliation flagged it failed post-send (24h window, blocked
+    // recipient, etc.).
+    const waError = result.finalReason ?? result.error;
+    const smsBody = await generateWelcomeSmsContent(userName, cityName);
+    const smsResult = await sendAndPersistOutbound({
+        channel: 'sms',
+        phone,
+        body: smsBody,
+        send: () => sendSMSMessage(phone, smsBody),
+    });
+    if (smsResult.success && smsResult.finalStatus !== 'failed') {
+        return { success: true };
+    }
+    const smsError = smsResult.finalReason ?? smsResult.error;
+    return { success: false, error: `WhatsApp: ${waError}; SMS: ${smsError}` };
+}
+
+// ---------------------------------------------------------------------------
+// Admin "Before-meeting" test send. Creates a real Notification +
+// NotificationDelivery row for a chosen user/city/meeting (mirroring the prod
+// flow that `createNotificationsForMeeting` runs after the agenda task), then
+// calls `releaseNotifications` so it goes through the same conversation +
+// message-row pipeline as a real notification.
+// ---------------------------------------------------------------------------
+
+export interface CityOption { id: string; name: string }
+export interface MeetingOption { id: string; name: string; dateTime: string }
+
+export async function listCitiesForTest(): Promise<CityOption[]> {
+    await withUserAuthorizedToEdit({});
+    const cities = await prisma.city.findMany({
+        select: { id: true, name: true },
+        orderBy: { name: 'asc' },
+    });
+    return cities;
+}
+
+export async function listMeetingsForTest(cityId: string): Promise<MeetingOption[]> {
+    await withUserAuthorizedToEdit({});
+    if (!cityId) return [];
+    const meetings = await prisma.councilMeeting.findMany({
+        where: { cityId },
+        select: { id: true, name: true, dateTime: true },
+        orderBy: { dateTime: 'desc' },
+        take: 20,
+    });
+    return meetings.map((m) => ({ ...m, dateTime: m.dateTime.toISOString() }));
+}
+
+export async function sendTestBeforeMeetingNotification(input: {
+    phone: string;
+    cityId: string;
+    meetingId: string;
+}): Promise<SendReplyResult> {
+    await withUserAuthorizedToEdit({});
+
+    const phone = input.phone.trim();
+    if (!phone) return { success: false, error: 'Phone number is required' };
+    if (!input.cityId) return { success: false, error: 'City is required' };
+    if (!input.meetingId) return { success: false, error: 'Meeting is required' };
+
+    const user = await prisma.user.findFirst({ where: { phone } });
+    if (!user) {
+        return { success: false, error: `No user found with phone ${phone}` };
+    }
+
+    const firstSubject = await prisma.subject.findFirst({
+        where: { councilMeetingId: input.meetingId, cityId: input.cityId },
+    });
+    if (!firstSubject) {
+        return { success: false, error: 'Meeting has no subjects to attach' };
+    }
+
+    let notificationId: string;
+    try {
+        // Include the relations `generateSmsContent` needs so we can
+        // pre-render the SMS body inline — same path the production flow
+        // takes in `createNotificationsForMeeting`.
+        const notification = await prisma.notification.create({
+            data: {
+                userId: user.id,
+                cityId: input.cityId,
+                meetingId: input.meetingId,
+                type: 'beforeMeeting',
+                subjects: {
+                    create: [{ subjectId: firstSubject.id, reason: 'generalInterest' }],
+                },
+            },
+            include: {
+                subjects: { include: { subject: { include: { topic: true } } } },
+                meeting: { include: { administrativeBody: true } },
+                city: true,
+            },
+        });
+        notificationId = notification.id;
+
+        const smsBody = await generateSmsContent({
+            id: notification.id,
+            userId: notification.userId,
+            cityId: notification.cityId,
+            type: 'beforeMeeting',
+            subjects: notification.subjects.map((ns) => ({
+                id: ns.subject.id,
+                name: ns.subject.name,
+                description: ns.subject.description,
+                topic: ns.subject.topic
+                    ? { name: ns.subject.topic.name, colorHex: ns.subject.topic.colorHex }
+                    : null,
+            })),
+            meeting: {
+                dateTime: notification.meeting.dateTime,
+                administrativeBody: notification.meeting.administrativeBody
+                    ? { name: notification.meeting.administrativeBody.name }
+                    : null,
+            },
+            city: { name_municipality: notification.city.name_municipality },
+        });
+
+        await prisma.notificationDelivery.create({
+            data: {
+                notificationId: notification.id,
+                medium: 'message',
+                status: 'pending',
+                phone,
+                body: smsBody,
+            },
+        });
+    } catch (error: any) {
+        if (error?.code === 'P2002' && error?.meta?.target?.includes('userId')) {
+            return {
+                success: false,
+                error: 'A beforeMeeting notification already exists for this user + meeting',
+            };
+        }
+        throw error;
+    }
+
+    const result = await releaseNotifications([notificationId]);
+
+    if (result.failed > 0) {
+        return { success: false, error: `Release failed (${result.failed} failed deliveries)` };
+    }
+    return { success: true };
+}

--- a/src/app/[locale]/(other)/admin/conversations/page.tsx
+++ b/src/app/[locale]/(other)/admin/conversations/page.tsx
@@ -1,0 +1,389 @@
+import { Metadata } from 'next';
+import type { Message } from '@prisma/client';
+import { getConversationSummaries } from '@/lib/db/conversations';
+import { formatNumericDateTime } from '@/lib/formatters/time';
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table';
+import { ExpandableTableRow } from '@/components/ui/expandable-table-row';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { MessageCircle, MessageSquare, ChevronRight } from 'lucide-react';
+import { FaWhatsapp } from 'react-icons/fa';
+import { ReplyForm } from '@/components/admin/conversations/ReplyForm';
+import { SendTemplateDialog } from '@/components/admin/conversations/SendTemplateDialog';
+import { ScrollableThread } from '@/components/admin/conversations/ScrollableThread';
+
+export const metadata: Metadata = {
+    title: 'Conversations - Admin',
+    description: 'Inbound and outbound message threads, grouped by participant.',
+};
+
+const PREVIEW_MAX = 120;
+
+function truncate(s: string, max = PREVIEW_MAX) {
+    return s.length <= max ? s : `${s.slice(0, max).trimEnd()}…`;
+}
+
+function statusBadgeVariant(status: Message['status']) {
+    return status === 'failed' ? 'destructive' : 'outline';
+}
+
+function directionBadgeVariant(direction: Message['direction']) {
+    return direction === 'inbound' ? 'default' : 'secondary';
+}
+
+/**
+ * WhatsApp keeps its brand mark (in-house green); SMS falls back to a generic
+ * chat-bubble icon. Both carry an aria-label for screen readers since they're
+ * the sole indicator that a "channel" badge would have shown.
+ */
+function ChannelIcon({ channel }: { channel: Message['channel'] }) {
+    if (channel === 'whatsapp') {
+        return <FaWhatsapp className="h-4 w-4 text-[#25D366]" aria-label="WhatsApp" />;
+    }
+    return <MessageSquare className="h-4 w-4 text-muted-foreground" aria-label="SMS" />;
+}
+
+/**
+ * Cells for the visible row. Same layout for plain rows and expandable rows
+ * so columns stay aligned regardless of which renderer the row uses.
+ */
+function ConversationCells({
+    phone,
+    lastMessage,
+    messageCount,
+}: {
+    phone: string;
+    lastMessage: Message;
+    messageCount: number;
+}) {
+    return (
+        <>
+            <TableCell className="font-mono">{phone}</TableCell>
+            <TableCell className="hidden lg:table-cell">
+                <ChannelIcon channel={lastMessage.channel} />
+            </TableCell>
+            <TableCell className="max-w-md break-words">{truncate(lastMessage.body)}</TableCell>
+            <TableCell>
+                <Badge variant={directionBadgeVariant(lastMessage.direction)}>
+                    {lastMessage.direction}
+                </Badge>
+            </TableCell>
+            <TableCell>
+                <Badge variant={statusBadgeVariant(lastMessage.status)}>
+                    {lastMessage.status}
+                </Badge>
+            </TableCell>
+            <TableCell className="hidden lg:table-cell tabular-nums">{messageCount}</TableCell>
+            <TableCell className="text-right tabular-nums text-muted-foreground">
+                {formatNumericDateTime(lastMessage.createdAt)}
+            </TableCell>
+        </>
+    );
+}
+
+/**
+ * Stacked card content for one conversation. Used on mobile in place of a
+ * table row. Layout matches the spec: phone + channel inline at top, body
+ * below, direction + status inline, timestamp at the bottom.
+ */
+function ConversationMobileCardContent({
+    phone,
+    lastMessage,
+    messageCount,
+}: {
+    phone: string;
+    lastMessage: Message;
+    messageCount: number;
+}) {
+    return (
+        <div className="flex flex-col gap-2 text-left">
+            <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 min-w-0">
+                    <span className="font-mono text-sm truncate">{phone}</span>
+                    <ChannelIcon channel={lastMessage.channel} />
+                </div>
+                {messageCount > 1 && (
+                    <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+                        {messageCount} messages
+                    </span>
+                )}
+            </div>
+            <p className="text-sm break-words">{truncate(lastMessage.body)}</p>
+            <div className="flex items-center justify-between gap-3 flex-wrap">
+                <div className="flex items-center gap-2">
+                    <Badge variant={directionBadgeVariant(lastMessage.direction)}>
+                        {lastMessage.direction}
+                    </Badge>
+                    <Badge variant={statusBadgeVariant(lastMessage.status)}>
+                        {lastMessage.status}
+                    </Badge>
+                </div>
+            </div>
+            <span className="text-xs text-muted-foreground tabular-nums">
+                {formatNumericDateTime(lastMessage.createdAt)}
+            </span>
+        </div>
+    );
+}
+
+/**
+ * Mobile card wrapper. Multi-message threads use a native `<details>` element
+ * for expansion (oldest-first thread view inside) — no client component or
+ * state needed. Single-message threads render as a plain styled card.
+ */
+function ConversationMobileCard({
+    phone,
+    messages,
+    lastMessage,
+    messageCount,
+}: {
+    phone: string;
+    messages: Message[];
+    lastMessage: Message;
+    messageCount: number;
+}) {
+    const replyTarget = lastMessage.conversationId
+        ? {
+            conversationId: lastMessage.conversationId,
+            phone,
+            channel: lastMessage.channel,
+        }
+        : null;
+    const expandable = messageCount > 1 || replyTarget !== null;
+
+    if (expandable) {
+        return (
+            <details className="group rounded-md border bg-background overflow-hidden">
+                <summary className="cursor-pointer list-none p-3 flex items-start gap-2">
+                    <ChevronRight className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
+                    <div className="flex-1 min-w-0">
+                        <ConversationMobileCardContent
+                            phone={phone}
+                            lastMessage={lastMessage}
+                            messageCount={messageCount}
+                        />
+                    </div>
+                </summary>
+                <div className="border-t bg-muted/30 p-3">
+                    <ThreadDetail messages={messages} replyTarget={replyTarget} />
+                </div>
+            </details>
+        );
+    }
+    return (
+        <div className="rounded-md border bg-background p-3">
+            <ConversationMobileCardContent
+                phone={phone}
+                lastMessage={lastMessage}
+                messageCount={messageCount}
+            />
+        </div>
+    );
+}
+
+/**
+ * Chat-style thread view — outbound messages align right with a tinted bubble
+ * (our side), inbound messages align left in a muted bubble (their side).
+ * Timestamp + non-final status sits above each bubble. Oldest first.
+ */
+function ThreadDetail({
+    messages,
+    replyTarget,
+}: {
+    messages: Message[];
+    /**
+     * If the conversation has a Bird conversationId we can post replies to it
+     * via the Conversations API. Carries the channel so the reply goes out on
+     * the right WA/SMS channel. Without it, no Bird thread exists yet so a
+     * free-form reply has nowhere to go.
+     */
+    replyTarget?: { conversationId: string; phone: string; channel: Message['channel'] } | null;
+}) {
+    return (
+        <div className="flex flex-col">
+            {/* Capped + scrollable thread; auto-scrolls to bottom on mount so
+              * the latest message is in view when the row first opens. */}
+            <ScrollableThread>
+                {messages.map((m) => {
+                    const isOutbound = m.direction === 'outbound';
+                    const showStatus = m.status === 'failed' || m.status === 'pending';
+                    const showFailureReason = m.status === 'failed' && m.failureReason;
+                    return (
+                        <li
+                            key={m.id}
+                            className={`flex flex-col gap-1 ${isOutbound ? 'items-end' : 'items-start'}`}
+                        >
+                            <div className="flex items-center gap-2 px-1 text-xs text-muted-foreground tabular-nums">
+                                <span>{formatNumericDateTime(m.createdAt)}</span>
+                                {showStatus && (
+                                    <span
+                                        className={
+                                            m.status === 'failed'
+                                                ? 'text-destructive font-medium'
+                                                : 'font-medium'
+                                        }
+                                    >
+                                        · {m.status}
+                                    </span>
+                                )}
+                            </div>
+                            {showFailureReason && (
+                                <div className="max-w-[80%] rounded-lg bg-red-100 dark:bg-red-900/30 px-3 py-1.5 text-xs text-red-700 dark:text-red-300 break-words">
+                                    {m.failureReason}
+                                </div>
+                            )}
+                            <div
+                                className={`max-w-[80%] rounded-2xl px-4 py-2 text-sm break-words ${isOutbound
+                                    ? 'bg-primary text-primary-foreground rounded-br-sm'
+                                    : 'bg-muted-foreground/15 text-foreground rounded-bl-sm'
+                                    }`}
+                            >
+                                {m.body}
+                            </div>
+                        </li>
+                    );
+                })}
+            </ScrollableThread>
+            {/* Reply form sits outside the scroll container so it stays
+              * visible regardless of how long the thread gets. */}
+            {replyTarget && (
+                <ReplyForm
+                    conversationId={replyTarget.conversationId}
+                    phone={replyTarget.phone}
+                    channel={replyTarget.channel}
+                />
+            )}
+        </div>
+    );
+}
+
+export default async function ConversationsPage() {
+    const conversations = await getConversationSummaries();
+
+    return (
+        <div className="container mx-auto py-8">
+            <div className="flex items-center justify-between mb-6 gap-4 flex-wrap">
+                <div className="flex items-baseline gap-3">
+                    <h1 className="text-3xl font-bold">Conversations</h1>
+                    <p className="text-sm text-muted-foreground">
+                        {conversations.length} {conversations.length === 1 ? 'thread' : 'threads'}
+                    </p>
+                </div>
+                <div className="flex items-center gap-2 flex-wrap">
+                    <SendTemplateDialog />
+                </div>
+            </div>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Threads</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    {conversations.length === 0 ? (
+                        <div className="flex flex-col items-center justify-center gap-3 py-12 text-center text-muted-foreground">
+                            <MessageCircle className="h-10 w-10" />
+                            <p className="font-medium">No conversations yet</p>
+                            <p className="text-sm">
+                                Send a test WhatsApp from the trigger above to see it land here.
+                            </p>
+                        </div>
+                    ) : (
+                        <>
+                            {/* Mobile: stacked card layout — visible below md. */}
+                            <ul className="md:hidden flex flex-col gap-3">
+                                {conversations.map((c) => {
+                                    const lastMessage = c.messages[c.messages.length - 1];
+                                    const count = c.messages.length;
+                                    // Composite key — same phone on WA + SMS is two rows.
+                                    const key = `${c.channel}:${c.phone}`;
+                                    return (
+                                        <li key={key}>
+                                            <ConversationMobileCard
+                                                phone={c.phone}
+                                                messages={c.messages}
+                                                lastMessage={lastMessage}
+                                                messageCount={count}
+                                            />
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                            <div className="hidden md:block">
+                                <Table className="table-auto">
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead className="w-12" />
+                                            <TableHead>Phone</TableHead>
+                                            <TableHead className="hidden lg:table-cell">Channel</TableHead>
+                                            <TableHead>Last message</TableHead>
+                                            <TableHead>Direction</TableHead>
+                                            <TableHead>Status</TableHead>
+                                            <TableHead className="hidden lg:table-cell">Messages</TableHead>
+                                            <TableHead className="text-right">Last activity</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {conversations.map((c) => {
+                                            const lastMessage = c.messages[c.messages.length - 1];
+                                            const count = c.messages.length;
+                                            const replyTarget = lastMessage.conversationId
+                                                ? {
+                                                    conversationId: lastMessage.conversationId,
+                                                    phone: c.phone,
+                                                    channel: lastMessage.channel,
+                                                }
+                                                : null;
+                                            const expandable = count > 1 || replyTarget !== null;
+                                            // Composite key — same phone on WA + SMS is two rows.
+                                            const rowKey = `${c.channel}:${c.phone}`;
+
+                                            if (expandable) {
+                                                return (
+                                                    <ExpandableTableRow
+                                                        key={rowKey}
+                                                        rowId={rowKey}
+                                                        ariaLabel={`${c.channel} conversation with ${c.phone}`}
+                                                        expandedContent={
+                                                            <ThreadDetail
+                                                                messages={c.messages}
+                                                                replyTarget={replyTarget}
+                                                            />
+                                                        }
+                                                    >
+                                                        <ConversationCells
+                                                            phone={c.phone}
+                                                            lastMessage={lastMessage}
+                                                            messageCount={count}
+                                                        />
+                                                    </ExpandableTableRow>
+                                                );
+                                            }
+                                            return (
+                                                <TableRow key={rowKey}>
+                                                    {/* Spacer to align with the expander column on multi-message rows. */}
+                                                    <TableCell className="w-12" />
+                                                    <ConversationCells
+                                                        phone={c.phone}
+                                                        lastMessage={lastMessage}
+                                                        messageCount={count}
+                                                    />
+                                                </TableRow>
+                                            );
+                                        })}
+                                    </TableBody>
+                                </Table>
+                            </div>
+                        </>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/src/app/api/webhooks/bird/__tests__/extract.test.ts
+++ b/src/app/api/webhooks/bird/__tests__/extract.test.ts
@@ -1,0 +1,464 @@
+/** @jest-environment node */
+import {
+    extractBody,
+    extractChannel,
+    extractDirection,
+    extractInboundPhone,
+    extractMessageFields,
+    extractOutboundPhone,
+    extractPhone,
+    unwrapEvent,
+    type BirdMessageLike,
+} from '../extract';
+
+// ---------------------------------------------------------------------------
+// unwrapEvent
+// ---------------------------------------------------------------------------
+
+describe('unwrapEvent', () => {
+    it('treats a conversation.updated event as the conversation, pulling lastMessage', () => {
+        const result = unwrapEvent({
+            event: 'conversation.updated',
+            payload: {
+                id: 'conv-123',
+                channelId: 'ch-wa',
+                lastMessage: { id: 'msg-1', body: 'hi' },
+            },
+        });
+
+        expect(result.conversationId).toBe('conv-123');
+        expect(result.payloadChannelId).toBe('ch-wa');
+        expect(result.message?.id).toBe('msg-1');
+    });
+
+    it('falls back to payload.message when the event is not conversation.updated', () => {
+        const result = unwrapEvent({
+            event: 'message.created',
+            payload: {
+                message: {
+                    id: 'msg-9',
+                    conversationId: 'conv-9',
+                    channelId: 'ch-sms',
+                },
+            },
+        });
+
+        expect(result.message?.id).toBe('msg-9');
+        expect(result.conversationId).toBe('conv-9');
+        expect(result.payloadChannelId).toBe('ch-sms');
+    });
+
+    it('accepts the legacy `data` envelope alongside `payload`', () => {
+        const result = unwrapEvent({
+            data: { message: { id: 'msg-d', conversation_id: 'conv-d' } },
+        });
+
+        expect(result.message?.id).toBe('msg-d');
+        // Note `conversation_id` (snake) — extractor recognizes both forms.
+        expect(result.conversationId).toBe('conv-d');
+    });
+
+    it('treats the raw object as the payload when no wrapper is present', () => {
+        const result = unwrapEvent({
+            id: 'msg-raw',
+            conversationId: 'conv-raw',
+            channelId: 'ch-raw',
+            body: 'unwrapped',
+        });
+
+        expect(result.message?.id).toBe('msg-raw');
+        expect(result.conversationId).toBe('conv-raw');
+        expect(result.payloadChannelId).toBe('ch-raw');
+    });
+
+    it('does not crash on null / undefined / non-objects', () => {
+        expect(unwrapEvent(null).message).toBeDefined();
+        expect(unwrapEvent(undefined).message).toBeDefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// extractDirection
+// ---------------------------------------------------------------------------
+
+describe('extractDirection', () => {
+    it('respects an explicit `direction: outbound` hint', () => {
+        expect(extractDirection({ direction: 'outbound' })).toBe('outbound');
+        expect(extractDirection({ direction: 'OUT' })).toBe('outbound');
+    });
+
+    it('respects an explicit `direction: inbound` hint', () => {
+        expect(extractDirection({ direction: 'inbound' })).toBe('inbound');
+        expect(extractDirection({ direction: 'IN' })).toBe('inbound');
+    });
+
+    it('reads `kind` as an alternative direction hint', () => {
+        expect(extractDirection({ kind: 'outbound' })).toBe('outbound');
+        expect(extractDirection({ kind: 'inbound' })).toBe('inbound');
+    });
+
+    it('falls back to sender.type=contact → inbound', () => {
+        expect(extractDirection({ sender: { type: 'contact' } })).toBe('inbound');
+    });
+
+    it('treats any non-contact sender.type as outbound (e.g. flow)', () => {
+        expect(extractDirection({ sender: { type: 'flow' } })).toBe('outbound');
+        expect(extractDirection({ sender: { type: 'agent' } })).toBe('outbound');
+    });
+
+    it('defaults to inbound when no signal is present', () => {
+        expect(extractDirection({})).toBe('inbound');
+        expect(extractDirection(undefined)).toBe('inbound');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// extractInboundPhone
+// ---------------------------------------------------------------------------
+
+describe('extractInboundPhone', () => {
+    it('prefers sender.contact.identifierValue', () => {
+        expect(
+            extractInboundPhone({
+                sender: { contact: { identifierValue: '+306900000001' } },
+            }),
+        ).toBe('+306900000001');
+    });
+
+    it('falls back to sender.contact.platformAddress', () => {
+        expect(
+            extractInboundPhone({
+                sender: { contact: { platformAddress: '+306900000002' } },
+            }),
+        ).toBe('+306900000002');
+    });
+
+    it('reads `from` as an object with identifierValue', () => {
+        expect(
+            extractInboundPhone({ from: { identifierValue: '+306900000003' } }),
+        ).toBe('+306900000003');
+    });
+
+    it('reads `from` as a string', () => {
+        expect(extractInboundPhone({ from: '+306900000004' })).toBe('+306900000004');
+    });
+
+    it('falls back to sender.identifierValue', () => {
+        expect(
+            extractInboundPhone({ sender: { identifierValue: '+306900000005' } }),
+        ).toBe('+306900000005');
+    });
+
+    it('falls back to contact.identifierValue', () => {
+        expect(
+            extractInboundPhone({ contact: { identifierValue: '+306900000006' } }),
+        ).toBe('+306900000006');
+    });
+
+    it('falls back to participant.identifierValue last', () => {
+        expect(
+            extractInboundPhone({ participant: { identifierValue: '+306900000007' } }),
+        ).toBe('+306900000007');
+    });
+
+    it('does NOT look at recipients (that is an outbound-only path)', () => {
+        expect(
+            extractInboundPhone({ recipients: [{ identifierValue: '+306900000008' }] }),
+        ).toBeUndefined();
+    });
+
+    it('returns undefined when nothing is set', () => {
+        expect(extractInboundPhone({})).toBeUndefined();
+        expect(extractInboundPhone(undefined)).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// extractOutboundPhone
+// ---------------------------------------------------------------------------
+
+describe('extractOutboundPhone', () => {
+    it('reads the first recipient on the message', () => {
+        expect(
+            extractOutboundPhone(
+                { recipients: [{ identifierValue: '+306900000010' }] },
+                {},
+            ),
+        ).toBe('+306900000010');
+    });
+
+    it('falls back to the conversation contact in featuredParticipants', () => {
+        expect(
+            extractOutboundPhone(
+                {},
+                {
+                    featuredParticipants: [
+                        { type: 'flow', contact: { identifierValue: '+30ignore' } },
+                        { type: 'contact', contact: { identifierValue: '+306900000011' } },
+                    ],
+                },
+            ),
+        ).toBe('+306900000011');
+    });
+
+    it('ignores non-contact featuredParticipants', () => {
+        expect(
+            extractOutboundPhone(
+                {},
+                {
+                    featuredParticipants: [
+                        { type: 'flow', contact: { identifierValue: '+30nope' } },
+                    ],
+                },
+            ),
+        ).toBeUndefined();
+    });
+
+    it('does NOT look at sender fields (that is an inbound-only path)', () => {
+        expect(
+            extractOutboundPhone(
+                { sender: { contact: { identifierValue: '+30nope' } } },
+                {},
+            ),
+        ).toBeUndefined();
+    });
+
+    it('returns undefined when nothing is set', () => {
+        expect(extractOutboundPhone({}, {})).toBeUndefined();
+        expect(extractOutboundPhone(undefined, {})).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// extractPhone (dispatcher)
+// ---------------------------------------------------------------------------
+
+describe('extractPhone', () => {
+    it('uses the inbound chain for inbound direction', () => {
+        const msg: BirdMessageLike = { sender: { contact: { identifierValue: '+30inbound' } } };
+        expect(extractPhone('inbound', msg, {})).toBe('+30inbound');
+    });
+
+    it('uses the outbound chain for outbound direction', () => {
+        const msg: BirdMessageLike = { recipients: [{ identifierValue: '+30outbound' }] };
+        expect(extractPhone('outbound', msg, {})).toBe('+30outbound');
+    });
+
+    it('does not cross paths — outbound never reads sender fields', () => {
+        const msg: BirdMessageLike = { sender: { contact: { identifierValue: '+30wrong' } } };
+        expect(extractPhone('outbound', msg, {})).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// extractBody
+// ---------------------------------------------------------------------------
+
+describe('extractBody', () => {
+    it('prefers preview.text', () => {
+        expect(extractBody({ preview: { text: 'preview wins' }, text: 'loses' })).toBe('preview wins');
+    });
+
+    it('reads body.text.text (nested object form)', () => {
+        expect(extractBody({ body: { text: { text: 'nested' } } })).toBe('nested');
+    });
+
+    it('reads body.text (flat string-on-object form)', () => {
+        expect(extractBody({ body: { text: 'flat' } })).toBe('flat');
+    });
+
+    it('reads top-level text', () => {
+        expect(extractBody({ text: 'top' })).toBe('top');
+    });
+
+    it('reads body when it is a plain string', () => {
+        expect(extractBody({ body: 'string-body' })).toBe('string-body');
+    });
+
+    it('returns empty string when nothing is set', () => {
+        expect(extractBody({})).toBe('');
+        expect(extractBody(undefined)).toBe('');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// extractChannel
+// ---------------------------------------------------------------------------
+
+describe('extractChannel', () => {
+    const channelIds = { sms: 'ch-sms-id', whatsapp: 'ch-wa-id' };
+
+    it('matches SMS channel ID', () => {
+        expect(extractChannel('ch-sms-id', {}, channelIds)).toBe('sms');
+    });
+
+    it('matches WhatsApp channel ID', () => {
+        expect(extractChannel('ch-wa-id', {}, channelIds)).toBe('whatsapp');
+    });
+
+    it('falls back to message.channel string hint containing "sms"', () => {
+        expect(extractChannel(undefined, { channel: 'channel-sms-eu' }, channelIds)).toBe('sms');
+        expect(extractChannel('unknown-id', { channel: 'SMS' }, channelIds)).toBe('sms');
+    });
+
+    it('defaults to whatsapp when no signal is present', () => {
+        expect(extractChannel(undefined, {}, channelIds)).toBe('whatsapp');
+        expect(extractChannel(undefined, undefined, channelIds)).toBe('whatsapp');
+    });
+
+    it('ignores an unknown payloadChannelId and falls through', () => {
+        expect(extractChannel('different-id', {}, channelIds)).toBe('whatsapp');
+    });
+
+    it('still works when channelIds are unconfigured', () => {
+        expect(extractChannel('any', { channel: 'sms' }, {})).toBe('sms');
+        expect(extractChannel('any', {}, {})).toBe('whatsapp');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// extractMessageFields (orchestrator integration)
+// ---------------------------------------------------------------------------
+
+describe('extractMessageFields', () => {
+    const channelIds = { sms: 'ch-sms-id', whatsapp: 'ch-wa-id' };
+
+    it('extracts a typical inbound WhatsApp message.created event', () => {
+        const event = {
+            event: 'message.created',
+            payload: {
+                message: {
+                    id: 'msg-inbound-1',
+                    conversationId: 'conv-1',
+                    channelId: 'ch-wa-id',
+                    direction: 'inbound',
+                    status: 'delivered',
+                    sender: {
+                        type: 'contact',
+                        contact: { identifierValue: '+306900000100' },
+                    },
+                    body: { text: { text: 'STOP' } },
+                },
+            },
+        };
+
+        const fields = extractMessageFields(event, channelIds);
+
+        expect(fields).toEqual({
+            birdMessageId: 'msg-inbound-1',
+            conversationId: 'conv-1',
+            direction: 'inbound',
+            phone: '+306900000100',
+            body: 'STOP',
+            channel: 'whatsapp',
+            status: 'delivered',
+            failureReason: undefined,
+        });
+    });
+
+    it('extracts a typical outbound conversation.updated event', () => {
+        const event = {
+            event: 'conversation.updated',
+            payload: {
+                id: 'conv-2',
+                channelId: 'ch-wa-id',
+                lastMessage: {
+                    id: 'msg-outbound-1',
+                    direction: 'outbound',
+                    status: 'sent',
+                    sender: { type: 'flow' },
+                    recipients: [{ identifierValue: '+306900000200' }],
+                },
+                featuredParticipants: [
+                    { type: 'contact', contact: { identifierValue: '+30ignored' } },
+                ],
+            },
+        };
+
+        const fields = extractMessageFields(event, channelIds);
+
+        expect(fields.birdMessageId).toBe('msg-outbound-1');
+        expect(fields.direction).toBe('outbound');
+        expect(fields.phone).toBe('+306900000200');
+        expect(fields.conversationId).toBe('conv-2');
+        expect(fields.channel).toBe('whatsapp');
+        expect(fields.status).toBe('sent');
+    });
+
+    it('uses featuredParticipants as outbound phone fallback when recipients is missing', () => {
+        const event = {
+            event: 'conversation.updated',
+            payload: {
+                id: 'conv-3',
+                channelId: 'ch-wa-id',
+                lastMessage: {
+                    id: 'msg-3',
+                    direction: 'outbound',
+                    sender: { type: 'flow' },
+                },
+                featuredParticipants: [
+                    { type: 'contact', contact: { identifierValue: '+306900000300' } },
+                ],
+            },
+        };
+
+        expect(extractMessageFields(event, channelIds).phone).toBe('+306900000300');
+    });
+
+    it('maps a failed status and surfaces the failure reason', () => {
+        const event = {
+            payload: {
+                message: {
+                    id: 'msg-fail',
+                    status: 'delivery_failed',
+                    failure: { description: 'outside 24h window' },
+                    direction: 'outbound',
+                    recipients: [{ identifierValue: '+306900000400' }],
+                },
+            },
+        };
+
+        const fields = extractMessageFields(event, channelIds);
+
+        expect(fields.status).toBe('failed');
+        expect(fields.failureReason).toBe('outside 24h window');
+    });
+
+    it('matches SMS channel by ID', () => {
+        const event = {
+            payload: {
+                message: {
+                    id: 'msg-sms',
+                    channelId: 'ch-sms-id',
+                    direction: 'inbound',
+                    sender: { type: 'contact', contact: { identifierValue: '+306900000500' } },
+                    body: 'sms text',
+                },
+            },
+        };
+
+        expect(extractMessageFields(event, channelIds).channel).toBe('sms');
+    });
+
+    it('reads messageId as a fallback for id', () => {
+        const event = {
+            payload: { message: { messageId: 'msg-alt-id', body: 'x' } },
+        };
+
+        expect(extractMessageFields(event, channelIds).birdMessageId).toBe('msg-alt-id');
+    });
+
+    it('returns undefined phone when nothing matches — the route guard catches this', () => {
+        const event = {
+            payload: { message: { id: 'msg-no-phone', body: 'x' } },
+        };
+
+        expect(extractMessageFields(event, channelIds).phone).toBeUndefined();
+    });
+
+    it('handles a malformed / unknown event without throwing', () => {
+        expect(() => extractMessageFields(null, channelIds)).not.toThrow();
+        expect(() => extractMessageFields({}, channelIds)).not.toThrow();
+        expect(() => extractMessageFields('not an object', channelIds)).not.toThrow();
+    });
+});

--- a/src/app/api/webhooks/bird/extract.ts
+++ b/src/app/api/webhooks/bird/extract.ts
@@ -1,0 +1,205 @@
+import { mapBirdMessageStatus } from '@/lib/notifications/bird-status';
+import type { MessageChannel, MessageDirection, MessageStatus } from '@prisma/client';
+
+/**
+ * Defensive subset of a Bird webhook message. The Conversations API has
+ * shifted field names between versions/events, so the type unions every
+ * variant we've seen.
+ */
+export interface BirdMessageLike {
+    id?: string;
+    messageId?: string;
+    conversationId?: string;
+    conversation_id?: string;
+    channelId?: string;
+    channel?: string;
+    direction?: string;
+    kind?: string;
+    status?: string;
+    reason?: string;
+    failure?: { description?: string };
+    sender?: {
+        type?: string;
+        identifierValue?: string;
+        phone?: string;
+        contact?: {
+            identifierValue?: string;
+            platformAddress?: string;
+        };
+    };
+    from?: string | { identifierValue?: string; phone?: string };
+    contact?: { identifierValue?: string };
+    participant?: { identifierValue?: string };
+    preview?: { text?: string };
+    body?: string | { text?: string | { text?: string } };
+    text?: string;
+    // Outbound events: sender is `type: "flow"` (us) with no phone — the
+    // recipient phone lives here instead.
+    recipients?: Array<{ identifierValue?: string }>;
+}
+
+export interface BirdWebhookPayload {
+    id?: string;
+    channelId?: string;
+    lastMessage?: BirdMessageLike;
+    message?: BirdMessageLike;
+    // Outbound events fall back to this when `lastMessage.recipients` is
+    // missing: the participant with `type: "contact"` is the user.
+    featuredParticipants?: Array<{ type?: string; contact?: { identifierValue?: string } }>;
+}
+
+interface BirdWebhookEvent {
+    event?: string;
+    payload?: BirdWebhookPayload;
+    data?: BirdWebhookPayload;
+}
+
+export interface ExtractedMessageFields {
+    birdMessageId?: string;
+    conversationId?: string;
+    direction: MessageDirection;
+    phone?: string;
+    body: string;
+    channel: MessageChannel;
+    status: MessageStatus;
+    failureReason?: string;
+}
+
+export interface UnwrappedEvent {
+    payload: BirdWebhookPayload;
+    message: BirdMessageLike | undefined;
+    conversationId: string | undefined;
+    payloadChannelId: string | undefined;
+}
+
+/** Bird channel IDs — passed in by callers instead of read from env so
+ *  the extractor stays pure and trivially testable. */
+export interface ChannelIds {
+    sms?: string;
+    whatsapp?: string;
+}
+
+/** Extract plain text from Bird's variant body shape (string | nested object). */
+function extractBodyText(body: BirdMessageLike['body']): string | undefined {
+    if (!body || typeof body === 'string') return undefined;
+    if (body.text && typeof body.text === 'object' && typeof body.text.text === 'string') {
+        return body.text.text;
+    }
+    if (typeof body.text === 'string') return body.text;
+    return undefined;
+}
+
+export function unwrapEvent(event: unknown): UnwrappedEvent {
+    const evt = (event ?? {}) as BirdWebhookEvent;
+    const eventName = String(evt.event ?? '');
+    const payload: BirdWebhookPayload = evt.payload ?? evt.data ?? (evt as BirdWebhookPayload);
+
+    if (eventName === 'conversation.updated' && payload.lastMessage) {
+        return {
+            payload,
+            message: payload.lastMessage,
+            conversationId: payload.id,
+            payloadChannelId: payload.channelId,
+        };
+    }
+
+    const message = payload.message ?? (payload as BirdMessageLike);
+    return {
+        payload,
+        message,
+        conversationId: message.conversationId ?? message.conversation_id,
+        payloadChannelId: message.channelId ?? payload.channelId,
+    };
+}
+
+export function extractDirection(message: BirdMessageLike | undefined): MessageDirection {
+    const explicit = String(message?.direction ?? message?.kind ?? '').toLowerCase();
+    if (explicit.includes('out')) return 'outbound';
+    if (explicit.includes('in')) return 'inbound';
+    const senderType = String(message?.sender?.type ?? '').toLowerCase();
+    if (senderType === 'contact') return 'inbound';
+    if (senderType) return 'outbound';
+    return 'inbound';
+}
+
+export function extractInboundPhone(message: BirdMessageLike | undefined): string | undefined {
+    const fromObj = message?.from && typeof message.from === 'object' ? message.from : undefined;
+    const fromStr = typeof message?.from === 'string' ? message.from : undefined;
+
+    return (
+        message?.sender?.contact?.identifierValue ??
+        message?.sender?.contact?.platformAddress ??
+        fromObj?.identifierValue ??
+        fromObj?.phone ??
+        fromStr ??
+        message?.sender?.identifierValue ??
+        message?.contact?.identifierValue ??
+        message?.sender?.phone ??
+        message?.participant?.identifierValue
+    );
+}
+
+export function extractOutboundPhone(
+    message: BirdMessageLike | undefined,
+    payload: BirdWebhookPayload,
+): string | undefined {
+    return (
+        message?.recipients?.[0]?.identifierValue ??
+        payload.featuredParticipants
+            ?.find((p) => p?.type === 'contact')
+            ?.contact?.identifierValue
+    );
+}
+
+export function extractPhone(
+    direction: MessageDirection,
+    message: BirdMessageLike | undefined,
+    payload: BirdWebhookPayload,
+): string | undefined {
+    return direction === 'outbound'
+        ? extractOutboundPhone(message, payload)
+        : extractInboundPhone(message);
+}
+
+export function extractBody(message: BirdMessageLike | undefined): string {
+    return (
+        message?.preview?.text ??
+        extractBodyText(message?.body) ??
+        message?.text ??
+        (typeof message?.body === 'string' ? message.body : '')
+    );
+}
+
+export function extractChannel(
+    payloadChannelId: string | undefined,
+    message: BirdMessageLike | undefined,
+    channelIds: ChannelIds,
+): MessageChannel {
+    if (payloadChannelId && payloadChannelId === channelIds.sms) return 'sms';
+    if (payloadChannelId && payloadChannelId === channelIds.whatsapp) return 'whatsapp';
+    if (String(message?.channel ?? '').toLowerCase().includes('sms')) return 'sms';
+    return 'whatsapp';
+}
+
+export function extractMessageFields(
+    event: unknown,
+    channelIds: ChannelIds,
+): ExtractedMessageFields {
+    const { payload, message, conversationId, payloadChannelId } = unwrapEvent(event);
+
+    const direction = extractDirection(message);
+    const phone = extractPhone(direction, message, payload);
+    const body = extractBody(message);
+    const channel = extractChannel(payloadChannelId, message, channelIds);
+
+    return {
+        birdMessageId: message?.id ?? message?.messageId,
+        conversationId,
+        direction,
+        phone,
+        body,
+        channel,
+        status: mapBirdMessageStatus(message?.status),
+        failureReason: message?.reason ?? message?.failure?.description ?? undefined,
+    };
+}

--- a/src/app/api/webhooks/bird/route.ts
+++ b/src/app/api/webhooks/bird/route.ts
@@ -1,0 +1,264 @@
+import { NextResponse } from 'next/server';
+import { createHmac, createHash, timingSafeEqual } from 'crypto';
+import { env } from '@/env.mjs';
+import prisma from '@/lib/db/prisma';
+import {
+    findUserByNotificationDeliveryId,
+    isUnsubscribeMessage,
+    sendUnsubscribeReply,
+    UNSUBSCRIBE_ALREADY_TEXT,
+    UNSUBSCRIBE_CONFIRMATION_TEXT,
+    UNSUBSCRIBE_RETRY_TEXT,
+    unsubscribeUserPhoneFromAllCities,
+    verifyUnsubscribeIntent,
+} from '@/lib/notifications/unsubscribe';
+import { normalizePhone } from '@/lib/notifications/phone';
+import type { VerifyRequestResult, VerifySignatureResult } from '@/lib/notifications/types';
+import { extractMessageFields, type ExtractedMessageFields } from './extract';
+import type { Prisma } from '@prisma/client';
+
+const SIGNATURE_HEADER = 'messagebird-signature';
+const TIMESTAMP_HEADER = 'messagebird-request-timestamp';
+const REPLAY_WINDOW_SECONDS = 300;
+
+function verifyBirdSignature(opts: {
+    rawBody: string;
+    url: string;
+    signatureHeader: string | null;
+    timestampHeader: string | null;
+    secret: string;
+}): VerifySignatureResult {
+    const { rawBody, url, signatureHeader, timestampHeader, secret } = opts;
+    if (!signatureHeader) return { ok: false, reason: 'missing signature header' };
+    if (!timestampHeader) return { ok: false, reason: 'missing timestamp header' };
+
+    const ts = Number(timestampHeader);
+    if (!Number.isFinite(ts)) return { ok: false, reason: 'invalid timestamp' };
+    const skew = Math.abs(Math.floor(Date.now() / 1000) - ts);
+    if (skew > REPLAY_WINDOW_SECONDS) return { ok: false, reason: `timestamp skew ${skew}s` };
+
+    const bodyHash = createHash('sha256').update(rawBody, 'utf8').digest();
+    const expected = createHmac('sha256', secret)
+        .update(`${timestampHeader}\n${url}\n`, 'utf8')
+        .update(bodyHash)
+        .digest();
+
+    const provided = Buffer.from(signatureHeader, 'base64');
+    if (provided.length !== expected.length) return { ok: false, reason: 'length mismatch' };
+    if (!timingSafeEqual(new Uint8Array(provided), new Uint8Array(expected))) {
+        return { ok: false, reason: 'signature mismatch' };
+    }
+    return { ok: true };
+}
+
+/**
+ * Read + signature-verify + JSON-parse the incoming webhook request.
+ * Returns the decoded event on success or a ready-to-return error response
+ * (401 invalid signature, 400 invalid JSON, 500 unconfigured-in-prod).
+ */
+async function verifyRequest(request: Request): Promise<VerifyRequestResult> {
+    const rawBody = await request.text();
+
+    if (!env.BIRD_WEBHOOK_SECRET) {
+        if (process.env.NODE_ENV === 'production') {
+            console.error('Bird webhook: BIRD_WEBHOOK_SECRET not set in production — refusing');
+            return {
+                ok: false,
+                response: NextResponse.json({ error: 'webhook not configured' }, { status: 500 }),
+            };
+        }
+        console.warn('Bird webhook: BIRD_WEBHOOK_SECRET not set — accepting unsigned events (dev only)');
+    } else {
+        const proto = request.headers.get('x-forwarded-proto') ?? 'https';
+        const host = request.headers.get('x-forwarded-host') ?? request.headers.get('host');
+        const origin = host ? `${proto}://${host}` : env.NEXTAUTH_URL;
+        const signedUrl = new URL('/api/webhooks/bird', origin).toString();
+        const result = verifyBirdSignature({
+            rawBody,
+            url: signedUrl,
+            signatureHeader: request.headers.get(SIGNATURE_HEADER),
+            timestampHeader: request.headers.get(TIMESTAMP_HEADER),
+            secret: env.BIRD_WEBHOOK_SECRET,
+        });
+        if (!result.ok) {
+            console.warn(`Bird webhook: signature verification failed — ${result.reason}`);
+            return {
+                ok: false,
+                response: NextResponse.json({ error: 'invalid signature' }, { status: 401 }),
+            };
+        }
+    }
+
+    try {
+        return { ok: true, event: JSON.parse(rawBody) };
+    } catch {
+        return {
+            ok: false,
+            response: NextResponse.json({ error: 'invalid JSON' }, { status: 400 }),
+        };
+    }
+}
+
+
+async function updateOutboundMessage(fields: ExtractedMessageFields): Promise<boolean> {
+    if (!fields.birdMessageId) return false;
+    const existing = await prisma.message.findUnique({
+        where: { birdMessageId: fields.birdMessageId },
+    });
+    if (!existing) return false;
+
+    if (existing.status !== fields.status) {
+        await prisma.message.update({
+            where: { id: existing.id },
+            data: {
+                status: fields.status,
+                // Only persist a reason on failure; clear it otherwise.
+                failureReason: fields.status === 'failed' ? fields.failureReason ?? null : null,
+            },
+        });
+    }
+    return true;
+}
+
+
+async function getNotificationDeliveryForMessage(
+    fields: ExtractedMessageFields,
+): Promise<string | null> {
+    if (fields.direction !== 'inbound' || !fields.conversationId) return null;
+    const lastWithDelivery = await prisma.message.findFirst({
+        where: {
+            conversationId: fields.conversationId,
+            notificationDeliveryId: { not: null },
+        },
+        orderBy: { createdAt: 'desc' },
+        select: { notificationDeliveryId: true },
+    });
+    return lastWithDelivery?.notificationDeliveryId ?? null;
+}
+
+
+async function persistMessageRow(
+    fields: ExtractedMessageFields,
+    notificationDeliveryId: string | null,
+): Promise<void> {
+    await prisma.message.create({
+        data: {
+            channel: fields.channel,
+            direction: fields.direction,
+            birdMessageId: fields.birdMessageId,
+            conversationId: fields.conversationId ?? null,
+            phone: normalizePhone(fields.phone),
+            body: fields.body,
+            status: fields.status,
+            failureReason: fields.status === 'failed' ? fields.failureReason ?? null : null,
+            notificationDeliveryId,
+        },
+    });
+}
+
+/**
+ * Two-stage unsubscribe handling for inbound WhatsApp messages with a
+ * resolved delivery link:
+ *   1. Regex keyword match (STOP / ΣΤΟΠ / απεγγραφή / etc.)
+ *   2. LLM intent verification (rules out e.g. "stop the meeting")
+ */
+async function handleUnsubscribeIfApplicable(
+    fields: ExtractedMessageFields,
+    notificationDeliveryId: string | null,
+): Promise<void> {
+    if (
+        fields.direction !== 'inbound' ||
+        fields.channel !== 'whatsapp' ||
+        !notificationDeliveryId ||
+        !isUnsubscribeMessage(fields.body)
+    ) return;
+
+    const user = await findUserByNotificationDeliveryId(notificationDeliveryId);
+    if (!user) {
+        console.warn(
+            `Bird webhook: unsubscribe keyword matched but no user resolved (delivery ${notificationDeliveryId})`,
+        );
+        return;
+    }
+
+    if (normalizePhone(user.phone) !== normalizePhone(fields.phone)) {
+        console.warn(
+            `Bird webhook: unsubscribe phone mismatch — inbound from ${fields.phone}, user.phone ${user.phone} (user ${user.id}, delivery ${notificationDeliveryId}); ignoring`,
+        );
+        return;
+    }
+
+    const intent = await verifyUnsubscribeIntent(fields.body);
+
+    if (intent === 'rejected') {
+        console.log(
+            `Bird webhook: unsubscribe keyword matched but LLM rejected intent (user ${user.id}, delivery ${notificationDeliveryId})`,
+        );
+        return;
+    }
+
+    if (intent === 'failed') {
+        console.warn(
+            `Bird webhook: LLM verification failed — asking user ${user.id} to retry (delivery ${notificationDeliveryId})`,
+        );
+        if (fields.conversationId) {
+            await sendUnsubscribeReply({
+                conversationId: fields.conversationId,
+                phone: normalizePhone(fields.phone),
+                notificationDeliveryId,
+                text: UNSUBSCRIBE_RETRY_TEXT,
+            });
+        }
+        return;
+    }
+
+    const { changedCount } = await unsubscribeUserPhoneFromAllCities(user.id);
+    const replyText = changedCount > 0 ? UNSUBSCRIBE_CONFIRMATION_TEXT : UNSUBSCRIBE_ALREADY_TEXT;
+    console.log(
+        changedCount > 0
+            ? `Bird webhook: disabled phone notifications for user ${user.id} across ${changedCount} cities (delivery ${notificationDeliveryId})`
+            : `Bird webhook: user ${user.id} already unsubscribed — sending reminder (delivery ${notificationDeliveryId})`,
+    );
+    if (fields.conversationId) {
+        await sendUnsubscribeReply({
+            conversationId: fields.conversationId,
+            phone: normalizePhone(fields.phone),
+            notificationDeliveryId,
+            text: replyText,
+        });
+    }
+}
+
+export async function POST(request: Request) {
+    const verified = await verifyRequest(request);
+    if (!verified.ok) return verified.response;
+
+    const fields = extractMessageFields(verified.event, {
+        sms: env.BIRD_SMS_CHANNEL_ID,
+        whatsapp: env.BIRD_WHATSAPP_CHANNEL_ID,
+    });
+    if (!fields.birdMessageId || !fields.phone) {
+        console.warn('Bird webhook: missing required fields, skipping insert');
+        return NextResponse.json({ ok: true });
+    }
+
+    if (fields.direction === 'outbound' && await updateOutboundMessage(fields)) {
+        return NextResponse.json({ ok: true });
+    }
+
+    const notificationDeliveryId = await getNotificationDeliveryForMessage(fields);
+
+    try {
+        await persistMessageRow(fields, notificationDeliveryId);
+        await handleUnsubscribeIfApplicable(fields, notificationDeliveryId);
+    } catch (error) {
+        const code = (error as Prisma.PrismaClientKnownRequestError | undefined)?.code;
+        if (code !== 'P2002') {
+            console.error('Bird webhook: persist error', error);
+            // Returning 500 makes Bird retry — appropriate for transient DB issues.
+            return NextResponse.json({ error: 'persist failed' }, { status: 500 });
+        }
+    }
+
+    return NextResponse.json({ ok: true });
+}

--- a/src/components/admin/conversations/ReplyForm.tsx
+++ b/src/components/admin/conversations/ReplyForm.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import type { MessageChannel } from '@prisma/client';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Loader2, Send, CheckCircle, XCircle } from 'lucide-react';
+import { sendTestReply } from '@/app/[locale]/(other)/admin/conversations/actions';
+import type { SendStatus } from './types';
+
+/**
+ * Inline reply form for the admin Conversations page. Sends free-form text
+ * via the Bird Conversations API into an existing thread, on the channel
+ * the conversation lives on. WhatsApp is bound by the 24h customer-service
+ * window; SMS isn't.
+ */
+export function ReplyForm({
+    conversationId,
+    phone,
+    channel,
+}: {
+    conversationId: string;
+    phone: string;
+    channel: MessageChannel;
+}) {
+    const [text, setText] = useState('');
+    const [status, setStatus] = useState<SendStatus>('idle');
+    const [error, setError] = useState<string | null>(null);
+    const [pending, startTransition] = useTransition();
+    const router = useRouter();
+
+    const submit = () => {
+        const body = text.trim();
+        if (!body) return;
+        setStatus('sending');
+        setError(null);
+        startTransition(async () => {
+            const result = await sendTestReply({ conversationId, phone, text: body, channel });
+            if (result.success) {
+                setStatus('sent');
+            } else {
+                setStatus('error');
+                setError(result.error ?? 'Send failed');
+            }
+            setText('');
+            // Refresh the RSC payload in both branches so the thread picks
+            // up the new row. `startTransition` alone doesn't trigger a
+            // re-fetch on this dynamic admin page.
+            router.refresh();
+        });
+    };
+
+    return (
+        <div className="flex flex-col gap-2 mt-4 pt-4 border-t">
+            <div className="flex items-end gap-2">
+                <Textarea
+                    value={text}
+                    onChange={(e) => setText(e.target.value)}
+                    placeholder={`Reply to ${phone}…`}
+                    rows={2}
+                    disabled={pending}
+                    className="text-sm"
+                />
+                <Button onClick={submit} disabled={pending || !text.trim()} size="sm">
+                    {pending ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                        <Send className="h-4 w-4" />
+                    )}
+                </Button>
+            </div>
+
+            {status === 'sent' && (
+                <div className="flex items-center gap-1.5 text-xs text-green-700">
+                    <CheckCircle className="h-3.5 w-3.5" />
+                    Message sent.
+                </div>
+            )}
+
+            {status === 'error' && (
+                <div className="flex items-start gap-1.5 text-xs text-destructive">
+                    <XCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                    <span className="break-words">{error}</span>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/admin/conversations/ScrollableThread.tsx
+++ b/src/components/admin/conversations/ScrollableThread.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { Children, useEffect, useRef, type ReactNode } from 'react';
+
+export function ScrollableThread({ children }: { children: ReactNode }) {
+    const ref = useRef<HTMLOListElement>(null);
+    // The component itself doesn't remount across an RSC refresh, so an
+    // empty-deps effect would only fire once on first mount.
+    const count = Children.count(children);
+
+    useEffect(() => {
+        const el = ref.current;
+        if (el) el.scrollTop = el.scrollHeight;
+    }, [count]);
+
+    return (
+        <ol
+            ref={ref}
+            className="flex flex-col gap-3 max-h-80 overflow-y-auto pr-2"
+        >
+            {children}
+        </ol>
+    );
+}

--- a/src/components/admin/conversations/SendTemplateDialog.tsx
+++ b/src/components/admin/conversations/SendTemplateDialog.tsx
@@ -1,0 +1,379 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { Send, Loader2, CheckCircle, XCircle, MessageSquare, Bell } from 'lucide-react';
+import { FaWhatsapp } from 'react-icons/fa';
+import {
+    sendTestTemplate,
+    sendTestSms,
+    sendTestBeforeMeetingNotification,
+    listCitiesForTest,
+    listMeetingsForTest,
+    type CityOption,
+    type MeetingOption,
+} from '@/app/[locale]/(other)/admin/conversations/actions';
+import type { SendStatus } from './types';
+
+/**
+ * Top-right "Send test message" button on the admin Conversations page.
+ * Tabbed dialog with two send modes:
+ *   - WhatsApp: pre-approved welcome template (Messaging API). Kicks off
+ *     a fresh thread; admin can then reply free-form within 24h.
+ *   - SMS: free-form text (Messaging API). No template/window restrictions.
+ */
+export function SendTemplateDialog() {
+    const [open, setOpen] = useState(false);
+    const [phone, setPhone] = useState('');
+    // WhatsApp template fields
+    const [userName, setUserName] = useState('');
+    const [cityName, setCityName] = useState('Athens');
+    // SMS body field
+    const [smsBody, setSmsBody] = useState('');
+    // Before-meeting test fields
+    const [cities, setCities] = useState<CityOption[]>([]);
+    const [meetings, setMeetings] = useState<MeetingOption[]>([]);
+    const [selectedCityId, setSelectedCityId] = useState('');
+    const [selectedMeetingId, setSelectedMeetingId] = useState('');
+    const [meetingsLoading, setMeetingsLoading] = useState(false);
+    const [status, setStatus] = useState<SendStatus>('idle');
+    const [error, setError] = useState<string | null>(null);
+    const [pending, startTransition] = useTransition();
+    const router = useRouter();
+
+    const reset = () => {
+        setStatus('idle');
+        setError(null);
+    };
+
+    // Load the city list once when the dialog opens; meetings are loaded on
+    // demand when a city is selected.
+    useEffect(() => {
+        if (!open || cities.length > 0) return;
+        listCitiesForTest().then(setCities).catch(() => setCities([]));
+    }, [open, cities.length]);
+
+    useEffect(() => {
+        if (!selectedCityId) {
+            setMeetings([]);
+            setSelectedMeetingId('');
+            return;
+        }
+        setMeetingsLoading(true);
+        listMeetingsForTest(selectedCityId)
+            .then((m) => setMeetings(m))
+            .catch(() => setMeetings([]))
+            .finally(() => setMeetingsLoading(false));
+        setSelectedMeetingId('');
+    }, [selectedCityId]);
+
+    const handleOpenChange = (next: boolean) => {
+        setOpen(next);
+        if (!next) {
+            setPhone('');
+            setUserName('');
+            setCityName('Athens');
+            setSmsBody('');
+            setSelectedCityId('');
+            setSelectedMeetingId('');
+            reset();
+        }
+    };
+
+    const submitWhatsApp = () => {
+        const trimmed = phone.trim();
+        if (!trimmed) return;
+        setStatus('sending');
+        setError(null);
+        startTransition(async () => {
+            const result = await sendTestTemplate({
+                phone: trimmed,
+                userName: userName || undefined,
+                cityName: cityName || undefined,
+            });
+            if (result.success) {
+                setStatus('sent');
+            } else {
+                setStatus('error');
+                setError(result.error ?? 'Send failed');
+            }
+            router.refresh();
+        });
+    };
+
+    const submitSms = () => {
+        const trimmed = phone.trim();
+        if (!trimmed || !smsBody.trim()) return;
+        setStatus('sending');
+        setError(null);
+        startTransition(async () => {
+            const result = await sendTestSms({ phone: trimmed, body: smsBody.trim() });
+            if (result.success) {
+                setStatus('sent');
+            } else {
+                setStatus('error');
+                setError(result.error ?? 'Send failed');
+            }
+            router.refresh();
+        });
+    };
+
+    const submitBeforeMeeting = () => {
+        const trimmed = phone.trim();
+        if (!trimmed || !selectedCityId || !selectedMeetingId) return;
+        setStatus('sending');
+        setError(null);
+        startTransition(async () => {
+            const result = await sendTestBeforeMeetingNotification({
+                phone: trimmed,
+                cityId: selectedCityId,
+                meetingId: selectedMeetingId,
+            });
+            if (result.success) {
+                setStatus('sent');
+            } else {
+                setStatus('error');
+                setError(result.error ?? 'Send failed');
+            }
+            router.refresh();
+        });
+    };
+
+    const phoneValid = /^\+[0-9]{6,}$/.test(phone.trim());
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogTrigger asChild>
+                <Button variant="outline" size="sm" className="gap-2">
+                    <Send className="h-4 w-4" />
+                    Send test message
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>Send test message</DialogTitle>
+                    <DialogDescription>
+                        Use a phone you control so you can reply and exercise the full
+                        inbound flow via the webhook.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-3">
+                    <div className="space-y-1.5">
+                        <Label htmlFor="send-template-phone">Phone (E.164)</Label>
+                        <Input
+                            id="send-template-phone"
+                            type="tel"
+                            placeholder="+306900000000"
+                            value={phone}
+                            onChange={(e) => setPhone(e.target.value)}
+                            disabled={pending}
+                        />
+                    </div>
+
+                    <Tabs defaultValue="whatsapp" local onValueChange={reset}>
+                        <TabsList className="grid grid-cols-3">
+                            <TabsTrigger value="whatsapp" className="gap-2">
+                                <FaWhatsapp className="h-3.5 w-3.5 text-[#25D366]" />
+                                Welcome
+                            </TabsTrigger>
+                            <TabsTrigger value="sms" className="gap-2">
+                                <MessageSquare className="h-3.5 w-3.5" />
+                                SMS
+                            </TabsTrigger>
+                            <TabsTrigger value="before-meeting" className="gap-2">
+                                <Bell className="h-3.5 w-3.5" />
+                                Notification
+                            </TabsTrigger>
+                        </TabsList>
+
+                        <TabsContent value="whatsapp" className="space-y-3">
+                            <p className="text-xs text-muted-foreground">
+                                Sends the pre-approved welcome template. Slots:{' '}
+                                <code>userName</code>, <code>cityName</code>.
+                            </p>
+                            <div className="grid grid-cols-2 gap-3">
+                                <div className="space-y-1.5">
+                                    <Label htmlFor="send-template-name">User name</Label>
+                                    <Input
+                                        id="send-template-name"
+                                        placeholder="Friend"
+                                        value={userName}
+                                        onChange={(e) => setUserName(e.target.value)}
+                                        disabled={pending}
+                                    />
+                                </div>
+                                <div className="space-y-1.5">
+                                    <Label htmlFor="send-template-city">City</Label>
+                                    <Input
+                                        id="send-template-city"
+                                        placeholder="Athens"
+                                        value={cityName}
+                                        onChange={(e) => setCityName(e.target.value)}
+                                        disabled={pending}
+                                    />
+                                </div>
+                            </div>
+                            <DialogFooter>
+                                <Button
+                                    variant="outline"
+                                    onClick={() => handleOpenChange(false)}
+                                    disabled={pending}
+                                >
+                                    Close
+                                </Button>
+                                <Button onClick={submitWhatsApp} disabled={pending || !phoneValid}>
+                                    {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                    Send WhatsApp
+                                </Button>
+                            </DialogFooter>
+                        </TabsContent>
+
+                        <TabsContent value="sms" className="space-y-3">
+                            <p className="text-xs text-muted-foreground">
+                                Free-form text via SMS. No template restrictions; sends instantly.
+                            </p>
+                            <div className="space-y-1.5">
+                                <Label htmlFor="send-sms-body">Message</Label>
+                                <Textarea
+                                    id="send-sms-body"
+                                    placeholder="Hello from OpenCouncil!"
+                                    rows={3}
+                                    value={smsBody}
+                                    onChange={(e) => setSmsBody(e.target.value)}
+                                    disabled={pending}
+                                />
+                            </div>
+                            <DialogFooter>
+                                <Button
+                                    variant="outline"
+                                    onClick={() => handleOpenChange(false)}
+                                    disabled={pending}
+                                >
+                                    Close
+                                </Button>
+                                <Button
+                                    onClick={submitSms}
+                                    disabled={pending || !phoneValid || !smsBody.trim()}
+                                >
+                                    {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                    Send SMS
+                                </Button>
+                            </DialogFooter>
+                        </TabsContent>
+
+                        <TabsContent value="before-meeting" className="space-y-3">
+                            <p className="text-xs text-muted-foreground">
+                                Creates a real <code>Notification</code> +{' '}
+                                <code>NotificationDelivery</code> for the matching user, then
+                                runs <code>releaseNotifications</code>. Use to exercise the
+                                full unsubscribe-by-reply chain. The phone must already match
+                                a User row.
+                            </p>
+                            <div className="space-y-1.5">
+                                <Label htmlFor="send-bm-city">City</Label>
+                                <Select
+                                    value={selectedCityId}
+                                    onValueChange={setSelectedCityId}
+                                    disabled={pending || cities.length === 0}
+                                >
+                                    <SelectTrigger id="send-bm-city">
+                                        <SelectValue placeholder="Select a city" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {cities.map((c) => (
+                                            <SelectItem key={c.id} value={c.id}>
+                                                {c.name}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                            <div className="space-y-1.5">
+                                <Label htmlFor="send-bm-meeting">Meeting</Label>
+                                <Select
+                                    value={selectedMeetingId}
+                                    onValueChange={setSelectedMeetingId}
+                                    disabled={pending || !selectedCityId || meetingsLoading || meetings.length === 0}
+                                >
+                                    <SelectTrigger id="send-bm-meeting">
+                                        <SelectValue
+                                            placeholder={
+                                                !selectedCityId
+                                                    ? 'Pick a city first'
+                                                    : meetingsLoading
+                                                        ? 'Loading meetings…'
+                                                        : meetings.length === 0
+                                                            ? 'No meetings for this city'
+                                                            : 'Select a meeting'
+                                            }
+                                        />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {meetings.map((m) => (
+                                            <SelectItem key={m.id} value={m.id}>
+                                                {new Date(m.dateTime).toLocaleDateString('el-GR')} — {m.name}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                            <DialogFooter>
+                                <Button
+                                    variant="outline"
+                                    onClick={() => handleOpenChange(false)}
+                                    disabled={pending}
+                                >
+                                    Close
+                                </Button>
+                                <Button
+                                    onClick={submitBeforeMeeting}
+                                    disabled={
+                                        pending || !phoneValid || !selectedCityId || !selectedMeetingId
+                                    }
+                                >
+                                    {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                    Send notification
+                                </Button>
+                            </DialogFooter>
+                        </TabsContent>
+                    </Tabs>
+
+                    {status === 'sent' && (
+                        <div className="flex items-center gap-2 rounded-md border border-green-200 bg-green-50 p-2 text-sm text-green-800">
+                            <CheckCircle className="h-4 w-4 shrink-0" />
+                            <span>Message queued. Check the recipient phone.</span>
+                        </div>
+                    )}
+                    {status === 'error' && (
+                        <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-2 text-sm text-destructive">
+                            <XCircle className="h-4 w-4 mt-0.5 shrink-0" />
+                            <span className="break-words">{error}</span>
+                        </div>
+                    )}
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/admin/conversations/types.ts
+++ b/src/components/admin/conversations/types.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared UI state machine for the admin Conversations send forms
+ * (`ReplyForm`, `SendTemplateDialog`). Centralizing the state machine here
+ * keeps the success/error banner copy and the disabled-button logic in
+ * lockstep across every send surface.
+ */
+export type SendStatus = 'idle' | 'sending' | 'sent' | 'error';

--- a/src/components/admin/sidebar.tsx
+++ b/src/components/admin/sidebar.tsx
@@ -1,4 +1,4 @@
-import { LayoutDashboard, Users, FileText, Settings, Files, FileOutput, Rocket, UserRound, List, RefreshCw, Search, Bell, QrCode, ClipboardCheck, MessageSquareText, Landmark, Tag, KeyRound } from "lucide-react";
+import { LayoutDashboard, Users, FileText, Settings, Files, FileOutput, Rocket, UserRound, List, RefreshCw, Search, Bell, QrCode, ClipboardCheck, MessageSquareText, Landmark, Tag, KeyRound, MessageCircle } from "lucide-react";
 import Link from "next/link";
 import {
     Sidebar,
@@ -43,6 +43,11 @@ const menuItems = [
         title: "Notifications",
         icon: Bell,
         url: "/admin/notifications",
+    },
+    {
+        title: "Conversations",
+        icon: MessageCircle,
+        url: "/admin/conversations",
     },
     {
         title: "Topics",

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -30,8 +30,12 @@ export function Tabs(props: {
    * Use this for tabs inside dialogs or other contexts where URL changes are undesirable.
    */
   local?: boolean;
+  /**
+   * Called when the user selects a different tab.
+   */
+  onValueChange?: (value: string) => void;
 }) {
-  const { children, className, searchParam = "tab", local, ...other } = props;
+  const { children, className, searchParam = "tab", local, onValueChange, ...other } = props;
 
   // Local (in-memory) state
   const [localSelected, setLocalSelected] = React.useState(props.defaultValue);
@@ -61,7 +65,12 @@ export function Tabs(props: {
   );
 
   const hrefFor: Context["hrefFor"] = local ? null : buildHref;
-  const onSelect: Context["onSelect"] = local ? setLocalSelected : null;
+  const onSelect: Context["onSelect"] = local
+    ? (value) => {
+      setLocalSelected(value);
+      onValueChange?.(value);
+    }
+    : null;
 
   return (
     <TabsContext.Provider value={{ ...other, hrefFor, onSelect, selected }}>

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -53,6 +53,7 @@ export const env = createEnv({
     BIRD_WHATSAPP_TEMPLATE_BEFORE_MEETING: z.string().optional(), // Template project ID from Bird Studio
     BIRD_WHATSAPP_TEMPLATE_AFTER_MEETING: z.string().optional(),  // Template project ID from Bird Studio
     BIRD_WHATSAPP_TEMPLATE_WELCOME: z.string().optional(),  // Welcome template when user signs up
+    BIRD_WEBHOOK_SECRET: z.string().optional(), // Shared secret for verifying inbound webhook signatures from Bird
 
     // Google Calendar Integration (OAuth 2.0)
     GOOGLE_CALENDAR_CLIENT_ID: z.string().optional(),
@@ -122,6 +123,7 @@ export const env = createEnv({
     BIRD_WHATSAPP_TEMPLATE_BEFORE_MEETING: process.env.BIRD_WHATSAPP_TEMPLATE_BEFORE_MEETING,
     BIRD_WHATSAPP_TEMPLATE_AFTER_MEETING: process.env.BIRD_WHATSAPP_TEMPLATE_AFTER_MEETING,
     BIRD_WHATSAPP_TEMPLATE_WELCOME: process.env.BIRD_WHATSAPP_TEMPLATE_WELCOME,
+    BIRD_WEBHOOK_SECRET: process.env.BIRD_WEBHOOK_SECRET,
     GOOGLE_CALENDAR_CLIENT_ID: process.env.GOOGLE_CALENDAR_CLIENT_ID,
     GOOGLE_CALENDAR_CLIENT_SECRET: process.env.GOOGLE_CALENDAR_CLIENT_SECRET,
     GOOGLE_CALENDAR_REFRESH_TOKEN: process.env.GOOGLE_CALENDAR_REFRESH_TOKEN,

--- a/src/lib/db/conversations.ts
+++ b/src/lib/db/conversations.ts
@@ -1,0 +1,68 @@
+import prisma from './prisma';
+import type { Message, MessageChannel } from '@prisma/client';
+
+/**
+ * One row per (participant phone, channel) — what the admin sees in the
+ * Conversations list. The same phone on WhatsApp and SMS is two distinct
+ * Bird conversations and shows as two separate rows. `messages` carries the
+ * full thread (oldest first); the page derives the last-message preview and
+ * the count from it.
+ */
+export interface ConversationSummary {
+    phone: string;
+    channel: MessageChannel;
+    messages: Message[];
+}
+
+/**
+ * v0 implementation: fetch a recent window of messages, then group by
+ * (phone, channel) in JS. Sorted by latest message first.
+ *
+ * The `recentMessageWindow` cap is generous — the admin list won't show more
+ * conversations than fit in that window. Once the message volume justifies
+ * it, swap this for a SQL `DISTINCT ON (phone, channel) ...` so we're not
+ * pulling unbounded rows into the app process.
+ */
+export async function getConversationSummaries(
+    limit = 50,
+    recentMessageWindow = 1000,
+): Promise<ConversationSummary[]> {
+    // Fetch newest-first so the window is the *recent* slice, not the oldest;
+    // otherwise once the table exceeds `recentMessageWindow` rows, fresh
+    // conversations would silently drop off the admin view. We reverse each
+    // conversation's messages below so the page still renders oldest-first.
+    const messages = await prisma.message.findMany({
+        orderBy: { createdAt: 'desc' },
+        take: recentMessageWindow,
+    });
+
+    // Composite key keeps WhatsApp and SMS threads to the same phone separate.
+    const groupKey = (m: { phone: string; channel: MessageChannel }) => `${m.channel}:${m.phone}`;
+
+    const byKey = new Map<string, ConversationSummary>();
+    for (const msg of messages) {
+        const key = groupKey(msg);
+        const existing = byKey.get(key);
+        if (existing) {
+            existing.messages.push(msg);
+        } else {
+            byKey.set(key, { phone: msg.phone, channel: msg.channel, messages: [msg] });
+        }
+    }
+    // Each `messages` array is currently newest-first (mirrors the query
+    // order); flip to oldest-first for chat-style rendering. The first item
+    // post-reversal is the oldest, the last item is the latest — which is
+    // also what we sort the conversation list by.
+    for (const conv of byKey.values()) {
+        conv.messages.reverse();
+    }
+
+    // Sort conversations by most recent message first.
+    return Array.from(byKey.values())
+        .sort((a, b) => {
+            const aLast = a.messages[a.messages.length - 1].createdAt.getTime();
+            const bLast = b.messages[b.messages.length - 1].createdAt.getTime();
+            return bLast - aLast;
+        })
+        .slice(0, limit);
+}

--- a/src/lib/db/messages.ts
+++ b/src/lib/db/messages.ts
@@ -1,0 +1,60 @@
+import prisma from './prisma';
+import type { Message, MessageChannel, MessageDirection, MessageStatus } from '@prisma/client';
+import { normalizePhone } from '@/lib/notifications/phone';
+
+export async function findRecentConversationIdByPhone(
+    phone: string,
+    channel: MessageChannel,
+): Promise<string | null> {
+    const formatted = normalizePhone(phone);
+    const recent = await prisma.message.findFirst({
+        where: {
+            phone: { in: [formatted, phone] },
+            channel,
+            conversationId: { not: null },
+        },
+        orderBy: { createdAt: 'desc' },
+        select: { conversationId: true },
+    });
+    return recent?.conversationId ?? null;
+}
+
+export async function recordOutboundMessage(input: {
+    channel: MessageChannel;
+    phone: string;
+    body: string;
+    conversationId?: string | null;
+    notificationDeliveryId?: string | null;
+}): Promise<Message> {
+    return prisma.message.create({
+        data: {
+            channel: input.channel,
+            direction: 'outbound' satisfies MessageDirection,
+            phone: input.phone,
+            body: input.body,
+            conversationId: input.conversationId ?? null,
+            notificationDeliveryId: input.notificationDeliveryId ?? null,
+            status: 'pending' satisfies MessageStatus,
+        },
+    });
+}
+
+export async function updateMessage(
+    id: string,
+    update: {
+        status: MessageStatus;
+        birdMessageId?: string | null;
+        conversationId?: string | null;
+        failureReason?: string | null;
+    },
+): Promise<Message> {
+    return prisma.message.update({
+        where: { id },
+        data: {
+            status: update.status,
+            ...(update.birdMessageId !== undefined ? { birdMessageId: update.birdMessageId } : {}),
+            ...(update.conversationId !== undefined ? { conversationId: update.conversationId } : {}),
+            ...(update.failureReason !== undefined ? { failureReason: update.failureReason } : {}),
+        },
+    });
+}

--- a/src/lib/formatters/time.ts
+++ b/src/lib/formatters/time.ts
@@ -118,6 +118,31 @@ export function formatDate(date: Date, timezone?: string, locale: string = 'el')
 }
 
 /**
+ * Numeric date-time, compact for tables/logs: `DD/MM/YYYY HH:mm:ss` (24h).
+ * Useful where `formatDateTime`'s long month names are too verbose.
+ *
+ * @param date - The date to format
+ * @param timezone - Optional timezone
+ * @param locale - 'el' (default) or 'en'; both produce day-first numeric output
+ * @returns e.g. "04/05/2026 10:07:30"
+ */
+export function formatNumericDateTime(date: Date, timezone?: string, locale: string = 'el'): string {
+    const options: Intl.DateTimeFormatOptions = {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+    };
+    if (timezone) options.timeZone = timezone;
+
+    const intlLocale = locale === 'en' ? 'en-GB' : 'el-GR';
+    return new Intl.DateTimeFormat(intlLocale, options).format(date).replace(', ', ' ');
+}
+
+/**
  * Formats a date and time to a standard string representation
  * @param date - The date to format
  * @param timezone - Optional timezone

--- a/src/lib/notifications/__tests__/bird-status.test.ts
+++ b/src/lib/notifications/__tests__/bird-status.test.ts
@@ -1,0 +1,64 @@
+/** @jest-environment node */
+import { mapBirdMessageStatus } from '../bird-status';
+
+describe('mapBirdMessageStatus', () => {
+    describe('delivered statuses', () => {
+        it.each(['delivered', 'read', 'DELIVERED', 'Read'])(
+            'maps %j to "delivered"',
+            (input) => {
+                expect(mapBirdMessageStatus(input)).toBe('delivered');
+            },
+        );
+    });
+
+    describe('failed statuses', () => {
+        it.each([
+            'rejected',
+            'failed',
+            'sending_failed',
+            'delivery_failed',
+            'REJECTED',
+            'Sending_Failed',
+        ])('maps %j to "failed"', (input) => {
+            expect(mapBirdMessageStatus(input)).toBe('failed');
+        });
+
+        it('matches any status string containing "failed"', () => {
+            // The `.includes('failed')` check catches future Bird variants.
+            expect(mapBirdMessageStatus('some_new_failed_variant')).toBe('failed');
+        });
+    });
+
+    describe('pending statuses', () => {
+        it.each(['pending', 'queued', 'PENDING', 'Queued'])(
+            'maps %j to "pending"',
+            (input) => {
+                expect(mapBirdMessageStatus(input)).toBe('pending');
+            },
+        );
+    });
+
+    describe('fallback to "sent"', () => {
+        it.each([
+            ['known sent status', 'sent'],
+            ['accepted', 'accepted'],
+            ['unrecognized string', 'some_unknown_value'],
+            ['empty string', ''],
+        ])('returns "sent" for %s (%j)', (_label, input) => {
+            expect(mapBirdMessageStatus(input)).toBe('sent');
+        });
+
+        it('returns "sent" for undefined', () => {
+            expect(mapBirdMessageStatus(undefined)).toBe('sent');
+        });
+    });
+
+    describe('priority ordering', () => {
+        it('treats "delivery_failed" as failed, not delivered', () => {
+            // The "failed" branch is checked before the substring of
+            // "delivered" would matter — guard against future refactors
+            // reordering the conditions and silently flipping behaviour.
+            expect(mapBirdMessageStatus('delivery_failed')).toBe('failed');
+        });
+    });
+});

--- a/src/lib/notifications/__tests__/unsubscribe.test.ts
+++ b/src/lib/notifications/__tests__/unsubscribe.test.ts
@@ -1,0 +1,185 @@
+/** @jest-environment node */
+jest.mock('@/env.mjs', () => ({
+    env: {
+        NEXTAUTH_SECRET: 'test-secret',
+        NEXTAUTH_URL: 'https://opencouncil.gr',
+        ANTHROPIC_API_KEY: 'test-key',
+    },
+}));
+
+jest.mock('@/lib/ai', () => ({
+    aiChat: jest.fn(),
+}));
+
+import { isUnsubscribeMessage, verifyUnsubscribeIntent } from '../unsubscribe';
+import { aiChat } from '@/lib/ai';
+
+const mockAiChat = aiChat as jest.MockedFunction<typeof aiChat>;
+
+describe('isUnsubscribeMessage', () => {
+    describe('nullish or empty input', () => {
+        it.each([
+            ['null', null],
+            ['undefined', undefined],
+            ['empty string', ''],
+        ])('returns false for %s', (_label, input) => {
+            expect(isUnsubscribeMessage(input)).toBe(false);
+        });
+    });
+
+    describe('English keywords', () => {
+        it('matches STOP as a standalone word', () => {
+            expect(isUnsubscribeMessage('STOP')).toBe(true);
+        });
+
+        it('matches stop case-insensitively', () => {
+            expect(isUnsubscribeMessage('stop')).toBe(true);
+            expect(isUnsubscribeMessage('Stop')).toBe(true);
+        });
+
+        it('matches stop with surrounding text (word boundary)', () => {
+            expect(isUnsubscribeMessage('please stop sending me messages')).toBe(true);
+        });
+
+        it('does not match stop substrings without a word boundary', () => {
+            expect(isUnsubscribeMessage('stopped')).toBe(false);
+            expect(isUnsubscribeMessage('nonstop')).toBe(false);
+        });
+
+        it('matches unsubscribe as a standalone word', () => {
+            expect(isUnsubscribeMessage('unsubscribe')).toBe(true);
+            expect(isUnsubscribeMessage('UNSUBSCRIBE')).toBe(true);
+            expect(isUnsubscribeMessage('please unsubscribe me')).toBe(true);
+        });
+
+        it('does not match unsubscribe substrings without a word boundary', () => {
+            expect(isUnsubscribeMessage('unsubscribed')).toBe(false);
+            expect(isUnsubscribeMessage('unsubscribing')).toBe(false);
+        });
+    });
+
+    describe('Greek keywords', () => {
+        it('matches ΣΤΟΠ case-insensitively', () => {
+            expect(isUnsubscribeMessage('ΣΤΟΠ')).toBe(true);
+            expect(isUnsubscribeMessage('στοπ')).toBe(true);
+        });
+
+        it('matches διακοπή', () => {
+            expect(isUnsubscribeMessage('διακοπή')).toBe(true);
+        });
+
+        it('matches απεγγραφή (full form)', () => {
+            expect(isUnsubscribeMessage('απεγγραφή')).toBe(true);
+        });
+
+        it('matches απεγγραφ (stem) so accent-less variants still trigger', () => {
+            expect(isUnsubscribeMessage('απεγγραφ')).toBe(true);
+        });
+
+        it('matches inside surrounding Greek text', () => {
+            expect(isUnsubscribeMessage('παρακαλώ διακοπή των ειδοποιήσεων')).toBe(true);
+        });
+
+        it('matches imperative verb form "απεγγράψτε" (φ→ψ aorist shift)', () => {
+            // Greek shifts φ→ψ in the aorist consonant cluster, so the
+            // imperative stem is `απεγγραψ-` not `απεγγραφ-`. The regex
+            // character class `απεγγρα[φψ]` covers both.
+            expect(isUnsubscribeMessage('Απεγγραψτε με')).toBe(true);
+            expect(isUnsubscribeMessage('Απεγγράψτε με')).toBe(true);
+            expect(isUnsubscribeMessage('απεγγράψω από όλα')).toBe(true);
+        });
+    });
+
+    describe('ambiguous matches (regex catches widely / LLM filters intent)', () => {
+        // Regex casts a wide net deliberately; verifyUnsubscribeIntent below
+        // is the safety net that rejects these. Documented here so the
+        // two-layer architecture is explicit.
+
+        it('matches "stop" as a verb in conversational text', () => {
+            expect(isUnsubscribeMessage('I want to stop the meeting')).toBe(true);
+            expect(isUnsubscribeMessage('θα stop περάσω αύριο')).toBe(true);
+        });
+
+        it('matches "στοπ" used as a noun (e.g. road sign)', () => {
+            expect(isUnsubscribeMessage('Το στοπ διπλα απο το σπιτι μου εχει πεσει')).toBe(true);
+        });
+
+        it('matches "απεγγραφ-" stem in a past-tense self-reference (after diacritic stripping)', () => {
+            expect(isUnsubscribeMessage('Απεγγράφτηκα προχτες και θέλω να ξαναεγγραφώ')).toBe(true);
+        });
+    });
+
+    describe('non-matching text', () => {
+        it.each([
+            'hello',
+            'this is fine',
+            'please send me more information',
+            '   ',
+        ])('returns false for %j', (input) => {
+            expect(isUnsubscribeMessage(input)).toBe(false);
+        });
+    });
+});
+
+describe('verifyUnsubscribeIntent', () => {
+    beforeEach(() => {
+        mockAiChat.mockReset();
+    });
+
+    // Helper: build the resolved value the Anthropic client returns from
+    // aiChat<T>. The wrapper only reads `result.unsubscribe`.
+    const mockVerdict = (unsubscribe: boolean, reasoning = '') => {
+        mockAiChat.mockResolvedValueOnce({
+            result: { unsubscribe, reasoning },
+        } as Awaited<ReturnType<typeof aiChat>>);
+    };
+
+    it('returns "confirmed" when the LLM votes unsubscribe=true', async () => {
+        mockVerdict(true);
+        await expect(verifyUnsubscribeIntent('STOP')).resolves.toBe('confirmed');
+    });
+
+    it('returns "rejected" when the LLM votes unsubscribe=false', async () => {
+        mockVerdict(false);
+        await expect(verifyUnsubscribeIntent('I want to stop the meeting')).resolves.toBe('rejected');
+    });
+
+    it('returns "failed" when the LLM call throws', async () => {
+        // The function deliberately logs to console.error in its catch block;
+        // silence it here so the expected outage doesn't look like a real
+        // failure in test output. Also asserts the log fires (defence
+        // against silent swallowing).
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+            mockAiChat.mockRejectedValueOnce(new Error('LLM outage'));
+            await expect(verifyUnsubscribeIntent('STOP')).resolves.toBe('failed');
+            expect(errorSpy).toHaveBeenCalledWith(
+                'verifyUnsubscribeIntent failed:',
+                expect.any(Error),
+            );
+        } finally {
+            errorSpy.mockRestore();
+        }
+    });
+
+    // Greek false positives — the regex catches the keyword but the user's
+    // intent is clearly not opt-out. The prompt has explicit examples for
+    // both; here we verify the wrapper propagates the LLM's `false` verdict
+    // correctly. The LLM behaviour itself (does the prompt actually reject
+    // these?) is validated separately by manual/integration testing.
+    describe('Greek ambiguous matches', () => {
+        it('propagates "rejected" for "Το στοπ διπλα..." (road sign)', async () => {
+            mockVerdict(false, 'reference to a stop sign, not an opt-out');
+            await expect(
+                verifyUnsubscribeIntent('Το στοπ διπλα απο το σπιτι μου εχει πεσει'),
+            ).resolves.toBe('rejected');
+        });
+
+        it('propagates "rejected" for "Απεγγράφτηκα προχτές..." (past narration)', async () => {
+            mockVerdict(false, 'past-tense narration, user asks to re-subscribe');
+            await expect(
+                verifyUnsubscribeIntent('Απεγγράφτηκα προχτες και θέλω να ξαναεγγραφώ'),
+            ).resolves.toBe('rejected');
+        });
+    });
+});

--- a/src/lib/notifications/bird-status.ts
+++ b/src/lib/notifications/bird-status.ts
@@ -1,0 +1,24 @@
+import type { MessageStatus } from '@prisma/client';
+
+/**
+ * Translate Bird's message status strings into our local `MessageStatus` enum.
+ * Pure helper, intentionally outside `bird.ts` so it isn't exposed as a
+ * server action (the bird module has `"use server"`).
+ *
+ * Bird's vocabulary observed so far:
+ *   - `delivered`, `read`        → delivered
+ *   - `rejected`, `failed`,
+ *     `sending_failed`,
+ *     `delivery_failed`          → failed
+ *   - `pending`, `queued`        → pending
+ *   - `sent`, `accepted` (or
+ *     anything else we don't
+ *     specifically recognize)    → sent
+ */
+export function mapBirdMessageStatus(birdStatus: string | undefined): MessageStatus {
+    const s = String(birdStatus ?? '').toLowerCase();
+    if (s === 'delivered' || s === 'read') return 'delivered';
+    if (s === 'rejected' || s === 'failed' || s.includes('failed')) return 'failed';
+    if (s === 'pending' || s === 'queued') return 'pending';
+    return 'sent';
+}

--- a/src/lib/notifications/bird.ts
+++ b/src/lib/notifications/bird.ts
@@ -1,21 +1,23 @@
 "use server";
 
 import { env } from '@/env.mjs';
+import { findRecentConversationIdByPhone } from '@/lib/db/messages';
+import { normalizePhone } from './phone';
+import type {
+    BirdCreateConversationResponse,
+    BirdSendMessageResponse,
+    ConversationResult,
+    MeetingNotificationParams,
+    OutboundSendResult,
+    WelcomeParams,
+} from './types';
 
-interface WhatsAppTemplateParams {
-    date: string;
-    cityName: string;
-    subjectsSummary: string;
-    adminBody: string;
+/** WhatsApp before-/after-meeting template params: the shared meeting
+ *  shape plus the notification ID Bird needs to thread the template. */
+interface WhatsAppTemplateParams extends MeetingNotificationParams {
     notificationId: string;
 }
 
-/**
- * Format phone number to ensure it starts with +
- */
-function formatPhoneNumber(phoneNumber: string): string {
-    return phoneNumber.startsWith('+') ? phoneNumber : `+${phoneNumber}`;
-}
 
 /**
  * Check if Bird credentials are configured
@@ -37,89 +39,101 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Fetch current status of a Bird message via the list endpoint
+ * Resolve a logical channel ('whatsapp' | 'sms') to its configured Bird
  */
-async function getMessageStatus(channelId: string, messageId: string): Promise<string | null> {
+export async function resolveBirdChannel(
+    channel: 'whatsapp' | 'sms',
+): Promise<{ channelId?: string; error?: string }> {
+    if (!env.BIRD_API_KEY || !env.BIRD_WORKSPACE_ID) {
+        return { error: 'Bird workspace not configured' };
+    }
+    const channelId = channel === 'sms' ? env.BIRD_SMS_CHANNEL_ID : env.BIRD_WHATSAPP_CHANNEL_ID;
+    if (!channelId) {
+        const envName = channel === 'sms' ? 'BIRD_SMS_CHANNEL_ID' : 'BIRD_WHATSAPP_CHANNEL_ID';
+        return { error: `${envName} is not configured` };
+    }
+    return { channelId };
+}
+
+/**
+ * Fetch a single Bird message's current state by hitting the path-form
+ * single-resource endpoint. Returns the raw status string and any failure
+ * reason from Bird's response.
+ *
+ * Endpoint: GET /workspaces/{ws}/channels/{channelId}/messages/{messageId}
+ */
+export async function getMessageStatus(
+    channelId: string,
+    messageId: string,
+): Promise<{ status?: string; reason?: string; error?: string }> {
+    if (!env.BIRD_API_KEY || !env.BIRD_WORKSPACE_ID) {
+        return { error: 'Bird workspace not configured' };
+    }
     try {
-        const response = await fetch(
-            `https://api.bird.com/workspaces/${env.BIRD_WORKSPACE_ID}/channels/${channelId}/messages?id=${messageId}`,
-            {
-                headers: {
-                    'Authorization': `AccessKey ${env.BIRD_API_KEY}`,
-                }
-            }
-        );
-
+        const url = `https://api.bird.com/workspaces/${env.BIRD_WORKSPACE_ID}/channels/${channelId}/messages/${messageId}`;
+        const response = await fetch(url, {
+            headers: { Authorization: `AccessKey ${env.BIRD_API_KEY}` },
+        });
         if (!response.ok) {
-            console.error(`Bird GET message status error: ${response.status}`);
-            return null;
+            return { error: `Bird returned ${response.status}` };
         }
-
         const data = await response.json();
-        const results = data.results;
-        if (Array.isArray(results) && results.length > 0) {
-            return results[0].status ?? null;
-        }
-        return null;
+        return {
+            status: data?.status,
+            reason: data?.reason ?? data?.failure?.description,
+        };
     } catch (error) {
-        console.error('Error fetching Bird message status:', error);
-        return null;
+        return { error: error instanceof Error ? error.message : 'Unknown error' };
     }
 }
 
 /**
  * Poll Bird API until message reaches a terminal status or timeout.
- * Returns the terminal status string, or null if polling timed out.
  */
-async function pollForDeliveryStatus(
+export async function pollForDeliveryStatus(
     channelId: string,
     messageId: string
-): Promise<string | null> {
+): Promise<{ status: string | null; reason?: string }> {
     for (let attempt = 1; attempt <= POLL_MAX_ATTEMPTS; attempt++) {
         await sleep(POLL_INTERVAL_MS);
 
-        const status = await getMessageStatus(channelId, messageId);
+        const { status, reason } = await getMessageStatus(channelId, messageId);
         console.log(`Bird message ${messageId} poll ${attempt}/${POLL_MAX_ATTEMPTS}: status=${status}`);
 
         if (status && (BIRD_TERMINAL_STATUSES as readonly string[]).includes(status)) {
-            return status;
+            return { status, reason };
         }
     }
 
     console.log(`Bird message ${messageId} polling timed out after ${POLL_MAX_ATTEMPTS} attempts`);
-    return null;
+    return { status: null };
 }
 
 /**
- * Check polling result and return success/failure for WhatsApp delivery.
- * Called after a successful Bird POST to determine actual delivery outcome.
+ * Minimal envelope fields read inside `makeBirdRequest` itself.
  */
-function resolveDeliveryResult(
-    finalStatus: string | null,
-    phoneNumber: string
-): { success: boolean; error?: string } {
-    if (finalStatus === 'delivered') {
-        return { success: true };
-    }
-
-    if (finalStatus === 'delivery_failed' || finalStatus === 'sending_failed' || finalStatus === 'rejected' || finalStatus === 'skipped') {
-        console.log(`WhatsApp delivery failed for ${phoneNumber}: status=${finalStatus}`);
-        return { success: false, error: `WhatsApp delivery status: ${finalStatus}` };
-    }
-
-    // Timeout (null) — optimistic, same as previous behavior
-    console.log(`WhatsApp delivery status unknown for ${phoneNumber}, treating as success`);
-    return { success: true };
+interface BirdResponseEnvelope {
+    id?: string;
+    conversationId?: string;
+    conversation?: { id?: string };
+    status?: string;
+    detail?: string;
+    title?: string;
 }
 
-/**
- * Make Bird API request with error handling
- */
-async function makeBirdRequest(
+async function makeBirdRequest<T = unknown>(
     url: string,
     payload: unknown,
-    logPrefix: string
-): Promise<{ success: boolean; error?: string; messageId?: string }> {
+    logPrefix: string,
+): Promise<{
+    success: boolean;
+    error?: string;
+    status?: number;
+    errorBody?: unknown;
+    messageId?: string;
+    conversationId?: string;
+    data?: T;
+}> {
     try {
         const response = await fetch(url, {
             method: 'POST',
@@ -133,21 +147,36 @@ async function makeBirdRequest(
         if (!response.ok) {
             const errorText = await response.text();
             console.error(`${logPrefix} API error:`, response.status, errorText);
-            return { success: false, error: `API returned ${response.status}` };
-        }
-
-        const result = await response.json();
-        console.log(`${logPrefix} sent via Bird:`, result);
-
-        // Check for immediate failure in response body even if status is 2xx
-        if (result.status === 'failed' || result.status === 'rejected') {
+            // Try to parse as JSON for structured callers (e.g. 409 recovery
+            // that needs to read details.conversationId); fall back to text.
+            let errorBody: unknown = errorText;
+            try { errorBody = JSON.parse(errorText); } catch { /* not JSON */ }
             return {
                 success: false,
-                error: result.detail || result.title || `Bird status: ${result.status}`
+                error: `API returned ${response.status}: ${errorText}`,
+                status: response.status,
+                errorBody,
             };
         }
 
-        return { success: true, messageId: result.id };
+        const raw: unknown = await response.json();
+        const envelope = (raw ?? {}) as BirdResponseEnvelope;
+
+        // Check for immediate failure in response body even if status is 2xx
+        if (envelope.status === 'failed' || envelope.status === 'rejected') {
+            return {
+                success: false,
+                error: envelope.detail || envelope.title || `Bird status: ${envelope.status}`,
+                data: raw as T,
+            };
+        }
+
+        return {
+            success: true,
+            messageId: envelope.id,
+            conversationId: envelope.conversationId ?? envelope.conversation?.id,
+            data: raw as T,
+        };
     } catch (error) {
         console.error(`Error ${logPrefix.toLowerCase()}:`, error);
         return {
@@ -157,90 +186,316 @@ async function makeBirdRequest(
     }
 }
 
+type TemplateBody = {
+    projectId: string;
+    version: string;
+    locale: string;
+    parameters: Array<{ type: string; key: string; value: string }>;
+};
+
+type WelcomeTemplateParams = WelcomeParams;
+
+type ConstructTemplateInput =
+    | { type: 'beforeMeeting' | 'afterMeeting'; params: WhatsAppTemplateParams }
+    | { type: 'welcome'; params: WelcomeTemplateParams };
+
 /**
- * Send WhatsApp message via Bird API using pre-approved templates
+ * Pure helper that assembles the WhatsApp-template payload Bird's APIs expect.
+ * Returns `{ error }` when the env-configured project ID is missing for the requested template type.
  */
-export async function sendWhatsAppMessage(
-    phoneNumber: string,
-    notificationType: 'beforeMeeting' | 'afterMeeting',
-    params: WhatsAppTemplateParams
-): Promise<{ success: boolean; error?: string }> {
-    console.log(`WhatsApp send to ${phoneNumber} (SIMULATE_WHATSAPP_UNAVAILABLE=${process.env.SIMULATE_WHATSAPP_UNAVAILABLE ? 'true' : 'false'})`);
-
-    if (process.env.SIMULATE_WHATSAPP_UNAVAILABLE) {
-        console.log(`[Simulated] WhatsApp unavailable for ${phoneNumber}, will fall back to SMS`);
-        return { success: false, error: 'Simulated: WhatsApp unavailable' };
+function constructTemplate(input: ConstructTemplateInput): { template?: TemplateBody; error?: string } {
+    if (input.type === 'welcome') {
+        const projectId = env.BIRD_WHATSAPP_TEMPLATE_WELCOME;
+        if (!projectId) {
+            return { error: 'Welcome template project ID not configured' };
+        }
+        return {
+            template: {
+                projectId,
+                version: 'latest',
+                locale: 'el',
+                parameters: [
+                    { type: 'string', key: 'userName', value: input.params.userName },
+                    { type: 'string', key: 'cityName', value: input.params.cityName },
+                ],
+            },
+        };
     }
 
-    const credentialsCheck = checkCredentials(env.BIRD_WHATSAPP_CHANNEL_ID, 'WhatsApp');
-    if (!credentialsCheck.configured) {
-        console.error('Bird WhatsApp credentials not configured');
-        return { success: false, error: credentialsCheck.error };
-    }
-
-    const templateProjectId = notificationType === 'beforeMeeting'
+    const templateProjectId = input.type === 'beforeMeeting'
         ? env.BIRD_WHATSAPP_TEMPLATE_BEFORE_MEETING
         : env.BIRD_WHATSAPP_TEMPLATE_AFTER_MEETING;
 
     if (!templateProjectId) {
-        console.error(`WhatsApp template project ID not configured for ${notificationType}`);
-        return { success: false, error: 'Template project ID not configured' };
+        return { error: `Template project ID not configured for ${input.type}` };
     }
 
-    const payload = {
-        receiver: {
-            contacts: [
-                {
-                    identifierValue: formatPhoneNumber(phoneNumber)
-                }
-            ]
-        },
+    return {
         template: {
             projectId: templateProjectId,
             version: 'latest',
             locale: 'el',
             parameters: [
-                {
-                    type: 'string',
-                    key: 'date',
-                    value: params.date
-                },
-                {
-                    type: 'string',
-                    key: 'cityName',
-                    value: params.cityName
-                },
-                {
-                    type: 'string',
-                    key: 'subjectsSummary',
-                    value: params.subjectsSummary
-                },
-                {
-                    type: 'string',
-                    key: 'adminBody',
-                    value: params.adminBody
-                },
-                {
-                    type: 'string',
-                    key: 'notificationId',
-                    value: params.notificationId
-                }
-            ]
-        }
+                { type: 'string', key: 'date', value: input.params.date },
+                { type: 'string', key: 'cityName', value: input.params.cityName },
+                { type: 'string', key: 'subjectsSummary', value: input.params.subjectsSummary },
+                { type: 'string', key: 'adminBody', value: input.params.adminBody },
+                { type: 'string', key: 'notificationId', value: input.params.notificationId },
+            ],
+        },
     };
+}
 
-    const result = await makeBirdRequest(
-        `https://api.bird.com/workspaces/${env.BIRD_WORKSPACE_ID}/channels/${env.BIRD_WHATSAPP_CHANNEL_ID}/messages`,
-        payload,
-        'WhatsApp message'
-    );
-
-    if (!result.success || !result.messageId) {
-        return { success: result.success, error: result.error };
+/**
+ * Send a message (text or template) INTO an existing Bird conversation via
+ * `POST /workspaces/{ws}/conversations/{id}/messages`.
+ */
+export async function sendConversationMessage(input: {
+    conversationId: string;
+    channel?: 'whatsapp' | 'sms';
+    text?: string;
+    template?: TemplateBody;
+    recipientPhone?: string;
+}): Promise<OutboundSendResult> {
+    if (!input.conversationId) {
+        return { success: false, error: 'conversationId is required' };
+    }
+    if (!input.text && !input.template) {
+        return { success: false, error: 'text or template is required' };
+    }
+    if (input.text && input.template) {
+        return { success: false, error: 'text and template are mutually exclusive' };
     }
 
-    const finalStatus = await pollForDeliveryStatus(env.BIRD_WHATSAPP_CHANNEL_ID!, result.messageId);
-    return resolveDeliveryResult(finalStatus, phoneNumber);
+    const { channelId, error: channelError } = await resolveBirdChannel(input.channel ?? 'whatsapp');
+    if (channelError || !channelId) {
+        return { success: false, error: channelError ?? 'Unknown channel' };
+    }
+
+    const url = `https://api.bird.com/workspaces/${env.BIRD_WORKSPACE_ID}/conversations/${input.conversationId}/messages`;
+    const payload: Record<string, unknown> = {
+        participantId: channelId,
+        participantType: 'flow',
+    };
+    if (input.text) {
+        payload.body = { type: 'text', text: { text: input.text } };
+    } else if (input.template) {
+        payload.template = input.template;
+    }
+    if (input.recipientPhone) {
+        payload.recipients = [{
+            type: 'to',
+            identifierKey: 'phonenumber',
+            identifierValue: normalizePhone(input.recipientPhone),
+        }];
+    }
+
+    return makeBirdRequest<BirdSendMessageResponse>(url, payload, 'Conversation message');
+}
+
+/**
+ * Bird's 409 ConflictError schema is `{ code, message, details }` where
+ * `details` is documented as a free-form object.
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const isUuid = (v: unknown): v is string => typeof v === 'string' && UUID_RE.test(v);
+
+function extractConflictingConversationId(body: unknown): string | undefined {
+    if (!body || typeof body !== 'object') return undefined;
+    const root = body as Record<string, unknown>;
+    const details = (root.details ?? {}) as Record<string, unknown>;
+
+    const namedCandidates: unknown[] = [
+        details.conversationId,
+        details.id,
+        details.conflictingResource,
+        details.resource,
+        details.existingConversationId,
+    ];
+    for (const c of namedCandidates) {
+        if (isUuid(c)) return c;
+    }
+    // Fallback: scan every value in `details` since the schema is free-form.
+    for (const v of Object.values(details)) {
+        if (isUuid(v)) return v;
+    }
+    return undefined;
+}
+
+/**
+ * Create a fresh Bird conversation seeded with an initial message
+ * (`POST /workspaces/{ws}/conversations`). Bird requires an `initialMessage` —
+ * pass either `text` or a pre-built `template` payload.
+ */
+export async function createConversation(input: {
+    channel?: 'whatsapp' | 'sms';
+    phone: string;
+    name: string;
+    text?: string;
+    template?: TemplateBody;
+    attributes?: Record<string, string>;
+}): Promise<ConversationResult> {
+    if (!input.text && !input.template) {
+        return { success: false, error: 'text or template is required for initialMessage' };
+    }
+    if (input.text && input.template) {
+        return { success: false, error: 'text and template are mutually exclusive' };
+    }
+
+    const { channelId, error: channelError } = await resolveBirdChannel(input.channel ?? 'whatsapp');
+    if (channelError || !channelId) {
+        return { success: false, error: channelError ?? 'Unknown channel' };
+    }
+
+    const phone = normalizePhone(input.phone);
+    const recipients = [{
+        type: 'to',
+        identifierKey: 'phonenumber',
+        identifierValue: phone,
+    }];
+    const initialMessage: Record<string, unknown> = { recipients };
+    if (input.text) {
+        initialMessage.body = { type: 'text', text: { text: input.text } };
+    } else if (input.template) {
+        initialMessage.template = input.template;
+    }
+
+    const payload = {
+        name: input.name,
+        channelId,
+        participants: [{
+            type: 'contact',
+            identifierKey: 'phonenumber',
+            identifierValue: phone,
+        }],
+        initialMessage,
+        ...(input.attributes ? { attributes: input.attributes } : {}),
+    };
+
+    const url = `https://api.bird.com/workspaces/${env.BIRD_WORKSPACE_ID}/conversations`;
+    const result = await makeBirdRequest<BirdCreateConversationResponse>(url, payload, 'Create conversation');
+    if (!result.success) {
+        if (result.status === 409) {
+            const existingId = extractConflictingConversationId(result.errorBody);
+            if (existingId) {
+                console.log(
+                    `Bird create-conversation: 409 for ${phone} — existing conversation is ${existingId}`,
+                );
+                return {
+                    success: false,
+                    error: result.error,
+                    conversationId: existingId,
+                    alreadyExisted: true,
+                };
+            }
+            console.error(
+                'Bird create-conversation: 409 received but existing conversation ID not found in response',
+                result.errorBody,
+            );
+        }
+        return { success: false, error: result.error };
+    }
+
+    const data = result.data ?? {};
+    const conversationId: string | undefined =
+        data?.id ?? data?.conversationId ?? data?.conversation?.id;
+    const messageId: string | undefined =
+        data?.initialMessage?.id ?? data?.lastMessage?.id ?? data?.messageId;
+
+    if (!conversationId) {
+        console.error('Bird create-conversation: response missing conversation id', data);
+        return { success: false, error: 'Bird response missing conversation id' };
+    }
+
+    return { success: true, conversationId, messageId };
+}
+
+type CreateOrUpdateConversationInput = { phone: string } & (
+    | {
+        notificationType: 'beforeMeeting' | 'afterMeeting';
+        params: WhatsAppTemplateParams;
+        notificationDeliveryId: string;
+    }
+    | {
+        notificationType: 'welcome';
+        params: WelcomeTemplateParams;
+    }
+);
+
+/**
+ * Send a WhatsApp template, automatically routing through the most recent Bird
+ * conversation associated with this phone if we have one on file; otherwise
+ * creates a fresh Bird conversation.
+ */
+export async function createOrUpdateConversation(input: CreateOrUpdateConversationInput): Promise<ConversationResult> {
+    if (process.env.SIMULATE_WHATSAPP_UNAVAILABLE) {
+        console.log(`[Simulated] WhatsApp unavailable for ${input.phone}, will fall back to SMS`);
+        return { success: false, error: 'Simulated: WhatsApp unavailable' };
+    }
+
+    const credentialsCheck = checkCredentials(env.BIRD_WHATSAPP_CHANNEL_ID, 'WhatsApp');
+    if (!credentialsCheck.configured) {
+        return { success: false, error: credentialsCheck.error };
+    }
+
+    const { template, error: templateError } = constructTemplate(
+        input.notificationType === 'welcome'
+            ? { type: 'welcome', params: input.params }
+            : { type: input.notificationType, params: input.params }
+    );
+    if (templateError || !template) {
+        return { success: false, error: templateError };
+    }
+
+    const existingConversationId = await findRecentConversationIdByPhone(input.phone, 'whatsapp');
+    if (existingConversationId) {
+        const result = await sendConversationMessage({
+            conversationId: existingConversationId,
+            channel: 'whatsapp',
+            template,
+            recipientPhone: input.phone,
+        });
+        return {
+            success: result.success,
+            error: result.error,
+            conversationId: result.success ? existingConversationId : undefined,
+            messageId: result.messageId,
+            created: false,
+        };
+    }
+
+    const name = input.notificationType === 'welcome'
+        ? `Welcome ${normalizePhone(input.phone)}`
+        : `Notification ${input.notificationType} ${input.notificationDeliveryId}`;
+    const attributes: Record<string, string> = input.notificationType === 'welcome'
+        ? { type: 'welcome' }
+        : { notificationDeliveryId: input.notificationDeliveryId };
+
+    const result = await createConversation({
+        channel: 'whatsapp',
+        phone: input.phone,
+        name,
+        template,
+        attributes,
+    });
+
+    if (result.alreadyExisted && result.conversationId) {
+        const sendResult = await sendConversationMessage({
+            conversationId: result.conversationId,
+            channel: 'whatsapp',
+            template,
+            recipientPhone: input.phone,
+        });
+        return {
+            success: sendResult.success,
+            error: sendResult.error,
+            conversationId: result.conversationId,
+            messageId: sendResult.messageId,
+            created: false,
+        };
+    }
+
+    return { ...result, created: true };
 }
 
 /**
@@ -249,7 +504,7 @@ export async function sendWhatsAppMessage(
 export async function sendSMSMessage(
     phoneNumber: string,
     message: string
-): Promise<{ success: boolean; error?: string }> {
+): Promise<OutboundSendResult> {
     const credentialsCheck = checkCredentials(env.BIRD_SMS_CHANNEL_ID, 'SMS');
     if (!credentialsCheck.configured) {
         console.error('Bird SMS credentials not configured');
@@ -260,7 +515,7 @@ export async function sendSMSMessage(
         receiver: {
             contacts: [
                 {
-                    identifierValue: formatPhoneNumber(phoneNumber)
+                    identifierValue: normalizePhone(phoneNumber)
                 }
             ]
         },
@@ -272,117 +527,10 @@ export async function sendSMSMessage(
         }
     };
 
-    return makeBirdRequest(
+    return makeBirdRequest<BirdSendMessageResponse>(
         `https://api.bird.com/workspaces/${env.BIRD_WORKSPACE_ID}/channels/${env.BIRD_SMS_CHANNEL_ID}/messages`,
         payload,
         'SMS'
     );
 }
 
-/**
- * Send welcome WhatsApp message when user signs up for notifications
- */
-export async function sendWelcomeWhatsAppMessage(
-    phoneNumber: string,
-    userName: string,
-    cityName: string
-): Promise<{ success: boolean; error?: string }> {
-    if (process.env.SIMULATE_WHATSAPP_UNAVAILABLE) {
-        console.log(`[Simulated] WhatsApp unavailable for ${phoneNumber}, will fall back to SMS`);
-        return { success: false, error: 'Simulated: WhatsApp unavailable' };
-    }
-
-    const credentialsCheck = checkCredentials(env.BIRD_WHATSAPP_CHANNEL_ID, 'WhatsApp');
-    if (!credentialsCheck.configured) {
-        console.error('Bird WhatsApp credentials not configured');
-        return { success: false, error: credentialsCheck.error };
-    }
-
-    const templateProjectId = env.BIRD_WHATSAPP_TEMPLATE_WELCOME;
-
-    if (!templateProjectId) {
-        console.error('WhatsApp welcome template project ID not configured');
-        return { success: false, error: 'Welcome template not configured' };
-    }
-
-    const payload = {
-        receiver: {
-            contacts: [
-                {
-                    identifierValue: formatPhoneNumber(phoneNumber)
-                }
-            ]
-        },
-        template: {
-            projectId: templateProjectId,
-            version: 'latest',
-            locale: 'el',
-            parameters: [
-                {
-                    type: 'string',
-                    key: 'userName',
-                    value: userName
-                },
-                {
-                    type: 'string',
-                    key: 'cityName',
-                    value: cityName
-                }
-            ]
-        }
-    };
-
-    console.log('Bird WhatsApp welcome message request:', JSON.stringify(payload, null, 2));
-
-    const result = await makeBirdRequest(
-        `https://api.bird.com/workspaces/${env.BIRD_WORKSPACE_ID}/channels/${env.BIRD_WHATSAPP_CHANNEL_ID}/messages`,
-        payload,
-        'WhatsApp welcome message'
-    );
-
-    if (!result.success || !result.messageId) {
-        return { success: result.success, error: result.error };
-    }
-
-    const finalStatus = await pollForDeliveryStatus(env.BIRD_WHATSAPP_CHANNEL_ID!, result.messageId);
-    return resolveDeliveryResult(finalStatus, phoneNumber);
-}
-
-/**
- * Send welcome SMS when user signs up for notifications
- */
-export async function sendWelcomeSMS(
-    phoneNumber: string,
-    userName: string,
-    cityName: string
-): Promise<{ success: boolean; error?: string }> {
-    const credentialsCheck = checkCredentials(env.BIRD_SMS_CHANNEL_ID, 'SMS');
-    if (!credentialsCheck.configured) {
-        console.error('Bird SMS credentials not configured');
-        return { success: false, error: credentialsCheck.error };
-    }
-
-    const message = `Γεια σας ${userName}! Εγγραφήκατε επιτυχώς για ειδοποιήσεις από το OpenCouncil για ${cityName}. Θα λαμβάνετε ενημερώσεις για θέματα που σας αφορούν.`;
-
-    const payload = {
-        receiver: {
-            contacts: [
-                {
-                    identifierValue: formatPhoneNumber(phoneNumber)
-                }
-            ]
-        },
-        body: {
-            type: 'text',
-            text: {
-                text: message
-            }
-        }
-    };
-
-    return makeBirdRequest(
-        `https://api.bird.com/workspaces/${env.BIRD_WORKSPACE_ID}/channels/${env.BIRD_SMS_CHANNEL_ID}/messages`,
-        payload,
-        'Welcome SMS'
-    );
-}

--- a/src/lib/notifications/content.ts
+++ b/src/lib/notifications/content.ts
@@ -84,3 +84,13 @@ export async function generateSmsContent(notification: NotificationData): Promis
     return `${notification.city.name_municipality} - ${adminBody} στις ${meetingDateFormatted}: ${subjectCount} νέα θέματα για εσάς. ${subjectNames}. Δείτε περισσότερα: ${notificationUrl}`;
 }
 
+/**
+ * Welcome SMS body
+ */
+export async function generateWelcomeSmsContent(
+    userName: string,
+    cityName: string,
+): Promise<string> {
+    return `Γεια σας ${userName}! Εγγραφήκατε επιτυχώς για ειδοποιήσεις από το OpenCouncil για ${cityName}. Θα λαμβάνετε ενημερώσεις για θέματα που σας αφορούν.`;
+}
+

--- a/src/lib/notifications/deliver.ts
+++ b/src/lib/notifications/deliver.ts
@@ -1,9 +1,12 @@
 "use server";
 
-import { NotificationDelivery } from '@prisma/client';
 import { sendEmail } from '@/lib/email/resend';
 import { getPendingDeliveries, updateDeliveryStatus } from '@/lib/db/notifications';
-import { sendWhatsAppMessage, sendSMSMessage } from './bird';
+import {
+    createOrUpdateConversation,
+    sendSMSMessage,
+} from './bird';
+import { sendAndPersistOutbound } from './outbound';
 import { env } from '@/env.mjs';
 
 /**
@@ -109,7 +112,10 @@ async function sendEmailDelivery(delivery: any): Promise<boolean> {
 }
 
 /**
- * Send message delivery via Bird (WhatsApp with SMS fallback)
+ * Send message delivery via Bird (WhatsApp template → SMS fallback).
+ *
+ * First send creates a Bird conversation via the Conversations API so every
+ * subsequent inbound + outbound message lands in the same conversation.
  */
 async function sendMessageDelivery(delivery: any): Promise<boolean> {
     try {
@@ -138,24 +144,41 @@ async function sendMessageDelivery(delivery: any): Promise<boolean> {
             notificationId: notification.id
         };
 
-        // Try WhatsApp first
-        const whatsappResult = await sendWhatsAppMessage(
-            delivery.phone,
-            notification.type,
-            templateParams
-        );
+        const waResult = await sendAndPersistOutbound({
+            notificationDeliveryId: delivery.id,
+            channel: 'whatsapp',
+            phone: delivery.phone,
+            body: delivery.body || '[template]',
+            send: () => createOrUpdateConversation({
+                phone: delivery.phone,
+                notificationType: notification.type,
+                params: templateParams,
+                notificationDeliveryId: delivery.id,
+            }),
+        });
 
-        if (whatsappResult.success) {
+        if (waResult.success && waResult.finalStatus !== 'failed') {
             await updateDeliveryStatus(delivery.id, 'sent', 'whatsapp');
-            console.log(`WhatsApp message sent successfully to ${delivery.phone}`);
+            console.log(`WhatsApp conversation seeded for ${delivery.phone}`);
             return true;
         }
+        
+        console.log(
+            waResult.success
+                ? `WhatsApp delivery failed post-send for ${delivery.phone}, falling back to SMS`
+                : `WhatsApp create-conversation failed for ${delivery.phone}: ${waResult.error}`,
+        );
 
-        // Fallback to SMS
-        console.log(`WhatsApp failed, falling back to SMS for ${delivery.phone}`);
-        const smsResult = await sendSMSMessage(delivery.phone, delivery.body || '');
+        const smsBody = delivery.body;
+        const smsResult = await sendAndPersistOutbound({
+            notificationDeliveryId: delivery.id,
+            channel: 'sms',
+            phone: delivery.phone,
+            body: smsBody,
+            send: () => sendSMSMessage(delivery.phone, smsBody),
+        });
 
-        if (smsResult.success) {
+        if (smsResult.success && smsResult.finalStatus !== 'failed') {
             await updateDeliveryStatus(delivery.id, 'sent', 'sms');
             console.log(`SMS sent successfully to ${delivery.phone}`);
             return true;

--- a/src/lib/notifications/outbound.ts
+++ b/src/lib/notifications/outbound.ts
@@ -1,0 +1,53 @@
+import { recordOutboundMessage, updateMessage } from '@/lib/db/messages';
+import { reconcileMessageStatus } from './reconcile';
+import type { SendAndPersistInput, SendAndPersistResult } from './types';
+
+/**
+ * Standard outbound lifecycle: persist a `Message` row, call Bird, update
+ * the row with the result, then optionally poll Bird for the terminal
+ * status.
+ */
+export async function sendAndPersistOutbound(
+    input: SendAndPersistInput,
+): Promise<SendAndPersistResult> {
+    const row = await recordOutboundMessage({
+        channel: input.channel,
+        phone: input.phone,
+        body: input.body,
+        conversationId: input.conversationId ?? null,
+        notificationDeliveryId: input.notificationDeliveryId ?? null,
+    });
+
+    let result: Awaited<ReturnType<typeof input.send>>;
+    try {
+        result = await input.send();
+    } catch (error) {
+        const reason = error instanceof Error ? error.message : 'Unknown error';
+        await updateMessage(row.id, { status: 'failed', failureReason: reason });
+        throw error;
+    }
+
+    await updateMessage(row.id, {
+        status: result.success ? 'sent' : 'failed',
+        birdMessageId: result.messageId ?? null,
+        failureReason: result.success ? null : result.error ?? null,
+        // (Bird discovers / creates the ID on a fresh `createConversation`).
+        ...(input.conversationId == null && result.conversationId
+            ? { conversationId: result.conversationId }
+            : {}),
+    });
+
+    let finalStatus: SendAndPersistResult['finalStatus'];
+    let finalReason: string | undefined;
+    if (input.reconcile !== false && result.success && result.messageId) {
+        const reconciled = await reconcileMessageStatus({
+            localMessageId: row.id,
+            channel: input.channel,
+            birdMessageId: result.messageId,
+        });
+        finalStatus = reconciled.status;
+        finalReason = reconciled.reason;
+    }
+
+    return { ...result, rowId: row.id, finalStatus, finalReason };
+}

--- a/src/lib/notifications/phone.ts
+++ b/src/lib/notifications/phone.ts
@@ -1,0 +1,10 @@
+/**
+ * Normalize a phone number to E.164-ish form: trim whitespace, ensure a
+ * leading `+`. Returns empty string for nullish/empty input.
+ */
+export function normalizePhone(phone: string | null | undefined): string {
+    if (!phone) return '';
+    const trimmed = phone.trim();
+    if (!trimmed) return '';
+    return trimmed.startsWith('+') ? trimmed : `+${trimmed}`;
+}

--- a/src/lib/notifications/reconcile.ts
+++ b/src/lib/notifications/reconcile.ts
@@ -1,0 +1,30 @@
+import type { MessageChannel } from '@prisma/client';
+import { updateMessage } from '@/lib/db/messages';
+import { mapBirdMessageStatus } from './bird-status';
+import { pollForDeliveryStatus, resolveBirdChannel } from './bird';
+import type { ReconcileResult } from './types';
+
+/**
+ * After an outbound send returns a Bird message ID, poll Bird until the
+ * message reaches a terminal status, then write that status onto the local
+ * `Message` row.
+ */
+export async function reconcileMessageStatus(input: {
+    localMessageId: string;
+    channel: MessageChannel;
+    birdMessageId: string;
+}): Promise<ReconcileResult> {
+    const { channelId } = await resolveBirdChannel(input.channel);
+    if (!channelId) return { status: null };
+
+    const { status: finalStatus, reason } = await pollForDeliveryStatus(channelId, input.birdMessageId);
+    if (!finalStatus) return { status: null };
+
+    const mapped = mapBirdMessageStatus(finalStatus);
+    await updateMessage(input.localMessageId, {
+        status: mapped,
+        // Only persist a reason on failure; clear it on success / in-flight.
+        failureReason: mapped === 'failed' ? reason ?? null : null,
+    });
+    return { status: mapped, reason: mapped === 'failed' ? reason : undefined };
+}

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -1,0 +1,108 @@
+import type { NextResponse } from 'next/server';
+import type { MessageChannel, MessageStatus } from '@prisma/client';
+
+// ---------------------------------------------------------------------------
+// Outbound send lifecycle
+// ---------------------------------------------------------------------------
+
+export interface OutboundSendResult {
+    success: boolean;
+    error?: string;
+    messageId?: string;
+    conversationId?: string;
+}
+
+
+export interface ConversationResult extends OutboundSendResult {
+    /** Set when Bird returned 409 and we recovered
+     *  the existing conversation ID from the error body. */
+    alreadyExisted?: boolean;
+    /** Set when a brand-new Bird conversation was created, `false` when we
+     *  routed into one we already knew about. */
+    created?: boolean;
+}
+
+export interface SendAndPersistInput {
+    channel: MessageChannel;
+    phone: string;
+    body: string;
+    /** Set when the row belongs to an existing conversation we already know. */
+    conversationId?: string | null;
+    /** Set when the outbound belongs to a notification-delivery flow so the
+     *  inbound webhook can walk back to a user via the row. */
+    notificationDeliveryId?: string | null;
+    /** The Bird call. Returns the standard `OutboundSendResult` shape. */
+    send: () => Promise<OutboundSendResult>;
+    /** Default true. Disable when the inbound webhook will reconcile this
+     *  message asynchronously, so the synchronous poll would be redundant. */
+    reconcile?: boolean;
+}
+
+export interface SendAndPersistResult extends OutboundSendResult {
+    rowId: string;
+    /**
+     * Post-reconcile delivery status. Only present when `reconcile` ran
+     * `null` means reconciliation was attempted but polling timed out
+     * or the channel wasn't configured.
+     */
+    finalStatus?: MessageStatus | null;
+    /** Bird failure reason when `finalStatus === 'failed'` — surfaces
+     *  "outside 24h window" etc. up to the UI. */
+    finalReason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Template + SMS parameters
+// ---------------------------------------------------------------------------
+
+export interface MeetingNotificationParams {
+    date: string;
+    cityName: string;
+    subjectsSummary: string;
+    adminBody: string;
+}
+
+export interface WelcomeParams {
+    userName: string;
+    cityName: string;
+}
+
+// ---------------------------------------------------------------------------
+// Bird HTTP response envelopes
+// ---------------------------------------------------------------------------
+
+export interface BirdSendMessageResponse {
+    id?: string;
+    conversationId?: string;
+    status?: string;
+}
+
+export interface BirdCreateConversationResponse {
+    id?: string;
+    conversationId?: string;
+    conversation?: { id?: string };
+    initialMessage?: { id?: string };
+    lastMessage?: { id?: string };
+    messageId?: string;
+    status?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Reconciliation
+// ---------------------------------------------------------------------------
+
+export interface ReconcileResult {
+    status: MessageStatus | null;
+    /** Failure reason from Bird */
+    reason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Webhook signature verification
+// ---------------------------------------------------------------------------
+
+export type VerifySignatureResult = { ok: true } | { ok: false; reason: string };
+
+export type VerifyRequestResult =
+    | { ok: true; event: unknown }
+    | { ok: false; response: NextResponse };

--- a/src/lib/notifications/unsubscribe.ts
+++ b/src/lib/notifications/unsubscribe.ts
@@ -1,0 +1,142 @@
+import prisma from '@/lib/db/prisma';
+import type { User } from '@prisma/client';
+import { aiChat } from '@/lib/ai';
+import { sendConversationMessage } from '@/lib/notifications/bird';
+import { sendAndPersistOutbound } from '@/lib/notifications/outbound';
+
+function stripDiacritics(s: string): string {
+    return s.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+// Keyword gate before we run the LLM verifier. The regex catches widely on
+// purpose — `verifyUnsubscribeIntent` does the precise filtering — but it's
+// intentionally NOT semantic: messages like "δεν θέλω άλλα μηνύματα" (clear
+// opt-out intent, no keyword) won't reach the LLM. Running Claude on every
+// inbound message would add cost and latency for what's overwhelmingly
+// noise, so we accept that purely-semantic opt-outs slip through and rely
+// on the explicit unsubscribe link in every notification as the alternative.
+//
+// `απεγγρα[φψ]` covers both Greek conjugation stems for "unsubscribe":
+//   - φ form: noun `απεγγραφή`, past `απεγγράφτηκα`
+//   - ψ form: imperative `απεγγράψτε`, aorist `απεγγράψω`
+// Greek shifts φ→ψ in the aorist consonant cluster.
+export const UNSUBSCRIBE_KEYWORDS_RE =
+    /(?:\bSTOP\b|\bunsubscribe\b|ΣΤΟΠ|διακοπη|απεγγρα[φψ])/iu;
+
+export function isUnsubscribeMessage(body: string | null | undefined): boolean {
+    if (!body) return false;
+    return UNSUBSCRIBE_KEYWORDS_RE.test(stripDiacritics(body));
+}
+
+const UNSUBSCRIBE_VERIFICATION_PROMPT = `Είσαι ένας ταξινομητής πρόθεσης απεγγραφής για το OpenCouncil.
+
+Δίνεται ένα εισερχόμενο μήνυμα από χρήστη μέσω WhatsApp/SMS. Πρέπει να κρίνεις αν ο χρήστης ζητάει ξεκάθαρα να σταματήσει να λαμβάνει ειδοποιήσεις από την υπηρεσία μας (απεγγραφή από όλα).
+
+Επιστρέφεις ΜΟΝΟ ένα JSON αντικείμενο με τη δομή:
+{
+    "unsubscribe": boolean,
+    "reasoning": string
+}
+
+Κανόνες:
+1. "unsubscribe": true ΜΟΝΟ όταν ο χρήστης δηλώνει σαφή, ενεργή πρόθεση να σταματήσει ΤΩΡΑ τις ειδοποιήσεις. Παραδείγματα: "STOP", "ΣΤΟΠ", "unsubscribe", "διακοπή", "απεγγραφή", "Απεγγραφή τώρα", "Απεγγράψτε με", "δεν θέλω άλλα μηνύματα", "stop sending me messages".
+
+2. "unsubscribe": false όταν η ίδια λέξη εμφανίζεται σε άλλο πλαίσιο. Συγκεκριμένα, απόρριψε όταν:
+   - Η λέξη χρησιμοποιείται ως ΟΥΣΙΑΣΤΙΚΟ ή αντικείμενο, όχι ως αίτημα. Π.χ. "Το στοπ δίπλα από το σπίτι μου έχει πέσει" (αναφορά σε πινακίδα οδικής σήμανσης).
+   - Ο χρήστης ΑΦΗΓΕΙΤΑΙ ή ΣΧΟΛΙΑΖΕΙ μια προηγούμενη/μελλοντική απεγγραφή χωρίς να τη ζητάει τώρα. Π.χ. "Απεγγράφτηκα προχτές και θέλω να ξαναεγγραφώ" (αφήγηση παρελθόντος + αίτημα εγγραφής, όχι απεγγραφής).
+   - Άλλη χρήση της λέξης. Π.χ. "θα stop περάσω αύριο", "stop the meeting".
+   - Σχόλιο/ερώτηση για συγκεκριμένη συνεδρίαση ή θέμα.
+
+3. Σε αμφιβολία, επέλεξε false. Είναι προτιμότερο να μην απεγγραφεί παρά να απεγγραφεί λάθος.
+
+4. "reasoning": μια σύντομη πρόταση (≤ 20 λέξεις) με την αιτιολόγησή σου.`;
+
+interface UnsubscribeVerificationResult {
+    unsubscribe: boolean;
+    reasoning?: string;
+}
+
+/**
+ * Three-state result so callers can distinguish a deliberate "no" from a
+ * transient LLM outage. `failed` lets the webhook reply with a "try again
+ * later" message instead of silently dropping a valid STOP.
+ */
+export type UnsubscribeIntent = 'confirmed' | 'rejected' | 'failed';
+
+export async function verifyUnsubscribeIntent(body: string): Promise<UnsubscribeIntent> {
+    try {
+        const { result } = await aiChat<UnsubscribeVerificationResult>(
+            UNSUBSCRIBE_VERIFICATION_PROMPT,
+            body,
+            undefined,
+            undefined,
+            { maxTokens: 200, model: 'claude-haiku-4-5-20251001' },
+        );
+        return result.unsubscribe === true ? 'confirmed' : 'rejected';
+    } catch (error) {
+        console.error('verifyUnsubscribeIntent failed:', error);
+        return 'failed';
+    }
+}
+
+export async function findUserByNotificationDeliveryId(
+    notificationDeliveryId: string,
+): Promise<User | null> {
+    const delivery = await prisma.notificationDelivery.findUnique({
+        where: { id: notificationDeliveryId },
+        include: { notification: { include: { user: true } } },
+    });
+    return delivery?.notification?.user ?? null;
+}
+
+/**
+ * Disables phone notifications across all cities for this user.
+ * Returns the number of rows actually changed — `0` means the user was
+ * already fully unsubscribed.
+ */
+export async function unsubscribeUserPhoneFromAllCities(
+    userId: string,
+): Promise<{ changedCount: number }> {
+    const result = await prisma.notificationPreference.updateMany({
+        where: { userId, notifyByPhone: true },
+        data: { notifyByPhone: false },
+    });
+    return { changedCount: result.count };
+}
+
+export const UNSUBSCRIBE_CONFIRMATION_TEXT =
+    'Δεν θα λαμβάνετε πλέον ειδοποιήσεις μέσω τηλεφώνου. Για να τις ενεργοποιήσετε ξανά, συνδεθείτε στο opencouncil.gr/profile?tab=notifications';
+
+// Used when a STOP arrives but no preference rows actually changed — phrased
+// as "you don't receive..." rather than "you've been unsubscribed..." so it
+// reads correctly for users who were never opted in.
+export const UNSUBSCRIBE_ALREADY_TEXT =
+    'Δεν λαμβάνετε ειδοποιήσεις μέσω τηλεφώνου. Για να τις ενεργοποιήσετε ξανά, συνδεθείτε στο opencouncil.gr/profile?tab=notifications';
+
+export const UNSUBSCRIBE_RETRY_TEXT =
+    'Παρουσιάστηκε προσωρινό πρόβλημα, παρακαλούμε δοκιμάστε ξανά σε λίγο.';
+
+export async function sendUnsubscribeReply(input: {
+    conversationId: string;
+    phone: string;
+    notificationDeliveryId: string | null;
+    text: string;
+}): Promise<void> {
+    // `reconcile: false` — the inbound webhook will reconcile this row
+    // when Bird emits the delivery-status event, so the synchronous poll
+    // would be redundant.
+    await sendAndPersistOutbound({
+        channel: 'whatsapp',
+        phone: input.phone,
+        body: input.text,
+        conversationId: input.conversationId,
+        notificationDeliveryId: input.notificationDeliveryId,
+        send: () => sendConversationMessage({
+            conversationId: input.conversationId,
+            channel: 'whatsapp',
+            text: input.text,
+            recipientPhone: input.phone,
+        }),
+        reconcile: false,
+    });
+}

--- a/src/lib/notifications/welcome.ts
+++ b/src/lib/notifications/welcome.ts
@@ -3,7 +3,9 @@
 import { sendEmail } from '@/lib/email/resend';
 import { renderReactEmailToHtml } from '@/lib/email/render';
 import { WelcomeEmail } from '@/lib/email/templates/WelcomeEmail';
-import { sendWelcomeWhatsAppMessage, sendWelcomeSMS } from './bird';
+import { createOrUpdateConversation, sendSMSMessage } from './bird';
+import { sendAndPersistOutbound } from './outbound';
+import { generateWelcomeSmsContent } from './content';
 import { klitiki } from '@/lib/utils';
 
 interface City {
@@ -44,17 +46,32 @@ export async function sendWelcomeMessages(userId: string, city: City, phone?: st
 
         // Send welcome WhatsApp/SMS if phone provided
         if (phone) {
-            // Try WhatsApp first
-            const whatsappResult = await sendWelcomeWhatsAppMessage(
+            const waResult = await sendAndPersistOutbound({
+                channel: 'whatsapp',
                 phone,
-                userName,
-                city.name
-            );
+                body: '[welcome template]',
+                send: () => createOrUpdateConversation({
+                    phone,
+                    notificationType: 'welcome',
+                    params: { userName, cityName: city.name },
+                }),
+            });
 
-            // Fallback to SMS if WhatsApp fails
-            if (!whatsappResult.success) {
-                console.log('WhatsApp welcome failed, falling back to SMS');
-                await sendWelcomeSMS(phone, userName, city.name);
+            // Fall back to SMS when the send failed, OR when reconciliation
+            // later flagged the WhatsApp message as failed (24h window,
+            // blocked recipient, etc.)
+            if (!waResult.success || waResult.finalStatus === 'failed') {
+                console.log(
+                    'WhatsApp welcome failed, falling back to SMS:',
+                    waResult.finalReason ?? waResult.error,
+                );
+                const smsBody = await generateWelcomeSmsContent(userName, city.name);
+                await sendAndPersistOutbound({
+                    channel: 'sms',
+                    phone,
+                    body: smsBody,
+                    send: () => sendSMSMessage(phone, smsBody),
+                });
             }
         }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds inbound Bird webhook handling for the "unsubscribe by reply" flow. It introduces a new `Message` table to track both inbound and outbound messages, a complete Bird webhook route (`/api/webhooks/bird`) with HMAC-SHA256 signature verification, two-stage unsubscribe detection (keyword regex + LLM intent verification), an admin Conversations UI with reply forms, and new `sendAndPersistOutbound` lifecycle helper.

- Adds `Message` schema + two migrations, the `extract.ts` parsing layer (well-typed, well-tested), and `route.ts` orchestration for outbound status updates and inbound STOP detection.
- Introduces `sendAndPersistOutbound` which correctly guards the `input.send()` call in a try/catch so a throw marks the row `failed` instead of leaving it `pending` indefinitely.
- The admin conversations page is entirely new, with tabbed test-send dialog and inline reply form; both use `router.refresh()` to re-fetch after each action.

<h3>Confidence Score: 3/5</h3>

The webhook handler and unsubscribe flow work correctly for the happy path, but a transient error during unsubscribe processing followed by a Bird retry permanently skips the unsubscribe action — the affected user remains subscribed with no indication anything went wrong.

Several interconnected correctness issues affect the core unsubscribe-by-reply feature this PR is meant to deliver: the retry-idempotency problem in route.ts means a single transient DB or LLM error silently neutralises a valid STOP; welcome-message conversations have no notificationDeliveryId so their replies never enter the unsubscribe flow at all; and SMS STOP messages are intentionally excluded but documented only in passing.

src/app/api/webhooks/bird/route.ts (retry/P2002 interaction with handleUnsubscribeIfApplicable), src/app/[locale]/(other)/admin/conversations/actions.ts (non-atomic notification + delivery creation, releaseNotifications success not checked), src/lib/notifications/bird.ts (participantId set to channelId in sendConversationMessage)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/api/webhooks/bird/route.ts | New webhook handler with HMAC verification, outbound status reconciliation, and two-stage unsubscribe detection. The P2002-tolerant try/catch wraps both persistMessageRow and handleUnsubscribeIfApplicable together, so a transient failure during the unsubscribe step followed by a Bird retry permanently skips the unsubscribe. |
| src/lib/notifications/unsubscribe.ts | Implements keyword regex gate + LLM intent verification for unsubscribes. Correctly distinguishes confirmed/rejected/failed LLM outcomes and sends appropriate replies. |
| src/app/api/webhooks/bird/extract.ts | Well-typed, pure extraction layer for Bird's variable event shapes; all major paths covered by the accompanying test suite. |
| src/lib/notifications/outbound.ts | sendAndPersistOutbound correctly wraps input.send() in try/catch, marking the row failed before rethrowing — the pending-row orphan issue from the earlier codebase is resolved here. |
| src/app/[locale]/(other)/admin/conversations/actions.ts | New server actions for test sends. sendTestBeforeMeetingNotification creates Notification + NotificationDelivery in two separate non-transactional calls (orphan risk on partial failure), and the releaseNotifications result check only inspects result.failed, not result.success. |
| src/lib/notifications/deliver.ts | sendMessageDelivery now routes through sendAndPersistOutbound, correctly linking outbound Message rows to NotificationDelivery for the inbound webhook's lookup. WhatsApp-then-SMS fallback logic uses finalStatus !== 'failed' guard, avoiding the earlier messageId-based double-delivery bug. |
| src/lib/db/conversations.ts | getConversationSummaries now correctly fetches newest-first (desc) and reverses per-conversation arrays for oldest-first display; the orderBy bug mentioned in an earlier review is addressed. |
| src/lib/notifications/bird.ts | sendConversationMessage sets participantId to the channel ID with participantType: 'flow', which may not correctly identify the sender in Bird's Conversations API and is likely to cause API errors. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Bird
    participant Route as /api/webhooks/bird
    participant Extract as extract.ts
    participant DB as Message (DB)
    participant Unsub as unsubscribe.ts
    participant BirdAPI as Bird Conversations API

    Bird->>Route: POST (HMAC-signed)
    Route->>Route: verifyBirdSignature()
    Route->>Extract: extractMessageFields(event)
    Extract-->>Route: "{direction, phone, body, channel, ...}"

    alt outbound status update
        Route->>DB: findUnique(birdMessageId)
        DB-->>Route: existing row
        Route->>DB: update status/failureReason
        Route-->>Bird: 200 OK
    else inbound message
        Route->>DB: findFirst(conversationId, notificationDeliveryId not null)
        DB-->>Route: notificationDeliveryId (or null)
        Route->>DB: message.create (try/catch P2002)
        alt isUnsubscribeMessage AND whatsapp AND notificationDeliveryId
            Route->>Unsub: verifyUnsubscribeIntent (LLM)
            Unsub-->>Route: "confirmed | rejected | failed"
            alt confirmed
                Route->>DB: updateMany notificationPreference
                Route->>BirdAPI: sendConversationMessage (confirmation)
            else failed
                Route->>BirdAPI: sendConversationMessage (retry text)
            end
        end
        Route-->>Bird: 200 OK
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (11)</h3></summary>

1. `src/app/api/webhooks/bird/route.ts`, line 698-758 ([link](https://github.com/schemalabz/opencouncil/blob/f177f10bde9264f1f0828d697684d83bb6e8b968/src/app/api/webhooks/bird/route.ts#L698-L758)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **No unsubscribe action on inbound "STOP" / "UNSUBSCRIBE" replies**

   The PR title is "Enable inbound messaging for unsubscribe by reply," but the webhook handler only persists the incoming message row — it never inspects the message body for opt-out keywords (e.g. `STOP`, `UNSUBSCRIBE`, `CANCEL`) or updates any user/notification-delivery record to halt future sends. Without that step, a user who replies "STOP" will have their message stored but will continue receiving notifications.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/api/webhooks/bird/route.ts
   Line: 698-758

   Comment:
   **No unsubscribe action on inbound "STOP" / "UNSUBSCRIBE" replies**

   The PR title is "Enable inbound messaging for unsubscribe by reply," but the webhook handler only persists the incoming message row — it never inspects the message body for opt-out keywords (e.g. `STOP`, `UNSUBSCRIBE`, `CANCEL`) or updates any user/notification-delivery record to halt future sends. Without that step, a user who replies "STOP" will have their message stored but will continue receiving notifications.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/app/api/webhooks/bird/route.ts`, line 634-696 ([link](https://github.com/schemalabz/opencouncil/blob/f177f10bde9264f1f0828d697684d83bb6e8b968/src/app/api/webhooks/bird/route.ts#L634-L696)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`any` type usage violates the style guide**

   `extractMessageFields(event: any)` and the `let m: any` block inside use `any` explicitly. The project rule is "Never cast to any, and avoid using any as a type in general." Consider typing `event` as `unknown` and narrowing with type guards, or defining a minimal interface for the expected Bird payload shapes.

   **Context Used:** .cursor/rules/general.mdc ([source](https://app.greptile.com/review/custom-context?memory=dc2172bf-e821-4a8e-b26f-cd165ffe6599))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: src/app/api/webhooks/bird/route.ts
   Line: 634-696
   
   Comment:
   **`any` type usage violates the style guide**
   
   `extractMessageFields(event: any)` and the `let m: any` block inside use `any` explicitly. The project rule is "Never cast to any, and avoid using any as a type in general." Consider typing `event` as `unknown` and narrowing with type guards, or defining a minimal interface for the expected Bird payload shapes.
   
   **Context Used:** .cursor/rules/general.mdc ([source](https://app.greptile.com/review/custom-context?memory=dc2172bf-e821-4a8e-b26f-cd165ffe6599))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

3. `src/lib/notifications/bird.ts` 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> Debug `console.log` logs the full API payload on every conversation message send. This will emit phone numbers and message bodies to server logs in production. Remove before merging.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/notifications/bird.ts
   Line: ?

   Comment:
   Debug `console.log` logs the full API payload on every conversation message send. This will emit phone numbers and message bodies to server logs in production. Remove before merging.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

4. `src/app/[locale]/(other)/admin/conversations/actions.ts`, line 301 ([link](https://github.com/schemalabz/opencouncil/blob/016af83ea50640a9794f2ae30ff562df27151018/src/app/[locale]/(other)/admin/conversations/actions.ts#L301)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`revalidatePath` includes route group — page never revalidates**

   `revalidatePath` expects a URL path, not a filesystem path. Route groups like `(other)` are stripped from URLs, so `/[locale]/(other)/admin/conversations` matches nothing and the conversations page is never revalidated. After `sendTestTemplate` or `sendTestBeforeMeetingNotification`, the admin sees stale data and has no feedback that the send succeeded. The same bug appears on line 397 for `sendTestBeforeMeetingNotification`. Compare to `sendTestReply` (line 215) and `sendTestSms` (line 253) which correctly omit the group.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/[locale]/(other)/admin/conversations/actions.ts
   Line: 301

   Comment:
   **`revalidatePath` includes route group — page never revalidates**

   `revalidatePath` expects a URL path, not a filesystem path. Route groups like `(other)` are stripped from URLs, so `/[locale]/(other)/admin/conversations` matches nothing and the conversations page is never revalidated. After `sendTestTemplate` or `sendTestBeforeMeetingNotification`, the admin sees stale data and has no feedback that the send succeeded. The same bug appears on line 397 for `sendTestBeforeMeetingNotification`. Compare to `sendTestReply` (line 215) and `sendTestSms` (line 253) which correctly omit the group.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

5. `src/lib/notifications/deliver.ts`, line 186-255 ([link](https://github.com/schemalabz/opencouncil/blob/0555d86a9c94122830c2aff2bd7b1f3733a7e5ee/src/lib/notifications/deliver.ts#L186-L255)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **WhatsApp success + missing `messageId` silently triggers SMS double-delivery**

   `createOrUpdateConversation` can return `{ success: true, conversationId: "...", messageId: undefined }` — for example when `createConversation` builds `messageId` from `data?.initialMessage?.id ?? data?.lastMessage?.id ?? data?.messageId` and none of those paths are present in Bird's response body. The guard `whatsappResult.success && whatsappResult.messageId` treats this as a failure: the `else` branch logs a misleading "WhatsApp create-conversation failed" message and falls through to `sendSMSMessage`, so the recipient receives the notification twice (once via WhatsApp, once via SMS) and the WhatsApp send is never recorded in the `Message` table.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/notifications/deliver.ts
   Line: 186-255

   Comment:
   **WhatsApp success + missing `messageId` silently triggers SMS double-delivery**

   `createOrUpdateConversation` can return `{ success: true, conversationId: "...", messageId: undefined }` — for example when `createConversation` builds `messageId` from `data?.initialMessage?.id ?? data?.lastMessage?.id ?? data?.messageId` and none of those paths are present in Bird's response body. The guard `whatsappResult.success && whatsappResult.messageId` treats this as a failure: the `else` branch logs a misleading "WhatsApp create-conversation failed" message and falls through to `sendSMSMessage`, so the recipient receives the notification twice (once via WhatsApp, once via SMS) and the WhatsApp send is never recorded in the `Message` table.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

6. `src/app/[locale]/(other)/admin/conversations/actions.ts`, line 623-630 ([link](https://github.com/schemalabz/opencouncil/blob/c2357e8a7ab5cd65ee96a49484d090c321becdfa/src/app/[locale]/(other)/admin/conversations/actions.ts#L623-L630)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Silent success when `releaseNotifications` fails at the outer level**

   `releaseNotifications` catches all top-level errors (e.g., `getPendingDeliveries` throws) and returns `{ success: false, failed: 0 }`. Because only `result.failed > 0` is checked here, that outer-failure case falls through to `return { success: true }` — the admin sees a green "sent" confirmation while no message was actually dispatched and no delivery row was ever transitioned from `pending`. `result.success` must also be consulted before returning success.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/[locale]/(other)/admin/conversations/actions.ts
   Line: 623-630

   Comment:
   **Silent success when `releaseNotifications` fails at the outer level**

   `releaseNotifications` catches all top-level errors (e.g., `getPendingDeliveries` throws) and returns `{ success: false, failed: 0 }`. Because only `result.failed > 0` is checked here, that outer-failure case falls through to `return { success: true }` — the admin sees a green "sent" confirmation while no message was actually dispatched and no delivery row was ever transitioned from `pending`. `result.success` must also be consulted before returning success.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

7. `src/app/[locale]/(other)/admin/conversations/actions.ts`, line 590-621 ([link](https://github.com/schemalabz/opencouncil/blob/c2357e8a7ab5cd65ee96a49484d090c321becdfa/src/app/[locale]/(other)/admin/conversations/actions.ts#L590-L621)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Non-atomic notification + delivery creation leaves a stuck orphan on partial failure**

   The `Notification` and `NotificationDelivery` rows are created in two separate `prisma.create` calls inside the same `try` block but without a transaction. If the `notification.create` succeeds but the `notificationDelivery.create` fails (any error other than the `userId` P2002), the function rethrows — leaving an orphaned `Notification` with no `NotificationDelivery`. On the admin's next retry, `notification.create` hits the unique-constraint violation, the catch recognises it as the `userId` P2002, and returns "A beforeMeeting notification already exists for this user + meeting" — even though no delivery was ever created. The test notification can never be triggered again without manual DB cleanup. Wrapping both creates in a `prisma.$transaction` eliminates the stuck state.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/[locale]/(other)/admin/conversations/actions.ts
   Line: 590-621

   Comment:
   **Non-atomic notification + delivery creation leaves a stuck orphan on partial failure**

   The `Notification` and `NotificationDelivery` rows are created in two separate `prisma.create` calls inside the same `try` block but without a transaction. If the `notification.create` succeeds but the `notificationDelivery.create` fails (any error other than the `userId` P2002), the function rethrows — leaving an orphaned `Notification` with no `NotificationDelivery`. On the admin's next retry, `notification.create` hits the unique-constraint violation, the catch recognises it as the `userId` P2002, and returns "A beforeMeeting notification already exists for this user + meeting" — even though no delivery was ever created. The test notification can never be triggered again without manual DB cleanup. Wrapping both creates in a `prisma.$transaction` eliminates the stuck state.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

8. `src/app/api/webhooks/bird/route.ts`, line 1319-1394 ([link](https://github.com/schemalabz/opencouncil/blob/9ae6a9d9d116b1c3917eab125cea293fd4d18dcf/src/app/api/webhooks/bird/route.ts#L1319-L1394)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Unsubscribe logic permanently skipped after transient error + Bird retry**

   The `try/catch` block wraps both `prisma.message.create` and the entire unsubscribe pipeline. If `message.create` succeeds but any downstream step throws a transient error (e.g., `findUserByNotificationDeliveryId`, `verifyUnsubscribeIntent`, or `unsubscribeUserPhoneFromAllCities` hits a brief DB timeout), the handler returns 500. Bird retries the event; on retry, `message.create` throws P2002 (row already exists), which the catch block swallows and returns 200 — so the unsubscribe is never processed and the user remains subscribed forever.

   The fix is to separate the two concerns: wrap only `prisma.message.create` in the P2002-tolerant try/catch, then run the unsubscribe detection outside it (with its own error handling that returns 500 on failure so Bird can retry just that step).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/api/webhooks/bird/route.ts
   Line: 1319-1394

   Comment:
   **Unsubscribe logic permanently skipped after transient error + Bird retry**

   The `try/catch` block wraps both `prisma.message.create` and the entire unsubscribe pipeline. If `message.create` succeeds but any downstream step throws a transient error (e.g., `findUserByNotificationDeliveryId`, `verifyUnsubscribeIntent`, or `unsubscribeUserPhoneFromAllCities` hits a brief DB timeout), the handler returns 500. Bird retries the event; on retry, `message.create` throws P2002 (row already exists), which the catch block swallows and returns 200 — so the unsubscribe is never processed and the user remains subscribed forever.

   The fix is to separate the two concerns: wrap only `prisma.message.create` in the P2002-tolerant try/catch, then run the unsubscribe detection outside it (with its own error handling that returns 500 on failure so Bird can retry just that step).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

9. `src/lib/notifications/deliver.ts`, line 3299-3313 ([link](https://github.com/schemalabz/opencouncil/blob/9ae6a9d9d116b1c3917eab125cea293fd4d18dcf/src/lib/notifications/deliver.ts#L3299-L3313)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Successful SMS with no `messageId` incorrectly marks delivery as `failed`**

   The guard `smsResult.success && smsResult.messageId` causes `persistAndPollOutbound` to be skipped when `smsResult.success` is `true` but `messageId` is `undefined` (e.g., Bird's Messaging API response omits `id`). Control then falls through to the "Both failed" path which calls `updateDeliveryStatus(delivery.id, 'failed', undefined)` — the user receives the SMS but the delivery row is permanently marked failed, and any retry logic upstream will re-send.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/notifications/deliver.ts
   Line: 3299-3313

   Comment:
   **Successful SMS with no `messageId` incorrectly marks delivery as `failed`**

   The guard `smsResult.success && smsResult.messageId` causes `persistAndPollOutbound` to be skipped when `smsResult.success` is `true` but `messageId` is `undefined` (e.g., Bird's Messaging API response omits `id`). Control then falls through to the "Both failed" path which calls `updateDeliveryStatus(delivery.id, 'failed', undefined)` — the user receives the SMS but the delivery row is permanently marked failed, and any retry logic upstream will re-send.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

10. `src/app/api/webhooks/bird/route.ts`, line 1307-1342 ([link](https://github.com/schemalabz/opencouncil/blob/179e88cc49c1c41f7eead2b1e13597fe2ff763ae/src/app/api/webhooks/bird/route.ts#L1307-L1342)) 

    <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Unsubscribe silently skipped for replies to welcome messages**

    The `notificationDeliveryId` lookup only succeeds when the conversation already contains at least one outbound message that has a `notificationDeliveryId` set. Welcome messages are recorded without a delivery link (`notificationDeliveryId: null`) because there is no `NotificationDelivery` row for the welcome flow. A user who receives only a welcome message and replies "STOP" will have `notificationDeliveryId = null`, the unsubscribe guard `notificationDeliveryId && isUnsubscribeMessage(...)` will evaluate to `false`, and the user will not be unsubscribed — despite the PR's goal of "unsubscribe by reply."

    To catch this case, consider falling back to a phone-based user lookup when `notificationDeliveryId` is null: look up the `User` by `fields.phone` directly and proceed with the unsubscribe flow if a matching user exists.

    <details><summary>Prompt To Fix With AI</summary>

    `````markdown
    This is a comment left during a code review.
    Path: src/app/api/webhooks/bird/route.ts
    Line: 1307-1342

    Comment:
    **Unsubscribe silently skipped for replies to welcome messages**

    The `notificationDeliveryId` lookup only succeeds when the conversation already contains at least one outbound message that has a `notificationDeliveryId` set. Welcome messages are recorded without a delivery link (`notificationDeliveryId: null`) because there is no `NotificationDelivery` row for the welcome flow. A user who receives only a welcome message and replies "STOP" will have `notificationDeliveryId = null`, the unsubscribe guard `notificationDeliveryId && isUnsubscribeMessage(...)` will evaluate to `false`, and the user will not be unsubscribed — despite the PR's goal of "unsubscribe by reply."

    To catch this case, consider falling back to a phone-based user lookup when `notificationDeliveryId` is null: look up the `User` by `fields.phone` directly and proceed with the unsubscribe flow if a matching user exists.

    How can I resolve this? If you propose a fix, please make it concise.
    `````
    </details>

11. `src/app/[locale]/(other)/admin/conversations/actions.ts`, line 617-622 ([link](https://github.com/schemalabz/opencouncil/blob/07b3ecdd5be50f877f0d12fbfd443c783b8d2d0f/src/app/[locale]/(other)/admin/conversations/actions.ts#L617-L622)) 

    <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`result.success` not checked — outer `releaseNotifications` failure returns silent success**

    `releaseNotifications` catches top-level errors (e.g. `getPendingDeliveries` throws) and returns `{ success: false, failed: 0 }`. Because only `result.failed > 0` is checked here, that outer-failure case falls through to `return { success: true }` — the admin sees a green confirmation while no message was dispatched and no delivery row was ever transitioned from `pending`. Add `!result.success` to the failure guard.

    

    <details><summary>Prompt To Fix With AI</summary>

    `````markdown
    This is a comment left during a code review.
    Path: src/app/[locale]/(other)/admin/conversations/actions.ts
    Line: 617-622

    Comment:
    **`result.success` not checked — outer `releaseNotifications` failure returns silent success**

    `releaseNotifications` catches top-level errors (e.g. `getPendingDeliveries` throws) and returns `{ success: false, failed: 0 }`. Because only `result.failed > 0` is checked here, that outer-failure case falls through to `return { success: true }` — the admin sees a green confirmation while no message was dispatched and no delivery row was ever transitioned from `pending`. Add `!result.success` to the failure guard.

    

    How can I resolve this? If you propose a fix, please make it concise.
    `````
    </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/app/[locale]/(other)/admin/conversations/actions.ts:244-245
The `catch (error: any)` annotation violates the project style guide ("Never cast to any"). `error` is `unknown` by default in TypeScript 4.0+ catch clauses, and Prisma exposes a proper typed error class that can be used with `instanceof` or a targeted cast instead.

```suggestion
    } catch (error) {
        const prismaError = error as Prisma.PrismaClientKnownRequestError | undefined;
        if (prismaError?.code === 'P2002' && prismaError?.meta?.target?.includes('userId')) {
```


`````

</details>

<sub>Reviews (15): Last reviewed commit: ["test(notifications): add unit tests for ..."](https://github.com/schemalabz/opencouncil/commit/867daf552abe86e838e23b92406d4a68b6e43143) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30965110)</sub>

**Context used:**

- Context used - .cursor/rules/general.mdc ([source](https://app.greptile.com/review/custom-context?memory=dc2172bf-e821-4a8e-b26f-cd165ffe6599))

<!-- /greptile_comment -->