### PR TITLE
fix(elasticsearch): fix deletion propagation and strip REF links via ingest pipeline

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -160,6 +160,7 @@ PGSync requires helper views to denormalize complex relationships and handle Pos
 1. **LocationSearchView** - Converts PostGIS geometry to GeoJSON format
 2. **IntroducedByPartyView** - Resolves party affiliation through the `Role` table
 3. **SubjectSpeakerSegmentSearchView** - Denormalizes speaker segments with concatenated utterances
+4. **SpeakerContributionSearchView** - Denormalizes speaker contributions with party resolution
 
 ### Create the Views
 
@@ -170,7 +171,7 @@ psql "$DATABASE_URL" < elasticsearch/views.sql
 ```
 
 The script will:
-- Create all three required views
+- Create all four required views
 - Run verification checks on each view
 - Display sample data to confirm everything works
 - Show statistics about data coverage
@@ -723,7 +724,13 @@ A: PGSync tracks its position in the WAL stream using Redis. When it restarts, i
 **Q: How do I update the schema?**  
 A: See <https://pgsync.com/advanced/re-indexing>
 
-**Q: Why use views instead of direct table joins in PGSync?**  
+**Q: Why are REF links (`[text](REF:TYPE:ID)`) indexed in Elasticsearch instead of being stripped?**
+A: This is intentional. The Greek analyzer strips punctuation during tokenization, so `[Ο Δήμαρχος](REF:PERSON:abc123)` tokenizes to the same search terms as `Ο Δήμαρχος`. The extra tokens (`ref`, `person`, `abc123`) are harmless noise that no user would search for. More importantly, **a view with `base_tables: ["Subject"]` would intercept Subject DELETE events in PGSync**, causing deletions to never propagate to Elasticsearch. By reading `description` directly from the Subject table (the root node), we ensure PGSync correctly processes root-table deletions. The app's frontend handles REF link rendering via `FormattedTextDisplay` and `stripMarkdown()`.
+
+**Q: Why must views never list the root table in `base_tables`?**
+A: PGSync builds an internal `base_table_to_node` mapping from all views' `base_tables`. If a view declares `base_tables: ["Subject"]` (the root table), PGSync treats Subject WAL events as child-node changes for that view, instead of root-table operations. This means DELETE events on Subject are never processed as document deletions — PGSync tries to "re-sync" the parent document instead, which fails silently because the row is already gone. **Rule: only use `base_tables` for tables that are NOT the root node.**
+
+**Q: Why use views instead of direct table joins in PGSync?**
 A: Views handle complex logic (PostGIS conversion, role-based party resolution, utterance concatenation) in PostgreSQL where it's more efficient. PGSync sees views as simple tables, keeping the sync configuration clean.
 
 **Q: Can I combine semantic search with traditional text search?**  

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -9,10 +9,11 @@ This document describes how OpenCouncil uses Elasticsearch to provide powerful s
 2. [Codebase Structure](#codebase-structure)
 3. [Set up Elasticsearch](#set-up-elasticsearch)
 4. [Configure PostgreSQL Views](#configure-postgresql-views)
-5. [Set up PGSync](#set-up-pgsync)
-6. [Sync Data](#sync-data)
-7. [Search Examples](#search-examples)
-8. [Best Practices & FAQ](#best-practices--faq)
+5. [Configure the Ingest Pipeline](#configure-the-ingest-pipeline)
+6. [Set up PGSync](#set-up-pgsync)
+7. [Sync Data](#sync-data)
+8. [Search Examples](#search-examples)
+9. [Best Practices & FAQ](#best-practices--faq)
 
 
 ### Architecture Overview
@@ -185,6 +186,60 @@ View the full view definitions and verification logic in `elasticsearch/views.sq
 
 
 
