### PR TITLE
feat: meeting-level attendance and extended vote types

### DIFF
--- a/messages/el.json
+++ b/messages/el.json
@@ -824,7 +824,9 @@
         "rejectedVerdict": "Απορρίφθηκε",
         "voteFor": "Υπέρ",
         "voteAgainst": "Κατά",
-        "voteAbstain": "Λευκό"
+        "voteAbstain": "Λευκό",
+        "votePresent": "Παρών",
+        "voteDidNotVote": "Αποχή"
     },
     "PersonCard": {
         "party": "Παράταξη",

--- a/messages/el/admin.json
+++ b/messages/el/admin.json
@@ -242,6 +242,8 @@
       "voteFor": "υπέρ",
       "voteAgainst": "κατά",
       "voteAbstain": "λευκό",
+      "votePresent": "παρών",
+      "voteDidNotVote": "αποχή",
       "showMore": "Περισσότερα",
       "showLess": "Λιγότερα",
       "unanimous": "Ομόφωνα ({count} υπέρ)",

--- a/messages/en.json
+++ b/messages/en.json
@@ -844,6 +844,8 @@
         "voteFor": "For",
         "voteAgainst": "Against",
         "voteAbstain": "Abstain",
+        "votePresent": "Present",
+        "voteDidNotVote": "Did not vote",
         "groupedDiscussion": "Discussion grouped with other subjects",
         "groupedDiscussionDescription": "This subject appears to have been discussed and voted on together with other subjects. See the discussion at:"
     },

--- a/messages/en/admin.json
+++ b/messages/en/admin.json
@@ -242,6 +242,8 @@
       "voteFor": "for",
       "voteAgainst": "against",
       "voteAbstain": "abstain",
+      "votePresent": "present",
+      "voteDidNotVote": "did not vote",
       "showMore": "Show more",
       "showLess": "Show less",
       "unanimous": "Unanimous ({count} for)",

