### PR TITLE
fix(instrumentation): probe prisma at boot to surface silent hangs

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,9 +1,56 @@
 export async function register() {
-  if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const { registerInitialCache } = await import(
-      '@neshca/cache-handler/instrumentation'
-    );
-    const CacheHandler = (await import('../cache-handler.mjs')).default;
-    await registerInitialCache(CacheHandler);
+  if (process.env.NEXT_RUNTIME !== 'nodejs') {
+    return;
+  }
+
+  const { registerInitialCache } = await import(
+    '@neshca/cache-handler/instrumentation'
+  );
+  const CacheHandler = (await import('../cache-handler.mjs')).default;
+  await registerInitialCache(CacheHandler);
+
+  // Prisma boot probe.
+  //
+  // We've seen DO Apps instances come up with no logs and 100% CPU until
+  // manually restarted. The most plausible cause is the Prisma query engine
+  // hanging on the first DB connection (DNS / IPv6 / TLS race against the
+  // managed Postgres). Without an explicit probe, the hang only surfaces on
+  // the first incoming request and never produces a useful log line, because
+  // the engine doesn't log connection attempts and the process never gets
+  // back to the event loop to flush anything.
+  //
+  // Forcing $connect() at boot with a hard timeout converts that silent
+  // wedge into a fast, loud failure: the process exits non-zero and the
+  // platform restarts the instance instead of leaving it stuck. We skip this
+  // in development so a local DB outage doesn't crash the dev server.
+  if (process.env.NODE_ENV !== 'development') {
+    const { default: prisma } = await import('@/lib/db/prisma');
+    const TIMEOUT_MS = 15_000;
+
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(
+        () =>
+          reject(
+            new Error(`Prisma $connect timed out after ${TIMEOUT_MS}ms`)
+          ),
+        TIMEOUT_MS
+      );
+    });
+
+    try {
+      await Promise.race([prisma.$connect(), timeoutPromise]);
+      console.info('[instrumentation] Prisma connected');
+    } catch (error) {
+      console.error(
+        '[instrumentation] Prisma connection failed at boot — exiting so the platform restarts:',
+        error
+      );
+      // Give stderr a tick to flush before exiting.
+      setTimeout(() => process.exit(1), 100).unref();
+      return;
+    } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Some DO Apps instances come up unresponsive with 100% CPU and zero log output until manually restarted (no rebuild needed). Symptom matches a silent hang in the Prisma query engine's first DB connection — likely a DNS / IPv6 / TLS race against the managed Postgres. Without an explicit probe the wedge only surfaces on the first incoming request and never produces a useful log line, since the engine doesn't log connection attempts and the process never gets back to the event loop to flush stdout.
- Force `prisma.$connect()` at boot inside the existing instrumentation hook with a 15 s timeout. On failure, log to stderr and `process.exit(1)` so the platform restarts the instance instead of leaving it wedged. Skipped in development so a local DB outage doesn't crash `npm run dev`.

## What this changes operationally
- Healthy boots gain one log line: `[instrumentation] Prisma connected`.
- A boot that would previously have wedged silently now exits with `[instrumentation] Prisma connection failed at boot — exiting so the platform restarts: …` and is restarted by App Platform. The DNS race is non-deterministic, so the restart almost always wins it.
- If wedges persist *without* that error log, the hang is happening before instrumentation runs (Next.js standalone bootstrap itself), and the next investigation step is the libuv/DNS thread-pool angle (`UV_THREADPOOL_SIZE`, `--dns-result-order=ipv4first`).