+## Configure the Ingest Pipeline
+
+Subject descriptions, speaker contributions, and segment summaries contain markdown REF links (`[text](REF:TYPE:ID)`). The database keeps the raw markdown, because the frontend renders these links. The search index must not contain them: the markup adds noise tokens and it degrades the `semantic_text` embeddings (see the [FAQ on REF links](#best-practices--faq)).
+
+An Elasticsearch [ingest pipeline](https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html) named `strip-refs` removes the links at index time. PGSync attaches the pipeline to every document it writes, through the top-level `"pipeline": "strip-refs"` key in `elasticsearch/schema.json`. The pipeline runs before analysis and before `semantic_text` inference, so tokens and embeddings both come out clean. Delete operations do not use the pipeline and are unaffected.
+
+The pipeline definition lives in [`elasticsearch/pipeline.json`](./pipeline.json). It uses one `gsub` processor for `description` and `foreach` processors for the nested arrays (`speaker_contributions.text`, `speaker_segments.summary`), because a plain `gsub` does not iterate arrays of objects.
+
+### Create or Update the Pipeline
+
+The pipeline is a cluster-level object. Create it once per cluster. The same command also updates it, because `PUT` replaces the stored definition:
+
+```bash
+curl -X PUT "$ELASTICSEARCH_URL/_ingest/pipeline/strip-refs" \
+  -H "Authorization: ApiKey $ELASTICSEARCH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @elasticsearch/pipeline.json
+```
+
+**Order matters:** create the pipeline before PGSync runs with a schema that references it. If the pipeline is missing, every bulk write fails.
+
+### Verify the Pipeline
+
+Check that the stored definition matches the repository file:
+
+```bash
+curl "$ELASTICSEARCH_URL/_ingest/pipeline/strip-refs" \
+  -H "Authorization: ApiKey $ELASTICSEARCH_API_KEY"
+```
+
+Simulate the pipeline against a sample document and confirm the REF links are stripped:
+
+```bash
+curl -X POST "$ELASTICSEARCH_URL/_ingest/pipeline/strip-refs/_simulate" \
+  -H "Authorization: ApiKey $ELASTICSEARCH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "docs": [{"_source": {
+      "description": "Ενημέρωση από [τον Δήμαρχο](REF:PERSON:abc123) για το θέμα",
+      "speaker_contributions": [{"text": "Αναφορά στην [εισήγηση](REF:UTTERANCE:xyz789)."}]
+    }}]
+  }'
+```
+
+Expected output: `"description": "Ενημέρωση από τον Δήμαρχο για το θέμα"` and `"text": "Αναφορά στην εισήγηση."`.
+
+### Scope and Re-indexing
+
+- The pipeline transforms documents at index time only. PostgreSQL keeps the raw markdown.
+- Existing documents keep their old text until they are re-indexed. Run a PGSync bootstrap to apply the pipeline to all documents.
+- To strip an additional field, add a processor to `pipeline.json`, run the `PUT` command again, and re-index.
+
+
+
 ## PGSync Setup and Data Synchronization
 
 [PGSync](https://github.com/toluaina/pgsync) is a change data capture (CDC) tool that syncs PostgreSQL to Elasticsearch using logical replication. It runs as a separate service in the [opencouncil-tasks](https://github.com/schemalabz/opencouncil-tasks) repository.
@@ -195,6 +250,7 @@ View the full view definitions and verification logic in `elasticsearch/views.sq
 
 The `elasticsearch/schema.json` file defines:
 - **Index mapping**: Elasticsearch field types, analyzers
+- **Ingest pipeline**: the top-level `pipeline` key names the pipeline that Elasticsearch runs on every indexed document (see [Configure the Ingest Pipeline](#configure-the-ingest-pipeline))
 - **Nodes**: PostgreSQL tables and their relationships  
 - **Transform rules**: Field renaming, scalar vs object variants
 - **Children**: Nested relationships (e.g., speaker_segments)
@@ -738,12 +794,14 @@ A: PGSync tracks its position in the WAL stream using Redis. When it restarts, i
 **Q: How do I update the schema?**  
 A: See <https://pgsync.com/advanced/re-indexing>
 
-**Q: Why are REF links (`[text](REF:TYPE:ID)`) indexed in Elasticsearch instead of being stripped?**
-A: The old SubjectSearchView stripped REF links, but it declared `base_tables: ["Subject"]` and broke deletion propagation (see the next question). We now read `description` directly from the root table, so REF links reach the index. The measured impact (`_analyze` and the e5 inference endpoint on the production cluster):
-- **Keyword (BM25) search: unaffected.** The Greek analyzer keeps each `(REF:TYPE:ID)` target as one token (for example `ref:person:abc123`). The app queries use term-based `multi_match` and `match` with no phrase matching, so the extra token is noise that no user searches for.
-- **Semantic search: a small, systematic cost.** `semantic_text` embeds the raw field value, so REF markup enters the embeddings. Measured on 300 staging subjects: markup-heavy documents gain similarity against every query, and clean documents lose the top result in ~4% of self-retrieval queries. A follow-up strips REF links with an Elasticsearch ingest pipeline (PGSync supports a `pipeline` key in schema.json), which cleans both the tokens and the embeddings in one place.
+**Q: Why are REF links (`[text](REF:TYPE:ID)`) stripped with an ingest pipeline instead of SQL views?**
+A: The old SubjectSearchView stripped REF links in SQL, but it declared `base_tables: ["Subject"]` and broke deletion propagation (see the next question). A view on the root table is not safe, so the stripping moved to the `strip-refs` ingest pipeline (see [Configure the Ingest Pipeline](#configure-the-ingest-pipeline)). The pipeline covers all text fields in one place and runs before analysis and before `semantic_text` inference.
 
-The frontend is unaffected either way: it renders REF links via `FormattedTextDisplay` and `stripMarkdown()`, and search results are hydrated from PostgreSQL, not from `_source`.
+Stripping matters mostly for semantic search. The measured impact of raw REF markup (`_analyze` and the e5 inference endpoint on the production cluster):
+- **Keyword (BM25) search: unaffected.** The Greek analyzer keeps each `(REF:TYPE:ID)` target as one token (for example `ref:person:abc123`). The app queries use term-based `multi_match` and `match` with no phrase matching, so the extra token is noise that no user searches for.
+- **Semantic search: a small, systematic cost.** `semantic_text` embeds the raw field value, so unstripped markup enters the embeddings. Measured on 300 staging subjects: markup-heavy documents gain similarity against every query, and clean documents lose the top result in ~4% of self-retrieval queries.
+
+The frontend is unaffected: it renders REF links via `FormattedTextDisplay` and `stripMarkdown()`, and search results are hydrated from PostgreSQL, not from `_source`.
 
 **Q: Why must views never list the root table in `base_tables`?**
 A: PGSync builds an internal `base_table_to_node` mapping from all views' `base_tables`. If a view declares `base_tables: ["Subject"]` (the root table), PGSync treats Subject WAL events as child-node changes for that view, instead of root-table operations. This means DELETE events on Subject are never processed as document deletions — PGSync tries to "re-sync" the parent document instead, which fails silently because the row is already gone. **Rule: only use `base_tables` for tables that are NOT the root node.**

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -160,6 +160,7 @@ PGSync requires helper views to denormalize complex relationships and handle Pos
 1. **LocationSearchView** - Converts PostGIS geometry to GeoJSON format
 2. **IntroducedByPartyView** - Resolves party affiliation through the `Role` table
 3. **SubjectSpeakerSegmentSearchView** - Denormalizes speaker segments with concatenated utterances
+4. **SpeakerContributionSearchView** - Denormalizes speaker contributions with party resolution
 
 ### Create the Views
 
@@ -170,7 +171,7 @@ psql "$DATABASE_URL" < elasticsearch/views.sql
 ```
 
 The script will:
-- Create all three required views
+- Create all four required views
 - Run verification checks on each view
 - Display sample data to confirm everything works
 - Show statistics about data coverage
@@ -737,7 +738,20 @@ A: PGSync tracks its position in the WAL stream using Redis. When it restarts, i
 **Q: How do I update the schema?**  
 A: See <https://pgsync.com/advanced/re-indexing>
 
-**Q: Why use views instead of direct table joins in PGSync?**  
+**Q: Why are REF links (`[text](REF:TYPE:ID)`) indexed in Elasticsearch instead of being stripped?**
+A: The old SubjectSearchView stripped REF links, but it declared `base_tables: ["Subject"]` and broke deletion propagation (see the next question). We now read `description` directly from the root table, so REF links reach the index. The measured impact (`_analyze` and the e5 inference endpoint on the production cluster):
+- **Keyword (BM25) search: unaffected.** The Greek analyzer keeps each `(REF:TYPE:ID)` target as one token (for example `ref:person:abc123`). The app queries use term-based `multi_match` and `match` with no phrase matching, so the extra token is noise that no user searches for.
+- **Semantic search: a small, systematic cost.** `semantic_text` embeds the raw field value, so REF markup enters the embeddings. Measured on 300 staging subjects: markup-heavy documents gain similarity against every query, and clean documents lose the top result in ~4% of self-retrieval queries. A follow-up strips REF links with an Elasticsearch ingest pipeline (PGSync supports a `pipeline` key in schema.json), which cleans both the tokens and the embeddings in one place.
+
+The frontend is unaffected either way: it renders REF links via `FormattedTextDisplay` and `stripMarkdown()`, and search results are hydrated from PostgreSQL, not from `_source`.
+
+**Q: Why must views never list the root table in `base_tables`?**
+A: PGSync builds an internal `base_table_to_node` mapping from all views' `base_tables`. If a view declares `base_tables: ["Subject"]` (the root table), PGSync treats Subject WAL events as child-node changes for that view, instead of root-table operations. This means DELETE events on Subject are never processed as document deletions — PGSync tries to "re-sync" the parent document instead, which fails silently because the row is already gone. **Rule: only use `base_tables` for tables that are NOT the root node.**
+
+**Q: The schema is correct, but deletes still do not propagate. Why?**
+A: Check the pgsync version that installed the `table_notify()` trigger function in the database. pgsync versions before 7.x have a bug: the DELETE branch of the function does not include the `indices` field in the notification, and the daemon drops every root DELETE notification. A bootstrap with pgsync >= 7.x re-creates the function and fixes this. To check, inspect the function: `SELECT prosrc FROM pg_proc WHERE proname = 'table_notify'` — the `TG_OP = 'DELETE'` branch must select `primary_keys, indices`, not only `primary_keys`.
+
+**Q: Why use views instead of direct table joins in PGSync?**
 A: Views handle complex logic (PostGIS conversion, role-based party resolution, utterance concatenation) in PostgreSQL where it's more efficient. PGSync sees views as simple tables, keeping the sync configuration clean.
 
 **Q: Can I combine semantic search with traditional text search?**  

--- a/elasticsearch/pipeline.json
+++ b/elasticsearch/pipeline.json
@@ -1,0 +1,43 @@
+{
+  "description": "Strip [text](REF:TYPE:ID) markdown links from indexed text. The database keeps the raw markdown; only the search index sees clean text. See README.md, section 'Create the Ingest Pipeline'.",
+  "processors": [
+    {
+      "gsub": {
+        "field": "description",
+        "pattern": "\\[([^\\]]+)\\]\\(REF:[^)]+\\)",
+        "replacement": "$1",
+        "ignore_missing": true
+      }
+    },
+    {
+      "foreach": {
+        "field": "speaker_contributions",
+        "if": "ctx.speaker_contributions != null",
+        "ignore_missing": true,
+        "processor": {
+          "gsub": {
+            "field": "_ingest._value.text",
+            "pattern": "\\[([^\\]]+)\\]\\(REF:[^)]+\\)",
+            "replacement": "$1",
+            "ignore_missing": true
+          }
+        }
+      }
+    },
+    {
+      "foreach": {
+        "field": "speaker_segments",
+        "if": "ctx.speaker_segments != null",
+        "ignore_missing": true,
+        "processor": {
+          "gsub": {
+            "field": "_ingest._value.summary",
+            "pattern": "\\[([^\\]]+)\\]\\(REF:[^)]+\\)",
+            "replacement": "$1",
+            "ignore_missing": true
+          }
+        }
+      }
+    }
+  ]
+}

--- a/elasticsearch/schema.json
+++ b/elasticsearch/schema.json
@@ -157,7 +157,8 @@
         "createdAt",
         "updatedAt",
         "context",
-        "contextCitationUrls"
+        "contextCitationUrls",
+        "description"
       ],
       "transform": {
         "rename": {
@@ -364,19 +365,6 @@
             "rename": {
               "id": "segment_id"
             }
-          }
-        },
-        {
-          "table": "SubjectSearchView",
-          "schema": "public",
-          "base_tables": ["Subject"],
-          "primary_key": ["id"],
-          "columns": ["description"],
-          "label": "description",
-          "relationship": {
-            "variant": "scalar",
-            "type": "one_to_one",
-            "foreign_key": { "parent": ["id"], "child": ["id"] }
           }
         },
         {

--- a/elasticsearch/schema.json
+++ b/elasticsearch/schema.json
@@ -2,6 +2,7 @@
   {
     "database": "production",
     "index": "subjects",
+    "pipeline": "strip-refs",
     "mapping": {
       "id": { "type": "keyword" },
       "name": {

--- a/elasticsearch/validate-views.sql
+++ b/elasticsearch/validate-views.sql
@@ -15,16 +15,15 @@
 -- 1. Check all views exist
 -- ============================================================================
 \echo '1. Checking all required views exist...'
-SELECT 
+SELECT
   viewname,
   CASE WHEN viewname IS NOT NULL THEN 'EXISTS' ELSE 'MISSING' END AS status
-FROM pg_views 
-WHERE schemaname = 'public' 
+FROM pg_views
+WHERE schemaname = 'public'
   AND viewname IN (
-    'LocationSearchView', 
-    'IntroducedByPartyView', 
+    'LocationSearchView',
+    'IntroducedByPartyView',
     'SubjectSpeakerSegmentSearchView',
-    'SubjectSearchView',
     'SpeakerContributionSearchView'
   )
 ORDER BY viewname;
@@ -32,51 +31,20 @@ ORDER BY viewname;
 \echo ''
 
 -- ============================================================================
--- 2. Validate SubjectSearchView - reference stripping
+-- 2. Validate SpeakerContributionSearchView - party resolution
 -- ============================================================================
-\echo '2. Validating SubjectSearchView (reference stripping)...'
-SELECT 
-  COUNT(*) AS total_subjects,
-  COUNT(CASE WHEN description ~ '\[.*\]\(REF:' THEN 1 END) AS refs_not_stripped,
-  CASE 
-    WHEN COUNT(CASE WHEN description ~ '\[.*\]\(REF:' THEN 1 END) = 0 
-    THEN 'PASS: All references stripped'
-    ELSE 'FAIL: Some references not stripped'
-  END AS validation_result
-FROM "SubjectSearchView"
-WHERE description IS NOT NULL;
-
-\echo ''
-\echo '   Sample descriptions (first 3):'
-SELECT 
-  id,
-  LEFT(description, 100) || CASE WHEN LENGTH(description) > 100 THEN '...' ELSE '' END AS description_preview
-FROM "SubjectSearchView"
-WHERE description IS NOT NULL AND description != ''
-LIMIT 3;
-
-\echo ''
-
--- ============================================================================
--- 3. Validate SpeakerContributionSearchView - reference stripping + party resolution
--- ============================================================================
-\echo '3. Validating SpeakerContributionSearchView...'
-SELECT 
+\echo '2. Validating SpeakerContributionSearchView...'
+SELECT
   COUNT(*) AS total_contributions,
   COUNT(speaker_person_id) AS with_speaker,
   COUNT(speaker_party_id) AS with_party,
-  COUNT(CASE WHEN text ~ '\[.*\]\(REF:' THEN 1 END) AS refs_not_stripped,
-  CASE 
-    WHEN COUNT(CASE WHEN text ~ '\[.*\]\(REF:' THEN 1 END) = 0 
-    THEN 'PASS: All references stripped'
-    ELSE 'FAIL: Some references not stripped'
-  END AS validation_result
+  COUNT(text) AS with_text
 FROM "SpeakerContributionSearchView";
 
 \echo ''
 \echo '   Sample contributions (first 3):'
-SELECT 
-  contribution_id,
+SELECT
+  id,
   speaker_person_name,
   speaker_party_name,
   LEFT(text, 80) || CASE WHEN LENGTH(text) > 80 THEN '...' ELSE '' END AS text_preview
@@ -87,10 +55,10 @@ LIMIT 3;
 \echo ''
 
 -- ============================================================================
--- 4. Validate SubjectSpeakerSegmentSearchView - party resolution
+-- 3. Validate SubjectSpeakerSegmentSearchView - party resolution
 -- ============================================================================
-\echo '4. Validating SubjectSpeakerSegmentSearchView...'
-SELECT 
+\echo '3. Validating SubjectSpeakerSegmentSearchView...'
+SELECT
   COUNT(*) AS total_segments,
   COUNT(speaker_person_id) AS with_speaker,
   COUNT(speaker_party_id) AS with_party,
@@ -101,10 +69,10 @@ FROM "SubjectSpeakerSegmentSearchView";
 \echo ''
 
 -- ============================================================================
--- 5. Validate IntroducedByPartyView - party resolution
+-- 4. Validate IntroducedByPartyView - party resolution
 -- ============================================================================
-\echo '5. Validating IntroducedByPartyView...'
-SELECT 
+\echo '4. Validating IntroducedByPartyView...'
+SELECT
   COUNT(*) AS total_mappings,
   COUNT(DISTINCT person_id) AS unique_persons,
   COUNT(DISTINCT party_id) AS unique_parties,
@@ -114,10 +82,10 @@ FROM "IntroducedByPartyView";
 \echo ''
 
 -- ============================================================================
--- 6. Validate LocationSearchView - GeoJSON conversion
+-- 5. Validate LocationSearchView - GeoJSON conversion
 -- ============================================================================
-\echo '6. Validating LocationSearchView...'
-SELECT 
+\echo '5. Validating LocationSearchView...'
+SELECT
   COUNT(*) AS total_locations,
   COUNT(geojson) AS with_geojson,
   COUNT(*) - COUNT(geojson) AS missing_geojson
@@ -132,6 +100,5 @@ FROM "LocationSearchView";
 \echo 'Validation Complete'
 \echo '========================================='
 \echo ''
-\echo 'If all checks show PASS and counts look reasonable,'
-\echo 'the views are ready for PGSync.'
+\echo 'If counts look reasonable, the views are ready for PGSync.'
 \echo ''

--- a/elasticsearch/views.sql
+++ b/elasticsearch/views.sql
@@ -93,26 +93,15 @@ LEFT JOIN LATERAL (
 \echo '✓ SubjectSpeakerSegmentSearchView created'
 \echo ''
 
--- View 4: Subject with stripped markdown references for description
--- Why this view? Subject.description now contains markdown with REF:TYPE:ID links
--- that should be stripped before indexing in Elasticsearch for cleaner search.
---   - Strips [text](REF:TYPE:ID) patterns, keeping only the display text
---   - This allows semantic search on the description without reference noise
-\echo 'Creating SubjectSearchView...'
-CREATE OR REPLACE VIEW "SubjectSearchView" AS
-SELECT 
-  id,
-  -- Strip [text](REF:TYPE:ID) -> text
-  regexp_replace(description, '\[([^\]]+)\]\(REF:[^)]+\)', '\1', 'g') AS description
-FROM "Subject";
-\echo '✓ SubjectSearchView created'
-\echo ''
-
--- View 5: Speaker contributions with party details via Role
+-- View 4: Speaker contributions with party details via Role
 -- Why this view? This view:
---   - Strips markdown reference links from contribution text
 --   - Resolves speaker party through active roles (same logic as other views)
 --   - Provides denormalized speaker/party info for Elasticsearch indexing
+--
+-- NOTE: REF links ([text](REF:TYPE:ID)) in contribution text are indexed as-is.
+-- The Greek analyzer strips punctuation, so search quality is unaffected.
+-- Keeping REF links avoids having the root table (Subject) in any view's
+-- base_tables, which would break PGSync deletion propagation.
 --
 -- IMPORTANT: Primary key column keeps original name (`id` not `contribution_id`)
 -- PGSync live sync receives WAL events with base table column names. If we alias
@@ -124,8 +113,7 @@ CREATE OR REPLACE VIEW "SpeakerContributionSearchView" AS
 SELECT
   sc.id,  -- Keep as `id` for WAL compatibility; renamed to contribution_id in schema.json
   sc."subjectId" AS subject_id,
-  -- Strip [text](REF:TYPE:ID) -> text
-  regexp_replace(sc.text, '\[([^\]]+)\]\(REF:[^)]+\)', '\1', 'g') AS text,
+  sc.text,
   sp.id AS speaker_person_id,
   sp.name AS speaker_person_name,
   sp.name_en AS speaker_person_name_en,
@@ -162,12 +150,12 @@ LEFT JOIN LATERAL (
 \echo '1. Checking if all views exist...'
 SELECT 
   CASE 
-    WHEN COUNT(*) = 5 THEN '   ✓ All 5 views exist'
-    ELSE '   ✗ Missing views! Expected 5, found ' || COUNT(*)::text
+    WHEN COUNT(*) = 4 THEN '   ✓ All 4 views exist'
+    ELSE '   ✗ Missing views! Expected 4, found ' || COUNT(*)::text
   END AS result
-FROM pg_views 
-WHERE schemaname = 'public' 
-  AND viewname IN ('LocationSearchView', 'IntroducedByPartyView', 'SubjectSpeakerSegmentSearchView', 'SubjectSearchView', 'SpeakerContributionSearchView');
+FROM pg_views
+WHERE schemaname = 'public'
+  AND viewname IN ('LocationSearchView', 'IntroducedByPartyView', 'SubjectSpeakerSegmentSearchView', 'SpeakerContributionSearchView');
 \echo ''
 
 -- Check 2: LocationSearchView - verify it returns data
@@ -235,25 +223,8 @@ LEFT JOIN "IntroducedByPartyView" ibp ON ibp.person_id = s."personId" AND ibp.ci
 WHERE s."personId" IS NOT NULL;
 \echo ''
 
--- Check 6: SubjectSearchView - verify description stripping works
-\echo '6. Checking SubjectSearchView data...'
-SELECT 
-  COUNT(*) AS total_subjects,
-  COUNT(description) AS subjects_with_description
-FROM "SubjectSearchView";
-\echo ''
-
-\echo '   Sample data from SubjectSearchView (showing stripped descriptions):'
-SELECT 
-  id,
-  LEFT(description, 100) || '...' AS description_preview
-FROM "SubjectSearchView"
-WHERE description IS NOT NULL AND description != ''
-LIMIT 3;
-\echo ''
-
--- Check 7: SpeakerContributionSearchView - verify contributions
-\echo '7. Checking SpeakerContributionSearchView data...'
+-- Check 6: SpeakerContributionSearchView - verify contributions
+\echo '6. Checking SpeakerContributionSearchView data...'
 SELECT 
   COUNT(*) AS total_contributions,
   COUNT(speaker_person_id) AS contributions_with_speaker,
@@ -263,8 +234,8 @@ FROM "SpeakerContributionSearchView";
 \echo ''
 
 \echo '   Sample data from SpeakerContributionSearchView:'
-SELECT 
-  contribution_id,
+SELECT
+  id,
   subject_id,
   speaker_person_name,
   speaker_party_name,

--- a/elasticsearch/views.sql
+++ b/elasticsearch/views.sql
@@ -11,6 +11,12 @@
 \echo '========================================='
 \echo ''
 
+-- Drop the legacy SubjectSearchView. schema.json no longer references it,
+-- and CREATE OR REPLACE below does not remove old views.
+DROP VIEW IF EXISTS "SubjectSearchView";
+\echo '✓ Dropped legacy SubjectSearchView (if present)'
+\echo ''
+
 -- View 1: Location geometry to GeoJSON
 -- Why this view? Converts PostGIS geometry to GeoJSON format that Elasticsearch can index.
 --   - PostgreSQL stores coordinates as PostGIS geometry type
@@ -93,26 +99,14 @@ LEFT JOIN LATERAL (
 \echo '✓ SubjectSpeakerSegmentSearchView created'
 \echo ''
 
--- View 4: Subject with stripped markdown references for description
--- Why this view? Subject.description now contains markdown with REF:TYPE:ID links
--- that should be stripped before indexing in Elasticsearch for cleaner search.
---   - Strips [text](REF:TYPE:ID) patterns, keeping only the display text
---   - This allows semantic search on the description without reference noise
-\echo 'Creating SubjectSearchView...'
-CREATE OR REPLACE VIEW "SubjectSearchView" AS
-SELECT 
-  id,
-  -- Strip [text](REF:TYPE:ID) -> text
-  regexp_replace(description, '\[([^\]]+)\]\(REF:[^)]+\)', '\1', 'g') AS description
-FROM "Subject";
-\echo '✓ SubjectSearchView created'
-\echo ''
-
--- View 5: Speaker contributions with party details via Role
+-- View 4: Speaker contributions with party details via Role
 -- Why this view? This view:
---   - Strips markdown reference links from contribution text
 --   - Resolves speaker party through active roles (same logic as other views)
 --   - Provides denormalized speaker/party info for Elasticsearch indexing
+--
+-- NOTE: REF links ([text](REF:TYPE:ID)) in contribution text are indexed as-is.
+-- The views do not strip text. See the README FAQ on REF links for the
+-- measured search impact and for the planned ingest-pipeline stripping.
 --
 -- IMPORTANT: Primary key column keeps original name (`id` not `contribution_id`)
 -- PGSync live sync receives WAL events with base table column names. If we alias
@@ -124,8 +118,7 @@ CREATE OR REPLACE VIEW "SpeakerContributionSearchView" AS
 SELECT
   sc.id,  -- Keep as `id` for WAL compatibility; renamed to contribution_id in schema.json
   sc."subjectId" AS subject_id,
-  -- Strip [text](REF:TYPE:ID) -> text
-  regexp_replace(sc.text, '\[([^\]]+)\]\(REF:[^)]+\)', '\1', 'g') AS text,
+  sc.text,
   sp.id AS speaker_person_id,
   sp.name AS speaker_person_name,
   sp.name_en AS speaker_person_name_en,
@@ -162,12 +155,12 @@ LEFT JOIN LATERAL (
 \echo '1. Checking if all views exist...'
 SELECT 
   CASE 
-    WHEN COUNT(*) = 5 THEN '   ✓ All 5 views exist'
-    ELSE '   ✗ Missing views! Expected 5, found ' || COUNT(*)::text
+    WHEN COUNT(*) = 4 THEN '   ✓ All 4 views exist'
+    ELSE '   ✗ Missing views! Expected 4, found ' || COUNT(*)::text
   END AS result
-FROM pg_views 
-WHERE schemaname = 'public' 
-  AND viewname IN ('LocationSearchView', 'IntroducedByPartyView', 'SubjectSpeakerSegmentSearchView', 'SubjectSearchView', 'SpeakerContributionSearchView');
+FROM pg_views
+WHERE schemaname = 'public'
+  AND viewname IN ('LocationSearchView', 'IntroducedByPartyView', 'SubjectSpeakerSegmentSearchView', 'SpeakerContributionSearchView');
 \echo ''
 
 -- Check 2: LocationSearchView - verify it returns data
@@ -235,25 +228,8 @@ LEFT JOIN "IntroducedByPartyView" ibp ON ibp.person_id = s."personId" AND ibp.ci
 WHERE s."personId" IS NOT NULL;
 \echo ''
 
--- Check 6: SubjectSearchView - verify description stripping works
-\echo '6. Checking SubjectSearchView data...'
-SELECT 
-  COUNT(*) AS total_subjects,
-  COUNT(description) AS subjects_with_description
-FROM "SubjectSearchView";
-\echo ''
-
-\echo '   Sample data from SubjectSearchView (showing stripped descriptions):'
-SELECT 
-  id,
-  LEFT(description, 100) || '...' AS description_preview
-FROM "SubjectSearchView"
-WHERE description IS NOT NULL AND description != ''
-LIMIT 3;
-\echo ''
-
--- Check 7: SpeakerContributionSearchView - verify contributions
-\echo '7. Checking SpeakerContributionSearchView data...'
+-- Check 6: SpeakerContributionSearchView - verify contributions
+\echo '6. Checking SpeakerContributionSearchView data...'
 SELECT 
   COUNT(*) AS total_contributions,
   COUNT(speaker_person_id) AS contributions_with_speaker,
@@ -263,8 +239,8 @@ FROM "SpeakerContributionSearchView";
 \echo ''
 
 \echo '   Sample data from SpeakerContributionSearchView:'
-SELECT 
-  contribution_id,
+SELECT
+  id,
   subject_id,
   speaker_person_name,
   speaker_party_name,


### PR DESCRIPTION
## Problem

When meetings are reprocessed, subjects are deleted and recreated in PostgreSQL. The DELETE events did not propagate to Elasticsearch — deleted subjects remained searchable as ghost documents. We run a cleanup script to purge them since we spotted this.

## Root cause: `base_tables: ["Subject"]` on a child view

`SubjectSearchView` stripped markdown REF links from `Subject.description` before indexing. In `schema.json` it declared `base_tables: ["Subject"]` — the root table of the sync tree. PGSync then routed Subject DELETE events to the child view node instead of the root node: it tried to re-sync the description, found no row, and never deleted the ES document.

**Rule: a child view must never list the root table in `base_tables`.**

## Fix (commit 1)

Remove `SubjectSearchView` and read `description` directly from the root table. `views.sql` now drops the view explicitly, because `CREATE OR REPLACE` does not remove old views.

## REF links move to an ingest pipeline (commit 2)

Removing the view meant REF links (`[text](REF:TYPE:ID)`) reached the index raw. Measured impact on the production cluster:
- **BM25: unaffected.** The Greek analyzer keeps each link target as one token (`ref:person:abc123`); our queries are term-based with no phrase matching.
- **Semantic: a small, systematic cost.** `semantic_text` embeds the raw field value. On 300 staging subjects, markup-heavy documents gain similarity against every query, and clean documents lose the top result in ~4% of self-retrieval queries.

The fix that needs no view on any table: a `strip-refs` **Elasticsearch ingest pipeline** (`elasticsearch/pipeline.json`), attached by PGSync through the top-level `"pipeline"` key in `schema.json`. It runs before analysis and before `semantic_text` inference, so tokens and embeddings both come out clean. Deletes do not use the pipeline. The database keeps the raw markdown; the frontend renders REF links from PostgreSQL.

## Verification

Full E2E with `pgsync-test.sh` (local PG + real cluster), against the exact production pgsync 7.0.1 image:

| pgsync | schema | insert | delete |
|---|---|---|---|
| 7.0.1 | old (main) | ✅ | ❌ — notification accepted, no ES operation (the misroute) |
| 7.0.1 | this PR | ✅ | ✅ — document deleted in ~6s |
| 7.0.1 | this PR + pipeline | ✅ stripped | ✅ |

Bootstrap documents and live updates both index stripped text (nested `speaker_contributions.text` included).

Found along the way: pgsync < 7.x installs a `table_notify()` trigger function that drops every root DELETE notification (`indices` missing from the DELETE branch). Production's function is already the fixed 7.x version (verified read-only), so this bug is not active on prod — it is documented in the README FAQ because any environment bootstrapped with an older pgsync has it.

## Deployment

1. Create the pipeline: `curl -X PUT "$ELASTICSEARCH_URL/_ingest/pipeline/strip-refs" ... -d @elasticsearch/pipeline.json` (must exist before PGSync references it)
2. Apply the views: `psql "$PG_URL" < elasticsearch/views.sql`
3. Update the schema gist that `SCHEMA_URL` points to
4. Run a PGSync `--bootstrap`, then start the daemon. The bootstrap applies the pipeline to all existing documents and removes the accumulated ghost documents.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes the root-table child view that interfered with Subject deletion propagation and moves REF-link normalization into an Elasticsearch ingest pipeline.
- Reads Subject descriptions directly from the root table so PGSync can process root deletes normally.
- Adds a `strip-refs` pipeline for descriptions, contribution text, and segment summaries.
- Updates view validation and operational documentation for the four remaining SQL views and pipeline deployment.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The ingest pipeline completes the prior semantic-text fix while the removal of the root-backed child view restores normal Subject deletion handling, and no blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| elasticsearch/schema.json | Removes the unsafe SubjectSearchView child node, indexes the root description directly, and attaches the REF-stripping ingest pipeline. |
| elasticsearch/pipeline.json | Defines guarded processors that strip REF markdown from the indexed fields implicated by the prior semantic-embedding comment. |
| elasticsearch/views.sql | Drops the legacy root-backed view and preserves raw contribution text for normalization at Elasticsearch ingest time. |
| elasticsearch/validate-views.sql | Updates validation for the four-view configuration and uses the current contribution view primary-key column. |
| elasticsearch/README.md | Documents pipeline creation order, re-indexing behavior, deletion propagation constraints, and the revised deployment flow. |

<sub>Reviews (3): Last reviewed commit: ["feat(elasticsearch): strip REF links at ..."](https://github.com/schemalabz/opencouncil/commit/fa4748fa5b37f0563f93d79477074c8945c12dbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31855910)</sub>

<!-- /greptile_comment -->