### PR TITLE
fix(highlights): delete uncommitted highlight when user cancels edit

### DIFF
--- a/src/components/meetings/HighlightContext.tsx
+++ b/src/components/meetings/HighlightContext.tsx
@@ -62,6 +62,7 @@ interface HighlightContextType {
     onSuccess?: (highlight: HighlightWithUtterances) => void;
     onError?: (error: Error) => void;
   }) => Promise<{ success: boolean; error?: any }>;
+  commitPendingCreation: () => void;
 }
 
 const HighlightContext = createContext<HighlightContextType | undefined>(undefined);
@@ -78,10 +79,15 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
   const [lastClickedUtteranceId, setLastClickedUtteranceId] = useState<string | null>(null);
   const [lastClickedAction, setLastClickedAction] = useState<'add' | 'remove' | null>(null);
 
+  // Tracks a highlight that was created via createHighlight() but not yet
+  // committed (no save, no generation). If the user exits edit mode while
+  // this is set, the orphan is cleaned up so it doesn't appear in the list.
+  const [pendingCreationId, setPendingCreationId] = useState<string | null>(null);
+
   // Get transcript and speaker data from CouncilMeetingDataContext
   const { transcript, speakerTags, getSpeakerTag, getPerson, getSpeakerSegmentById, meeting } = useCouncilMeetingData();
   // Mutations come from the stable actions context — they never change identity.
-  const { addHighlight, updateHighlight } = useCouncilMeetingActions();
+  const { addHighlight, updateHighlight, removeHighlight } = useCouncilMeetingActions();
   const { currentTime, seekTo, isPlaying, setIsPlaying, seekToAndPlay } = useVideo();
   const router = useRouter();
   const pathname = usePathname();
@@ -117,6 +123,8 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
   lastClickedIdRef.current = lastClickedUtteranceId;
   const lastClickedActionRef = useRef(lastClickedAction);
   lastClickedActionRef.current = lastClickedAction;
+  const pendingCreationIdRef = useRef(pendingCreationId);
+  pendingCreationIdRef.current = pendingCreationId;
 
   const calculateHighlightData = useCallback((highlight: HighlightWithUtterances | null): HighlightCalculationResult | null => {
     if (!highlight) {
@@ -440,14 +448,27 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
   const exitEditMode = useCallback(() => {
     if (!editingHighlight) return;
     setIsPlaying(false);
-    router.push(`/${editingHighlight.cityId}/${editingHighlight.meetingId}/highlights`);
-  }, [editingHighlight, router, setIsPlaying]);
+    const { id: highlightId, cityId, meetingId } = editingHighlight;
+    if (pendingCreationIdRef.current === highlightId) {
+      setPendingCreationId(null);
+      removeHighlight(highlightId);
+      fetch(`/api/highlights/${highlightId}`, { method: 'DELETE' }).catch(err => {
+        console.error('Failed to delete uncommitted highlight:', err);
+      });
+    }
+    router.push(`/${cityId}/${meetingId}/highlights`);
+  }, [editingHighlight, router, setIsPlaying, removeHighlight]);
 
   const exitEditModeAndRedirectToHighlight = useCallback(() => {
     if (!editingHighlight) return;
     setIsPlaying(false);
+    setPendingCreationId(null);
     router.push(`/${editingHighlight.cityId}/${editingHighlight.meetingId}/highlights/${editingHighlight.id}`);
   }, [editingHighlight, router, setIsPlaying]);
+
+  const commitPendingCreation = useCallback(() => {
+    setPendingCreationId(null);
+  }, []);
 
   const saveHighlight = useCallback(async (options?: {
     name?: string;
@@ -494,6 +515,9 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
       updateHighlight(editingHighlight.id, updatedHighlight);
 
       setIsDirty(false);
+      if (pendingCreationIdRef.current === editingHighlight.id) {
+        setPendingCreationId(null);
+      }
       options?.onSuccess?.();
 
       return { success: true };
@@ -536,6 +560,7 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
       const highlight = await res.json();
 
       addHighlight(highlight);
+      setPendingCreationId(highlight.id);
       enterEditMode(highlight);
 
       if (preSelectedUtteranceId) {
@@ -586,6 +611,7 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     calculateHighlightData,
     saveHighlight,
     createHighlight,
+    commitPendingCreation,
   }), [
     editingHighlight,
     previewMode,
@@ -612,6 +638,7 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     calculateHighlightData,
     saveHighlight,
     createHighlight,
+    commitPendingCreation,
   ]);
 
   return (

--- a/src/components/meetings/HighlightPreviewDialog.tsx
+++ b/src/components/meetings/HighlightPreviewDialog.tsx
@@ -26,6 +26,7 @@ export function HighlightPreviewDialog() {
     saveHighlight,
     exitEditModeAndRedirectToHighlight,
     exitEditMode,
+    commitPendingCreation,
   } = useHighlight();
 
   const { isPlaying, togglePlayPause } = useVideo();
@@ -71,6 +72,10 @@ export function HighlightPreviewDialog() {
         })
       });
       if (!res.ok) throw new Error('Failed to start generation');