## Test plan
- [ ] CI build & typecheck pass.
- [ ] Deploy to staging; confirm `[instrumentation] Prisma connected` appears in logs on a normal boot.
- [ ] (Optional) simulate failure by pointing `DATABASE_URL` at an unroutable host on a preview deploy and verify the instance exits with the expected stderr line within ~15 s and is restarted by the platform.
- [ ] Watch production over the next few wedges to confirm they now surface as restart loops with logs rather than silent hangs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app boot behavior by forcing a Prisma DB connection and exiting the process on failure, which could cause restart loops if the database is unreachable or slow in non-development environments.
> 
> **Overview**
> Adds a **boot-time Prisma connectivity probe** in `src/instrumentation.ts`, racing `prisma.$connect()` against a 15s timeout to surface otherwise-silent startup hangs.
> 
> On success it logs `[instrumentation] Prisma connected`; on failure/timeout (outside development) it logs an error and exits with code 1 after a short delay so the platform restarts the instance. Also simplifies the runtime guard by early-returning when `NEXT_RUNTIME` is not `nodejs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f9edc672d559a7e8fa673c915a8abc5913fa3c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an explicit `prisma.$connect()` probe at boot inside the Next.js instrumentation hook, with a 15-second timeout and `process.exit(1)` on failure, to convert previously silent Prisma-hang deployments into observable, restartable crash-loops on Digital Ocean App Platform. The existing cache-handler setup is refactored from an `if`-block to an early-return guard with no behaviour change.

- **Boot probe**: imports the singleton Prisma client, races `$connect()` against a 15s timeout, logs success or calls a deferred `process.exit(1)` on failure — skipped when `NODE_ENV === 'development'`.
- **Floating promise risk**: in the timeout path, the original `prisma.$connect()` call is left as an un-caught floating promise; if it eventually rejects, Node.js 15+ raises an `UnhandledPromiseRejection` alongside the intended exit path.
- **Deferred exit**: `register()` returns normally after scheduling the exit, so Next.js briefly starts the server for the 100ms flush window before the process terminates.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one small fix recommended: attach a no-op `.catch` to the `prisma.$connect()` call before passing it to `Promise.race` to prevent a potential unhandled-rejection on the timeout path.

The change touches only instrumentation boot logic and has no impact on the normal request path. The dangling `prisma.$connect()` promise in the timeout branch can produce an unhandled rejection in Node.js 15+, emitting extra noise on stderr and potentially triggering a secondary termination event — though the net result (process exits with code 1) is still correct in practice.

src/instrumentation.ts — specifically the `Promise.race` call and the exit timer on the failure path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/instrumentation.ts | Adds a Prisma `$connect()` boot probe with a 15s timeout; refactors existing `nodejs` runtime guard to early-return style. Two subtle issues: dangling connect promise can leak an unhandled rejection on the timeout path, and `.unref()` on the exit timer means the guaranteed `process.exit(1)` relies on other active event-loop handles. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Next.js as Next.js Boot
    participant Instr as instrumentation.ts register()
    participant Prisma as Prisma $connect()
    participant Timer as 15s Timeout

    Next.js->>Instr: call register()
    Instr->>Instr: registerInitialCache(CacheHandler)
    Instr->>Prisma: prisma.$connect()
    Instr->>Timer: start 15s timeout

    alt Connection succeeds within 15s
        Prisma-->>Instr: resolved
        Instr->>Timer: clearTimeout (finally)
        Instr->>Next.js: log "Prisma connected", return
        Next.js->>Next.js: server starts accepting requests
    else Timeout fires first (15s)
        Timer-->>Instr: reject("timed out")
        Instr->>Timer: clearTimeout (noop – already fired)
        Note over Prisma: still pending (floating promise)
        Instr->>Instr: log error to stderr
        Instr->>Instr: setTimeout(exit(1), 100).unref()
        Instr-->>Next.js: return (register resolves!)
        Next.js->>Next.js: briefly starts server (~100ms)
        Instr->>Instr: process.exit(1)
    else Prisma rejects immediately
        Prisma-->>Instr: rejected
        Instr->>Timer: clearTimeout (finally)
        Instr->>Instr: log error to stderr
        Instr->>Instr: setTimeout(exit(1), 100).unref()
        Instr-->>Next.js: return
        Instr->>Instr: process.exit(1)
    end
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/instrumentation.ts:41-42
When the 15-second timeout wins the race, `prisma.$connect()` is still running in the background as a floating, un-caught promise. If that promise eventually rejects (e.g. once a TCP RST arrives after the hang resolves), Node.js 15+ will emit an `UnhandledPromiseRejection` and may trigger its own termination path, producing misleading stderr noise alongside the intended exit message. Attaching a no-op `.catch` suppresses the unhandled-rejection while keeping all intentional error handling in the `try/catch` block.

```suggestion
    const connectPromise = prisma.$connect().catch(() => {/* swallowed after Promise.race settles */});
    try {
      await Promise.race([connectPromise, timeoutPromise]);
```

### Issue 2 of 2
src/instrumentation.ts:50
Calling `.unref()` on the exit timer tells Node.js to let the process exit naturally if this is the last pending handle. In a healthy Next.js boot there will always be active HTTP-server handles, so in practice the timer fires. But the intent here is an unconditional `process.exit(1)` on failure — `.unref()` introduces a theoretical gap where, if all other handles drain within 100ms, the process exits with code 0 (not 1) and the platform may not restart it. Removing `.unref()` guarantees the intended exit code.

```suggestion
      setTimeout(() => process.exit(1), 100);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(instrumentation): probe prisma at bo..."](https://github.com/schemalabz/opencouncil/commit/0f9edc672d559a7e8fa673c915a8abc5913fa3c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31186977)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->