--- a/prisma/migrations/20260505000001_add_meeting_attendance_and_extended_vote_types/migration.sql
+++ b/prisma/migrations/20260505000001_add_meeting_attendance_and_extended_vote_types/migration.sql
@@ -1,0 +1,40 @@
+-- AlterEnum
+ALTER TYPE "VoteType" ADD VALUE 'PRESENT';
+ALTER TYPE "VoteType" ADD VALUE 'DID_NOT_VOTE';
+
+-- CreateTable
+CREATE TABLE "MeetingAttendance" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "councilMeetingId" TEXT NOT NULL,
+    "cityId" TEXT NOT NULL,
+    "personId" TEXT NOT NULL,
+    "status" "AttendanceStatus" NOT NULL,
+    "source" "DataSource" NOT NULL,
+    "taskId" TEXT,
+    "createdById" TEXT,
+
+    CONSTRAINT "MeetingAttendance_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MeetingAttendance_councilMeetingId_cityId_idx" ON "MeetingAttendance"("councilMeetingId", "cityId");
+
+-- CreateIndex
+CREATE INDEX "MeetingAttendance_personId_idx" ON "MeetingAttendance"("personId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MeetingAttendance_councilMeetingId_cityId_personId_source_key" ON "MeetingAttendance"("councilMeetingId", "cityId", "personId", "source");
+
+-- AddForeignKey
+ALTER TABLE "MeetingAttendance" ADD CONSTRAINT "MeetingAttendance_cityId_councilMeetingId_fkey" FOREIGN KEY ("cityId", "councilMeetingId") REFERENCES "CouncilMeeting"("cityId", "id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MeetingAttendance" ADD CONSTRAINT "MeetingAttendance_personId_fkey" FOREIGN KEY ("personId") REFERENCES "Person"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MeetingAttendance" ADD CONSTRAINT "MeetingAttendance_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "TaskStatus"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MeetingAttendance" ADD CONSTRAINT "MeetingAttendance_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -161,6 +161,7 @@ model Person {
   speakerContributions SpeakerContribution[]
   subjectAttendance SubjectAttendance[]
   subjectVotes SubjectVote[]
+  meetingAttendance MeetingAttendance[]
 
   @@index([cityId])
 }
@@ -190,6 +191,7 @@ model CouncilMeeting {
   highlights Highlight[]
   subjects Subject[]
   podcastSpecs PodcastSpec[]
+  meetingAttendance MeetingAttendance[]
 
   notifications Notification[]
   meetingOperator MeetingOperator?
@@ -238,6 +240,7 @@ model TaskStatus {
   decisions Decision[]
   subjectAttendance SubjectAttendance[]
   subjectVotes SubjectVote[]
+  meetingAttendance MeetingAttendance[]
 
   @@index([councilMeetingId, cityId])
 }
@@ -533,6 +536,32 @@ enum AttendanceStatus {
   ABSENT
 }
 
+model MeetingAttendance {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  councilMeeting   CouncilMeeting @relation(fields: [cityId, councilMeetingId], references: [cityId, id], onDelete: Cascade)
+  councilMeetingId String
+  cityId           String
+
+  person   Person @relation(fields: [personId], references: [id], onDelete: Cascade)
+  personId String
+
+  status AttendanceStatus // PRESENT | ABSENT at session start (initial roll call)
+  source DataSource       // decision | transcript | manual
+
+  // Track whether added by task or manually by user
+  task      TaskStatus? @relation(fields: [taskId], references: [id], onDelete: SetNull)
+  taskId    String?
+  createdBy User?       @relation(fields: [createdById], references: [id], onDelete: SetNull)
+  createdById String?
+
+  @@unique([councilMeetingId, cityId, personId, source])
+  @@index([councilMeetingId, cityId])
+  @@index([personId])
+}
+
 model SubjectVote {
   id        String   @id @default(cuid())
   createdAt DateTime @default(now())
@@ -559,9 +588,11 @@ model SubjectVote {
 }
 
 enum VoteType {
-  FOR      // ΥΠΕΡ
-  AGAINST  // ΚΑΤΑ
-  ABSTAIN  // ΛΕΥΚΟ
+  FOR           // ΥΠΕΡ — vote in favor
+  AGAINST       // ΚΑΤΑ — vote against
+  ABSTAIN       // ΛΕΥΚΟ — vote with no position (counts as a vote)
+  PRESENT       // ΠΑΡΩΝ — physically present but not participating in the vote (declaration, not a vote)
+  DID_NOT_VOTE  // ΑΠΟΧΗ — declined to participate (declaration, not a vote)
 }
 
 enum DataSource {
@@ -772,6 +803,7 @@ model User {
   meetingOperatorAssignments MeetingOperator[]
   subjectAttendance SubjectAttendance[]
   subjectVotes SubjectVote[]
+  meetingAttendance MeetingAttendance[]
   serviceApiKeys ServiceApiKey[]
 }
  

--- a/scripts/find-municipal-committee.ts
+++ b/scripts/find-municipal-committee.ts
@@ -1,0 +1,515 @@
+/**
+ * Find the Δημοτική Επιτροπή (Municipal Committee) for a given municipality.
+ *
+ * Searches Diavgeia for the committee election decision published at the
+ * start of each council term (1η Ειδική Συνεδρίαση), downloads the PDF,
+ * and uses Claude to extract structured committee composition.
+ *
+ * The Δημοτική Επιτροπή was introduced by N.5056/2023 (replacing Οικονομική
+ * Επιτροπή + Επιτροπή Ποιότητας Ζωής). It is elected at the special
+ * installation session of the new council. The decision is published on
+ * Diavgeia as type 2.4.7.1 (Λοιπές ατομικές διοικητικές πράξεις).
+ *
+ * Usage:
+ *   npx tsx scripts/find-municipal-committee.ts --org 6104
+ *   npx tsx scripts/find-municipal-committee.ts --name "Ζωγράφου"
+ *   npx tsx scripts/find-municipal-committee.ts --name "Χαλάνδρι" --json
+ *   npx tsx scripts/find-municipal-committee.ts --name "Ζωγράφου" --term 2024-2029
+ *
+ * Requires ANTHROPIC_API_KEY in .env or environment.
+ */
+
+import { execSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import Anthropic from '@anthropic-ai/sdk'
+import dotenv from 'dotenv'
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+
+dotenv.config()
+
+// ---------------------------------------------------------------------------
+// Diavgeia API helpers
+// ---------------------------------------------------------------------------
+
+const BASE_URL = 'https://diavgeia.gov.gr'
+
+type Organization = {
+  uid: string
+  label: string
+  category?: string
+  status?: string
+}
+
+type Decision = {
+  ada: string
+  subject: string
+  issueDate: number
+  organizationId: string
+  decisionTypeId: string
+  documentUrl: string
+  [key: string]: unknown
+}
+
+type SearchResponse = {
+  info: { total: number; page: number; size: number }
+  decisions: Decision[]
+}
+
+async function diavgeiaApi<T>(
+  path: string,
+  params?: Record<string, string | number | undefined>
+): Promise<T> {
+  const url = new URL(`/luminapi/opendata${path}`, BASE_URL)
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      if (v !== undefined) url.searchParams.set(k, String(v))
+    }
+  }
+  const res = await fetch(url.toString(), { signal: AbortSignal.timeout(30_000) })
+  if (!res.ok) throw new Error(`Diavgeia API ${res.status}: ${url}`)
+  return res.json() as Promise<T>
+}
+
+async function diavgeiaSearch(
+  params: Record<string, string | number | undefined>
+): Promise<SearchResponse> {
+  const url = new URL('/opendata/search.json', BASE_URL)
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined) url.searchParams.set(k, String(v))
+  }
+  const res = await fetch(url.toString(), { signal: AbortSignal.timeout(30_000) })
+  if (!res.ok) throw new Error(`Diavgeia search API ${res.status}: ${url}`)
+  return res.json() as Promise<SearchResponse>
+}
+
+async function diavgeiaSearchAdvanced(
+  q: string,
+  page = 0,
+  size = 50
+): Promise<SearchResponse> {
+  const url = new URL('/opendata/search/advanced.json', BASE_URL)
+  url.searchParams.set('q', q)
+  url.searchParams.set('page', String(page))
+  url.searchParams.set('size', String(size))
+  const res = await fetch(url.toString(), { signal: AbortSignal.timeout(30_000) })
+  if (!res.ok) throw new Error(`Diavgeia advanced search API ${res.status}: ${url}`)
+  return res.json() as Promise<SearchResponse>
+}
+
+// ---------------------------------------------------------------------------
+// Greek text helpers
+// ---------------------------------------------------------------------------
+
+function normalizeGreek(str: string): string {
+  return str
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toUpperCase()
+    .replace(/Ϊ/g, 'Ι')
+    .replace(/Ϋ/g, 'Υ')
+}
+
+function msToDate(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10)
+}
+
+// ---------------------------------------------------------------------------
+// Council term helpers
+// ---------------------------------------------------------------------------
+
+const TERM_STARTS: Record<string, { from: string; to: string }> = {
+  '2024-2029': { from: '2024-01-01', to: '2024-03-31' },
+  '2019-2023': { from: '2019-09-01', to: '2019-12-31' },
+}
+
+const DEFAULT_TERM = '2024-2029'
+
+// ---------------------------------------------------------------------------
+// Find the municipality org ID
+// ---------------------------------------------------------------------------
+
+async function findOrganization(name: string): Promise<Organization | null> {
+  const { organizations } = await diavgeiaApi<{ organizations: Organization[] }>(
+    '/organizations.json',
+    { category: 'MUNICIPALITY' }
+  )
+
+  const normalized = normalizeGreek(name)
+
+  const exact = organizations.find(
+    (o) => normalizeGreek(o.label) === `ΔΗΜΟΣ ${normalized}`
+  )
+  if (exact) return exact
+
+  const partial = organizations.find((o) =>
+    normalizeGreek(o.label).includes(normalized)
+  )
+  if (partial) return partial
+
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Search strategies to find the committee election decision
+// ---------------------------------------------------------------------------
+
+const SUBJECT_SEARCHES = [
+  'εκλογή μελών δημοτική επιτροπή',
+  'εκλογή μελών δημοτικής επιτροπής',
+  'εκλογή δημοτική επιτροπή',
+]
+
+function isCommitteeElection(d: Decision): boolean {
+  const subj = normalizeGreek(d.subject)
+  if (subj.includes('ΑΝΤΙΠΡΟΕΔΡ')) return false
+  return (
+    subj.includes('ΕΚΛΟΓ') &&
+    (subj.includes('ΔΗΜΟΤΙΚΗ') || subj.includes('ΔΗΜΟΤΙΚΗΣ')) &&
+    (subj.includes('ΕΠΙΤΡΟΠΗ') || subj.includes('ΕΠΙΤΡΟΠΗΣ'))
+  )
+}
+
+async function findCommitteeDecision(
+  orgId: string,
+  dateRange: { from: string; to: string }
+): Promise<Decision | null> {
+  // Strategy 1: Advanced search with subject-word patterns
+  for (const subjectWords of SUBJECT_SEARCHES) {
+    const tokens = subjectWords
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((t) => `subject:${t}`)
+      .join(' AND ')
+    const q = `organizationUid:${orgId} AND ${tokens}`
+
+    try {
+      const result = await diavgeiaSearchAdvanced(q)
+      if (result.decisions.length > 0) {
+        const inRange = result.decisions.filter((d) => {
+          const date = msToDate(d.issueDate)
+          return date >= dateRange.from && date <= dateRange.to
+        })
+        if (inRange.length > 0) return inRange[0]
+        return result.decisions[0]
+      }
+    } catch {
+      // Some query patterns may 400, try next
+    }
+  }
+
+  // Strategy 2: Scan all decisions in the date range, filter locally
+  console.error(
+    'Subject-word search did not match, scanning decisions in the installation period...'
+  )
+
+  let page = 0
+  const size = 500
+  while (true) {
+    const result = await diavgeiaSearch({
+      org: orgId,
+      from_issue_date: dateRange.from,
+      to_issue_date: dateRange.to,
+      size,
+      page,
+    })
+    const match = result.decisions.find(isCommitteeElection)
+    if (match) return match
+
+    const totalPages = Math.ceil(result.info.total / size)
+    page++
+    if (page >= totalPages) break
+  }
+
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// PDF download and text extraction
+// ---------------------------------------------------------------------------
+
+async function downloadPdf(ada: string): Promise<string> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'committee-'))
+  const pdfPath = path.join(tmpDir, `${ada}.pdf`)
+
+  const docUrl = `${BASE_URL}/luminapi/opendata/decisions/${encodeURIComponent(ada)}/document`
+  const res = await fetch(docUrl, { signal: AbortSignal.timeout(60_000) })
+  if (!res.ok) throw new Error(`Failed to download PDF for ${ada}: ${res.status}`)
+
+  const buffer = Buffer.from(await res.arrayBuffer())
+  fs.writeFileSync(pdfPath, buffer)
+  return pdfPath
+}
+
+function pdfToText(pdfPath: string): string {
+  try {
+    return execSync(`pdftotext "${pdfPath}" -`, {
+      maxBuffer: 10 * 1024 * 1024,
+    }).toString('utf-8')
+  } catch {
+    throw new Error(
+      `pdftotext failed — is poppler-utils installed? (path: ${pdfPath})`
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// LLM-based extraction
+// ---------------------------------------------------------------------------
+
+type CommitteeMember = {
+  name: string
+  side: 'majority' | 'minority' | 'unknown'
+}
+
+type CommitteeData = {
+  regular: CommitteeMember[]
+  alternate: CommitteeMember[]
+  president: string | null
+  vicePresident: string | null
+  termStart: string | null
+  termEnd: string | null
+}
+
+const EXTRACTION_PROMPT = `You are extracting structured data from a Greek municipal council decision document about the election of a Δημοτική Επιτροπή (Municipal Committee).
+
+The document is the minutes (πρακτικό) of the special installation session where committee members are elected. Extract the FINAL elected composition — the authoritative list that appears near the end of the document after phrases like "ανακοίνωσε τα ονόματα", "ως εξής", or "ΤΑΚΤΙΚΑ ΜΕΛΗ" / "ΑΝΑΠΛΗΡΩΜΑΤΙΚΑ ΜΕΛΗ".
+
+Do NOT extract intermediate vote tallies or candidate lists — only the final elected members.
+
+Return a JSON object with this exact structure:
+{
+  "regular": [
+    { "name": "FULL NAME", "side": "majority" | "minority" }
+  ],
+  "alternate": [
+    { "name": "FULL NAME", "side": "majority" | "minority" }
+  ],
+  "president": "name or null",
+  "vicePresident": "name or null",
+  "termStart": "DD-MM-YYYY or null",
+  "termEnd": "DD-MM-YYYY or null"
+}
+
+Rules:
+- "side" is "majority" if the member represents the mayor's faction (παράταξη Δημάρχου, εκ μέρους της πλειοψηφίας), "minority" otherwise (παρατάξεις μειοψηφίας, εκ μέρους της μειοψηφίας).
+- Include nicknames in parentheses as part of the name, e.g. "ΣΤΑΜΑΤΑΚΗΣ ΖΑΧΑΡΙΑΣ (ΧΑΡΗΣ)"
+- The president (πρόεδρος) of the committee is the mayor (Δήμαρχος) by law — extract their name if mentioned.
+- The vice-president (αντιπρόεδρος) may or may not be mentioned in this document.
+- For term dates, look for phrases like "07-01-2024 έως 30-06-2026".
+- Return ONLY the JSON, no markdown fences, no explanation.`
+
+async function extractWithLLM(
+  anthropic: Anthropic,
+  pdfText: string
+): Promise<CommitteeData> {
+  const response = await anthropic.messages.create({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 2048,
+    messages: [
+      {
+        role: 'user',
+        content: `${EXTRACTION_PROMPT}\n\n---\nDOCUMENT TEXT:\n${pdfText}`,
+      },
+    ],
+  })
+
+  const text =
+    response.content[0].type === 'text' ? response.content[0].text : ''
+
+  // Strip markdown fences if present
+  const jsonStr = text.replace(/^```json?\n?/m, '').replace(/\n?```$/m, '')
+
+  try {
+    const data = JSON.parse(jsonStr)
+    return {
+      regular: data.regular ?? [],
+      alternate: data.alternate ?? [],
+      president: data.president ?? null,
+      vicePresident: data.vicePresident ?? null,
+      termStart: data.termStart ?? null,
+      termEnd: data.termEnd ?? null,
+    }
+  } catch (e) {
+    throw new Error(
+      `Failed to parse LLM response as JSON: ${e}\nResponse: ${text.slice(0, 500)}`
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const argv = await yargs(hideBin(process.argv))
+    .option('org', {
+      type: 'string',
+      description: 'Diavgeia organization UID (e.g. 6104)',
+    })
+    .option('name', {
+      type: 'string',
+      description: 'Municipality name to search for (e.g. "Ζωγράφου")',
+    })
+    .option('term', {
+      type: 'string',
+      default: DEFAULT_TERM,
+      description: 'Council term period (e.g. 2024-2029)',
+    })
+    .option('json', {
+      type: 'boolean',
+      default: false,
+      description: 'Output as JSON',
+    })
+    .check((argv) => {
+      if (!argv.org && !argv.name) {
+        throw new Error('Provide either --org or --name')
+      }
+      return true
+    }).argv
+
+  const anthropic = new Anthropic({
+    apiKey: process.env.ANTHROPIC_API_KEY!,
+  })
+
+  // Resolve org ID
+  let orgId = argv.org
+  let orgLabel: string | undefined
+
+  if (!orgId) {
+    console.error(`Searching for municipality "${argv.name}"...`)
+    const org = await findOrganization(argv.name!)
+    if (!org) {
+      console.error(`Could not find municipality matching "${argv.name}"`)
+      process.exit(1)
+    }
+    orgId = org.uid
+    orgLabel = org.label
+    console.error(`Found: ${org.label} (uid: ${org.uid})`)
+  } else {
+    try {
+      const org = await diavgeiaApi<Organization>(
+        `/organizations/${orgId}.json`
+      )
+      orgLabel = org.label
+      console.error(`Organization: ${org.label} (uid: ${orgId})`)
+    } catch {
+      console.error(`Warning: could not fetch org details for uid ${orgId}`)
+    }
+  }
+
+  // Determine date range for the term
+  const dateRange = TERM_STARTS[argv.term]
+  if (!dateRange) {
+    console.error(
+      `Unknown term "${argv.term}". Known terms: ${Object.keys(TERM_STARTS).join(', ')}`
+    )
+    process.exit(1)
+  }
+
+  // Find the committee election decision
+  console.error(
+    `Searching for committee election decision (term ${argv.term})...`
+  )
+  const decision = await findCommitteeDecision(orgId, dateRange)
+
+  if (!decision) {
+    console.error(
+      'Could not find a committee election decision for this municipality and term.'
+    )
+    process.exit(1)
+  }
+
+  console.error(
+    `Found decision: ${decision.ada} (${msToDate(decision.issueDate)})`
+  )
+  console.error(`Subject: ${decision.subject}`)
+
+  // Download PDF and extract text
+  console.error('Downloading PDF...')
+  const pdfPath = await downloadPdf(decision.ada)
+  const pdfText = pdfToText(pdfPath)
+  fs.unlinkSync(pdfPath)
+
+  // Extract committee composition via LLM
+  console.error('Extracting committee composition...')
+  const committee = await extractWithLLM(anthropic, pdfText)
+
+  // Build output
+  const output = {
+    municipality: {
+      uid: orgId,
+      label: orgLabel || orgId,
+    },
+    term: argv.term,
+    decision: {
+      ada: decision.ada,
+      subject: decision.subject,
+      issueDate: msToDate(decision.issueDate),
+      url: `https://diavgeia.gov.gr/doc/${decision.ada}`,
+    },
+    committee,
+  }
+
+  if (argv.json) {
+    console.log(JSON.stringify(output, null, 2))
+  } else {
+    console.log()
+    console.log(`=== Δημοτική Επιτροπή — ${orgLabel || orgId} ===`)
+    console.log()
+    console.log(`Απόφαση:  ${decision.ada}`)
+    console.log(`URL:      https://diavgeia.gov.gr/doc/${decision.ada}`)
+    console.log(`Ημ/νία:   ${msToDate(decision.issueDate)}`)
+    if (committee.termStart && committee.termEnd) {
+      console.log(`Θητεία:   ${committee.termStart} — ${committee.termEnd}`)
+    }
+    if (committee.president) {
+      console.log(`Πρόεδρος: ${committee.president}`)
+    }
+    if (committee.vicePresident) {
+      console.log(`Αντιπρόεδρος: ${committee.vicePresident}`)
+    }
+    console.log()
+
+    if (committee.regular.length > 0) {
+      console.log('ΤΑΚΤΙΚΑ ΜΕΛΗ:')
+      for (const m of committee.regular) {
+        const sideLabel =
+          m.side === 'majority'
+            ? 'πλειοψηφία'
+            : m.side === 'minority'
+              ? 'μειοψηφία'
+              : ''
+        console.log(`  ${m.name}${sideLabel ? `  (${sideLabel})` : ''}`)
+      }
+      console.log()
+    }
+
+    if (committee.alternate.length > 0) {
+      console.log('ΑΝΑΠΛΗΡΩΜΑΤΙΚΑ ΜΕΛΗ:')
+      for (const m of committee.alternate) {
+        const sideLabel =
+          m.side === 'majority'
+            ? 'πλειοψηφία'
+            : m.side === 'minority'
+              ? 'μειοψηφία'
+              : ''
+        console.log(`  ${m.name}${sideLabel ? `  (${sideLabel})` : ''}`)
+      }
+      console.log()
+    }
+
+    if (committee.regular.length === 0 && committee.alternate.length === 0) {
+      console.log(
+        'WARNING: Could not extract member names. Check the decision URL manually.'
+      )
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(`Error: ${err.message}`)
+  process.exit(1)
+})

--- a/src/app/api/cities/[cityId]/meetings/[meetingId]/decisions/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/[meetingId]/decisions/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { withUserAuthorizedToEdit } from '@/lib/auth';
-import { getDecisionsForMeeting, getExtractedDataForMeeting, upsertDecision, deleteDecision, clearExtractedDataForMeeting } from '@/lib/db/decisions';
+import { getDecisionsForMeeting, getExtractedDataForMeeting, getMeetingAttendance, upsertDecision, deleteDecision, clearExtractedDataForMeeting } from '@/lib/db/decisions';
 import prisma from '@/lib/db/prisma';
 import { revalidateTag } from 'next/cache';
 import { z } from 'zod';
@@ -12,11 +12,12 @@ export async function GET(
 ) {
     await withUserAuthorizedToEdit({ cityId: params.cityId });
 
-    const [decisions, extractedData] = await Promise.all([
+    const [decisions, extractedData, meetingAttendance] = await Promise.all([
         getDecisionsForMeeting(params.cityId, params.meetingId),
         getExtractedDataForMeeting(params.cityId, params.meetingId),
+        getMeetingAttendance(params.cityId, params.meetingId),
     ]);
-    return NextResponse.json({ decisions, extractedData });
+    return NextResponse.json({ decisions, extractedData, meetingAttendance });
 }
 
 const upsertSchema = z.object({

--- a/src/components/meetings/admin/DecisionsPanel.tsx
+++ b/src/components/meetings/admin/DecisionsPanel.tsx
@@ -12,7 +12,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useCouncilMeetingData } from '../CouncilMeetingDataContext';
 import { useTranslations } from 'next-intl';
 import { ExternalLink, Trash2, FileCheck, FileX, Loader2, Bot, UserIcon, Plus, X, Clock, ChevronRight, ChevronDown, Users, Vote, Eraser, Search } from 'lucide-react';
-import { DecisionWithSource, SubjectExtractedData } from '@/lib/db/decisions';
+import { DecisionWithSource, MeetingAttendanceRecord, SubjectExtractedData } from '@/lib/db/decisions';
 import { LinkOrDrop } from '@/components/ui/link-or-drop';
 import { getPollingHistoryForMeeting, requestPollDecisions } from '@/lib/tasks/pollDecisions';
 import { calculateVoteResult } from '@/lib/utils/votes';
@@ -88,12 +88,51 @@ function NameList({ names, label }: { names: string[]; label: string }) {
     );
 }
 
+function MeetingAttendanceSummary({ attendance }: { attendance: MeetingAttendanceRecord[] }) {
+    const [expanded, setExpanded] = useState(false);
+    const present = attendance.filter(a => a.status === 'PRESENT');
+    const absent = attendance.filter(a => a.status === 'ABSENT');
+
+    return (
+        <div className="border rounded-lg p-2.5 bg-muted/30">
+            <button
+                onClick={() => setExpanded(!expanded)}
+                className="flex items-center gap-1.5 w-full text-left"
+            >
+                {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                <Users className="h-3.5 w-3.5" />
+                <span className="text-xs font-medium">
+                    Initial roll call
+                </span>
+                <span className="text-xs text-muted-foreground ml-1">
+                    {present.length} present, {absent.length} absent ({attendance.length} total)
+                </span>
+            </button>
+            {expanded && (
+                <div className="mt-2 ml-5 space-y-1.5">
+                    <div>
+                        <span className="text-[11px] font-medium text-green-700">Present ({present.length})</span>
+                        <p className="text-[11px] text-muted-foreground">{present.map(a => a.person.name).join(', ')}</p>
+                    </div>
+                    {absent.length > 0 && (
+                        <div>
+                            <span className="text-[11px] font-medium text-red-700">Absent ({absent.length})</span>
+                            <p className="text-[11px] text-muted-foreground">{absent.map(a => a.person.name).join(', ')}</p>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
 export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
     const { toast } = useToast();
     const { subjects, meeting } = useCouncilMeetingData();
     const t = useTranslations('admin.adminActions');
     const [decisions, setDecisions] = useState<Record<string, DecisionWithSource>>({});
     const [extractedData, setExtractedData] = useState<Record<string, SubjectExtractedData>>({});
+    const [meetingAttendance, setMeetingAttendance] = useState<MeetingAttendanceRecord[]>([]);
     const [expandedManualEntry, setExpandedManualEntry] = useState<string | null>(null);
     const [expandedExtracted, setExpandedExtracted] = useState<string | null>(null);
     const [editState, setEditState] = useState<ManualEntryState>({ pdfUrl: '', ada: '', protocolNumber: '', title: '' });
@@ -113,7 +152,7 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
         try {
             const response = await fetch(`/api/cities/${meeting.cityId}/meetings/${meeting.id}/decisions`);
             if (!response.ok) return;
-            const data: { decisions: DecisionWithSource[]; extractedData: SubjectExtractedData[] } = await response.json();
+            const data: { decisions: DecisionWithSource[]; extractedData: SubjectExtractedData[]; meetingAttendance: MeetingAttendanceRecord[] } = await response.json();
             const decisionMap: Record<string, DecisionWithSource> = {};
             for (const d of data.decisions) {
                 decisionMap[d.subjectId] = d;
@@ -124,6 +163,7 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
                 extractedMap[e.subjectId] = e;
             }
             setExtractedData(extractedMap);
+            setMeetingAttendance(data.meetingAttendance || []);
         } catch {
             // silent
         } finally {
@@ -429,6 +469,11 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
                         </div>
                     )}
                 </div>
+
+                {/* Meeting-level attendance (initial roll call) */}
+                {meetingAttendance.length > 0 && (
+                    <MeetingAttendanceSummary attendance={meetingAttendance} />
+                )}
 
                 {/* Filter tabs */}
                 <div className="flex rounded-lg border p-0.5 bg-muted/50 self-start">

--- a/src/components/meetings/admin/MinutesPreviewContent.tsx
+++ b/src/components/meetings/admin/MinutesPreviewContent.tsx
@@ -48,9 +48,9 @@ export function MinutesPreviewContent({ data }: MinutesPreviewContentProps) {
 
             <hr className="my-8 border-gray-300" />
 
-            {/* Council Composition */}
+            {/* Council Composition + Absent Members */}
             {data.councilComposition && (
-                <CouncilCompositionSection composition={data.councilComposition} />
+                <CouncilCompositionSection composition={data.councilComposition} absentMembers={data.absentMembers} />
             )}
 
             {/* Table of Contents */}
@@ -79,14 +79,19 @@ export function MinutesPreviewContent({ data }: MinutesPreviewContentProps) {
     );
 }
 
-function CouncilCompositionSection({ composition }: { composition: MinutesCouncilComposition }) {
+function CouncilCompositionSection({ composition, absentMembers }: {
+    composition: MinutesCouncilComposition;
+    absentMembers: MinutesMember[] | null;
+}) {
+    const absentPersonIds = new Set(absentMembers?.map(m => m.personId) ?? []);
+
     return (
         <div className="mb-8">
             {composition.mayor && (
                 <p className="text-sm mb-1">
                     <span className="font-bold">ΔΗΜΑΡΧΟΣ: </span>
                     {composition.mayor.name}
-                    {!composition.mayor.present && (
+                    {absentPersonIds.has(composition.mayor.personId) && (
                         <span className="text-gray-500"> (ΑΠΩΝ)</span>
                     )}
                 </p>
@@ -96,7 +101,7 @@ function CouncilCompositionSection({ composition }: { composition: MinutesCounci
                 <p className="text-sm mb-4">
                     <span className="font-bold">ΠΡΟΕΔΡΟΣ: </span>
                     {composition.president.name}
-                    {!composition.president.present && (
+                    {absentPersonIds.has(composition.president.personId) && (
                         <span className="text-gray-500"> (ΑΠΩΝ)</span>
                     )}
                 </p>
@@ -115,6 +120,19 @@ function CouncilCompositionSection({ composition }: { composition: MinutesCounci
                     </li>
                 ))}
             </ul>
+
+            {absentMembers && absentMembers.length > 0 && (() => {
+                const absentListMembers = absentMembers.filter(m =>
+                    !composition.mayor || m.personId !== composition.mayor.personId
+                );
+                return absentListMembers.length > 0 ? (
+                    <p className="text-sm mt-4">
+                        <span className="font-bold">ΑΠΟΝΤΕΣ ({absentListMembers.length}): </span>
+                        {absentListMembers.map(m => m.name).join(', ')}
+                    </p>
+                ) : null;
+            })()}
+
 
             <hr className="my-8 border-gray-300" />
         </div>

--- a/src/components/meetings/admin/MinutesPreviewContent.tsx
+++ b/src/components/meetings/admin/MinutesPreviewContent.tsx
@@ -128,8 +128,8 @@ function CouncilCompositionSection({ composition, absentMembers }: {
                 );
                 return absentListMembers.length > 0 ? (
                     <p className="text-sm mt-4">
-                        <span className="font-bold">ΑΠΟΝΤΕΣ ({absentListMembers.length}): </span>
-                        {absentListMembers.map(m => m.name).join(', ')}
+                        Κατά την έναρξη της συνεδρίασης απουσίαζαν οι {absentListMembers.map(m => m.name).join(', ')}
+                        <span className="text-gray-500"> ({absentListMembers.length})</span>
                     </p>
                 ) : null;
             })()}

--- a/src/components/meetings/admin/MinutesPreviewContent.tsx
+++ b/src/components/meetings/admin/MinutesPreviewContent.tsx
@@ -32,7 +32,7 @@ export function MinutesPreviewContent({ data }: MinutesPreviewContentProps) {
             <div className="text-center mb-12 pt-16">
                 <p className="text-base mb-2">{data.city.name_municipality}</p>
                 {data.administrativeBody && (
-                    <p className="text-base mb-2">{data.administrativeBody}</p>
+                    <p className="text-base mb-2">{data.administrativeBody.name}</p>
                 )}
                 <h1 className="text-xl font-bold mt-6 mb-3">ΠΡΑΚΤΙΚΑ ΣΥΝΕΔΡΙΑΣΗΣ</h1>
                 <p className="text-base font-bold mb-3">{data.meeting.name}</p>
@@ -51,7 +51,7 @@ export function MinutesPreviewContent({ data }: MinutesPreviewContentProps) {
 
             {/* Council Composition + Absent Members */}
             {data.councilComposition && (
-                <CouncilCompositionSection composition={data.councilComposition} absentMembers={data.absentMembers} />
+                <CouncilCompositionSection composition={data.councilComposition} absentMembers={data.absentMembers} adminBody={data.administrativeBody} />
             )}
 
             {/* Table of Contents */}
@@ -80,15 +80,17 @@ export function MinutesPreviewContent({ data }: MinutesPreviewContentProps) {
     );
 }
 
-function CouncilCompositionSection({ composition, absentMembers }: {
+function CouncilCompositionSection({ composition, absentMembers, adminBody }: {
     composition: MinutesCouncilComposition;
     absentMembers: MinutesMember[] | null;
+    adminBody: { name: string; type: string } | null;
 }) {
     const absentPersonIds = new Set(absentMembers?.map(m => m.personId) ?? []);
+    const isCommittee = adminBody?.type === 'committee';
 
     return (
         <div className="mb-8">
-            {composition.mayor && (
+            {!isCommittee && composition.mayor && (
                 <p className="text-sm mb-1">
                     <span className="font-bold">ΔΗΜΑΡΧΟΣ: </span>
                     {composition.mayor.name}
@@ -102,41 +104,108 @@ function CouncilCompositionSection({ composition, absentMembers }: {
                 <p className="text-sm mb-4">
                     <span className="font-bold">ΠΡΟΕΔΡΟΣ: </span>
                     {composition.president.name}
+                    {isCommittee && ' (ΔΗΜΑΡΧΟΣ)'}
                     {absentPersonIds.has(composition.president.personId) && (
                         <span className="text-gray-500"> ({getAbsentLabel(extractFirstName(composition.president.name, 'surnameFirst'))})</span>
                     )}
                 </p>
             )}
 
-            <h2 className="text-base font-bold mb-3">
-                ΣΥΝΘΕΣΗ ΔΗΜΟΤΙΚΟΥ ΣΥΜΒΟΥΛΙΟΥ ({composition.members.length})
-            </h2>
-            <ul className="list-disc pl-6 space-y-1">
-                {composition.members.map((member) => (
-                    <li key={member.personId}>
-                        <span>{member.name}</span>
-                        {member.party && (
-                            <span className="text-gray-500"> ({member.party}{member.isPartyHead ? ', Επικεφαλής' : ''})</span>
-                        )}
-                    </li>
-                ))}
-            </ul>
+            {!isCommittee && (
+                <h2 className="text-base font-bold mb-3">
+                    ΣΥΝΘΕΣΗ ΔΗΜΟΤΙΚΟΥ ΣΥΜΒΟΥΛΙΟΥ ({composition.members.length})
+                </h2>
+            )}
 
-            {absentMembers && absentMembers.length > 0 && (() => {
-                const absentListMembers = absentMembers.filter(m =>
-                    !composition.mayor || m.personId !== composition.mayor.personId
-                );
-                return absentListMembers.length > 0 ? (
-                    <p className="text-sm mt-4">
-                        Κατά την έναρξη της συνεδρίασης απουσίαζαν οι {absentListMembers.map(m => m.name).join(', ')}
-                        <span className="text-gray-500"> ({absentListMembers.length})</span>
-                    </p>
-                ) : null;
-            })()}
+            {isCommittee ? (
+                <CommitteeAttendanceSection composition={composition} absentMembers={absentMembers} />
+            ) : (
+                <>
+                    <ul className="list-disc pl-6 space-y-1">
+                        {composition.members.map((member) => (
+                            <li key={member.personId}>
+                                <span>{member.name}</span>
+                                {member.party && (
+                                    <span className="text-gray-500"> ({member.party}{member.isPartyHead ? ', Επικεφαλής' : ''})</span>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
 
+                    {absentMembers && absentMembers.length > 0 && (() => {
+                        const absentListMembers = absentMembers.filter(m =>
+                            (!composition.mayor || m.personId !== composition.mayor.personId) &&
+                            (!composition.president || m.personId !== composition.president.personId)
+                        );
+                        return absentListMembers.length > 0 ? (
+                            <p className="text-sm mt-4">
+                                Κατά την έναρξη της συνεδρίασης απουσίαζαν οι {absentListMembers.map(m => m.name).join(', ')}
+                                <span className="text-gray-500"> ({absentListMembers.length})</span>
+                            </p>
+                        ) : null;
+                    })()}
+                </>
+            )}
 
             <hr className="my-8 border-gray-300" />
         </div>
+    );
+}
+
+/** Strip Greek diacritics — uppercase Greek convention omits accents (τόνοι). */
+function stripDiacritics(text: string): string {
+    return text.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+/**
+ * Committee-specific attendance: ΠΑΡΟΝΤΑ ΜΕΛΗ and ΑΠΟΝΤΑ ΜΕΛΗ as bullet lists,
+ * with (αναπλ. μέλος) notation for substitute members.
+ */
+function CommitteeAttendanceSection({ composition, absentMembers }: {
+    composition: MinutesCouncilComposition;
+    absentMembers: MinutesMember[] | null;
+}) {
+    const substituteIds = new Set(composition.substituteMembers.map(m => m.personId));
+    const absentPersonIds = new Set(absentMembers?.map(m => m.personId) ?? []);
+
+    const allMembers = [...composition.members, ...composition.substituteMembers];
+    const presentMembers = allMembers.filter(m => !absentPersonIds.has(m.personId));
+    const absentMembersList = allMembers.filter(m => absentPersonIds.has(m.personId));
+
+    const renderMember = (m: MinutesMember) => {
+        const labels: string[] = [];
+        if (substituteIds.has(m.personId)) labels.push('αναπλ. μέλος');
+        if (m.party) labels.push(m.isPartyHead ? `${m.party}, Επικεφαλής` : m.party);
+        return (
+            <li key={m.personId}>
+                <span>{m.name}</span>
+                {labels.length > 0 && (
+                    <span className="text-gray-500"> ({labels.join(', ')})</span>
+                )}
+            </li>
+        );
+    };
+
+    return (
+        <>
+            {presentMembers.length > 0 && (
+                <>
+                    <p className="text-sm font-bold mt-2 mb-1">ΠΑΡΟΝΤΑ ΜΕΛΗ ({presentMembers.length})</p>
+                    <ul className="list-disc pl-6 space-y-1">
+                        {presentMembers.map(renderMember)}
+                    </ul>
+                </>
+            )}
+
+            {absentMembersList.length > 0 && (
+                <>
+                    <p className="text-sm font-bold mt-4 mb-1">ΑΠΟΝΤΑ ΜΕΛΗ ({absentMembersList.length})</p>
+                    <ul className="list-disc pl-6 space-y-1">
+                        {absentMembersList.map(renderMember)}
+                    </ul>
+                </>
+            )}
+        </>
     );
 }
 

--- a/src/components/meetings/admin/MinutesPreviewContent.tsx
+++ b/src/components/meetings/admin/MinutesPreviewContent.tsx
@@ -2,6 +2,7 @@
 
 import { formatTimestamp } from '@/lib/utils';
 import { formatGapDuration } from '@/lib/formatters/time';
+import { getAbsentLabel, extractFirstName } from '@/lib/formatters/name';
 import { el } from 'date-fns/locale';
 import { formatInTimeZone } from 'date-fns-tz';
 import {
@@ -92,7 +93,7 @@ function CouncilCompositionSection({ composition, absentMembers }: {
                     <span className="font-bold">ΔΗΜΑΡΧΟΣ: </span>
                     {composition.mayor.name}
                     {absentPersonIds.has(composition.mayor.personId) && (
-                        <span className="text-gray-500"> (ΑΠΩΝ)</span>
+                        <span className="text-gray-500"> ({getAbsentLabel(extractFirstName(composition.mayor.name, 'surnameFirst'))})</span>
                     )}
                 </p>
             )}
@@ -102,7 +103,7 @@ function CouncilCompositionSection({ composition, absentMembers }: {
                     <span className="font-bold">ΠΡΟΕΔΡΟΣ: </span>
                     {composition.president.name}
                     {absentPersonIds.has(composition.president.personId) && (
-                        <span className="text-gray-500"> (ΑΠΩΝ)</span>
+                        <span className="text-gray-500"> ({getAbsentLabel(extractFirstName(composition.president.name, 'surnameFirst'))})</span>
                     )}
                 </p>
             )}

--- a/src/components/meetings/admin/MinutesPreviewContent.tsx
+++ b/src/components/meetings/admin/MinutesPreviewContent.tsx
@@ -265,6 +265,18 @@ function SubjectFooter({ subject }: { subject: MinutesSubject }) {
                             {formatMemberList(subject.voteResult.abstainMembers)}
                         </p>
                     )}
+                    {subject.voteResult.presentMembers.length > 0 && (
+                        <p className="my-0.5">
+                            <span className="font-bold">ΠΑΡΟΝΤΕΣ ({subject.voteResult.presentMembers.length}): </span>
+                            {formatMemberList(subject.voteResult.presentMembers)}
+                        </p>
+                    )}
+                    {subject.voteResult.didNotVoteMembers.length > 0 && (
+                        <p className="my-0.5">
+                            <span className="font-bold">ΑΠΟΧΗ ({subject.voteResult.didNotVoteMembers.length}): </span>
+                            {formatMemberList(subject.voteResult.didNotVoteMembers)}
+                        </p>
+                    )}
                     {subject.voteResult.absentMembers.length > 0 && (
                         <p className="my-0.5">
                             <span className="font-bold">ΑΠΟΝΤΕΣ ({subject.voteResult.absentMembers.length}): </span>

--- a/src/components/meetings/admin/MinutesPreviewDialog.tsx
+++ b/src/components/meetings/admin/MinutesPreviewDialog.tsx
@@ -85,7 +85,7 @@ export function MinutesPreviewDialog({ open, onOpenChange }: MinutesPreviewDialo
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-5xl max-h-[90vh] flex flex-col">
+            <DialogContent align="start" className="max-w-5xl max-h-[90vh] flex flex-col">
                 <DialogHeader>
                     <DialogTitle>{t('minutes.title')}</DialogTitle>
                     <DialogDescription>{meeting.name}</DialogDescription>

--- a/src/components/meetings/docx/MinutesDocx.ts
+++ b/src/components/meetings/docx/MinutesDocx.ts
@@ -7,6 +7,7 @@ import {
 } from 'docx';
 import { formatTimestamp } from '@/lib/utils';
 import { formatGapDuration } from '@/lib/formatters/time';
+import { getAbsentLabel, extractFirstName } from '@/lib/formatters/name';
 import { markdownToDocxParagraphs } from '@/lib/minutes/markdownToDocx';
 import { getWithdrawnLabel } from '@/lib/utils/subjects';
 import {
@@ -135,7 +136,7 @@ function createCouncilCompositionSection(
             children: [
                 new TextRun({ text: 'ΔΗΜΑΡΧΟΣ: ', bold: true, size: FONT_SIZE.BODY }),
                 new TextRun({ text: composition.mayor.name, size: FONT_SIZE.BODY }),
-                ...(isAbsent ? [new TextRun({ text: ' (ΑΠΩΝ)', size: FONT_SIZE.BODY, color: '666666' })] : []),
+                ...(isAbsent ? [new TextRun({ text: ` (${getAbsentLabel(extractFirstName(composition.mayor.name, 'surnameFirst'))})`, size: FONT_SIZE.BODY, color: '666666' })] : []),
             ],
         }));
     }
@@ -147,7 +148,7 @@ function createCouncilCompositionSection(
             children: [
                 new TextRun({ text: 'ΠΡΟΕΔΡΟΣ: ', bold: true, size: FONT_SIZE.BODY }),
                 new TextRun({ text: composition.president.name, size: FONT_SIZE.BODY }),
-                ...(isAbsent ? [new TextRun({ text: ' (ΑΠΩΝ)', size: FONT_SIZE.BODY, color: '666666' })] : []),
+                ...(isAbsent ? [new TextRun({ text: ` (${getAbsentLabel(extractFirstName(composition.president.name, 'surnameFirst'))})`, size: FONT_SIZE.BODY, color: '666666' })] : []),
             ],
         }));
     }

--- a/src/components/meetings/docx/MinutesDocx.ts
+++ b/src/components/meetings/docx/MinutesDocx.ts
@@ -110,27 +110,44 @@ function createTitlePage(data: MinutesData): Paragraph[] {
     ];
 }
 
-function createCouncilCompositionSection(composition: MinutesCouncilComposition): Paragraph[] {
+/**
+ * Renders the council composition section (ΣΥΝΘΕΣΗ ΔΗΜΟΤΙΚΟΥ ΣΥΜΒΟΥΛΙΟΥ)
+ * and the absent members section (ΑΠΟΝΤΕΣ) if initial roll call data is available.
+ *
+ * Mayor/president absence is derived from the absent members list rather than
+ * being stored on the composition itself — attendance and composition are
+ * independent concerns.
+ *
+ * @param composition - Council members, mayor, and president (structural, no attendance)
+ * @param absentMembers - Members absent at session start (from MeetingAttendance), or null if no roll call data
+ */
+function createCouncilCompositionSection(
+    composition: MinutesCouncilComposition,
+    absentMembers: MinutesMember[] | null,
+): Paragraph[] {
     const paragraphs: Paragraph[] = [];
+    const absentPersonIds = new Set(absentMembers?.map(m => m.personId) ?? []);
 
     if (composition.mayor) {
+        const isAbsent = absentPersonIds.has(composition.mayor.personId);
         paragraphs.push(new Paragraph({
             spacing: { before: 200, after: 80 },
             children: [
                 new TextRun({ text: 'ΔΗΜΑΡΧΟΣ: ', bold: true, size: FONT_SIZE.BODY }),
                 new TextRun({ text: composition.mayor.name, size: FONT_SIZE.BODY }),
-                ...(!composition.mayor.present ? [new TextRun({ text: ' (ΑΠΩΝ)', size: FONT_SIZE.BODY, color: '666666' })] : []),
+                ...(isAbsent ? [new TextRun({ text: ' (ΑΠΩΝ)', size: FONT_SIZE.BODY, color: '666666' })] : []),
             ],
         }));
     }
 
     if (composition.president) {
+        const isAbsent = absentPersonIds.has(composition.president.personId);
         paragraphs.push(new Paragraph({
             spacing: { before: 80, after: 200 },
             children: [
                 new TextRun({ text: 'ΠΡΟΕΔΡΟΣ: ', bold: true, size: FONT_SIZE.BODY }),
                 new TextRun({ text: composition.president.name, size: FONT_SIZE.BODY }),
-                ...(!composition.president.present ? [new TextRun({ text: ' (ΑΠΩΝ)', size: FONT_SIZE.BODY, color: '666666' })] : []),
+                ...(isAbsent ? [new TextRun({ text: ' (ΑΠΩΝ)', size: FONT_SIZE.BODY, color: '666666' })] : []),
             ],
         }));
     }
@@ -154,6 +171,21 @@ function createCouncilCompositionSection(composition: MinutesCouncilComposition)
             children.push(new TextRun({ text: ` (${partyLabel})`, size: FONT_SIZE.BODY, color: '666666' }));
         }
         paragraphs.push(new Paragraph({ bullet: { level: 0 }, spacing: { before: 40, after: 40 }, children }));
+    }
+
+    // Absent members — inline list, only shown when we have initial roll call data.
+    // Mayor is excluded from the list (shown with (ΑΠΩΝ/ΑΠΟΥΣΑ) tag on their own line above).
+    const absentListMembers = absentMembers?.filter(m =>
+        !composition.mayor || m.personId !== composition.mayor.personId
+    );
+    if (absentListMembers && absentListMembers.length > 0) {
+        paragraphs.push(new Paragraph({
+            spacing: { before: 200, after: 80 },
+            children: [
+                new TextRun({ text: `ΑΠΟΝΤΕΣ (${absentListMembers.length}): `, bold: true, size: FONT_SIZE.BODY }),
+                new TextRun({ text: absentListMembers.map(m => m.name).join(', '), size: FONT_SIZE.BODY }),
+            ],
+        }));
     }
 
     paragraphs.push(new Paragraph({ pageBreakBefore: true }));
@@ -413,9 +445,9 @@ export async function renderMinutesDocx(data: MinutesData): Promise<Blob> {
     // Title page
     children.push(...createTitlePage(data));
 
-    // Council composition
+    // Council composition + absent members
     if (data.councilComposition) {
-        children.push(...createCouncilCompositionSection(data.councilComposition));
+        children.push(...createCouncilCompositionSection(data.councilComposition, data.absentMembers));
     }
 
     // Table of contents (split into ΕΚΤΟΣ ΗΔ + ΗΔ tables)

--- a/src/components/meetings/docx/MinutesDocx.ts
+++ b/src/components/meetings/docx/MinutesDocx.ts
@@ -201,7 +201,7 @@ function createTitlePage(
             alignment: AlignmentType.CENTER,
             spacing: { after: 200 },
             children: [new TextRun({
-                text: data.administrativeBody,
+                text: data.administrativeBody.name,
                 size: FONT_SIZE.SUBTITLE,
             })],
         }));
@@ -336,24 +336,27 @@ function createTitlePage(
 }
 
 /**
- * Renders the council composition section (ΣΥΝΘΕΣΗ ΔΗΜΟΤΙΚΟΥ ΣΥΜΒΟΥΛΙΟΥ)
- * and the absent members section (ΑΠΟΝΤΕΣ) if initial roll call data is available.
+ * Renders the composition section and absent members for the meeting body.
+ * Adapts to the administrative body type:
+ * - Council: ΔΗΜΑΡΧΟΣ + ΠΡΟΕΔΡΟΣ + ΣΥΝΘΕΣΗ ΔΗΜΟΤΙΚΟΥ ΣΥΜΒΟΥΛΙΟΥ (flat list)
+ * - Committee: ΠΡΟΕΔΡΟΣ + ΤΑΚΤΙΚΑ ΜΕΛΗ + ΑΝΑΠΛΗΡΩΜΑΤΙΚΑ ΜΕΛΗ
  *
- * Mayor/president absence is derived from the absent members list rather than
- * being stored on the composition itself — attendance and composition are
- * independent concerns.
- *
- * @param composition - Council members, mayor, and president (structural, no attendance)
- * @param absentMembers - Members absent at session start (from MeetingAttendance), or null if no roll call data
+ * @param composition - Members, substitute members, mayor, and president
+ * @param absentMembers - Members absent at session start, or null if no roll call data
+ * @param adminBody - Administrative body info (name and type) for heading and layout
  */
 function createCouncilCompositionSection(
     composition: MinutesCouncilComposition,
     absentMembers: MinutesMember[] | null,
+    adminBody: { name: string; type: string } | null,
 ): Paragraph[] {
     const paragraphs: Paragraph[] = [];
     const absentPersonIds = new Set(absentMembers?.map(m => m.personId) ?? []);
+    const isCommittee = adminBody?.type === 'committee';
 
-    if (composition.mayor) {
+    // For councils: show mayor separately, then president
+    // For committees: president IS the mayor, shown as ΠΡΟΕΔΡΟΣ only
+    if (!isCommittee && composition.mayor) {
         const isAbsent = absentPersonIds.has(composition.mayor.personId);
         paragraphs.push(new Paragraph({
             spacing: { before: 200, after: 80 },
@@ -367,51 +370,95 @@ function createCouncilCompositionSection(
 
     if (composition.president) {
         const isAbsent = absentPersonIds.has(composition.president.personId);
+        const presidentSuffix = isCommittee ? ' (ΔΗΜΑΡΧΟΣ)' : '';
         paragraphs.push(new Paragraph({
-            spacing: { before: 80, after: 200 },
+            spacing: { before: isCommittee ? 200 : 80, after: 200 },
             children: [
                 new TextRun({ text: 'ΠΡΟΕΔΡΟΣ: ', bold: true, size: FONT_SIZE.BODY }),
-                new TextRun({ text: composition.president.name, size: FONT_SIZE.BODY }),
+                new TextRun({ text: composition.president.name + presidentSuffix, size: FONT_SIZE.BODY }),
                 ...(isAbsent ? [new TextRun({ text: ` (${getAbsentLabel(extractFirstName(composition.president.name, 'surnameFirst'))})`, size: FONT_SIZE.BODY, color: '666666' })] : []),
             ],
         }));
     }
 
-    paragraphs.push(new Paragraph({
-        heading: HeadingLevel.HEADING_2,
-        spacing: { before: 360, after: 200 },
-        children: [new TextRun({
-            text: `ΣΥΝΘΕΣΗ ΔΗΜΟΤΙΚΟΥ ΣΥΜΒΟΥΛΙΟΥ (${composition.members.length})`,
-            size: FONT_SIZE.HEADING,
-            bold: true,
-        })],
-    }));
-
-    for (const member of composition.members) {
-        const children: TextRun[] = [
-            new TextRun({ text: member.name, size: FONT_SIZE.BODY }),
-        ];
-        if (member.party) {
-            const partyLabel = member.isPartyHead ? `${member.party}, Επικεφαλής` : member.party;
-            children.push(new TextRun({ text: ` (${partyLabel})`, size: FONT_SIZE.BODY, color: '666666' }));
-        }
-        paragraphs.push(new Paragraph({ bullet: { level: 0 }, spacing: { before: 40, after: 40 }, children }));
+    // Council: composition heading. Committees skip — go straight to ΠΑΡΟΝΤΑ/ΑΠΟΝΤΑ ΜΕΛΗ.
+    if (!isCommittee) {
+        paragraphs.push(new Paragraph({
+            heading: HeadingLevel.HEADING_2,
+            spacing: { before: 360, after: 200 },
+            children: [new TextRun({
+                text: `ΣΥΝΘΕΣΗ ΔΗΜΟΤΙΚΟΥ ΣΥΜΒΟΥΛΙΟΥ (${composition.members.length})`,
+                size: FONT_SIZE.HEADING,
+                bold: true,
+            })],
+        }));
     }
 
-    // Absent members — inline list, only shown when we have initial roll call data.
-    // Mayor is excluded from the list (shown with (ΑΠΩΝ/ΑΠΟΥΣΑ) tag on their own line above).
-    const absentListMembers = absentMembers?.filter(m =>
-        !composition.mayor || m.personId !== composition.mayor.personId
-    );
-    if (absentListMembers && absentListMembers.length > 0) {
-        paragraphs.push(new Paragraph({
-            spacing: { before: 200, after: 80 },
-            children: [
-                new TextRun({ text: 'Κατά την έναρξη της συνεδρίασης απουσίαζαν οι ', size: FONT_SIZE.BODY }),
-                new TextRun({ text: absentListMembers.map(m => m.name).join(', '), size: FONT_SIZE.BODY }),
-                new TextRun({ text: ` (${absentListMembers.length})`, size: FONT_SIZE.BODY, color: '666666' }),
-            ],
-        }));
+    // Council: flat member list. Committees skip this — members shown in ΠΑΡΟΝΤΕΣ/ΑΠΟΝΤΕΣ below.
+    if (!isCommittee) {
+        for (const member of composition.members) {
+            const children: TextRun[] = [
+                new TextRun({ text: member.name, size: FONT_SIZE.BODY }),
+            ];
+            if (member.party) {
+                const partyLabel = member.isPartyHead ? `${member.party}, Επικεφαλής` : member.party;
+                children.push(new TextRun({ text: ` (${partyLabel})`, size: FONT_SIZE.BODY, color: '666666' }));
+            }
+            paragraphs.push(new Paragraph({ bullet: { level: 0 }, spacing: { before: 40, after: 40 }, children }));
+        }
+    }
+
+    // Attendance section — format depends on body type
+    if (isCommittee && absentMembers) {
+        // Committee: ΠΑΡΟΝΤΑ ΜΕΛΗ and ΑΠΟΝΤΑ ΜΕΛΗ as bullet lists
+        const substituteIds = new Set(composition.substituteMembers.map(m => m.personId));
+        const absentPersonIds = new Set(absentMembers.map(m => m.personId));
+        const allMembers = [...composition.members, ...composition.substituteMembers];
+
+        const presentList = allMembers.filter(m => !absentPersonIds.has(m.personId));
+        const absentList = allMembers.filter(m => absentPersonIds.has(m.personId));
+
+        const memberBullet = (m: MinutesMember) => {
+            const children: TextRun[] = [new TextRun({ text: m.name, size: FONT_SIZE.BODY })];
+            const labels: string[] = [];
+            if (substituteIds.has(m.personId)) labels.push('αναπλ. μέλος');
+            if (m.party) labels.push(m.isPartyHead ? `${m.party}, Επικεφαλής` : m.party);
+            if (labels.length > 0) {
+                children.push(new TextRun({ text: ` (${labels.join(', ')})`, size: FONT_SIZE.BODY, color: '666666' }));
+            }
+            return new Paragraph({ bullet: { level: 0 }, spacing: { before: 40, after: 40 }, children });
+        };
+
+        if (presentList.length > 0) {
+            paragraphs.push(new Paragraph({
+                spacing: { before: 200, after: 80 },
+                children: [new TextRun({ text: `ΠΑΡΟΝΤΑ ΜΕΛΗ (${presentList.length})`, bold: true, size: FONT_SIZE.BODY })],
+            }));
+            for (const m of presentList) paragraphs.push(memberBullet(m));
+        }
+        if (absentList.length > 0) {
+            paragraphs.push(new Paragraph({
+                spacing: { before: 200, after: 80 },
+                children: [new TextRun({ text: `ΑΠΟΝΤΑ ΜΕΛΗ (${absentList.length})`, bold: true, size: FONT_SIZE.BODY })],
+            }));
+            for (const m of absentList) paragraphs.push(memberBullet(m));
+        }
+    } else {
+        // Council: absent inline sentence
+        const absentListMembers = absentMembers?.filter(m =>
+            (!composition.mayor || m.personId !== composition.mayor.personId) &&
+            (!composition.president || m.personId !== composition.president.personId)
+        );
+        if (absentListMembers && absentListMembers.length > 0) {
+            paragraphs.push(new Paragraph({
+                spacing: { before: 200, after: 80 },
+                children: [
+                    new TextRun({ text: 'Κατά την έναρξη της συνεδρίασης απουσίαζαν οι ', size: FONT_SIZE.BODY }),
+                    new TextRun({ text: absentListMembers.map(m => m.name).join(', '), size: FONT_SIZE.BODY }),
+                    new TextRun({ text: ` (${absentListMembers.length})`, size: FONT_SIZE.BODY, color: '666666' }),
+                ],
+            }));
+        }
     }
 
     paragraphs.push(new Paragraph({ pageBreakBefore: true }));
@@ -679,7 +726,7 @@ export async function renderMinutesDocx(data: MinutesData): Promise<Blob> {
 
     // Council composition + absent members
     if (data.councilComposition) {
-        children.push(...createCouncilCompositionSection(data.councilComposition, data.absentMembers));
+        children.push(...createCouncilCompositionSection(data.councilComposition, data.absentMembers, data.administrativeBody));
     }
 
     // Table of contents (split into ΕΚΤΟΣ ΗΔ + ΗΔ tables)

--- a/src/components/meetings/docx/MinutesDocx.ts
+++ b/src/components/meetings/docx/MinutesDocx.ts
@@ -377,6 +377,8 @@ function createSubjectSection(subject: MinutesSubject): (Paragraph | Table)[] {
             { label: 'ΥΠΕΡ', members: subject.voteResult.forMembers },
             { label: 'ΚΑΤΑ', members: subject.voteResult.againstMembers },
             { label: 'ΛΕΥΚΑ', members: subject.voteResult.abstainMembers },
+            { label: 'ΠΑΡΟΝΤΕΣ', members: subject.voteResult.presentMembers },
+            { label: 'ΑΠΟΧΗ', members: subject.voteResult.didNotVoteMembers },
             { label: 'ΑΠΟΝΤΕΣ', members: subject.voteResult.absentMembers },
         ];
         for (const { label, members } of voteCategories) {

--- a/src/components/meetings/docx/MinutesDocx.ts
+++ b/src/components/meetings/docx/MinutesDocx.ts
@@ -1,9 +1,12 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
 import { el } from 'date-fns/locale';
 import { formatInTimeZone } from 'date-fns-tz';
 import {
     Document, Paragraph, TextRun, HeadingLevel, Packer, AlignmentType,
-    Table, TableRow, TableCell, WidthType, Bookmark, PageReference,
-    InternalHyperlink,
+    Table, TableRow, TableCell, WidthType, BorderStyle, VerticalAlign, Bookmark, PageReference,
+    InternalHyperlink, ImageRun, Header, PageNumber, Tab, TabStopType,
+    TabStopPosition,
 } from 'docx';
 import { formatTimestamp } from '@/lib/utils';
 import { formatGapDuration } from '@/lib/formatters/time';
@@ -27,88 +30,309 @@ const FONT_SIZE = {
     CAPTION: 18,    // 9pt
 };
 
+const HEADER_FONT_SIZE = 16; // 8pt
+const HEADER_COLOR = '888888';
+
 /** Bookmark IDs must be alphanumeric + underscores */
 function subjectBookmarkId(subject: MinutesSubject): string {
     return `subject_${subject.subjectId.replace(/[^a-zA-Z0-9]/g, '_')}`;
 }
 
-function createTitlePage(data: MinutesData): Paragraph[] {
+const BRANDING_FONT = 'Relative Book Pro';
+
+/** Strip Greek diacritics — uppercase Greek convention omits accents (τόνοι). */
+function stripDiacritics(text: string): string {
+    return text.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+/** Detect image type from magic bytes in the buffer. */
+function detectImageType(buf: Buffer): 'png' | 'jpg' | 'gif' | 'bmp' {
+    if (buf[0] === 0x89 && buf[1] === 0x50) return 'png';
+    if (buf[0] === 0xFF && buf[1] === 0xD8) return 'jpg';
+    if (buf[0] === 0x47 && buf[1] === 0x49) return 'gif';
+    if (buf[0] === 0x42 && buf[1] === 0x4D) return 'bmp';
+    return 'png'; // fallback
+}
+
+/** Read image dimensions from buffer headers (PNG and JPEG). */
+function getImageDimensions(buf: Buffer, type: string): { width: number; height: number } | null {
+    if (type === 'png' && buf.length >= 24) {
+        // PNG: IHDR chunk at offset 16 — width (4 bytes BE), height (4 bytes BE)
+        return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+    }
+    if (type === 'jpg' && buf.length >= 4) {
+        // JPEG: scan for SOF0/SOF2 marker (0xFF 0xC0 or 0xFF 0xC2)
+        let i = 2;
+        while (i < buf.length - 9) {
+            if (buf[i] !== 0xFF) { i++; continue; }
+            const marker = buf[i + 1];
+            if (marker === 0xC0 || marker === 0xC2) {
+                return { width: buf.readUInt16BE(i + 7), height: buf.readUInt16BE(i + 5) };
+            }
+            // Skip to next marker using segment length
+            const segLen = buf.readUInt16BE(i + 2);
+            i += 2 + segLen;
+        }
+    }
+    return null;
+}
+
+/**
+ * Scale image to fit within a bounding box (in points) while preserving aspect ratio.
+ * Uses native pixel dimensions only to compute the ratio — the output size is
+ * determined entirely by maxWidth/maxHeight, so the logo always occupies the
+ * intended amount of page real estate regardless of source resolution.
+ */
+function scaleImage(buf: Buffer, type: string, maxWidth: number, maxHeight: number): { width: number; height: number } {
+    const dims = getImageDimensions(buf, type);
+    if (!dims) return { width: maxWidth, height: maxHeight };
+    const ratio = dims.width / dims.height;
+    // Fit within the bounding box: if wider than tall, width is the constraint; otherwise height
+    if (ratio >= maxWidth / maxHeight) {
+        return { width: maxWidth, height: Math.round(maxWidth / ratio) };
+    }
+    return { width: Math.round(maxHeight * ratio), height: maxHeight };
+}
+
+// --- Image fetching ---
+
+interface FetchedImage {
+    data: Buffer;
+    type: 'png' | 'jpg' | 'gif' | 'bmp';
+}
+
+async function fetchImageBuffer(url: string): Promise<FetchedImage | null> {
+    try {
+        const response = await fetch(url);
+        if (!response.ok) return null;
+        const data = Buffer.from(await response.arrayBuffer());
+        return { data, type: detectImageType(data) };
+    } catch {
+        return null;
+    }
+}
+
+async function getOpenCouncilLogo(): Promise<Buffer | null> {
+    try {
+        return await readFile(join(process.cwd(), 'public', 'logo.png'));
+    } catch {
+        return null;
+    }
+}
+
+// --- Headers (book-style even/odd) ---
+
+function createHeaders(data: MinutesData): {
+    default: Header;
+    even: Header;
+    first: Header;
+} {
+    const headerStyle = { size: HEADER_FONT_SIZE, color: HEADER_COLOR };
+
+    // Even pages (left side of book): [page number] ........... ΠΡΑΚΤΙΚΑ ΣΥΝΕΔΡΙΑΣΗΣ · Municipality
+    const even = new Header({
+        children: [new Paragraph({
+            tabStops: [{ type: TabStopType.RIGHT, position: TabStopPosition.MAX }],
+            children: [
+                new TextRun({ children: [PageNumber.CURRENT], ...headerStyle }),
+                new TextRun({ children: [new Tab(), `ΠΡΑΚΤΙΚΑ ΣΥΝΕΔΡΙΑΣΗΣ · ${data.city.name_municipality}`], ...headerStyle }),
+            ],
+        })],
+    });
+
+    // Odd pages (right side of book): Meeting name ........... [page number]
+    const defaultHeader = new Header({
+        children: [new Paragraph({
+            tabStops: [{ type: TabStopType.RIGHT, position: TabStopPosition.MAX }],
+            children: [
+                new TextRun({ children: [data.meeting.name], ...headerStyle }),
+                new TextRun({ children: [new Tab(), PageNumber.CURRENT], ...headerStyle }),
+            ],
+        })],
+    });
+
+    // Title page: no header
+    const first = new Header({ children: [] });
+
+    return { default: defaultHeader, even, first };
+}
+
+// --- Title page ---
+
+function createTitlePage(
+    data: MinutesData,
+    cityLogo: FetchedImage | null,
+    ocLogoBuffer: Buffer | null,
+): (Paragraph | Table)[] {
     const meetingDate = new Date(data.meeting.dateTime);
+    const paragraphs: (Paragraph | Table)[] = [];
 
-    return [
-        new Paragraph({ spacing: { before: 2400 } }),
-
-        new Paragraph({
+    // Municipality logo — scaled to fit within 200x200pt preserving aspect ratio
+    if (cityLogo) {
+        const logoDims = scaleImage(cityLogo.data, cityLogo.type, 200, 200);
+        paragraphs.push(new Paragraph({ spacing: { before: 1200 } }));
+        paragraphs.push(new Paragraph({
             alignment: AlignmentType.CENTER,
-            spacing: { after: 200 },
-            children: [new TextRun({
-                text: data.city.name_municipality,
-                size: FONT_SIZE.SUBTITLE,
+            children: [new ImageRun({
+                data: cityLogo.data,
+                transformation: logoDims,
+                type: cityLogo.type,
             })],
-        }),
+        }));
+        paragraphs.push(new Paragraph({ spacing: { after: 200 } }));
+    } else {
+        paragraphs.push(new Paragraph({ spacing: { before: 2400 } }));
+    }
 
-        ...(data.administrativeBody ? [new Paragraph({
+    // Municipality name — uppercase without accents (Greek typographic convention)
+    paragraphs.push(new Paragraph({
+        alignment: AlignmentType.CENTER,
+        spacing: { after: 120 },
+        children: [new TextRun({
+            text: stripDiacritics(data.city.name_municipality.toUpperCase()),
+            size: FONT_SIZE.SUBTITLE,
+            bold: true,
+        })],
+    }));
+
+    // Administrative body
+    if (data.administrativeBody) {
+        paragraphs.push(new Paragraph({
             alignment: AlignmentType.CENTER,
             spacing: { after: 200 },
             children: [new TextRun({
                 text: data.administrativeBody,
                 size: FONT_SIZE.SUBTITLE,
             })],
-        })] : []),
+        }));
+    }
 
-        new Paragraph({
-            heading: HeadingLevel.HEADING_1,
-            alignment: AlignmentType.CENTER,
-            spacing: { before: 400, after: 200 },
-            children: [new TextRun({
-                text: 'ΠΡΑΚΤΙΚΑ ΣΥΝΕΔΡΙΑΣΗΣ',
-                size: FONT_SIZE.TITLE,
-                bold: true,
+    // Decorative separator
+    paragraphs.push(new Paragraph({
+        alignment: AlignmentType.CENTER,
+        spacing: { before: 300, after: 300 },
+        children: [new TextRun({
+            text: '━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+            color: 'CCCCCC',
+            size: FONT_SIZE.BODY,
+        })],
+    }));
+
+    // Main title
+    paragraphs.push(new Paragraph({
+        heading: HeadingLevel.HEADING_1,
+        alignment: AlignmentType.CENTER,
+        spacing: { after: 200 },
+        children: [new TextRun({
+            text: 'ΠΡΑΚΤΙΚΑ ΣΥΝΕΔΡΙΑΣΗΣ',
+            size: FONT_SIZE.TITLE,
+            bold: true,
+        })],
+    }));
+
+    // Meeting name
+    paragraphs.push(new Paragraph({
+        alignment: AlignmentType.CENTER,
+        spacing: { after: 200 },
+        children: [new TextRun({
+            text: data.meeting.name,
+            size: FONT_SIZE.SUBTITLE,
+            bold: true,
+        })],
+    }));
+
+    // Date
+    paragraphs.push(new Paragraph({
+        alignment: AlignmentType.CENTER,
+        spacing: { after: 200 },
+        children: [new TextRun({
+            text: formatInTimeZone(meetingDate, data.city.timezone, 'EEEE, d MMMM yyyy, HH:mm', { locale: el }),
+            size: FONT_SIZE.BODY,
+        })],
+    }));
+
+    // Decorative separator
+    paragraphs.push(new Paragraph({
+        alignment: AlignmentType.CENTER,
+        spacing: { before: 300, after: 300 },
+        children: [new TextRun({
+            text: '━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+            color: 'CCCCCC',
+            size: FONT_SIZE.BODY,
+        })],
+    }));
+
+    // Spacer to push OpenCouncil branding toward the bottom
+    paragraphs.push(new Paragraph({ spacing: { before: 2400 } }));
+
+    // OpenCouncil branding — logo aligned with "OpenCouncil" name, subtitle lines below
+    const noBorders = {
+        top: { style: BorderStyle.NONE },
+        bottom: { style: BorderStyle.NONE },
+        left: { style: BorderStyle.NONE },
+        right: { style: BorderStyle.NONE },
+    };
+
+    if (ocLogoBuffer) {
+        const ocLogoDims = scaleImage(ocLogoBuffer, 'png', 40, 40);
+        const logoCell = new TableCell({
+            verticalAlign: VerticalAlign.CENTER,
+            width: { size: 700, type: WidthType.DXA },
+            borders: noBorders,
+            children: [new Paragraph({
+                children: [new ImageRun({
+                    data: ocLogoBuffer,
+                    transformation: ocLogoDims,
+                    type: 'png',
+                })],
             })],
-        }),
-
-        new Paragraph({
-            alignment: AlignmentType.CENTER,
-            spacing: { after: 200 },
-            children: [new TextRun({
-                text: data.meeting.name,
-                size: FONT_SIZE.SUBTITLE,
-                bold: true,
+        });
+        const nameCell = new TableCell({
+            verticalAlign: VerticalAlign.CENTER,
+            borders: noBorders,
+            children: [new Paragraph({
+                children: [new TextRun({
+                    text: 'OpenCouncil',
+                    size: FONT_SIZE.BODY,
+                    color: '888888',
+                    font: BRANDING_FONT,
+                })],
             })],
-        }),
+        });
+        paragraphs.push(new Table({
+            columnWidths: [700, 8100],
+            rows: [new TableRow({ children: [logoCell, nameCell] })],
+        }));
+    } else {
+        paragraphs.push(new Paragraph({
+            spacing: { after: 20 },
+            children: [new TextRun({ text: 'OpenCouncil', size: FONT_SIZE.BODY, color: '888888', font: BRANDING_FONT })],
+        }));
+    }
 
-        new Paragraph({
-            alignment: AlignmentType.CENTER,
-            spacing: { after: 400 },
-            children: [new TextRun({
-                text: formatInTimeZone(meetingDate, data.city.timezone, 'EEEE, d MMMM yyyy, HH:mm', { locale: el }),
-                size: FONT_SIZE.BODY,
-            })],
-        }),
+    // Tagline and URL below, indented to align with the text column
+    const brandingIndent = 700; // matches logo column width in twips
+    paragraphs.push(new Paragraph({
+        spacing: { before: 40, after: 20 },
+        indent: { left: brandingIndent },
+        children: [new TextRun({
+            text: 'Το λειτουργικό σύστημα των συλλογικών οργάνων',
+            size: FONT_SIZE.CAPTION,
+            color: 'AAAAAA',
+            italics: true,
+        })],
+    }));
+    paragraphs.push(new Paragraph({
+        indent: { left: brandingIndent },
+        children: [new TextRun({
+            text: `opencouncil.gr/${data.meeting.cityId}`,
+            size: FONT_SIZE.CAPTION,
+            color: 'AAAAAA',
+        })],
+    }));
 
-        new Paragraph({
-            alignment: AlignmentType.CENTER,
-            spacing: { before: 480, after: 240 },
-            children: [new TextRun({
-                text: 'Προσοχή: Ανεπίσημο έγγραφο',
-                color: 'FF6B00',
-                bold: true,
-                size: FONT_SIZE.BODY,
-            })],
-        }),
-
-        new Paragraph({
-            alignment: AlignmentType.CENTER,
-            spacing: { before: 200 },
-            children: [new TextRun({
-                text: 'Παράγεται αυτόματα από το OpenCouncil',
-                size: FONT_SIZE.SMALL,
-                color: '666666',
-            })],
-        }),
-
-        new Paragraph({ pageBreakBefore: true }),
-    ];
+    paragraphs.push(new Paragraph({ pageBreakBefore: true }));
+    return paragraphs;
 }
 
 /**
@@ -183,8 +407,9 @@ function createCouncilCompositionSection(
         paragraphs.push(new Paragraph({
             spacing: { before: 200, after: 80 },
             children: [
-                new TextRun({ text: `ΑΠΟΝΤΕΣ (${absentListMembers.length}): `, bold: true, size: FONT_SIZE.BODY }),
+                new TextRun({ text: 'Κατά την έναρξη της συνεδρίασης απουσίαζαν οι ', size: FONT_SIZE.BODY }),
                 new TextRun({ text: absentListMembers.map(m => m.name).join(', '), size: FONT_SIZE.BODY }),
+                new TextRun({ text: ` (${absentListMembers.length})`, size: FONT_SIZE.BODY, color: '666666' }),
             ],
         }));
     }
@@ -441,10 +666,16 @@ function createSubjectSection(subject: MinutesSubject): (Paragraph | Table)[] {
 }
 
 export async function renderMinutesDocx(data: MinutesData): Promise<Blob> {
+    // Fetch images in parallel
+    const [cityLogo, ocLogoBuffer] = await Promise.all([
+        data.city.logoImage ? fetchImageBuffer(data.city.logoImage) : Promise.resolve(null),
+        getOpenCouncilLogo(),
+    ]);
+
     const children: (Paragraph | Table)[] = [];
 
     // Title page
-    children.push(...createTitlePage(data));
+    children.push(...createTitlePage(data, cityLogo, ocLogoBuffer));
 
     // Council composition + absent members
     if (data.councilComposition) {
@@ -472,13 +703,19 @@ export async function renderMinutesDocx(data: MinutesData): Promise<Blob> {
         children.push(...createTranscriptParagraphs(data.epilogueEntries));
     }
 
+    const headers = createHeaders(data);
+
     const doc = new Document({
         creator: 'OpenCouncil',
         description: 'Πρακτικά Συνεδρίασης',
         title: data.meeting.name,
         subject: 'Πρακτικά',
+        evenAndOddHeaderAndFooters: true,
         sections: [{
-            properties: {},
+            properties: {
+                titlePage: true,
+            },
+            headers,
             children,
         }],
     });

--- a/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
+++ b/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
@@ -89,6 +89,8 @@ describe('renderMinutesDocx', () => {
                         ],
                         againstMembers: [],
                         abstainMembers: [],
+                        presentMembers: [],
+                        didNotVoteMembers: [],
                         absentMembers: [
                             { personId: 'p3', name: 'Νίκος Δημητρίου', party: 'ΠΑΣΟΚ', isPartyHead: false, role: null },
                         ],

--- a/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
+++ b/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
@@ -15,7 +15,7 @@ function makeMinutesData(overrides: Partial<MinutesData> = {}): MinutesData {
             name: 'Τακτική Συνεδρίαση',
             dateTime: '2024-06-15T18:00:00.000Z',
         },
-        administrativeBody: 'Δημοτικό Συμβούλιο',
+        administrativeBody: { name: 'Δημοτικό Συμβούλιο', type: 'council' },
         councilComposition: null,
         absentMembers: null,
         preambleEntries: [],
@@ -72,6 +72,8 @@ describe('renderMinutesDocx', () => {
                     { personId: 'p1', name: 'Γιώργος Παπαδόπουλος', party: 'ΝΔ', isPartyHead: false, role: 'Πρόεδρος' },
                     { personId: 'p2', name: 'Μαρία Ιωάννου', party: 'ΣΥΡΙΖΑ', isPartyHead: false, role: null },
                     { personId: 'p3', name: 'Νίκος Δημητρίου', party: 'ΠΑΣΟΚ', isPartyHead: false, role: null },
+                ],
+                substituteMembers: [
                 ],
             },
             subjects: [

--- a/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
+++ b/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
@@ -7,6 +7,7 @@ function makeMinutesData(overrides: Partial<MinutesData> = {}): MinutesData {
             name: 'Ζωγράφου',
             name_municipality: 'Δήμος Ζωγράφου',
             timezone: 'Europe/Athens',
+            logoImage: null,
         },
         meeting: {
             id: 'meeting-1',

--- a/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
+++ b/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
@@ -16,6 +16,7 @@ function makeMinutesData(overrides: Partial<MinutesData> = {}): MinutesData {
         },
         administrativeBody: 'Δημοτικό Συμβούλιο',
         councilComposition: null,
+        absentMembers: null,
         preambleEntries: [],
         subjects: [],
         epilogueEntries: [],
@@ -64,8 +65,8 @@ describe('renderMinutesDocx', () => {
     it('should handle subjects with full data', async () => {
         const data = makeMinutesData({
             councilComposition: {
-                mayor: { name: 'Δημήτρης Αντωνίου', present: true },
-                president: { name: 'Γιώργος Παπαδόπουλος', present: true },
+                mayor: { name: 'Δημήτρης Αντωνίου', personId: 'mayor-1' },
+                president: { name: 'Γιώργος Παπαδόπουλος', personId: 'p1' },
                 members: [
                     { personId: 'p1', name: 'Γιώργος Παπαδόπουλος', party: 'ΝΔ', isPartyHead: false, role: 'Πρόεδρος' },
                     { personId: 'p2', name: 'Μαρία Ιωάννου', party: 'ΣΥΡΙΖΑ', isPartyHead: false, role: null },

--- a/src/components/meetings/subject/VotingSection.tsx
+++ b/src/components/meetings/subject/VotingSection.tsx
@@ -63,6 +63,8 @@ function VoteBreakdown({ votes }: { votes: Vote[] }) {
     const forVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'FOR')), [votes]);
     const againstVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'AGAINST')), [votes]);
     const abstainVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'ABSTAIN')), [votes]);
+    const presentVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'PRESENT')), [votes]);
+    const didNotVoteVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'DID_NOT_VOTE')), [votes]);
 
     return (
         <div className="p-4 space-y-3">
@@ -107,6 +109,26 @@ function VoteBreakdown({ votes }: { votes: Vote[] }) {
                             </td>
                             <td className="py-1.5">
                                 {abstainVoters.map(v => formatSurnameFirst(v.person.name)).join(', ')}
+                            </td>
+                        </tr>
+                    )}
+                    {presentVoters.length > 0 && (
+                        <tr>
+                            <td className="py-1.5 pr-4 text-muted-foreground font-medium whitespace-nowrap align-top">
+                                {t('votePresent')} ({presentVoters.length})
+                            </td>
+                            <td className="py-1.5">
+                                {presentVoters.map(v => formatSurnameFirst(v.person.name)).join(', ')}
+                            </td>
+                        </tr>
+                    )}
+                    {didNotVoteVoters.length > 0 && (
+                        <tr>
+                            <td className="py-1.5 pr-4 text-muted-foreground font-medium whitespace-nowrap align-top">
+                                {t('voteDidNotVote')} ({didNotVoteVoters.length})
+                            </td>
+                            <td className="py-1.5">
+                                {didNotVoteVoters.map(v => formatSurnameFirst(v.person.name)).join(', ')}
                             </td>
                         </tr>
                     )}

--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -453,7 +453,7 @@ export interface ExtractedDecisionData {
     absentMemberIds: string[];
     mayorPresent?: boolean;
     voteResult: string | null;
-    voteDetails: { personId: string; vote: 'FOR' | 'AGAINST' | 'ABSTAIN' }[];
+    voteDetails: { personId: string; vote: 'FOR' | 'AGAINST' | 'ABSTAIN' | 'PRESENT' | 'DID_NOT_VOTE' }[];
     unmatchedMembers: string[];
     subjectInfo: { number: number; isOutOfAgenda: boolean } | null;
     fromCache?: boolean;
@@ -521,6 +521,10 @@ export interface PollDecisionsResult {
     extractions: {
         decisions: ExtractedDecisionData[];
         warnings: string[];
+        /** Initial roll call — who was present/absent at session start (meeting-level, not per-subject) */
+        initialAttendance?: { personId: string; status: 'PRESENT' | 'ABSENT' }[];
+        /** Names from the initial roll call that couldn't be matched to any person in the database */
+        unmatchedInitialAttendance?: string[];
     } | null;
     costs: {
         input_tokens: number;

--- a/src/lib/db/decisions.ts
+++ b/src/lib/db/decisions.ts
@@ -1,5 +1,5 @@
 import prisma from './prisma';
-import { AttendanceStatus, DataSource, Decision, TaskStatus, User, VoteType } from '@prisma/client';
+import { AttendanceStatus, DataSource, Decision, Prisma, TaskStatus, User, VoteType } from '@prisma/client';
 
 export type DecisionWithSource = Decision & {
     task: TaskStatus | null;
@@ -90,6 +90,9 @@ export async function clearExtractedDataForMeeting(cityId: string, meetingId: st
         }),
         prisma.subjectVote.deleteMany({
             where: { subjectId: { in: subjectIds }, source: DataSource.decision },
+        }),
+        prisma.meetingAttendance.deleteMany({
+            where: { cityId, councilMeetingId: meetingId, source: DataSource.decision },
         }),
     ]);
 
@@ -184,6 +187,25 @@ export async function getExtractedDataForMeeting(
                 voteType: v.voteType,
             })),
         }));
+}
+
+const meetingAttendanceSelect = {
+    personId: true,
+    status: true,
+    person: { select: { name: true } },
+} satisfies Prisma.MeetingAttendanceSelect;
+
+export type MeetingAttendanceRecord = Prisma.MeetingAttendanceGetPayload<{ select: typeof meetingAttendanceSelect }>;
+
+export async function getMeetingAttendance(
+    cityId: string,
+    meetingId: string,
+): Promise<MeetingAttendanceRecord[]> {
+    return prisma.meetingAttendance.findMany({
+        where: { cityId, councilMeetingId: meetingId },
+        select: meetingAttendanceSelect,
+        orderBy: { person: { name: 'asc' } },
+    });
 }
 
 export async function getDecisionForSubject(subjectId: string): Promise<{

--- a/src/lib/formatters/name.ts
+++ b/src/lib/formatters/name.ts
@@ -10,3 +10,54 @@ export function formatSurnameFirst(name: string): string {
     const rest = parts.slice(0, -1).join(' ');
     return `${surname} ${rest}`;
 }
+
+/**
+ * Extracts the first name from a full name string.
+ * Works with both "Firstname Lastname" and "Lastname Firstname" formats:
+ * - "Firstname Lastname" → first word ("Δημήτρης Παπαδόπουλος" → "Δημήτρης")
+ * - "Lastname Firstname" → last word ("Παπαδόπουλος Δημήτρης" → "Δημήτρης")
+ *
+ * @param fullName - Full name in either format.
+ * @param format - Which format the name is in. Defaults to "firstnameFirst".
+ */
+export function extractFirstName(
+    fullName: string,
+    format: 'firstnameFirst' | 'surnameFirst' = 'firstnameFirst',
+): string {
+    const parts = fullName.trim().split(/\s+/);
+    if (parts.length <= 1) return fullName;
+    return format === 'surnameFirst' ? parts[parts.length - 1] : parts[0];
+}
+
+/**
+ * Detects whether a Greek first name is female based on its ending.
+ *
+ * Greek first names are strongly gendered by their suffix:
+ * - Female: -α, -ά, -η, -ή, -ω, -ώ, -ού (Μαρία, Ελένη, Καλλιόπη, Φωτεινή)
+ * - Male: -ος, -ός, -ης, -ής, -ας, -άς, -ων, -ών, -ις, -ίς (Δημήτρης, Γεώργιος, Νικόλαος)
+ *
+ * Checks male endings first since -ας/-ης are supersets of -α/-η.
+ *
+ * @param firstName - A single Greek first name (not a full name).
+ */
+export function isFemaleName(firstName: string): boolean {
+    // Male endings (checked first — -ας contains -α, -ης contains -η)
+    if (/(?:ος|ός|ης|ής|ας|άς|ων|ών|ις|ίς)$/ui.test(firstName)) {
+        return false;
+    }
+    // Female endings
+    if (/(?:α|ά|η|ή|ω|ώ|ού)$/ui.test(firstName)) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Returns the grammatically correct Greek word for "absent" (ΑΠΩΝ/ΑΠΟΥΣΑ)
+ * based on the person's gender, inferred from their first name.
+ *
+ * @param firstName - A single Greek first name (not a full name).
+ */
+export function getAbsentLabel(firstName: string): string {
+    return isFemaleName(firstName) ? 'ΑΠΟΥΣΑ' : 'ΑΠΩΝ';
+}

--- a/src/lib/minutes/__tests__/builders.test.ts
+++ b/src/lib/minutes/__tests__/builders.test.ts
@@ -307,7 +307,7 @@ describe('buildCouncilComposition', () => {
         const mayor = { personId: 'mayor-1', name: 'Dimitris Antoniou' };
 
         const result = buildCouncilComposition(
-            members, mayor, null, 'mayor-1', noElectedOrder,
+            members, [], mayor, null, 'mayor-1', noElectedOrder,
         );
 
         expect(result.mayor).toEqual({ name: 'Antoniou Dimitris', personId: 'mayor-1' });
@@ -318,7 +318,7 @@ describe('buildCouncilComposition', () => {
         const president = { personId: 'pres-1', name: 'Giorgos Papadopoulos' };
 
         const result = buildCouncilComposition(
-            members, null, president, null, noElectedOrder,
+            members, [], null, president, null, noElectedOrder,
         );
 
         expect(result.president).toEqual({ name: 'Papadopoulos Giorgos', personId: 'pres-1' });
@@ -332,7 +332,7 @@ describe('buildCouncilComposition', () => {
         ];
 
         const result = buildCouncilComposition(
-            members, null, null, 'mayor-1', noElectedOrder,
+            members, [], null, null, 'mayor-1', noElectedOrder,
         );
 
         expect(result.members.map(m => m.personId)).toEqual(['p1', 'p2']);
@@ -347,7 +347,7 @@ describe('buildCouncilComposition', () => {
         const electedOrder = makeElectedOrder({ p1: 3, p2: 1, p3: 2 });
 
         const result = buildCouncilComposition(
-            members, null, null, null, electedOrder,
+            members, [], null, null, null, electedOrder,
         );
 
         expect(result.members.map(m => m.personId)).toEqual(['p2', 'p3', 'p1']);
@@ -357,7 +357,7 @@ describe('buildCouncilComposition', () => {
         const members = [makeMember('p1', 'Alice')];
 
         const result = buildCouncilComposition(
-            members, null, null, null, noElectedOrder,
+            members, [], null, null, null, noElectedOrder,
         );
 
         expect(result.mayor).toBeNull();

--- a/src/lib/minutes/__tests__/builders.test.ts
+++ b/src/lib/minutes/__tests__/builders.test.ts
@@ -302,102 +302,67 @@ describe('buildCouncilComposition', () => {
         role: null,
     });
 
-    it('includes mayor with presence status', () => {
-        const attendance = { present: [makeMember('p1', 'Alice')], absent: [] };
-        const rawPresentIds = new Set(['p1', 'mayor-1']);
+    it('includes mayor with personId', () => {
+        const members = [makeMember('p1', 'Alice')];
         const mayor = { personId: 'mayor-1', name: 'Dimitris Antoniou' };
 
         const result = buildCouncilComposition(
-            attendance, rawPresentIds, mayor, null, 'mayor-1', noElectedOrder,
+            members, mayor, null, 'mayor-1', noElectedOrder,
         );
 
-        expect(result.mayor).toEqual({ name: 'Antoniou Dimitris', present: true });
+        expect(result.mayor).toEqual({ name: 'Antoniou Dimitris', personId: 'mayor-1' });
     });
 
-    it('marks mayor as absent when not in rawPresentIds', () => {
-        const attendance = { present: [makeMember('p1', 'Alice')], absent: [] };
-        const rawPresentIds = new Set(['p1']);
-        const mayor = { personId: 'mayor-1', name: 'Dimitris Antoniou' };
-
-        const result = buildCouncilComposition(
-            attendance, rawPresentIds, mayor, null, 'mayor-1', noElectedOrder,
-        );
-
-        expect(result.mayor!.present).toBe(false);
-    });
-
-    it('includes president with presence status', () => {
-        const attendance = { present: [makeMember('p1', 'Alice')], absent: [] };
-        const rawPresentIds = new Set(['p1', 'pres-1']);
+    it('includes president with personId', () => {
+        const members = [makeMember('p1', 'Alice')];
         const president = { personId: 'pres-1', name: 'Giorgos Papadopoulos' };
 
         const result = buildCouncilComposition(
-            attendance, rawPresentIds, null, president, null, noElectedOrder,
+            members, null, president, null, noElectedOrder,
         );
 
-        expect(result.president).toEqual({ name: 'Papadopoulos Giorgos', present: true });
+        expect(result.president).toEqual({ name: 'Papadopoulos Giorgos', personId: 'pres-1' });
     });
 
     it('excludes mayor from members list', () => {
-        const attendance = {
-            present: [makeMember('mayor-1', 'Mayor'), makeMember('p1', 'Alice')],
-            absent: [makeMember('p2', 'Bob')],
-        };
-        const rawPresentIds = new Set(['mayor-1', 'p1']);
+        const members = [
+            makeMember('mayor-1', 'Mayor'),
+            makeMember('p1', 'Alice'),
+            makeMember('p2', 'Bob'),
+        ];
 
         const result = buildCouncilComposition(
-            attendance, rawPresentIds, null, null, 'mayor-1', noElectedOrder,
+            members, null, null, 'mayor-1', noElectedOrder,
         );
 
         expect(result.members.map(m => m.personId)).toEqual(['p1', 'p2']);
     });
 
     it('sorts members by elected order', () => {
-        const attendance = {
-            present: [
-                makeMember('p3', 'Charlie'),
-                makeMember('p1', 'Alice'),
-                makeMember('p2', 'Bob'),
-            ],
-            absent: [],
-        };
-        const rawPresentIds = new Set(['p1', 'p2', 'p3']);
+        const members = [
+            makeMember('p3', 'Charlie'),
+            makeMember('p1', 'Alice'),
+            makeMember('p2', 'Bob'),
+        ];
         const electedOrder = makeElectedOrder({ p1: 3, p2: 1, p3: 2 });
 
         const result = buildCouncilComposition(
-            attendance, rawPresentIds, null, null, null, electedOrder,
+            members, null, null, null, electedOrder,
         );
 
         expect(result.members.map(m => m.personId)).toEqual(['p2', 'p3', 'p1']);
     });
 
     it('handles null mayor and president', () => {
-        const attendance = { present: [makeMember('p1', 'Alice')], absent: [] };
-        const rawPresentIds = new Set(['p1']);
+        const members = [makeMember('p1', 'Alice')];
 
         const result = buildCouncilComposition(
-            attendance, rawPresentIds, null, null, null, noElectedOrder,
+            members, null, null, null, noElectedOrder,
         );
 
         expect(result.mayor).toBeNull();
         expect(result.president).toBeNull();
         expect(result.members).toHaveLength(1);
-    });
-
-    it('combines present and absent in members list', () => {
-        const attendance = {
-            present: [makeMember('p1', 'Alice')],
-            absent: [makeMember('p2', 'Bob')],
-        };
-        const rawPresentIds = new Set(['p1']);
-
-        const result = buildCouncilComposition(
-            attendance, rawPresentIds, null, null, null, noElectedOrder,
-        );
-
-        expect(result.members).toHaveLength(2);
-        expect(result.members.map(m => m.personId)).toContain('p1');
-        expect(result.members.map(m => m.personId)).toContain('p2');
     });
 });
 

--- a/src/lib/minutes/builders.ts
+++ b/src/lib/minutes/builders.ts
@@ -87,6 +87,8 @@ export function buildVoteResult(
     const forMembers: MinutesMember[] = [];
     const againstMembers: MinutesMember[] = [];
     const abstainMembers: MinutesMember[] = [];
+    const presentMembers: MinutesMember[] = [];
+    const didNotVoteMembers: MinutesMember[] = [];
 
     const voterIds = new Set<string>();
     for (const v of sortedVotes) {
@@ -97,6 +99,8 @@ export function buildVoteResult(
             case 'FOR': forMembers.push(member); break;
             case 'AGAINST': againstMembers.push(member); break;
             case 'ABSTAIN': abstainMembers.push(member); break;
+            case 'PRESENT': presentMembers.push(member); break;
+            case 'DID_NOT_VOTE': didNotVoteMembers.push(member); break;
         }
     }
 
@@ -111,7 +115,7 @@ export function buildVoteResult(
 
     const { passed, isUnanimous } = calculateVoteResult(votes);
 
-    return { forMembers, againstMembers, abstainMembers, absentMembers, passed, isUnanimous };
+    return { forMembers, againstMembers, abstainMembers, presentMembers, didNotVoteMembers, absentMembers, passed, isUnanimous };
 }
 
 /**

--- a/src/lib/minutes/builders.ts
+++ b/src/lib/minutes/builders.ts
@@ -119,11 +119,15 @@ export function buildVoteResult(
 }
 
 /**
- * Builds the overall council composition for the meeting.
- * Pure structural data — no attendance dependency. Lists all council members
+ * Builds the overall composition for the meeting body.
+ * Pure structural data — no attendance dependency. Lists all members
  * sorted by elected order, plus mayor and president.
  *
- * @param members - All council members resolved as MinutesMember
+ * For committees, members are split into regular (τακτικά) and substitute
+ * (αναπληρωματικά) — the caller provides them pre-split.
+ *
+ * @param members - Regular members resolved as MinutesMember
+ * @param substituteMembers - Substitute members (αναπληρωματικά μέλη)
  * @param mayor - Mayor info, or null if not found
  * @param president - Council president info, or null if not found
  * @param mayorPersonId - Mayor's person ID (to exclude from members list)
@@ -131,6 +135,7 @@ export function buildVoteResult(
  */
 export function buildCouncilComposition(
     members: MinutesMember[],
+    substituteMembers: MinutesMember[],
     mayor: { name: string; personId: string } | null,
     president: { name: string; personId: string } | null,
     mayorPersonId: string | null,
@@ -149,7 +154,11 @@ export function buildCouncilComposition(
         .filter(m => m.personId !== mayorPersonId)
         .sort((a, b) => sortByElectedOrder(a, b, getElectedOrder));
 
-    return { mayor: mayorResult, president: presidentResult, members: sortedMembers };
+    const sortedSubstitutes = substituteMembers
+        .filter(m => m.personId !== mayorPersonId)
+        .sort((a, b) => sortByElectedOrder(a, b, getElectedOrder));
+
+    return { mayor: mayorResult, president: presidentResult, members: sortedMembers, substituteMembers: sortedSubstitutes };
 }
 
 

--- a/src/lib/minutes/builders.ts
+++ b/src/lib/minutes/builders.ts
@@ -120,36 +120,39 @@ export function buildVoteResult(
 
 /**
  * Builds the overall council composition for the meeting.
+ * Pure structural data — no attendance dependency. Lists all council members
+ * sorted by elected order, plus mayor and president.
  *
- * @param attendance - The attendance split (already excludes mayor)
- * @param rawPresentIds - Set of person IDs marked present (from raw extracted data, includes mayor)
+ * @param members - All council members resolved as MinutesMember
  * @param mayor - Mayor info, or null if not found
  * @param president - Council president info, or null if not found
  * @param mayorPersonId - Mayor's person ID (to exclude from members list)
+ * @param getElectedOrder - Resolver for council election order
  */
 export function buildCouncilComposition(
-    attendance: MinutesAttendance,
-    rawPresentIds: Set<string>,
+    members: MinutesMember[],
     mayor: { name: string; personId: string } | null,
     president: { name: string; personId: string } | null,
     mayorPersonId: string | null,
     getElectedOrder: ElectedOrderGetter,
 ): MinutesCouncilComposition {
     const mayorResult: MinutesCouncilComposition['mayor'] = mayor
-        ? { name: formatSurnameFirst(mayor.name), present: rawPresentIds.has(mayor.personId) }
+        ? { name: formatSurnameFirst(mayor.name), personId: mayor.personId }
         : null;
 
     const presidentResult: MinutesCouncilComposition['president'] = president
-        ? { name: formatSurnameFirst(president.name), present: rawPresentIds.has(president.personId) }
+        ? { name: formatSurnameFirst(president.name), personId: president.personId }
         : null;
 
     // Exclude mayor from members list — they're shown separately
-    const allMembers = [...attendance.present, ...attendance.absent]
-        .filter(m => m.personId !== mayorPersonId);
-    allMembers.sort((a, b) => sortByElectedOrder(a, b, getElectedOrder));
+    const sortedMembers = members
+        .filter(m => m.personId !== mayorPersonId)
+        .sort((a, b) => sortByElectedOrder(a, b, getElectedOrder));
 
-    return { mayor: mayorResult, president: presidentResult, members: allMembers };
+    return { mayor: mayorResult, president: presidentResult, members: sortedMembers };
 }
+
+
 
 interface SortableSubject {
     id: string;

--- a/src/lib/minutes/getMinutesData.ts
+++ b/src/lib/minutes/getMinutesData.ts
@@ -383,18 +383,37 @@ export async function getMinutesData(
         }
     }
 
-    // Council composition and absent members both come from the initial roll call
-    // (MeetingAttendance). The composition IS present + absent — the full council
-    // as recorded at the start of the meeting.
+    // Council/committee composition and absent members both come from the initial
+    // roll call (MeetingAttendance). The composition IS present + absent — the full
+    // body as recorded at the start of the meeting.
+    //
+    // For committees, members are split into regular (τακτικά) and substitute
+    // (αναπληρωματικά) based on their Role.name in the administrative body.
     let councilCompositionResult = null;
     let absentMembers: MinutesMember[] | null = null;
+
+    // Build a set of substitute member IDs (those with "Αναπληρωματικό Μέλος" role)
+    const substitutePersonIds = new Set<string>();
+    if (adminBodyId) {
+        for (const person of people) {
+            const substituteRole = person.roles.find(r =>
+                isRoleActiveAt(r, meetingDate) &&
+                r.administrativeBodyId === adminBodyId &&
+                r.name === 'Αναπληρωματικό Μέλος'
+            );
+            if (substituteRole) substitutePersonIds.add(person.id);
+        }
+    }
 
     if (meetingAttendance.length > 0) {
         const allMembers = meetingAttendance
             .map(a => resolveMember(a.personId, a.person.name));
 
+        const regularMembers = allMembers.filter(m => !substitutePersonIds.has(m.personId));
+        const substituteMembers = allMembers.filter(m => substitutePersonIds.has(m.personId));
+
         councilCompositionResult = buildCouncilComposition(
-            allMembers, mayor, president, mayorPersonId, getElectedOrder,
+            regularMembers, substituteMembers, mayor, president, mayorPersonId, getElectedOrder,
         );
 
         absentMembers = meetingAttendance
@@ -417,7 +436,9 @@ export async function getMinutesData(
             name: meeting.name,
             dateTime: meeting.dateTime.toISOString(),
         },
-        administrativeBody: meeting.administrativeBody?.name ?? null,
+        administrativeBody: meeting.administrativeBody
+            ? { name: meeting.administrativeBody.name, type: meeting.administrativeBody.type }
+            : null,
         councilComposition: councilCompositionResult,
         absentMembers,
         preambleEntries,

--- a/src/lib/minutes/getMinutesData.ts
+++ b/src/lib/minutes/getMinutesData.ts
@@ -409,6 +409,7 @@ export async function getMinutesData(
             name: city.name,
             name_municipality: city.name_municipality,
             timezone: city.timezone,
+            logoImage: city.logoImage,
         },
         meeting: {
             id: meeting.id,

--- a/src/lib/minutes/getMinutesData.ts
+++ b/src/lib/minutes/getMinutesData.ts
@@ -1,6 +1,6 @@
 import { getCouncilMeeting } from '@/lib/db/meetings';
 import { getSubjectsForMeeting } from '@/lib/db/subject';
-import { getExtractedDataForMeeting, SubjectExtractedData } from '@/lib/db/decisions';
+import { getExtractedDataForMeeting, getMeetingAttendance, SubjectExtractedData } from '@/lib/db/decisions';
 import { getPeopleForCity } from '@/lib/db/people';
 import { getCity } from '@/lib/db/cities';
 import { getSpeakerDisplayInfo, isRoleActiveAt, isMayorRole, simplifyRoleName } from '@/lib/utils/roles';
@@ -18,6 +18,7 @@ import {
     buildVoteResult,
     buildCouncilComposition,
     sortSubjectsByDiscussionOrder,
+    sortByElectedOrder,
     MemberResolver,
     ElectedOrderGetter,
 } from './builders';
@@ -28,12 +29,13 @@ export async function getMinutesData(
     cityId: string,
     meetingId: string,
 ): Promise<MinutesData> {
-    const [meeting, city, subjects, extractedData, people] = await Promise.all([
+    const [meeting, city, subjects, extractedData, people, meetingAttendance] = await Promise.all([
         getCouncilMeeting(cityId, meetingId),
         getCity(cityId),
         getSubjectsForMeeting(cityId, meetingId),
         getExtractedDataForMeeting(cityId, meetingId),
         getPeopleForCity(cityId),
+        getMeetingAttendance(cityId, meetingId),
     ]);
 
     if (!meeting) {
@@ -363,15 +365,10 @@ export async function getMinutesData(
     });
 
     // Council composition: all members sorted by elected order,
-    // plus mayor and president of the administrative body
-    const firstSubjectWithAttendance = sortedSubjects.find(s => extractedDataMap.get(s.id)?.attendance?.length);
-    const overallExtractedData = firstSubjectWithAttendance ? extractedDataMap.get(firstSubjectWithAttendance.id)! : null;
-    const overallAttendance = overallExtractedData
-        ? buildAttendance(overallExtractedData.attendance, mayorPersonId, resolveMember, getElectedOrder)
-        : null;
+    // plus mayor and president of the administrative body.
+    // Built from roles — no attendance dependency.
     const adminBodyId = meeting.administrativeBody?.id ?? null;
 
-    // Find mayor and president for council composition
     const mayorPerson = mayorPersonId ? people.find(p => p.id === mayorPersonId) : null;
     const mayor = mayorPerson ? { personId: mayorPerson.id, name: mayorPerson.name } : null;
 
@@ -389,15 +386,26 @@ export async function getMinutesData(
         }
     }
 
+    // Council composition and absent members both come from the initial roll call
+    // (MeetingAttendance). The composition IS present + absent — the full council
+    // as recorded at the start of the meeting.
     let councilCompositionResult = null;
-    if (overallAttendance && overallExtractedData) {
-        const rawPresentIds = new Set(
-            overallExtractedData.attendance.filter(a => a.status === 'PRESENT').map(a => a.personId)
-        );
+    let absentMembers: MinutesMember[] | null = null;
+
+    if (meetingAttendance.length > 0) {
+        const allMembers = meetingAttendance
+            .map(a => resolveMember(a.personId, a.person.name));
+
         councilCompositionResult = buildCouncilComposition(
-            overallAttendance, rawPresentIds, mayor, president, mayorPersonId, getElectedOrder,
+            allMembers, mayor, president, mayorPersonId, getElectedOrder,
         );
+
+        absentMembers = meetingAttendance
+            .filter(a => a.status === 'ABSENT')
+            .map(a => resolveMember(a.personId, a.person.name))
+            .sort((a, b) => sortByElectedOrder(a, b, getElectedOrder));
     }
+
 
     return {
         city: {
@@ -413,6 +421,7 @@ export async function getMinutesData(
         },
         administrativeBody: meeting.administrativeBody?.name ?? null,
         councilComposition: councilCompositionResult,
+        absentMembers,
         preambleEntries,
         subjects: minutesSubjects,
         epilogueEntries,

--- a/src/lib/minutes/getMinutesData.ts
+++ b/src/lib/minutes/getMinutesData.ts
@@ -284,19 +284,16 @@ export async function getMinutesData(
             continue;
         }
 
-        // Find which subject this orphan falls before: it belongs to the first subject
-        // whose first utterance starts after this orphan
+        // Assign orphan to the next subject that starts after it. This handles both:
+        // - Orphans in the gap between subjects (the common case)
+        // - Orphans interleaved within a subject's range (e.g. OTHER utterances
+        //   between VOTE and SUBJECT_DISCUSSION of the next subject)
         let assigned = false;
         for (let i = 0; i < sortedSubjects.length; i++) {
             const bounds = subjectBounds[i];
             if (bounds.firstTs === Infinity) continue;
 
-            // Check if orphan falls between previous subject's end and this subject's start
-            const prevEnd = i > 0
-                ? Math.max(...subjectBounds.slice(0, i).filter(b => b.lastTs !== -Infinity).map(b => b.lastTs))
-                : firstSubjectTs;
-
-            if (u.startTimestamp >= prevEnd && u.startTimestamp < bounds.firstTs) {
+            if (u.startTimestamp < bounds.firstTs) {
                 const list = preDiscussionByIndex.get(i) || [];
                 list.push(u);
                 preDiscussionByIndex.set(i, list);
@@ -305,9 +302,9 @@ export async function getMinutesData(
             }
         }
 
-        // Orphans within a subject's range that weren't assigned — append to preamble
+        // Orphans after the last subject's start but before lastSubjectTs — append to epilogue
         if (!assigned) {
-            preambleUtterances.push(u);
+            epilogueUtterances.push(u);
         }
     }
 

--- a/src/lib/minutes/types.ts
+++ b/src/lib/minutes/types.ts
@@ -11,14 +11,9 @@ export interface MinutesAttendance {
     absent: MinutesMember[];
 }
 
-export interface MinutesOfficialRole {
-    name: string;
-    present: boolean;
-}
-
 export interface MinutesCouncilComposition {
-    mayor: MinutesOfficialRole | null;
-    president: MinutesOfficialRole | null;
+    mayor: { name: string; personId: string } | null;
+    president: { name: string; personId: string } | null;
     members: MinutesMember[];
 }
 
@@ -94,6 +89,8 @@ export interface MinutesData {
     };
     administrativeBody: string | null;
     councilComposition: MinutesCouncilComposition | null;
+    /** Members absent at the start of the meeting (initial roll call) */
+    absentMembers: MinutesMember[] | null;
     /** Orphaned utterances before the first subject (opening remarks, procedural content) */
     preambleEntries: MinutesTranscriptEntry[];
     subjects: MinutesSubject[];

--- a/src/lib/minutes/types.ts
+++ b/src/lib/minutes/types.ts
@@ -15,6 +15,8 @@ export interface MinutesCouncilComposition {
     mayor: { name: string; personId: string } | null;
     president: { name: string; personId: string } | null;
     members: MinutesMember[];
+    /** Substitute members (αναπληρωματικά μέλη) — only for committees */
+    substituteMembers: MinutesMember[];
 }
 
 export interface MinutesVoteResult {
@@ -88,7 +90,7 @@ export interface MinutesData {
         name: string;
         dateTime: string; // ISO string for JSON serialization
     };
-    administrativeBody: string | null;
+    administrativeBody: { name: string; type: string } | null;
     councilComposition: MinutesCouncilComposition | null;
     /** Members absent at the start of the meeting (initial roll call) */
     absentMembers: MinutesMember[] | null;

--- a/src/lib/minutes/types.ts
+++ b/src/lib/minutes/types.ts
@@ -26,6 +26,10 @@ export interface MinutesVoteResult {
     forMembers: MinutesMember[];
     againstMembers: MinutesMember[];
     abstainMembers: MinutesMember[];
+    /** Members who declared physical presence but did not participate in the vote (ΠΑΡΩΝ) */
+    presentMembers: MinutesMember[];
+    /** Members who declined to participate (ΑΠΟΧΗ) */
+    didNotVoteMembers: MinutesMember[];
     absentMembers: MinutesMember[];
     passed: boolean;
     isUnanimous: boolean;

--- a/src/lib/minutes/types.ts
+++ b/src/lib/minutes/types.ts
@@ -80,6 +80,7 @@ export interface MinutesData {
         name: string;
         name_municipality: string;
         timezone: string;
+        logoImage: string | null;
     };
     meeting: {
         id: string;

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -1282,24 +1282,28 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
 
         // --- Store meeting-level initial attendance (roll call) ---
         if (result.extractions.initialAttendance && result.extractions.initialAttendance.length > 0) {
-            const cityId = task.cityId!;
-            const meetingId = task.councilMeetingId!;
-            await prisma.$transaction(async (tx) => {
-                await tx.meetingAttendance.deleteMany({
-                    where: { cityId, councilMeetingId: meetingId, source: DataSource.decision },
+            try {
+                const cityId = task.cityId!;
+                const meetingId = task.councilMeetingId!;
+                await prisma.$transaction(async (tx) => {
+                    await tx.meetingAttendance.deleteMany({
+                        where: { cityId, councilMeetingId: meetingId, source: DataSource.decision },
+                    });
+                    await tx.meetingAttendance.createMany({
+                        data: result.extractions!.initialAttendance!.map(a => ({
+                            cityId,
+                            councilMeetingId: meetingId,
+                            personId: a.personId,
+                            status: a.status,
+                            source: DataSource.decision,
+                            taskId,
+                        })),
+                    });
                 });
-                await tx.meetingAttendance.createMany({
-                    data: result.extractions!.initialAttendance!.map(a => ({
-                        cityId,
-                        councilMeetingId: meetingId,
-                        personId: a.personId,
-                        status: a.status,
-                        source: DataSource.decision,
-                        taskId,
-                    })),
-                });
-            });
-            console.log(`Stored ${result.extractions.initialAttendance.length} meeting-level attendance records`);
+                console.log(`Stored ${result.extractions.initialAttendance.length} meeting-level attendance records`);
+            } catch (error) {
+                console.error('Failed to store meeting-level attendance:', error);
+            }
         }
 
         if (result.extractions.warnings.length > 0) {

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -1280,6 +1280,28 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
             }
         }
 
+        // --- Store meeting-level initial attendance (roll call) ---
+        if (result.extractions.initialAttendance && result.extractions.initialAttendance.length > 0) {
+            const cityId = task.cityId!;
+            const meetingId = task.councilMeetingId!;
+            await prisma.$transaction(async (tx) => {
+                await tx.meetingAttendance.deleteMany({
+                    where: { cityId, councilMeetingId: meetingId, source: DataSource.decision },
+                });
+                await tx.meetingAttendance.createMany({
+                    data: result.extractions!.initialAttendance!.map(a => ({
+                        cityId,
+                        councilMeetingId: meetingId,
+                        personId: a.personId,
+                        status: a.status,
+                        source: DataSource.decision,
+                        taskId,
+                    })),
+                });
+            });
+            console.log(`Stored ${result.extractions.initialAttendance.length} meeting-level attendance records`);
+        }
+
         if (result.extractions.warnings.length > 0) {
             console.log(`Extraction warnings (${result.extractions.warnings.length}):`);
             for (const w of result.extractions.warnings) {

--- a/src/lib/utils/__tests__/votes.test.ts
+++ b/src/lib/utils/__tests__/votes.test.ts
@@ -12,6 +12,8 @@ describe('calculateVoteResult', () => {
             forCount: 0,
             againstCount: 0,
             abstainCount: 0,
+            presentCount: 0,
+            didNotVoteCount: 0,
             totalVotes: 0,
             isUnanimous: false,
             passed: false,

--- a/src/lib/utils/votes.ts
+++ b/src/lib/utils/votes.ts
@@ -4,6 +4,10 @@ export interface VoteResultSummary {
     forCount: number;
     againstCount: number;
     abstainCount: number;
+    /** Members who declared ΠΑΡΩΝ — present but not participating (not counted in totalVotes) */
+    presentCount: number;
+    /** Members who declared ΑΠΟΧΗ — declined to participate (not counted in totalVotes) */
+    didNotVoteCount: number;
     totalVotes: number;
     isUnanimous: boolean;
     passed: boolean;
@@ -13,6 +17,8 @@ export function calculateVoteResult(votes: { voteType: VoteType }[]): VoteResult
     let forCount = 0;
     let againstCount = 0;
     let abstainCount = 0;
+    let presentCount = 0;
+    let didNotVoteCount = 0;
 
     for (const vote of votes) {
         switch (vote.voteType) {
@@ -25,12 +31,19 @@ export function calculateVoteResult(votes: { voteType: VoteType }[]): VoteResult
             case 'ABSTAIN':
                 abstainCount++;
                 break;
+            case 'PRESENT':
+                presentCount++;
+                break;
+            case 'DID_NOT_VOTE':
+                didNotVoteCount++;
+                break;
         }
     }
 
+    // PRESENT and DID_NOT_VOTE are declarations, not votes — excluded from totalVotes
     const totalVotes = forCount + againstCount + abstainCount;
     const passed = forCount > againstCount;
     const isUnanimous = totalVotes > 0 && againstCount === 0 && abstainCount === 0;
 
-    return { forCount, againstCount, abstainCount, totalVotes, isUnanimous, passed };
+    return { forCount, againstCount, abstainCount, presentCount, didNotVoteCount, totalVotes, isUnanimous, passed };
 }


### PR DESCRIPTION
## Summary

- Add `MeetingAttendance` model to store the initial roll call (quorum/απαρτία) — who was present/absent when the session started
- Extend `VoteType` with `PRESENT` (Παρών) and `DID_NOT_VOTE` (Αποχή) — parliamentary declarations distinct from votes
- Decouple council composition from per-subject attendance — composition now comes from `MeetingAttendance` (the full council), with a separate ΑΠΟΝΤΕΣ section
- Add attendance summary in DecisionsPanel for extraction review
- Gender-aware absent labels (ΑΠΩΝ/ΑΠΟΥΣΑ) for mayor and president

## Context

Continues #173. See [status update comment](https://github.com/schemalabz/opencouncil/issues/173#issuecomment-4380781189) for the full plan. Companion PR: schemalabz/opencouncil-tasks#38.

<!-- preview-link: tasks=38 -->

## Test plan

- [ ] Migration applies cleanly
- [ ] Trigger extraction on a meeting with linked decisions — verify MeetingAttendance records created
- [ ] Preview minutes: composition section shows full council from roll call, ΑΠΟΝΤΕΣ section shows absent members
- [ ] Export DOCX — verify structure matches preview
- [ ] Clear extracted data — verify MeetingAttendance also cleared
- [ ] Meeting without MeetingAttendance data — no composition section, no crash

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `MeetingAttendance` model for the initial roll call (quorum check) and extends `VoteType` with `PRESENT` (Παρών) and `DID_NOT_VOTE` (Αποχή) parliamentary declarations. Council composition is now derived from the meeting-level roll call rather than per-subject attendance data.

- Adds the `MeetingAttendance` DB table (migration + Prisma schema), stored via `pollDecisions` under `source: decision`, and cleared alongside other extracted data.
- Extends `buildVoteResult` / `MinutesVoteResult` to track `presentMembers` and `didNotVoteMembers`, renders them in both the HTML preview and DOCX export, and excludes these declarations from `totalVotes` / `isUnanimous` logic.
- Wires meeting-level attendance into `getMinutesData`, exposes it through the decisions API, and adds a collapsible summary in `DecisionsPanel` for admin review.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — the new MeetingAttendance model, extended VoteType enum, and all rendering paths are wired up correctly and consistently across the preview, DOCX, and admin panel.

The new MeetingAttendance model, extended VoteType enum, and all rendering paths are wired up correctly. The previously flagged rendering gaps have been addressed in the current code. The only gaps are test coverage for the new vote types, which does not affect runtime correctness.

src/lib/utils/__tests__/votes.test.ts and src/lib/minutes/__tests__/builders.test.ts have no test cases for the new PRESENT and DID_NOT_VOTE VoteType values.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/minutes/builders.ts | Adds PRESENT and DID_NOT_VOTE cases to buildVoteResult switch and stores them in dedicated member lists; absent-member derivation is correct. |
| src/lib/utils/votes.ts | calculateVoteResult correctly excludes PRESENT/DID_NOT_VOTE from totalVotes; passed/isUnanimous semantics are intentional per PR description. |
| src/components/meetings/admin/MinutesPreviewContent.tsx | SubjectFooter now renders presentMembers and didNotVoteMembers; CouncilCompositionSection filters both mayor and president from the ΑΠΟΝΤΕΣ inline list. |
| src/components/meetings/docx/MinutesDocx.ts | DOCX vote breakdown includes ΠΑΡΟΝΤΕΣ and ΑΠΟΧΗ sections; absent-member inline sentence correctly excludes mayor and president. |
| src/lib/minutes/getMinutesData.ts | Council composition and absentMembers now derived from MeetingAttendance roll call; null when no roll call data, no crash. |
| prisma/migrations/20260505000001_add_meeting_attendance_and_extended_vote_types/migration.sql | Migration safely adds PRESENT/DID_NOT_VOTE enum values and creates MeetingAttendance table with correct composite unique constraint and FK cascades. |
| src/lib/db/decisions.ts | getMeetingAttendance is straightforward; clearExtractedDataForMeeting atomically deletes MeetingAttendance rows with source=decision alongside other extracted data. |
| src/lib/tasks/pollDecisions.ts | MeetingAttendance write wrapped in transaction with delete-then-create, failure isolated in try/catch; does not break per-subject extraction. |
| src/components/meetings/admin/DecisionsPanel.tsx | Adds MeetingAttendanceSummary component with collapsible roll-call display; hardcoded English strings are a known cosmetic gap. |
| src/lib/utils/__tests__/votes.test.ts | Tests cover all original vote outcomes but have no cases for the new PRESENT and DID_NOT_VOTE vote types (e.g., excluded from totalVotes, unanimity behavior with mixed declarations). |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Task as pollDecisions task
    participant DB as Prisma / DB
    participant API as decisions route (GET)
    participant UI as DecisionsPanel
    participant Minutes as getMinutesData

    Task->>DB: "deleteMany MeetingAttendance (source=decision)"
    Task->>DB: createMany MeetingAttendance (roll-call records)

    UI->>API: GET /decisions
    API->>DB: getMeetingAttendance
    API-->>UI: "{ meetingAttendance }"
    UI->>UI: render MeetingAttendanceSummary (present/absent counts)

    Minutes->>DB: getMeetingAttendance
    Minutes->>Minutes: buildCouncilComposition (from roll call)
    Minutes->>Minutes: "filter absentMembers (status=ABSENT)"
    Minutes-->>UI: "MinutesData { councilComposition, absentMembers }"

    Note over UI: Preview and DOCX render ΣΥΝΘΕΣΗ plus ΑΠΟΝΤΕΣ section and per-subject ΠΑΡΟΝΤΕΣ and ΑΠΟΧΗ rows
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `src/components/meetings/admin/DecisionsPanel.tsx`, line 176-212 ([link](https://github.com/schemalabz/opencouncil/blob/347bbf0b0171c2c1ae085a9c36d562141fcbd631/src/components/meetings/admin/DecisionsPanel.tsx#L176-L212)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Hardcoded English strings**

   `"Initial roll call"`, `"Present"`, and `"Absent"` are hardcoded in this component while the rest of the admin panel uses `useTranslations`. If the application is ever served in a non-English locale these labels will stay in English.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/meetings/admin/DecisionsPanel.tsx
   Line: 176-212

   Comment:
   **Hardcoded English strings**

   `"Initial roll call"`, `"Present"`, and `"Absent"` are hardcoded in this component while the rest of the admin panel uses `useTranslations`. If the application is ever served in a non-English locale these labels will stay in English.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/lib/minutes/builders.ts`, line 96-101 ([link](https://github.com/schemalabz/opencouncil/blob/347bbf0b0171c2c1ae085a9c36d562141fcbd631/src/lib/minutes/builders.ts#L96-L101)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **New vote types silently dropped from minutes output**

   `buildVoteResult` iterates all votes and adds every person to `voterIds`, but the switch only handles `FOR`, `AGAINST`, and `ABSTAIN`. Members who cast `PRESENT` or `DID_NOT_VOTE` are excluded from absent (because they're in `voterIds`), yet are never added to any output list — they completely disappear from the rendered minutes. `MinutesVoteResult` has no fields for these new parliamentary declarations either, so the fix requires both adding those fields to the type and handling the new cases here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/minutes/builders.ts
   Line: 96-101

   Comment:
   **New vote types silently dropped from minutes output**

   `buildVoteResult` iterates all votes and adds every person to `voterIds`, but the switch only handles `FOR`, `AGAINST`, and `ABSTAIN`. Members who cast `PRESENT` or `DID_NOT_VOTE` are excluded from absent (because they're in `voterIds`), yet are never added to any output list — they completely disappear from the rendered minutes. `MinutesVoteResult` has no fields for these new parliamentary declarations either, so the fix requires both adding those fields to the type and handling the new cases here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

3. `src/components/meetings/admin/MinutesPreviewContent.tsx`, line 329-373 ([link](https://github.com/schemalabz/opencouncil/blob/2929297a6f58a7a8ae5b8e0694a3fd08143b8591/src/components/meetings/admin/MinutesPreviewContent.tsx#L329-L373)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **PRESENT/DID_NOT_VOTE votes not rendered in preview**

   `SubjectFooter` renders `forMembers`, `againstMembers`, `abstainMembers`, and `absentMembers` but silently drops `presentMembers` and `didNotVoteMembers`. The DOCX renderer (`MinutesDocx.ts` lines 685–686) correctly outputs ΠΑΡΟΝΤΕΣ and ΑΠΟΧΗ sections, so the preview and the exported document will diverge for any meeting that includes these new vote types.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/meetings/admin/MinutesPreviewContent.tsx
   Line: 329-373

   Comment:
   **PRESENT/DID_NOT_VOTE votes not rendered in preview**

   `SubjectFooter` renders `forMembers`, `againstMembers`, `abstainMembers`, and `absentMembers` but silently drops `presentMembers` and `didNotVoteMembers`. The DOCX renderer (`MinutesDocx.ts` lines 685–686) correctly outputs ΠΑΡΟΝΤΕΣ and ΑΠΟΧΗ sections, so the preview and the exported document will diverge for any meeting that includes these new vote types.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

4. `src/components/meetings/admin/MinutesPreviewContent.tsx`, line 350-356 ([link](https://github.com/schemalabz/opencouncil/blob/b405ad49ad7b759cdb32b019dfcbfe4ab8317978/src/components/meetings/admin/MinutesPreviewContent.tsx#L350-L356)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> The `SubjectFooter` renders `forMembers`, `againstMembers`, `abstainMembers`, and `absentMembers` but silently drops `presentMembers` and `didNotVoteMembers`. The DOCX renderer (`MinutesDocx.ts`) correctly outputs ΠΑΡΟΝΤΕΣ and ΑΠΟΧΗ sections, so any meeting that uses the new vote types will show a different result in the HTML preview than in the exported document.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/meetings/admin/MinutesPreviewContent.tsx
   Line: 350-356

   Comment:
   The `SubjectFooter` renders `forMembers`, `againstMembers`, `abstainMembers`, and `absentMembers` but silently drops `presentMembers` and `didNotVoteMembers`. The DOCX renderer (`MinutesDocx.ts`) correctly outputs ΠΑΡΟΝΤΕΣ and ΑΠΟΧΗ sections, so any meeting that uses the new vote types will show a different result in the HTML preview than in the exported document.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/lib/utils/__tests__/votes.test.ts:96-103
**No test coverage for the new PRESENT / DID_NOT_VOTE vote types**

The test suite covers every pre-existing `VoteType` but has no cases for `PRESENT` or `DID_NOT_VOTE`. Concretely, there is no test verifying that `presentCount`/`didNotVoteCount` increment correctly, that both are excluded from `totalVotes`, or that a mix of `FOR + PRESENT` votes still yields `isUnanimous = true` (the intended "declarations don't break unanimity" semantic described in the PR). Similarly, `builders.test.ts` never passes `makeVote(…, 'PRESENT')` or `makeVote(…, 'DID_NOT_VOTE')` to `buildVoteResult`, so the routing to `presentMembers`/`didNotVoteMembers` and the correct exclusion of those members from `absentMembers` is untested.


`````

</details>

<sub>Reviews (7): Last reviewed commit: ["feat: add script to find municipal commi..."](https://github.com/schemalabz/opencouncil/commit/62e9a97a804ff0eac99116d8a49ec37ec25f77ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31162388)</sub>

<!-- /greptile_comment -->