+
+      // Generation implies commit — even if the user never explicitly saved,
+      // they've committed to this highlight by generating a video for it.
+      commitPendingCreation();
 
       toast({
         title: t('previewDialog.generationStarted'),


### PR DESCRIPTION
## Summary

Closes #353.

`createHighlight()` POSTs to `/api/highlights` the moment the user clicks the highlight icon — before they've done anything. If they then click **Cancel**, the highlight stays in the list with its auto-generated name. From [Chalandri user feedback (2026-05-13)](#353): the user pressed Cancel, was redirected to `/highlights`, and saw a phantom unnamed entry.

### Fix

Track the new highlight's id as `pendingCreationId` in `HighlightContext`. Two commit signals clear it:

- `saveHighlight()` succeeds (explicit save), or
- The user starts video generation (`HighlightPreviewDialog.handleGenerate`).

`exitEditMode()` checks the flag — if still set, it removes the highlight from local state and fires a background `DELETE /api/highlights/{id}` before navigating.

`exitEditModeAndRedirectToHighlight()` also clears the flag, since it's only reachable from the post-generation status view.

### Out of scope

The same bug can occur if the user closes the tab or hard-navigates away mid-edit — the highlight remains an orphan. That requires a `beforeunload` handler / server-side cleanup, which is a bigger change. This PR only fixes the reported cancel path.

## Test plan

- [ ] Click highlight icon on transcript → click **Cancel** → no orphan appears in `/highlights`
- [ ] Click highlight icon → add utterances → **Save** → click **Cancel** → highlight stays (it was committed)
- [ ] Click highlight icon → **Generate video** → return to `/highlights` → highlight stays (generation = commit)
- [ ] Edit an existing highlight → click **Cancel** → highlight stays (only `createHighlight` flagged it pending)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds client-side tracking and deletion of newly-created highlights when exiting edit mode, which could accidentally remove a highlight if the pending/commit state gets out of sync. Also introduces a background `DELETE` call during navigation, so failures could leave server/client state inconsistent.
> 
> **Overview**
> Prevents newly created highlights from lingering in the highlights list when a user cancels out of edit mode.
> 
> `createHighlight` now marks the new highlight as *pending*; that pending state is cleared on successful `saveHighlight` or when video generation starts (via a new `commitPendingCreation` hook called from `HighlightPreviewDialog`). If the user exits edit mode while the highlight is still pending, the highlight is removed from local state (`removeHighlight`) and a best-effort `DELETE /api/highlights/{id}` is fired before navigating back to `/highlights`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35778be1f3fd56112399307aa28901b5ec7941c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a phantom-highlight bug where clicking the highlight icon immediately POSTs a new highlight, and clicking **Cancel** left it as an orphan in `/highlights`. A `pendingCreationId` flag is added to `HighlightContext`; `exitEditMode` checks it on cancel and, if still set, removes the highlight from local state and fires a background `DELETE` request.

- `exitEditMode` now deletes the uncommitted highlight from both local state and the server when the user clicks Cancel, provided neither `saveHighlight` nor video generation has already committed it.
- `commitPendingCreation` is exposed on the context and called in `HighlightPreviewDialog.handleGenerate` (after a successful generation request) so that generating a video is treated as an implicit commit.
- The parallel soft-navigation code path — the cleanup `useEffect` that fires when the user presses the browser back button — is not updated, so the phantom-highlight bug remains on that path even though the same cleanup mechanism is already present there.

<h3>Confidence Score: 3/5</h3>

The Cancel-button path is correctly fixed and won't regress existing highlights; however, the browser-back-button path through the existing cleanup effect still leaves phantom highlights.

The Cancel flow is well-handled: pendingCreationId is set on create, cleared on save/generate, and checked in exitEditMode before firing the DELETE. The gap is in the cleanup useEffect (lines 354-364), which already fires on soft navigation but doesn't replicate the removeHighlight + DELETE logic.

The navigation-away cleanup effect in HighlightContext.tsx (lines 354-364) needs attention — it is the gap where the browser-back scenario falls through without cleaning up the pending highlight.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/meetings/HighlightContext.tsx | Adds pendingCreationId state and ref to track uncommitted highlights; exitEditMode now deletes and removes them on cancel. The Cancel button path is correctly handled, but the parallel soft-navigation cleanup effect (browser back) is not updated to perform the same deletion. |
| src/components/meetings/HighlightPreviewDialog.tsx | Adds commitPendingCreation() call after a successful video-generation request so the highlight is not deleted if the user subsequently cancels. Placement after the !res.ok guard is correct. Pre-existing double-navigation in status-view handlers remains. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/components/meetings/HighlightContext.tsx`, line 354-364 ([link](https://github.com/schemalabz/opencouncil/blob/35778be1f3fd56112399307aa28901b5ec7941c1/src/components/meetings/HighlightContext.tsx#L354-L364)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Soft navigation (browser back) still leaves an orphan highlight**

   The cleanup `useEffect` fires whenever the user navigates away from the transcript page via Next.js soft navigation (e.g., the browser back button). It clears `editingHighlight` and other editing state, but it does NOT check `pendingCreationId`, call `removeHighlight`, or fire a `DELETE` request. A user who clicks the highlight icon and then hits the browser back button will still land on `/highlights` with the phantom entry, because this code path bypasses `exitEditMode` entirely. The fix for the explicit Cancel button is correct, but this parallel soft-navigation path is left unaddressed even though the cleanup mechanism is already in place here.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/meetings/HighlightContext.tsx
   Line: 354-364

   Comment:
   **Soft navigation (browser back) still leaves an orphan highlight**

   The cleanup `useEffect` fires whenever the user navigates away from the transcript page via Next.js soft navigation (e.g., the browser back button). It clears `editingHighlight` and other editing state, but it does NOT check `pendingCreationId`, call `removeHighlight`, or fire a `DELETE` request. A user who clicks the highlight icon and then hits the browser back button will still land on `/highlights` with the phantom entry, because this code path bypasses `exitEditMode` entirely. The fix for the explicit Cancel button is correct, but this parallel soft-navigation path is left unaddressed even though the cleanup mechanism is already in place here.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/components/meetings/HighlightPreviewDialog.tsx`, line 99-111 ([link](https://github.com/schemalabz/opencouncil/blob/35778be1f3fd56112399307aa28901b5ec7941c1/src/components/meetings/HighlightPreviewDialog.tsx#L99-L111)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Double navigation in status-view actions**

   `handleViewAllHighlights` and `handleReturnToTranscript` both call `exitEditMode()` (which itself calls `router.push` to `/highlights`) and then immediately call their own `router.push`. For `handleViewAllHighlights` this results in two identical pushes (harmless but noisy in history). For `handleReturnToTranscript` it's worse: the first push goes to `/highlights` and the second to `/transcript`, adding an extra history entry — clicking browser back from transcript lands on `/highlights` instead of the expected prior page.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/meetings/HighlightPreviewDialog.tsx
   Line: 99-111

   Comment:
   **Double navigation in status-view actions**

   `handleViewAllHighlights` and `handleReturnToTranscript` both call `exitEditMode()` (which itself calls `router.push` to `/highlights`) and then immediately call their own `router.push`. For `handleViewAllHighlights` this results in two identical pushes (harmless but noisy in history). For `handleReturnToTranscript` it's worse: the first push goes to `/highlights` and the second to `/transcript`, adding an extra history entry — clicking browser back from transcript lands on `/highlights` instead of the expected prior page.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/components/meetings/HighlightContext.tsx:354-364
**Soft navigation (browser back) still leaves an orphan highlight**

The cleanup `useEffect` fires whenever the user navigates away from the transcript page via Next.js soft navigation (e.g., the browser back button). It clears `editingHighlight` and other editing state, but it does NOT check `pendingCreationId`, call `removeHighlight`, or fire a `DELETE` request. A user who clicks the highlight icon and then hits the browser back button will still land on `/highlights` with the phantom entry, because this code path bypasses `exitEditMode` entirely. The fix for the explicit Cancel button is correct, but this parallel soft-navigation path is left unaddressed even though the cleanup mechanism is already in place here.

### Issue 2 of 2
src/components/meetings/HighlightPreviewDialog.tsx:99-111
**Double navigation in status-view actions**

`handleViewAllHighlights` and `handleReturnToTranscript` both call `exitEditMode()` (which itself calls `router.push` to `/highlights`) and then immediately call their own `router.push`. For `handleViewAllHighlights` this results in two identical pushes (harmless but noisy in history). For `handleReturnToTranscript` it's worse: the first push goes to `/highlights` and the second to `/transcript`, adding an extra history entry — clicking browser back from transcript lands on `/highlights` instead of the expected prior page.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(highlights): delete uncommitted high..."](https://github.com/schemalabz/opencouncil/commit/35778be1f3fd56112399307aa28901b5ec7941c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31976314)</sub>

<!-- /greptile_comment -->