### PR TITLE
fix(onboarding): match notifications phone field UX to profile

### DIFF
--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,3 @@
+// Stub for CSS imports in Jest. Tests don't render real styles; we just
+// need the import not to be parsed as JavaScript.
+module.exports = {};

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   workerIdleMemoryLimit: '512MB',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    '\\.css$': '<rootDir>/__mocks__/styleMock.js',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/', '<rootDir>/tests/integration/'],

--- a/src/components/onboarding/UserInfoForm.tsx
+++ b/src/components/onboarding/UserInfoForm.tsx
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { PhoneInput } from 'react-international-phone';
-import 'react-international-phone/style.css';
+import { PhoneField, PhoneFieldValidity } from '@/components/ui/phone-field';
 import { useSession } from 'next-auth/react';
 import { User, Mail, Phone, Lock, AlertCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -40,9 +39,13 @@ export function UserInfoForm({
     const [name, setName] = useState(initialData?.name || '');
     const [email, setEmail] = useState(initialData?.email || '');
     const [phone, setPhone] = useState(initialData?.phone || '');
+    const [phoneValidity, setPhoneValidity] = useState<PhoneFieldValidity>({
+        isActive: false,
+        isEmpty: true,
+        isValid: false,
+    });
     const [nameError, setNameError] = useState<string | null>(null);
     const [emailError, setEmailError] = useState<string | null>(null);
-    const [phoneError, setPhoneError] = useState<string | null>(null);
 
     // Check if the user is logged in
     const isLoggedIn = sessionStatus === 'authenticated' && !!session?.user;
@@ -68,18 +71,6 @@ export function UserInfoForm({
         return /.+@.+\..+/.test(email);
     };
 
-    const validatePhone = (phone: string) => {
-        // If phone is empty or only contains the +30 prefix, return true
-        if (!phone || phone === '+30') return true;
-        
-        // Remove any non-digit characters and the +30 prefix for validation
-        const digitsOnly = phone.replace(/\D/g, '');
-        // Remove the +30 prefix if it exists (first 2 digits)
-        const numberWithoutPrefix = digitsOnly.startsWith('30') ? digitsOnly.slice(2) : digitsOnly;
-        // Greek phone numbers should be 10 digits (without the country code)
-        return numberWithoutPrefix.length === 10;
-    };
-
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         let valid = true;
@@ -98,18 +89,15 @@ export function UserInfoForm({
             setEmailError(null);
         }
 
-        if (showPhone && (!validatePhone(phone))) {
-            setPhoneError('Παρακαλώ εισάγετε ένα έγκυρο τηλέφωνο (10 ψηφία)');
+        if (showPhone && phoneValidity.isActive && !phoneValidity.isEmpty && !phoneValidity.isValid) {
             valid = false;
-        } else {
-            setPhoneError(null);
         }
 
         if (valid) {
             onSubmit({
                 name: name.trim(),
                 email: email.trim(),
-                phone: phone.trim() || undefined
+                phone: phoneValidity.isActive && !phoneValidity.isEmpty ? phone : undefined
             });
         }
     };
@@ -201,22 +189,14 @@ export function UserInfoForm({
                         <Phone className="h-4 w-4" />
                         <span>Τηλέφωνο {!requirePhone && '(προαιρετικό)'}</span>
                     </Label>
-                    <div className="phone-input-container relative">
-                        <PhoneInput
-                            defaultCountry="gr"
-                            hideDropdown={true}
-                            value={phone}
-                            onChange={(value) => setPhone(value)}
-                            inputClassName="flex h-11 md:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base md:text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-                            placeholder="Το τηλέφωνό σας"
-                        />
-                    </div>
-                    {phoneError && (
-                        <div className="flex items-center gap-1 text-red-500 text-sm">
-                            <AlertCircle className="h-3 w-3" />
-                            <p>{phoneError}</p>
-                        </div>
-                    )}
+                    <PhoneField
+                        value={phone}
+                        onChange={setPhone}
+                        onValidityChange={setPhoneValidity}
+                        placeholder="Προσθήκη αριθμού τηλεφώνου"
+                        activePlaceholder="Το τηλέφωνό σας"
+                        invalidMessage="Παρακαλώ εισάγετε ένα έγκυρο τηλέφωνο"
+                    />
                 </div>
             )}
         </form>

--- a/src/components/profile/UserInfoForm.tsx
+++ b/src/components/profile/UserInfoForm.tsx
@@ -4,8 +4,6 @@ import { useState } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { useRouter } from "next/navigation";
 import { signOut } from "next-auth/react";
-import { PhoneInput } from 'react-international-phone';
-import 'react-international-phone/style.css';
 import type { User } from "@prisma/client";
 import { CardDescription } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
@@ -13,8 +11,8 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { X, HelpCircle } from "lucide-react";
-import { detectCountryFromPhone, isPhoneValid, isPhoneEmpty } from "@/lib/utils/phone";
+import { HelpCircle } from "lucide-react";
+import { PhoneField, PhoneFieldValidity } from "@/components/ui/phone-field";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { NotificationPreferencesSection } from "@/components/profile/NotificationPreferencesSection";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -33,9 +31,11 @@ export function UserInfoForm({ user, isOnboarded }: UserInfoFormProps) {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
     const [deleteError, setDeleteError] = useState(false);
-    const [phoneActive, setPhoneActive] = useState(!isPhoneEmpty(user.phone || ""));
-    const [shouldAutoFocus, setShouldAutoFocus] = useState(false);
-    const [phoneCountry, setPhoneCountry] = useState(detectCountryFromPhone(user.phone || "") || "GR");
+    const [phoneValidity, setPhoneValidity] = useState<PhoneFieldValidity>({
+        isActive: false,
+        isEmpty: true,
+        isValid: false,
+    });
 
     const [formData, setFormData] = useState({
         name: user.name || "",
@@ -44,8 +44,7 @@ export function UserInfoForm({ user, isOnboarded }: UserInfoFormProps) {
         allowPetitionUpdates: user.allowPetitionUpdates,
     });
 
-    const phoneEmpty = isPhoneEmpty(formData.phone);
-    const phoneValid = isPhoneValid(formData.phone, [phoneCountry]);
+    const phoneSubmitBlocked = phoneValidity.isActive && !phoneValidity.isEmpty && !phoneValidity.isValid;
 
     async function saveToApi(payload: object) {
         setIsSubmitting(true);
@@ -66,10 +65,10 @@ export function UserInfoForm({ user, isOnboarded }: UserInfoFormProps) {
 
     async function handlePersonalSubmit(e: React.FormEvent) {
         e.preventDefault();
-        if (phoneActive && !phoneEmpty && !phoneValid) return;
+        if (phoneSubmitBlocked) return;
         await saveToApi({
             name: formData.name,
-            phone: phoneEmpty ? null : formData.phone,
+            phone: phoneValidity.isEmpty ? null : formData.phone,
             onboarded: true,
         });
     }
@@ -161,46 +160,13 @@ export function UserInfoForm({ user, isOnboarded }: UserInfoFormProps) {
 
                                 <div className="space-y-2">
                                     <Label htmlFor="phone">{t("phone")}</Label>
-                                    {phoneActive ? (
-                                        <div className="relative">
-                                            <PhoneInput
-                                                defaultCountry="gr"
-                                                value={formData.phone}
-                                                onChange={(phone, meta) => {
-                                                    setFormData({ ...formData, phone });
-                                                    setPhoneCountry(meta.country.iso2);
-                                                }}
-                                                inputProps={{ autoFocus: shouldAutoFocus }}
-                                                inputClassName="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 pr-8"
-                                            />
-                                            <button
-                                                type="button"
-                                                onClick={() => {
-                                                    setFormData({ ...formData, phone: "" });
-                                                    setPhoneActive(false);
-                                                    setShouldAutoFocus(false);
-                                                }}
-                                                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                                            >
-                                                <X className="h-4 w-4" />
-                                            </button>
-                                        </div>
-                                    ) : (
-                                        <Input
-                                            type="text"
-                                            id="phone"
-                                            placeholder={t("phonePlaceholder")}
-                                            onFocus={() => {
-                                                setPhoneActive(true);
-                                                setShouldAutoFocus(true);
-                                            }}
-                                            readOnly
-                                            className="cursor-text"
-                                        />
-                                    )}
-                                    {phoneActive && !phoneEmpty && !phoneValid && (
-                                        <p className="text-sm text-destructive">{t("phoneInvalid")}</p>
-                                    )}
+                                    <PhoneField
+                                        value={formData.phone}
+                                        onChange={(phone) => setFormData({ ...formData, phone })}
+                                        onValidityChange={setPhoneValidity}
+                                        placeholder={t("phonePlaceholder")}
+                                        invalidMessage={t("phoneInvalid")}
+                                    />
                                 </div>
 
                                 <div className="flex flex-col justify-between gap-2">
@@ -209,7 +175,7 @@ export function UserInfoForm({ user, isOnboarded }: UserInfoFormProps) {
                                     </p>
                                     <Button
                                         type="submit"
-                                        disabled={isSubmitting || !formData.name || (phoneActive && !phoneEmpty && !phoneValid)}
+                                        disabled={isSubmitting || !formData.name || phoneSubmitBlocked}
                                         className="whitespace-normal h-auto"
                                     >
                                         {isSubmitting ? t("saving") : t("savePersonalInfo")}

--- a/src/components/ui/__tests__/phone-field.test.tsx
+++ b/src/components/ui/__tests__/phone-field.test.tsx
@@ -1,0 +1,104 @@
+import '@testing-library/jest-dom';
+import { useState } from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { PhoneField, PhoneFieldValidity } from '../phone-field';
+
+function Harness({
+    initialValue = '',
+    onValidityChange,
+}: {
+    initialValue?: string;
+    onValidityChange?: (validity: PhoneFieldValidity) => void;
+}) {
+    const [value, setValue] = useState(initialValue);
+    return (
+        <PhoneField
+            value={value}
+            onChange={setValue}
+            onValidityChange={onValidityChange}
+            placeholder="Add phone"
+            activePlaceholder="Your phone"
+            invalidMessage="Enter a valid phone"
+        />
+    );
+}
+
+describe('PhoneField', () => {
+    it('renders the inactive placeholder input by default when value is empty', () => {
+        render(<Harness />);
+        const input = screen.getByPlaceholderText('Add phone');
+        expect(input).toBeInTheDocument();
+        expect(input).toHaveAttribute('readonly');
+    });
+
+    it('switches to PhoneInput on focus and shows the +30 country prefix', () => {
+        render(<Harness />);
+        fireEvent.focus(screen.getByPlaceholderText('Add phone'));
+        expect(screen.getByPlaceholderText('Your phone')).toBeInTheDocument();
+        // react-international-phone renders the dial code prefix when active
+        expect(screen.getByText(/\+30/)).toBeInTheDocument();
+    });
+
+    it('initial validity is inactive + empty + invalid', () => {
+        const onValidityChange = jest.fn();
+        render(<Harness onValidityChange={onValidityChange} />);
+        expect(onValidityChange).toHaveBeenLastCalledWith({ isActive: false, isEmpty: true, isValid: false });
+    });
+
+    it('emits isValid=true once a complete GR mobile number is entered', () => {
+        const onValidityChange = jest.fn();
+        render(<Harness onValidityChange={onValidityChange} />);
+        act(() => {
+            fireEvent.focus(screen.getByPlaceholderText('Add phone'));
+        });
+        const activeInput = screen.getByPlaceholderText('Your phone');
+        act(() => {
+            fireEvent.change(activeInput, { target: { value: '+30 698 000 0000' } });
+        });
+        expect(onValidityChange).toHaveBeenLastCalledWith({ isActive: true, isEmpty: false, isValid: true });
+    });
+
+    it('emits isValid=false when only an incomplete number is entered', () => {
+        const onValidityChange = jest.fn();
+        render(<Harness onValidityChange={onValidityChange} />);
+        act(() => {
+            fireEvent.focus(screen.getByPlaceholderText('Add phone'));
+        });
+        const activeInput = screen.getByPlaceholderText('Your phone');
+        act(() => {
+            fireEvent.change(activeInput, { target: { value: '+30 698' } });
+        });
+        expect(onValidityChange).toHaveBeenLastCalledWith({ isActive: true, isEmpty: false, isValid: false });
+    });
+
+    it('shows the invalid message after typing an incomplete number', () => {
+        render(<Harness />);
+        fireEvent.focus(screen.getByPlaceholderText('Add phone'));
+        fireEvent.change(screen.getByPlaceholderText('Your phone'), { target: { value: '+30 698' } });
+        expect(screen.getByText('Enter a valid phone')).toBeInTheDocument();
+    });
+
+    it('hides the invalid message once a complete valid number is entered', () => {
+        render(<Harness />);
+        fireEvent.focus(screen.getByPlaceholderText('Add phone'));
+        fireEvent.change(screen.getByPlaceholderText('Your phone'), { target: { value: '+30 698 000 0000' } });
+        expect(screen.queryByText('Enter a valid phone')).not.toBeInTheDocument();
+    });
+
+    it('X button clears the value, deactivates, and emits empty inactive validity', () => {
+        const onValidityChange = jest.fn();
+        render(<Harness initialValue="+306980000000" onValidityChange={onValidityChange} />);
+
+        // started active because initial value is non-empty
+        expect(screen.getByPlaceholderText('Your phone')).toBeInTheDocument();
+
+        const clearButton = screen.getByRole('button');
+        act(() => {
+            fireEvent.click(clearButton);
+        });
+
+        // back to inactive placeholder
+        expect(screen.getByPlaceholderText('Add phone')).toBeInTheDocument();
+        expect(onValidityChange).toHaveBeenLastCalledWith({ isActive: false, isEmpty: true, isValid: false });
+    });
+});

--- a/src/components/ui/phone-field.tsx
+++ b/src/components/ui/phone-field.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { PhoneInput } from 'react-international-phone';
+import 'react-international-phone/style.css';
+import { AlertCircle, X } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { detectCountryFromPhone, isPhoneEmpty, isPhoneValid } from '@/lib/utils/phone';
+
+export interface PhoneFieldValidity {
+    isActive: boolean;
+    isEmpty: boolean;
+    isValid: boolean;
+}
+
+interface PhoneFieldProps {
+    value: string;
+    onChange: (value: string) => void;
+    onValidityChange?: (validity: PhoneFieldValidity) => void;
+    placeholder?: string;
+    activePlaceholder?: string;
+    invalidMessage?: string;
+    id?: string;
+}
+
+export function PhoneField({
+    value,
+    onChange,
+    onValidityChange,
+    placeholder,
+    activePlaceholder,
+    invalidMessage,
+    id = 'phone',
+}: PhoneFieldProps) {
+    const [active, setActive] = useState(!isPhoneEmpty(value));
+    const [shouldAutoFocus, setShouldAutoFocus] = useState(false);
+    const [country, setCountry] = useState(detectCountryFromPhone(value) || 'GR');
+
+    // If the parent pushes a non-empty value after mount (e.g. async session
+    // load), promote the field to active so the number is visible.
+    const prevValueRef = useRef(value);
+    useEffect(() => {
+        if (!active && !isPhoneEmpty(value) && isPhoneEmpty(prevValueRef.current)) {
+            setActive(true);
+        }
+        prevValueRef.current = value;
+    }, [value, active]);
+
+    const isEmpty = isPhoneEmpty(value);
+    const isValid = isPhoneValid(value, [country]);
+    const showError = active && !isEmpty && !isValid;
+
+    // Emit validity changes without causing render loops when the parent
+    // passes an unmemoized callback: track the last emitted state via a ref.
+    const onValidityChangeRef = useRef(onValidityChange);
+    onValidityChangeRef.current = onValidityChange;
+    const lastEmittedRef = useRef<string>();
+    useEffect(() => {
+        const key = `${active}|${isEmpty}|${isValid}`;
+        if (lastEmittedRef.current !== key) {
+            lastEmittedRef.current = key;
+            onValidityChangeRef.current?.({ isActive: active, isEmpty, isValid });
+        }
+    }, [active, isEmpty, isValid]);
+
+    return (
+        <>
+            {active ? (
+                <div className="phone-input-container relative">
+                    <PhoneInput
+                        defaultCountry="gr"
+                        value={value}
+                        onChange={(next, meta) => {
+                            onChange(next);
+                            setCountry(meta.country.iso2.toUpperCase());
+                        }}
+                        inputProps={{ autoFocus: shouldAutoFocus, id }}
+                        inputClassName="flex h-11 md:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base md:text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 pr-8"
+                        placeholder={activePlaceholder}
+                    />
+                    <button
+                        type="button"
+                        onClick={() => {
+                            onChange('');
+                            setActive(false);
+                            setShouldAutoFocus(false);
+                            setCountry('GR');
+                        }}
+                        className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                    >
+                        <X className="h-4 w-4" />
+                    </button>
+                </div>
+            ) : (
+                <Input
+                    id={id}
+                    type="text"
+                    placeholder={placeholder}
+                    onFocus={() => {
+                        setActive(true);
+                        setShouldAutoFocus(true);
+                    }}
+                    readOnly
+                    className="h-11 md:h-10 text-base md:text-sm cursor-text"
+                />
+            )}
+            {showError && invalidMessage && (
+                <div className="flex items-center gap-1 text-red-500 text-sm">
+                    <AlertCircle className="h-3 w-3" />
+                    <p>{invalidMessage}</p>
+                </div>
+            )}
+        </>
+    );
+}


### PR DESCRIPTION
## Summary

- Adopts the same active/inactive phone pattern used on `/profile` in the onboarding `UserInfoForm`, which is shared by the `/[cityId]/notifications` last step and the petition registration step.
- The phone field starts inactive (readonly placeholder input). Clicking it switches to the `PhoneInput` with `defaultCountry="gr"`, so the field starts with **+30** and autofocuses.
- An `X` button clears the input and returns it to the inactive state.
- If the user never opens the field (or clears it), the form submits `phone: undefined`, so `saveNotificationPreferences` stores **NULL** for newly created users and leaves authenticated users' existing phone unchanged.

The `/profile` phone field is intentionally left as-is.

Resolves https://github.com/schemalabz/opencouncil/issues/304

## Test plan

- [x] `/<cityId>/notifications` last step:
  - [x] Phone field is initially the inactive placeholder ("Προσθήκη αριθμού τηλεφώνου")
  - [x] Clicking activates `PhoneInput` with the `+30` prefix and autofocuses
  - [x] Submitting without touching the field stores NULL for a new user
  - [x] Submitting with a valid GR number stores it
  - [x] Invalid number shows the inline error
  - [x] `X` button clears and returns to inactive state
- [x] Same on the petition registration step (shares the form)
- [x] `/profile` personal tab phone field still behaves as before

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the active/inactive phone field UX into a shared `PhoneField` component and adopts it in both the onboarding `UserInfoForm` and the notifications step, bringing them in line with the existing `/profile` pattern. The profile form is also refactored to use `PhoneField` in place of its own inline implementation, and Jest is wired up with a CSS stub so the new unit tests can run.

- **New `PhoneField` component** (`src/components/ui/phone-field.tsx`): manages active/inactive state, autofocus, country tracking, validity emission via a stable ref pattern, and an X-clear button.
- **Onboarding form** replaces `PhoneInput` + custom `validatePhone` with `PhoneField`; submit logic now relies on the `PhoneFieldValidity` object to decide whether to send `phone` or `undefined`.
- **Profile form** removes its own `phoneActive`/`shouldAutoFocus`/`phoneCountry` state trio and delegates everything to `PhoneField`, using `phoneValidity.isEmpty` to decide whether to persist `null` or the current value.

<h3>Confidence Score: 5/5</h3>

Safe to merge; changes are well-scoped refactors with test coverage and no data-loss paths introduced by this diff alone.

The extracted PhoneField component is straightforward, the validity-ref pattern avoids render loops, and the submit paths in both forms correctly gate on the emitted validity object. The only finding is an absent aria-label on the clear button, which is a cosmetic accessibility gap and does not affect data correctness or form submission behaviour.

No files require special attention beyond the accessibility nit on src/components/ui/phone-field.tsx.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/ui/phone-field.tsx | New shared component extracting the active/inactive phone UX; handles async value promotion via ref+effect; missing aria-label on the clear button. |
| src/components/onboarding/UserInfoForm.tsx | Replaces inline PhoneInput + custom validatePhone with the new PhoneField component; submit logic now delegates validity tracking to PhoneField via the phoneValidity state object. |
| src/components/profile/UserInfoForm.tsx | Refactored to use PhoneField; submit payload uses phoneValidity.isEmpty to decide null vs current value, which is correct once the validity effect has fired. |
| src/components/ui/__tests__/phone-field.test.tsx | New test suite covering inactive/active states, validity emissions, error display, and the clear button; tests look structurally sound. |
| jest.config.js | Adds CSS module mock mapping so Jest does not choke on react-international-phone's style import. |
| __mocks__/styleMock.js | Minimal CSS stub for Jest; correct and idiomatic. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Parent as Parent Form
    participant PF as PhoneField
    participant PI as PhoneInput (react-intl-phone)

    Parent->>PF: value, onChange, onValidityChange
    PF->>PF: "useState(active = !isPhoneEmpty(value))"
    PF-->>Parent: "onValidityChange({ isActive, isEmpty, isValid }) via useEffect"

    alt User clicks inactive Input
        PF->>PF: setActive(true), setShouldAutoFocus(true)
        PF->>PI: "mount with defaultCountry=gr"
        PI-->>PF: onChange("+30") on mount
        PF-->>Parent: onChange("+30")
        PF-->>Parent: "onValidityChange({ isActive:true, isEmpty:false, isValid:false })"
    end

    alt User types a valid number
        PI-->>PF: onChange("+306980000000", meta)
        PF-->>Parent: onChange("+306980000000")
        PF-->>Parent: "onValidityChange({ isActive:true, isEmpty:false, isValid:true })"
    end

    alt User clicks X button
        PF->>PF: setActive(false), setCountry(GR)
        PF-->>Parent: onChange("")
        PF-->>Parent: "onValidityChange({ isActive:false, isEmpty:true, isValid:false })"
    end

    alt Parent pushes non-empty value (async session load)
        Parent->>PF: "value = "+306980000000""
        PF->>PF: "useEffect promotes active=true (empty to non-empty transition)"
        PF-->>Parent: "onValidityChange({ isActive:true, isEmpty:false, isValid:true })"
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/onboarding/UserInfoForm.tsx`, line 209-212 ([link](https://github.com/schemalabz/opencouncil/blob/b402ca5cfd187d98057f5f88cb0e24130a1e77b0/src/components/onboarding/UserInfoForm.tsx#L209-L212)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The `Label` has `htmlFor="phone"`, which targets the inactive `Input`'s `id="phone"`. When `phoneActive` is `true` the `PhoneInput` renders without that ID, so clicking the label no longer focuses the phone field — screenreaders and keyboard users lose the label→input association.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/onboarding/UserInfoForm.tsx
   Line: 209-212

   Comment:
   The `Label` has `htmlFor="phone"`, which targets the inactive `Input`'s `id="phone"`. When `phoneActive` is `true` the `PhoneInput` renders without that ID, so clicking the label no longer focuses the phone field — screenreaders and keyboard users lose the label→input association.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/components/ui/phone-field.tsx:81-90
The clear button has no accessible name — screen readers announce it only as "button" with no indication of its purpose. Adding an `aria-label` gives assistive technology users the context they need.

```suggestion
                    <button
                        type="button"
                        aria-label="Clear phone number"
                        onClick={() => {
                            onChange('');
                            setActive(false);
                            setShouldAutoFocus(false);
                            setCountry('GR');
                        }}
                        className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                    >
```


`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(profile,onboarding): extract shared ..."](https://github.com/schemalabz/opencouncil/commit/fa94a20f5e85212c7cbd1a3e9a3258c00734ac51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31939252)</sub>

<!-- /greptile_comment -->