### PR TITLE
feat: effective attendance, arrivals/departures, and elected order scoping

### DIFF
--- a/messages/el.json
+++ b/messages/el.json
@@ -826,7 +826,8 @@
         "voteAgainst": "Κατά",
         "voteAbstain": "Λευκό",
         "votePresent": "Παρών",
-        "voteDidNotVote": "Αποχή"
+        "voteDidNotVote": "Αποχή",
+        "voteAbsent": "Απόντες"
     },
     "PersonCard": {
         "party": "Παράταξη",

--- a/messages/en.json
+++ b/messages/en.json
@@ -846,6 +846,7 @@
         "voteAbstain": "Abstain",
         "votePresent": "Present",
         "voteDidNotVote": "Did not vote",
+        "voteAbsent": "Absent",
         "groupedDiscussion": "Discussion grouped with other subjects",
         "groupedDiscussionDescription": "This subject appears to have been discussed and voted on together with other subjects. See the discussion at:"
     },

--- a/scripts/find-municipal-committee.ts
+++ b/scripts/find-municipal-committee.ts
@@ -15,6 +15,11 @@
  *   npx tsx scripts/find-municipal-committee.ts --name "Ζωγράφου"
  *   npx tsx scripts/find-municipal-committee.ts --name "Χαλάνδρι" --json
  *   npx tsx scripts/find-municipal-committee.ts --name "Ζωγράφου" --term 2024-2029
+ *   npx tsx scripts/find-municipal-committee.ts --city zografou --write --dry-run
+ *   npx tsx scripts/find-municipal-committee.ts --city zografou --write
+ *
+ * When --city is provided, the Diavgeia org ID is resolved from the city's
+ * diavgeiaUid in the database (set by import_diavgeia.ts).
  *
  * Requires ANTHROPIC_API_KEY in .env or environment.
  */
@@ -27,8 +32,12 @@ import Anthropic from '@anthropic-ai/sdk'
 import dotenv from 'dotenv'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
+import { PrismaClient } from '@prisma/client'
+import { matchByName, DbMember } from './lib/greek-name-matching'
 
 dotenv.config()
+
+const prisma = new PrismaClient()
 
 // ---------------------------------------------------------------------------
 // Diavgeia API helpers
@@ -340,6 +349,146 @@ async function extractWithLLM(
 }
 
 // ---------------------------------------------------------------------------
+// Database write
+// ---------------------------------------------------------------------------
+
+async function writeCommitteeToDb(
+  committee: CommitteeData,
+  cityId: string,
+  dryRun: boolean,
+): Promise<void> {
+  // Find the committee administrative body
+  const committeeBody = await prisma.administrativeBody.findFirst({
+    where: { cityId, type: 'committee' },
+    select: { id: true, name: true },
+  })
+
+  if (!committeeBody) {
+    console.error(
+      `No committee administrative body found for city ${cityId}. Create one first.`
+    )
+    process.exit(1)
+  }
+  console.log(`\nAdministrative body: ${committeeBody.name} (${committeeBody.id})`)
+
+  // Load people from database
+  const people = await prisma.person.findMany({
+    where: { cityId },
+    select: {
+      id: true,
+      name: true,
+      roles: {
+        where: { administrativeBodyId: committeeBody.id },
+        select: { id: true, electedOrder: true },
+        take: 1,
+      },
+    },
+  })
+
+  const dbMembers: DbMember[] = people.map(p => ({ id: p.id, name: p.name }))
+
+  // Build candidate list: regulars first, then alternates
+  const allMembers = [
+    ...committee.regular.map((m, i) => ({
+      name: m.name,
+      index: i,
+      type: 'regular' as const,
+    })),
+    ...committee.alternate.map((m, i) => ({
+      name: m.name,
+      index: committee.regular.length + i,
+      type: 'alternate' as const,
+    })),
+  ]
+
+  const candidates = allMembers.map(m => ({ name: m.name, index: m.index }))
+  const { matched, unmatched } = matchByName(candidates, dbMembers)
+
+  console.log(`\nMatched: ${matched.size}/${allMembers.length}`)
+  if (unmatched.length > 0) {
+    console.log(`Unmatched DB members (not in committee): ${unmatched.length}`)
+  }
+
+  // Show matches and plan
+  const operations: Array<{
+    personId: string
+    personName: string
+    memberType: 'regular' | 'alternate'
+    electedOrder: number
+    existingRoleId: string | null
+  }> = []
+
+  for (const [personId, candidateIdx] of matched) {
+    const person = people.find(p => p.id === personId)!
+    const member = allMembers[candidateIdx]
+    const existingRole = person.roles[0] ?? null
+    operations.push({
+      personId,
+      personName: person.name,
+      memberType: member.type,
+      electedOrder: candidateIdx + 1,
+      existingRoleId: existingRole?.id ?? null,
+    })
+  }
+
+  // Log unmatched committee members (from external data)
+  const matchedIndices = new Set(matched.values())
+  const unmatchedCommitteeMembers = allMembers.filter(
+    (_, i) => !matchedIndices.has(i)
+  )
+  if (unmatchedCommitteeMembers.length > 0) {
+    console.log(`\nUnmatched committee members (not found in DB):`)
+    for (const m of unmatchedCommitteeMembers) {
+      console.log(`  - ${m.name} (${m.type})`)
+    }
+  }
+
+  // Show planned operations
+  console.log(`\nPlanned operations:`)
+  for (const op of operations.sort((a, b) => a.electedOrder - b.electedOrder)) {
+    const action = op.existingRoleId ? 'UPDATE' : 'CREATE'
+    const roleName = op.memberType === 'alternate' ? ' [Αναπληρωματικό Μέλος]' : ''
+    console.log(
+      `  ${op.electedOrder.toString().padStart(2)}. ${op.personName} — ${action}${roleName}`
+    )
+  }
+
+  if (dryRun) {
+    console.log(`\nDry run — no database changes.`)
+    return
+  }
+
+  // Execute
+  await prisma.$transaction(async (tx) => {
+    for (const op of operations) {
+      const roleName =
+        op.memberType === 'alternate' ? 'Αναπληρωματικό Μέλος' : null
+
+      if (op.existingRoleId) {
+        await tx.role.update({
+          where: { id: op.existingRoleId },
+          data: { electedOrder: op.electedOrder, name: roleName },
+        })
+      } else {
+        await tx.role.create({
+          data: {
+            personId: op.personId,
+            administrativeBodyId: committeeBody.id,
+            isHead: false,
+            name: roleName,
+            electedOrder: op.electedOrder,
+          },
+        })
+      }
+    }
+  })
+
+  console.log(
+    `\nWritten ${operations.length} committee roles to database.`
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -363,9 +512,26 @@ async function main() {
       default: false,
       description: 'Output as JSON',
     })
+    .option('write', {
+      type: 'boolean',
+      default: false,
+      description: 'Write committee roles and elected order to database',
+    })
+    .option('city', {
+      type: 'string',
+      description: 'City ID in our database (required for --write)',
+    })
+    .option('dry-run', {
+      type: 'boolean',
+      default: false,
+      description: 'Preview database changes without writing (use with --write)',
+    })
     .check((argv) => {
-      if (!argv.org && !argv.name) {
-        throw new Error('Provide either --org or --name')
+      if (!argv.org && !argv.name && !argv.city) {
+        throw new Error('Provide either --org, --name, or --city')
+      }
+      if (argv.write && !argv.city) {
+        throw new Error('--city is required when using --write')
       }
       return true
     }).argv
@@ -374,11 +540,32 @@ async function main() {
     apiKey: process.env.ANTHROPIC_API_KEY!,
   })
 
-  // Resolve org ID
+  // Resolve org ID — three sources: --org, --name, or --city (DB lookup)
   let orgId = argv.org
   let orgLabel: string | undefined
 
-  if (!orgId) {
+  if (!orgId && argv.city) {
+    // Look up the city's diavgeiaUid from the database
+    const city = await prisma.city.findUnique({
+      where: { id: argv.city },
+      select: { name_municipality: true, diavgeiaUid: true },
+    })
+    if (!city) {
+      console.error(`City not found in database: ${argv.city}`)
+      process.exit(1)
+    }
+    if (!city.diavgeiaUid) {
+      console.error(
+        `City "${city.name_municipality}" has no diavgeiaUid. Run import_diavgeia.ts first, or use --org/--name.`
+      )
+      process.exit(1)
+    }
+    orgId = city.diavgeiaUid
+    orgLabel = city.name_municipality
+    console.error(`City: ${city.name_municipality} (diavgeiaUid: ${orgId})`)
+  }
+
+  if (!orgId && argv.name) {
     console.error(`Searching for municipality "${argv.name}"...`)
     const org = await findOrganization(argv.name!)
     if (!org) {
@@ -388,7 +575,14 @@ async function main() {
     orgId = org.uid
     orgLabel = org.label
     console.error(`Found: ${org.label} (uid: ${org.uid})`)
-  } else {
+  }
+
+  if (!orgId) {
+    console.error('Could not resolve Diavgeia organization ID')
+    process.exit(1)
+  }
+
+  if (!orgLabel) {
     try {
       const org = await diavgeiaApi<Organization>(
         `/organizations/${orgId}.json`
@@ -507,9 +701,17 @@ async function main() {
       )
     }
   }
+
+  if (argv.write) {
+    await writeCommitteeToDb(committee, argv.city!, argv.dryRun)
+  }
 }
 
-main().catch((err) => {
-  console.error(`Error: ${err.message}`)
-  process.exit(1)
-})
+main()
+  .catch((err) => {
+    console.error(`Error: ${err.message}`)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/scripts/lib/greek-name-matching.ts
+++ b/scripts/lib/greek-name-matching.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared Greek name normalization and token-sort matching utilities.
+ *
+ * Used by scripts that need to match Greek names from external sources
+ * (election data, Diavgeia documents) to database Person records.
+ */
+
+/**
+ * Normalize a Greek name for matching: strip diacritics (tonos), remove
+ * parenthetical nicknames like "(ΜΠΑΜΠΗΣ)", collapse whitespace, lowercase.
+ */
+export function normalizeGreekName(name: string): string {
+    return name
+        .replace(/\s*\([^)]*\)\s*/g, ' ')
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/ς/g, 'σ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+/** Build a sorted token key from a normalized name string. */
+function buildSortKey(normalized: string): string {
+    return normalized
+        .replace(/[-–—]/g, ' ')
+        .split(/\s+/)
+        .filter(Boolean)
+        .sort()
+        .join(' ');
+}
+
+/**
+ * Generate token-sort keys for a name. Returns multiple keys when the name
+ * contains a parenthetical nickname like "(ΚΩΣΤΗΣ)": one key with the nickname
+ * stripped and one with the nickname replacing the preceding name part.
+ */
+export function tokenSortKeys(name: string): string[] {
+    const keys: string[] = [];
+
+    keys.push(buildSortKey(normalizeGreekName(name)));
+
+    const nicknameMatch = name.match(/(\S+)\s*\(([^)]+)\)/);
+    if (nicknameMatch) {
+        const replaced = name
+            .replace(/\S+\s*\([^)]+\)/, nicknameMatch[2]);
+        const nicknameKey = buildSortKey(normalizeGreekName(replaced));
+        if (nicknameKey !== keys[0]) {
+            keys.push(nicknameKey);
+        }
+    }
+
+    // Handle names with multiple parenthetical nicknames
+    const allNicknameMatches = [...name.matchAll(/\S+\s*\(([^)]+)\)/g)];
+    if (allNicknameMatches.length > 1) {
+        let allReplaced = name;
+        for (const m of allNicknameMatches) {
+            allReplaced = allReplaced.replace(m[0], m[1]);
+        }
+        const allNicknameKey = buildSortKey(normalizeGreekName(allReplaced));
+        if (!keys.includes(allNicknameKey)) {
+            keys.push(allNicknameKey);
+        }
+    }
+
+    return keys;
+}
+
+export interface MatchCandidate {
+    name: string;
+    index: number;
+}
+
+export interface DbMember {
+    id: string;
+    name: string;
+}
+
+/**
+ * Match a list of candidates (from external data) to database members by name.
+ * Returns a map from dbMember.id to the matched candidate index.
+ */
+export function matchByName(
+    candidates: MatchCandidate[],
+    dbMembers: DbMember[],
+): { matched: Map<string, number>; unmatched: string[] } {
+    const matched = new Map<string, number>();
+    const usedCandidates = new Set<number>();
+
+    // Build lookup: token-sort key → candidate index
+    const candidateLookup = new Map<string, number>();
+    for (const c of candidates) {
+        for (const key of tokenSortKeys(c.name)) {
+            if (!candidateLookup.has(key)) {
+                candidateLookup.set(key, c.index);
+            }
+        }
+    }
+
+    for (const m of dbMembers) {
+        const keys = tokenSortKeys(m.name);
+        let matchIdx: number | undefined;
+        for (const k of keys) {
+            const idx = candidateLookup.get(k);
+            if (idx !== undefined && !usedCandidates.has(idx)) {
+                matchIdx = idx;
+                break;
+            }
+        }
+        if (matchIdx !== undefined) {
+            matched.set(m.id, matchIdx);
+            usedCandidates.add(matchIdx);
+        }
+    }
+
+    const unmatched = dbMembers
+        .filter(m => !matched.has(m.id))
+        .map(m => m.name);
+
+    return { matched, unmatched };
+}

--- a/scripts/update_elected_order.ts
+++ b/scripts/update_elected_order.ts
@@ -283,13 +283,25 @@ async function main() {
     console.log(`City: ${city.name_municipality} (${city.id})\n`);
 
     // Resolve DHM_ID
-    let dhmId = argv.dhmId;
+    let dhmId: string | undefined = argv.dhmId;
     if (!dhmId) {
-        dhmId = await findDhmId(city.name_municipality);
+        dhmId = await findDhmId(city.name_municipality) ?? undefined;
         if (!dhmId) {
             process.exit(1);
         }
     }
+
+    // Find the council administrative body for this city
+    const councilBody = await prisma.administrativeBody.findFirst({
+        where: { cityId, type: 'council' },
+        select: { id: true, name: true },
+    });
+
+    if (!councilBody) {
+        console.error(`No council administrative body found for city ${cityId}`);
+        process.exit(1);
+    }
+    console.log(`Administrative body: ${councilBody.name} (${councilBody.id})\n`);
 
     // Load people from database (council members with active roles)
     const people = await prisma.person.findMany({
@@ -304,14 +316,24 @@ async function main() {
         },
     });
 
-    // Find the representative role for each person (same logic as ElectedOrderSheet)
+    // Find each person's council body role
     const dbMembers: DbMember[] = people.flatMap(person => {
-        const role = person.roles.find(r => r.electedOrder != null)
-            ?? person.roles.find(r => r.cityId === cityId)
-            ?? person.roles[0];
+        const role = person.roles.find(r => r.administrativeBodyId === councilBody.id);
         if (!role) return [];
         return [{ roleId: role.id, personId: person.id, name: person.name }];
     });
+
+    // Warn about people with no council role
+    const peopleWithoutCouncilRole = people.filter(
+        p => p.roles.length > 0 && !p.roles.some(r => r.administrativeBodyId === councilBody.id)
+    );
+    if (peopleWithoutCouncilRole.length > 0) {
+        console.log(`Warning: ${peopleWithoutCouncilRole.length} people have roles but no council body role:`);
+        for (const p of peopleWithoutCouncilRole) {
+            console.log(`  - ${p.name}`);
+        }
+        console.log();
+    }
 
     console.log(`Loaded ${dbMembers.length} council members from database\n`);
 

--- a/scripts/update_elected_order.ts
+++ b/scripts/update_elected_order.ts
@@ -1,0 +1,397 @@
+/**
+ * Updates elected order for a municipality's council members based on official
+ * election results from the greek-municipal-elections open data repo.
+ *
+ * Elected order is determined by:
+ *   - Party ordering: parties with more seats come first (winning party first)
+ *   - Within each party: the party head (mayoral candidate) is first, then
+ *     council members ordered by votes (σταυροί) descending
+ *   - Replacement members (who entered the council after the election) are
+ *     placed right after the last elected member of their party, based on
+ *     their vote ranking
+ *
+ * Usage:
+ *   npx tsx scripts/update_elected_order.ts --city chalandri [--dry-run]
+ *   npx tsx scripts/update_elected_order.ts --city chalandri --dhm-id 9178 [--dry-run]
+ *   npx tsx scripts/update_elected_order.ts --search χαλάνδρι
+ *
+ * The script reads people from the database, loads election data from the
+ * greek-municipal-elections repo (local clone or GitHub), matches names, and
+ * writes electedOrder directly to Role records.
+ *
+ * Data source: https://github.com/schemalabz/greek-municipal-elections
+ *
+ * Name matching uses token-sort keys with Greek name normalization (same
+ * approach as decisionPdfExtraction.ts in opencouncil-tasks). Handles reversed
+ * name order, nicknames in parentheses, diacritics, and final sigma differences.
+ * Members that can't be matched to election candidates (replacements not in the
+ * original election) are placed at the end.
+ */
+import { PrismaClient } from '@prisma/client';
+import dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { normalizeGreekName, tokenSortKeys, matchByName, MatchCandidate, DbMember as MatchDbMember } from './lib/greek-name-matching';
+
+dotenv.config();
+
+const prisma = new PrismaClient();
+
+// Resolve the election data directory: local sibling clone or GitHub raw URL
+const LOCAL_DATA_DIR = path.resolve(__dirname, '../../greek-municipal-elections/data/2023');
+const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/schemalabz/greek-municipal-elections/main/data/2023';
+
+// --- Types (matching the open data schema) ---
+
+interface ElectionCandidate {
+    surname: string;
+    firstname: string;
+    fathersName: string;
+    votes: number;
+    elected: boolean;
+}
+
+interface ElectionPartyHead {
+    surname: string;
+    firstname: string;
+    fathersName: string;
+}
+
+interface ElectionParty {
+    id: number;
+    name: string;
+    head: ElectionPartyHead;
+    round1: { votes: number; percentage: number };
+    round2: { votes: number; percentage: number } | null;
+    seatsWon: number;
+    isWinner: boolean;
+    candidates: ElectionCandidate[];
+}
+
+interface MunicipalityData {
+    id: number;
+    name: string;
+    parties: ElectionParty[];
+}
+
+interface IndexEntry {
+    id: number;
+    name: string;
+    seats: number;
+}
+
+interface IndexData {
+    municipalities: IndexEntry[];
+}
+
+interface ElectedMember {
+    surname: string;
+    firstname: string;
+    partyName: string;
+    candId: number;
+    votes: number;
+    isPartyHead: boolean;
+    globalOrder: number;
+    partyInternalRank: number;
+}
+
+interface DbMember {
+    roleId: string;
+    personId: string;
+    name: string;
+}
+
+// --- Data loading ---
+
+async function loadJson<T>(relativePath: string): Promise<T> {
+    const localPath = path.join(LOCAL_DATA_DIR, relativePath);
+    if (fs.existsSync(localPath)) {
+        return JSON.parse(fs.readFileSync(localPath, 'utf-8'));
+    }
+    // Fallback: fetch from GitHub
+    const url = `${GITHUB_RAW_BASE}/${relativePath}`;
+    console.log(`  (fetching from GitHub: ${relativePath})`);
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`HTTP ${response.status}: ${url}`);
+    return response.json() as Promise<T>;
+}
+
+// --- Core logic ---
+
+async function loadElectionData(dhmId: string): Promise<ElectedMember[]> {
+    const data = await loadJson<MunicipalityData>(`municipalities/${dhmId}.json`);
+    console.log(`Municipality: ${data.name}`);
+    console.log(`Parties: ${data.parties.length}`);
+
+    // Build elected member list from the open data JSON.
+    // Parties are already sorted (seats desc, then votes) in the data.
+    const elected: ElectedMember[] = [];
+    let globalOrder = 1;
+
+    for (const party of data.parties) {
+        // Party head gets first position
+        elected.push({
+            surname: party.head.surname,
+            firstname: party.head.firstname,
+            partyName: party.name,
+            candId: party.id,
+            votes: party.round1.votes,
+            isPartyHead: true,
+            globalOrder: globalOrder++,
+            partyInternalRank: 1,
+        });
+
+        // All candidates — elected ones get globalOrder, rest get 0 (resolved during matching)
+        for (let i = 0; i < party.candidates.length; i++) {
+            const c = party.candidates[i];
+            elected.push({
+                surname: c.surname,
+                firstname: c.firstname,
+                partyName: party.name,
+                candId: party.id,
+                votes: c.votes,
+                isPartyHead: false,
+                globalOrder: c.elected ? globalOrder++ : 0,
+                partyInternalRank: i + 2,
+            });
+        }
+    }
+
+    return elected;
+}
+
+// --- Greek name matching (same approach as decisionPdfExtraction.ts in opencouncil-tasks) ---
+
+function matchMembers(
+    elected: ElectedMember[],
+    dbMembers: DbMember[]
+): { matched: Map<string, number>; unmatched: string[] } {
+    // Build candidates from election data
+    const candidates: MatchCandidate[] = elected.map((e, i) => ({
+        name: `${e.surname} ${e.firstname}`,
+        index: i,
+    }));
+
+    const matchDbMembers: MatchDbMember[] = dbMembers.map(m => ({
+        id: m.personId,
+        name: m.name,
+    }));
+
+    const { matched: personMatches, unmatched } = matchByName(candidates, matchDbMembers);
+
+    // Convert person matches to globalOrder values
+    const matched = new Map<string, number>();
+    for (const [personId, electedIdx] of personMatches) {
+        const e = elected[electedIdx];
+        if (e.globalOrder > 0) {
+            matched.set(personId, e.globalOrder);
+        } else {
+            // Replacement: candidate beyond seat cutoff
+            const lastElectedInParty = elected
+                .filter(el => el.candId === e.candId && el.globalOrder > 0)
+                .reduce((max, el) => Math.max(max, el.globalOrder), 0);
+            const seatsInParty = elected.filter(el => el.candId === e.candId && el.globalOrder > 0).length;
+            const offset = e.partyInternalRank - seatsInParty;
+            matched.set(personId, lastElectedInParty + offset);
+        }
+    }
+
+    return { matched, unmatched };
+}
+
+// --- Municipality lookup ---
+
+async function searchMunicipalities(query: string): Promise<IndexEntry[]> {
+    const stripped = query.replace(/^δήμος\s+|^δημος\s+/i, '');
+    const normalizedQuery = normalizeGreekName(stripped);
+
+    const index = await loadJson<IndexData>('index.json');
+    return index.municipalities.filter(m =>
+        normalizeGreekName(m.name).includes(normalizedQuery)
+    );
+}
+
+async function findDhmId(cityName: string): Promise<string | null> {
+    console.log(`Searching for "${cityName}" in election data...\n`);
+    const matches = await searchMunicipalities(cityName);
+
+    if (matches.length === 0) {
+        console.log('No matches found.');
+        return null;
+    } else if (matches.length === 1) {
+        console.log(`Found: ${matches[0].id} — ${matches[0].name} (${matches[0].seats} seats)\n`);
+        return String(matches[0].id);
+    } else {
+        console.log(`Multiple matches found:\n`);
+        for (const m of matches) {
+            console.log(`  ${m.id} — ${m.name} (${m.seats} seats)`);
+        }
+        console.log(`\nPlease specify --dhm-id explicitly.`);
+        return null;
+    }
+}
+
+// --- Main ---
+
+async function main() {
+    const argv = await yargs(hideBin(process.argv))
+        .option('city', { type: 'string', describe: 'City ID from our database' })
+        .option('dhm-id', { type: 'string', describe: 'Municipality DHM_ID (optional, auto-detected from city name)' })
+        .option('dry-run', { type: 'boolean', default: false, describe: 'Preview changes without writing to database' })
+        .option('search', { type: 'string', describe: 'Search for a municipality by name' })
+        .check(argv => {
+            if (argv.search) return true;
+            if (argv.city) return true;
+            throw new Error('Either --city or --search is required');
+        })
+        .help()
+        .argv;
+
+    // Check data source
+    if (fs.existsSync(LOCAL_DATA_DIR)) {
+        console.log(`Data source: ${LOCAL_DATA_DIR}\n`);
+    } else {
+        console.log(`Data source: ${GITHUB_RAW_BASE} (no local clone found)\n`);
+    }
+
+    if (argv.search) {
+        const matches = await searchMunicipalities(argv.search);
+        if (matches.length === 0) {
+            console.log('No matches found.');
+        } else {
+            console.log(`Found ${matches.length} match${matches.length > 1 ? 'es' : ''}:\n`);
+            for (const m of matches) {
+                console.log(`  ${m.id} — ${m.name} (${m.seats} seats)`);
+            }
+        }
+        return;
+    }
+
+    const cityId = argv.city!;
+
+    // Load city from database
+    const city = await prisma.city.findUnique({
+        where: { id: cityId },
+        select: { id: true, name: true, name_municipality: true },
+    });
+    if (!city) {
+        console.error(`City not found: ${cityId}`);
+        process.exit(1);
+    }
+    console.log(`City: ${city.name_municipality} (${city.id})\n`);
+
+    // Resolve DHM_ID
+    let dhmId = argv.dhmId;
+    if (!dhmId) {
+        dhmId = await findDhmId(city.name_municipality);
+        if (!dhmId) {
+            process.exit(1);
+        }
+    }
+
+    // Load people from database (council members with active roles)
+    const people = await prisma.person.findMany({
+        where: { cityId },
+        select: {
+            id: true,
+            name: true,
+            roles: {
+                where: { endDate: null },
+                select: { id: true, electedOrder: true, cityId: true, partyId: true, administrativeBodyId: true },
+            },
+        },
+    });
+
+    // Find the representative role for each person (same logic as ElectedOrderSheet)
+    const dbMembers: DbMember[] = people.flatMap(person => {
+        const role = person.roles.find(r => r.electedOrder != null)
+            ?? person.roles.find(r => r.cityId === cityId)
+            ?? person.roles[0];
+        if (!role) return [];
+        return [{ roleId: role.id, personId: person.id, name: person.name }];
+    });
+
+    console.log(`Loaded ${dbMembers.length} council members from database\n`);
+
+    // Load election data
+    const elected = await loadElectionData(dhmId);
+    console.log(`\nElected members from election data: ${elected.length}\n`);
+
+    // Print election results
+    let currentParty = -1;
+    for (const e of elected) {
+        if (e.candId !== currentParty) {
+            currentParty = e.candId;
+            console.log(`--- ${e.partyName} ---`);
+        }
+        const label = e.isPartyHead ? '(head)' : `${e.votes} votes`;
+        console.log(`  ${e.globalOrder.toString().padStart(2)}. ${e.surname} ${e.firstname} — ${label}`);
+    }
+
+    // Match
+    console.log(`\nMatching names...`);
+    const { matched, unmatched } = matchMembers(elected, dbMembers);
+    console.log(`Matched: ${matched.size}/${dbMembers.length}`);
+
+    if (unmatched.length > 0) {
+        console.log(`\nUnmatched members (may be replacements not in election data):`);
+        for (const name of unmatched) {
+            console.log(`  - ${name}`);
+        }
+        const maxOrder = Math.max(...[...matched.values()], 0);
+        let nextOrder = maxOrder + 1;
+        for (const m of dbMembers) {
+            if (!matched.has(m.personId)) {
+                matched.set(m.personId, nextOrder++);
+                console.log(`  → ${m.name} assigned order ${nextOrder - 1}`);
+            }
+        }
+    }
+
+    // Renumber sequentially to eliminate gaps and collisions
+    const sortedByRawOrder = [...dbMembers]
+        .map(m => ({ personId: m.personId, roleId: m.roleId, rawOrder: matched.get(m.personId) ?? Infinity }))
+        .sort((a, b) => a.rawOrder - b.rawOrder);
+    const finalOrder = new Map<string, { roleId: string; order: number }>();
+    sortedByRawOrder.forEach((entry, i) => finalOrder.set(entry.personId, { roleId: entry.roleId, order: i + 1 }));
+
+    // Show results
+    console.log(`\nFinal elected order:`);
+    const sorted = [...finalOrder.entries()].sort((a, b) => a[1].order - b[1].order);
+    for (const [personId, { order }] of sorted) {
+        const member = dbMembers.find(m => m.personId === personId)!;
+        console.log(`  ${order.toString().padStart(2)}. ${member.name}`);
+    }
+
+    // Write to database
+    if (!argv.dryRun) {
+        const rankings = [...finalOrder.values()].map(({ roleId, order }) => ({
+            roleId,
+            electedOrder: order,
+        }));
+
+        await prisma.$transaction(
+            rankings.map(({ roleId, electedOrder }) =>
+                prisma.role.update({
+                    where: { id: roleId },
+                    data: { electedOrder },
+                })
+            )
+        );
+
+        console.log(`\nWritten ${rankings.length} elected orders to database.`);
+    } else {
+        console.log(`\nDry run — no database changes.`);
+    }
+}
+
+main()
+    .catch(err => {
+        console.error(err);
+        process.exit(1);
+    })
+    .finally(async () => {
+        await prisma.$disconnect();
+    });

--- a/src/app/[locale]/(other)/admin/people/page.tsx
+++ b/src/app/[locale]/(other)/admin/people/page.tsx
@@ -1,8 +1,10 @@
 import { getCities } from "@/lib/db/cities";
 import { getPeopleForCity, PersonWithRelations } from "@/lib/db/people";
+import { getAdministrativeBodiesForCity } from "@/lib/db/administrativeBodies";
 import { sortPersonsByLastName } from "@/lib/sorting/people";
 import CitySelector from "@/components/admin/people/city-selector";
 import People from "@/components/admin/people/people";
+import { AdministrativeBody } from "@prisma/client";
 
 interface PageProps {
     searchParams: { cityId?: string };
@@ -14,9 +16,14 @@ export default async function PeoplePage({ searchParams }: PageProps) {
     const selectedCityId = searchParams.cityId || (cities.length > 0 ? cities[0].id : "");
 
     let people: PersonWithRelations[] = [];
+    let administrativeBodies: AdministrativeBody[] = [];
     if (selectedCityId) {
-        const peopleData = await getPeopleForCity(selectedCityId);
+        const [peopleData, bodies] = await Promise.all([
+            getPeopleForCity(selectedCityId),
+            getAdministrativeBodiesForCity(selectedCityId),
+        ]);
         people = sortPersonsByLastName(peopleData);
+        administrativeBodies = bodies;
     }
 
     const currentCityName = cities.find(c => c.id === selectedCityId)?.name || "Select City";
@@ -33,7 +40,11 @@ export default async function PeoplePage({ searchParams }: PageProps) {
                 </div>
             </div>
 
-            <People people={people} currentCityName={currentCityName} />
+            <People
+                people={people}
+                currentCityName={currentCityName}
+                administrativeBodies={administrativeBodies}
+            />
         </div>
     );
 }

--- a/src/app/api/cities/[cityId]/roles/elected-order/route.ts
+++ b/src/app/api/cities/[cityId]/roles/elected-order/route.ts
@@ -5,6 +5,7 @@ import { updateElectedOrder } from '@/lib/db/roles'
 import { z } from 'zod'
 
 const electedOrderSchema = z.object({
+    administrativeBodyId: z.string().min(1),
     rankings: z.array(z.object({
         roleId: z.string().min(1),
         electedOrder: z.number().int().nonnegative().nullable(),
@@ -19,9 +20,9 @@ export async function POST(
         await withUserAuthorizedToEdit({ cityId: params.cityId });
 
         const body = await request.json();
-        const { rankings } = electedOrderSchema.parse(body);
+        const { administrativeBodyId, rankings } = electedOrderSchema.parse(body);
 
-        await updateElectedOrder(params.cityId, rankings);
+        await updateElectedOrder(params.cityId, administrativeBodyId, rankings);
 
         revalidateTag(`city:${params.cityId}:people`);
 

--- a/src/components/admin/people/ElectedOrderSheet.tsx
+++ b/src/components/admin/people/ElectedOrderSheet.tsx
@@ -24,7 +24,6 @@ import { PersonWithRelations } from '@/lib/db/people';
 import { GripVertical, Loader2, Download, Upload } from 'lucide-react';
 import { toast } from '@/hooks/use-toast';
 import { useTranslations } from 'next-intl';
-import { isRoleActive } from '@/lib/utils';
 import { compareRanks } from '@/lib/sorting/people';
 import { downloadFile } from '@/lib/export/meetings';
 
@@ -33,6 +32,7 @@ interface ElectedOrderSheetProps {
     onOpenChange: (open: boolean) => void;
     people: PersonWithRelations[];
     cityId: string;
+    administrativeBodyId: string;
 }
 
 interface SortableMember {
@@ -83,21 +83,12 @@ function SortableMemberRow({ member, index }: { member: SortableMember; index: n
     );
 }
 
-/**
- * Find the best representative role for a person to store electedOrder on.
- * Prefers a role that already has electedOrder, otherwise first active role in the city.
- */
-function getRepresentativeRole(person: PersonWithRelations, cityId: string) {
-    return person.roles.find(r => r.electedOrder != null)
-        ?? person.roles.find(r => r.cityId === cityId && isRoleActive(r))
-        ?? person.roles[0];
-}
-
 export default function ElectedOrderSheet({
     open,
     onOpenChange,
     people,
     cityId,
+    administrativeBodyId,
 }: ElectedOrderSheetProps) {
     const router = useRouter();
     const [isSaving, setIsSaving] = useState(false);
@@ -105,11 +96,11 @@ export default function ElectedOrderSheet({
     const [members, setMembers] = useState<SortableMember[]>([]);
     const t = useTranslations('ElectedOrderSheet');
 
-    // Initialize members from people data
+    // Initialize members: only people who have a role in this administrative body
     useEffect(() => {
         const membersData: SortableMember[] = people
             .flatMap(person => {
-                const role = getRepresentativeRole(person, cityId);
+                const role = person.roles.find(r => r.administrativeBodyId === administrativeBodyId);
                 if (!role) return [];
                 return [{
                     personId: person.id,
@@ -125,7 +116,7 @@ export default function ElectedOrderSheet({
             });
 
         setMembers(membersData);
-    }, [people, cityId]);
+    }, [people, administrativeBodyId]);
 
     const sensors = useSensors(
         useSensor(PointerSensor),
@@ -160,7 +151,7 @@ export default function ElectedOrderSheet({
                 {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ rankings }),
+                    body: JSON.stringify({ administrativeBodyId, rankings }),
                 }
             );
 
@@ -201,7 +192,7 @@ export default function ElectedOrderSheet({
                 {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ rankings }),
+                    body: JSON.stringify({ administrativeBodyId, rankings }),
                 }
             );
 
@@ -231,6 +222,7 @@ export default function ElectedOrderSheet({
     const handleExport = () => {
         const data = {
             cityId,
+            administrativeBodyId,
             exportedAt: new Date().toISOString(),
             members: members.map((m, index) => ({
                 roleId: m.roleId,
@@ -240,7 +232,7 @@ export default function ElectedOrderSheet({
             })),
         };
         const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-        downloadFile(blob, `elected-order-${cityId}.json`);
+        downloadFile(blob, `elected-order-${cityId}-${administrativeBodyId}.json`);
     };
 
     const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -264,7 +256,7 @@ export default function ElectedOrderSheet({
                 {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ rankings }),
+                    body: JSON.stringify({ administrativeBodyId, rankings }),
                 }
             );
 

--- a/src/components/admin/people/people.tsx
+++ b/src/components/admin/people/people.tsx
@@ -12,15 +12,24 @@ import { PersonBadge } from "@/components/persons/PersonBadge";
 import { VoiceprintActions } from "./voiceprint-actions";
 import { BulkVoiceprintDialog } from "./bulk-voiceprint-dialog";
 import ElectedOrderSheet from "./ElectedOrderSheet";
+import { AdministrativeBody } from "@prisma/client";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 interface PeopleProps {
     people: PersonWithRelations[];
     currentCityName: string;
+    administrativeBodies: AdministrativeBody[];
 }
 
-export default function People({ people, currentCityName }: PeopleProps) {
+export default function People({ people, currentCityName, administrativeBodies }: PeopleProps) {
     const [searchQuery, setSearchQuery] = useState("");
     const [electedOrderOpen, setElectedOrderOpen] = useState(false);
+    const [selectedBodyId, setSelectedBodyId] = useState<string | null>(null);
     const t = useTranslations("Person");
     const tElectedOrder = useTranslations("ElectedOrderSheet");
 
@@ -39,14 +48,18 @@ export default function People({ people, currentCityName }: PeopleProps) {
             totalPeople: filteredPeople.length,
             peopleWithRoles: filteredPeople.filter(person => person.roles.length > 0).length,
             peopleWithImages: filteredPeople.filter(person => person.image !== null).length,
-            peopleWithVoiceprints: filteredPeople.filter(person => person.voicePrints && person.voicePrints.length > 0)
-                .length,
+            peopleWithVoiceprints: filteredPeople.filter(person => person.voicePrints && person.voicePrints.length > 0).length,
         }),
         [filteredPeople],
     );
 
     // Get the cityId from the first person or use empty string as fallback
     const cityId = people.length > 0 ? people[0].cityId : "";
+
+    const handleBodySelect = (bodyId: string) => {
+        setSelectedBodyId(bodyId);
+        setElectedOrderOpen(true);
+    };
 
     return (
         <>
@@ -72,14 +85,24 @@ export default function People({ people, currentCityName }: PeopleProps) {
                     <CardTitle className='flex justify-between'>
                         <span>People</span>
                         <div className='flex items-center gap-2'>
-                            {cityId && (
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={() => setElectedOrderOpen(true)}
-                                >
-                                    {tElectedOrder('triggerButton')}
-                                </Button>
+                            {cityId && administrativeBodies.length > 0 && (
+                                <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                        <Button variant="outline" size="sm">
+                                            {tElectedOrder('triggerButton')}
+                                        </Button>
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent align="end">
+                                        {administrativeBodies.map(body => (
+                                            <DropdownMenuItem
+                                                key={body.id}
+                                                onClick={() => handleBodySelect(body.id)}
+                                            >
+                                                {body.name}
+                                            </DropdownMenuItem>
+                                        ))}
+                                    </DropdownMenuContent>
+                                </DropdownMenu>
                             )}
                             {cityId && <BulkVoiceprintDialog cityId={cityId} currentCityName={currentCityName} />}
                             <span className='text-muted-foreground text-sm ml-2'>{currentCityName}</span>
@@ -110,12 +133,13 @@ export default function People({ people, currentCityName }: PeopleProps) {
                 </CardContent>
             </Card>
 
-            {cityId && (
+            {cityId && selectedBodyId && (
                 <ElectedOrderSheet
                     open={electedOrderOpen}
                     onOpenChange={setElectedOrderOpen}
                     people={people}
                     cityId={cityId}
+                    administrativeBodyId={selectedBodyId}
                 />
             )}
         </>

--- a/src/components/admin/people/people.tsx
+++ b/src/components/admin/people/people.tsx
@@ -58,7 +58,10 @@ export default function People({ people, currentCityName, administrativeBodies }
 
     const handleBodySelect = (bodyId: string) => {
         setSelectedBodyId(bodyId);
-        setElectedOrderOpen(true);
+        // Delay opening the Sheet to let the DropdownMenu (also a Radix Dialog)
+        // fully close first — otherwise two dialogs transitioning simultaneously
+        // can leave pointer-events: none stuck on the body.
+        requestAnimationFrame(() => setElectedOrderOpen(true));
     };
 
     return (
@@ -133,13 +136,13 @@ export default function People({ people, currentCityName, administrativeBodies }
                 </CardContent>
             </Card>
 
-            {cityId && selectedBodyId && (
+            {cityId && (
                 <ElectedOrderSheet
-                    open={electedOrderOpen}
+                    open={electedOrderOpen && selectedBodyId !== null}
                     onOpenChange={setElectedOrderOpen}
                     people={people}
                     cityId={cityId}
-                    administrativeBodyId={selectedBodyId}
+                    administrativeBodyId={selectedBodyId ?? ""}
                 />
             )}
         </>

--- a/src/components/meetings/admin/DecisionsPanel.tsx
+++ b/src/components/meetings/admin/DecisionsPanel.tsx
@@ -18,7 +18,7 @@ import { getPollingHistoryForMeeting, requestPollDecisions } from '@/lib/tasks/p
 import { calculateVoteResult } from '@/lib/utils/votes';
 import { getWithdrawnLabel } from '@/lib/utils/subjects';
 import { isMayorRole, isRoleActiveAt } from '@/lib/utils/roles';
-import { compareRanks } from '@/lib/sorting/people';
+import { compareRanks, getElectedOrderForBody } from '@/lib/sorting/people';
 import { PersonWithRelations } from '@/lib/db/people';
 import ReactMarkdown from 'react-markdown';
 
@@ -89,15 +89,6 @@ function NameList({ names, label }: { names: string[]; label: string }) {
             )}
         </span>
     );
-}
-
-/** Get elected order for a person in the meeting's administrative body. */
-function getElectedOrderForBody(person: PersonWithRelations | undefined, administrativeBodyId: string | null): number | null {
-    if (!person || !administrativeBodyId) return null;
-    const role = person.roles.find(
-        r => r.administrativeBodyId === administrativeBodyId && r.electedOrder != null
-    );
-    return role?.electedOrder ?? null;
 }
 
 /** Sort names by elected order, falling back to alphabetical. */

--- a/src/components/meetings/admin/DecisionsPanel.tsx
+++ b/src/components/meetings/admin/DecisionsPanel.tsx
@@ -17,6 +17,9 @@ import { LinkOrDrop } from '@/components/ui/link-or-drop';
 import { getPollingHistoryForMeeting, requestPollDecisions } from '@/lib/tasks/pollDecisions';
 import { calculateVoteResult } from '@/lib/utils/votes';
 import { getWithdrawnLabel } from '@/lib/utils/subjects';
+import { isMayorRole, isRoleActiveAt } from '@/lib/utils/roles';
+import { compareRanks } from '@/lib/sorting/people';
+import { PersonWithRelations } from '@/lib/db/people';
 import ReactMarkdown from 'react-markdown';
 
 type FilterTab = 'all' | 'unlinked' | 'extracted';
@@ -88,10 +91,49 @@ function NameList({ names, label }: { names: string[]; label: string }) {
     );
 }
 
-function MeetingAttendanceSummary({ attendance }: { attendance: MeetingAttendanceRecord[] }) {
+/** Get elected order for a person in the meeting's administrative body. */
+function getElectedOrderForBody(person: PersonWithRelations | undefined, administrativeBodyId: string | null): number | null {
+    if (!person || !administrativeBodyId) return null;
+    const role = person.roles.find(
+        r => r.administrativeBodyId === administrativeBodyId && r.electedOrder != null
+    );
+    return role?.electedOrder ?? null;
+}
+
+/** Sort names by elected order, falling back to alphabetical. */
+function sortNamesByElectedOrder(
+    items: { personId: string; personName: string }[],
+    getPerson: (id: string) => PersonWithRelations | undefined,
+    administrativeBodyId: string | null,
+): { personId: string; personName: string }[] {
+    return [...items].sort((a, b) => {
+        const aOrder = getElectedOrderForBody(getPerson(a.personId), administrativeBodyId);
+        const bOrder = getElectedOrderForBody(getPerson(b.personId), administrativeBodyId);
+        const orderCompare = compareRanks(aOrder, bOrder);
+        if (orderCompare !== 0) return orderCompare;
+        return a.personName.localeCompare(b.personName);
+    });
+}
+
+function MeetingAttendanceSummary({ attendance, getPerson, administrativeBodyId, mayorPersonId }: {
+    attendance: MeetingAttendanceRecord[];
+    getPerson: (id: string) => PersonWithRelations | undefined;
+    administrativeBodyId: string | null;
+    mayorPersonId: string | null;
+}) {
     const [expanded, setExpanded] = useState(false);
-    const present = attendance.filter(a => a.status === 'PRESENT');
-    const absent = attendance.filter(a => a.status === 'ABSENT');
+    const filtered = attendance.filter(a => a.personId !== mayorPersonId);
+    const present = filtered.filter(a => a.status === 'PRESENT');
+    const absent = filtered.filter(a => a.status === 'ABSENT');
+
+    const sortedPresent = sortNamesByElectedOrder(
+        present.map(a => ({ personId: a.personId, personName: a.person.name })),
+        getPerson, administrativeBodyId,
+    );
+    const sortedAbsent = sortNamesByElectedOrder(
+        absent.map(a => ({ personId: a.personId, personName: a.person.name })),
+        getPerson, administrativeBodyId,
+    );
 
     return (
         <div className="border rounded-lg p-2.5 bg-muted/30">
@@ -105,19 +147,19 @@ function MeetingAttendanceSummary({ attendance }: { attendance: MeetingAttendanc
                     Initial roll call
                 </span>
                 <span className="text-xs text-muted-foreground ml-1">
-                    {present.length} present, {absent.length} absent ({attendance.length} total)
+                    {present.length} present, {absent.length} absent ({filtered.length} total)
                 </span>
             </button>
             {expanded && (
                 <div className="mt-2 ml-5 space-y-1.5">
                     <div>
-                        <span className="text-[11px] font-medium text-green-700">Present ({present.length})</span>
-                        <p className="text-[11px] text-muted-foreground">{present.map(a => a.person.name).join(', ')}</p>
+                        <span className="text-[11px] font-medium text-green-700">Present ({sortedPresent.length})</span>
+                        <p className="text-[11px] text-muted-foreground">{sortedPresent.map(a => a.personName).join(', ')}</p>
                     </div>
-                    {absent.length > 0 && (
+                    {sortedAbsent.length > 0 && (
                         <div>
-                            <span className="text-[11px] font-medium text-red-700">Absent ({absent.length})</span>
-                            <p className="text-[11px] text-muted-foreground">{absent.map(a => a.person.name).join(', ')}</p>
+                            <span className="text-[11px] font-medium text-red-700">Absent ({sortedAbsent.length})</span>
+                            <p className="text-[11px] text-muted-foreground">{sortedAbsent.map(a => a.personName).join(', ')}</p>
                         </div>
                     )}
                 </div>
@@ -128,8 +170,13 @@ function MeetingAttendanceSummary({ attendance }: { attendance: MeetingAttendanc
 
 export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
     const { toast } = useToast();
-    const { subjects, meeting } = useCouncilMeetingData();
+    const { subjects, meeting, people, getPerson } = useCouncilMeetingData();
     const t = useTranslations('admin.adminActions');
+    const administrativeBodyId = meeting.administrativeBodyId ?? null;
+    const meetingDate = new Date(meeting.dateTime);
+    const mayorPersonId = people.find(p =>
+        p.roles.some(r => isRoleActiveAt(r, meetingDate) && isMayorRole(r))
+    )?.id ?? null;
     const [decisions, setDecisions] = useState<Record<string, DecisionWithSource>>({});
     const [extractedData, setExtractedData] = useState<Record<string, SubjectExtractedData>>({});
     const [meetingAttendance, setMeetingAttendance] = useState<MeetingAttendanceRecord[]>([]);
@@ -472,7 +519,12 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
 
                 {/* Meeting-level attendance (initial roll call) */}
                 {meetingAttendance.length > 0 && (
-                    <MeetingAttendanceSummary attendance={meetingAttendance} />
+                    <MeetingAttendanceSummary
+                        attendance={meetingAttendance}
+                        getPerson={getPerson}
+                        administrativeBodyId={administrativeBodyId}
+                        mayorPersonId={mayorPersonId}
+                    />
                 )}
 
                 {/* Filter tabs */}
@@ -579,8 +631,9 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
                                                     )}
                                                     {/* Inline attendance & vote summary */}
                                                     {extracted && (extracted.attendance.length > 0 || extracted.votes.length > 0) && (() => {
-                                                        const present = extracted.attendance.filter(a => a.status === 'PRESENT');
-                                                        const absent = extracted.attendance.filter(a => a.status === 'ABSENT');
+                                                        const filteredInline = extracted.attendance.filter(a => a.personId !== mayorPersonId);
+                                                        const present = filteredInline.filter(a => a.status === 'PRESENT');
+                                                        const absent = filteredInline.filter(a => a.status === 'ABSENT');
                                                         const voteResult = extracted.votes.length > 0 ? calculateVoteResult(extracted.votes) : null;
                                                         return (
                                                             <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
@@ -720,8 +773,15 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
 
                                                 {/* Attendance */}
                                                 {extracted && extracted.attendance.length > 0 && (() => {
-                                                    const present = extracted.attendance.filter(a => a.status === 'PRESENT');
-                                                    const absent = extracted.attendance.filter(a => a.status === 'ABSENT');
+                                                    const filteredAttendance = extracted.attendance.filter(a => a.personId !== mayorPersonId);
+                                                    const present = sortNamesByElectedOrder(
+                                                        filteredAttendance.filter(a => a.status === 'PRESENT'),
+                                                        getPerson, administrativeBodyId,
+                                                    );
+                                                    const absent = sortNamesByElectedOrder(
+                                                        filteredAttendance.filter(a => a.status === 'ABSENT'),
+                                                        getPerson, administrativeBodyId,
+                                                    );
                                                     return (
                                                         <div>
                                                             <div className="text-xs font-medium text-muted-foreground mb-1">

--- a/src/components/meetings/admin/DecisionsPanel.tsx
+++ b/src/components/meetings/admin/DecisionsPanel.tsx
@@ -594,8 +594,8 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
                                         {/* Main row */}
                                         <div className="flex items-start justify-between gap-3">
                                             <div className="flex-1 min-w-0 flex items-start gap-2">
-                                                {/* Expand chevron for linked decisions with extracted data */}
-                                                {decision && hasExtractedContent ? (
+                                                {/* Expand chevron for subjects with extracted data (decisions or attendance) */}
+                                                {hasExtractedContent ? (
                                                     <button
                                                         onClick={() => toggleExtracted(subject.id)}
                                                         className="mt-0.5 text-muted-foreground hover:text-foreground shrink-0"
@@ -731,7 +731,7 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
                                             </div>
                                         </div>
 
-                                        {/* Extracted data panel - expandable for linked decisions */}
+                                        {/* Extracted data panel - expandable for subjects with attendance/vote data */}
                                         {isExtractedExpanded && hasExtractedContent && (
                                             <div className="mt-3 ml-6 pl-4 border-l-2 border-muted space-y-3">
                                                 {/* Excerpt */}

--- a/src/components/meetings/admin/MinutesPreviewContent.tsx
+++ b/src/components/meetings/admin/MinutesPreviewContent.tsx
@@ -13,7 +13,7 @@ import {
     MinutesTranscriptEntry,
     MinutesAttendanceChange,
 } from '@/lib/minutes/types';
-import { interleaveSubstitutes } from '@/lib/minutes/builders';
+import { interleaveSubstitutes, formatSubjectLabel } from '@/lib/minutes/builders';
 import { getWithdrawnLabel } from '@/lib/utils/subjects';
 
 interface MinutesPreviewContentProps {
@@ -59,6 +59,14 @@ export function MinutesPreviewContent({ data }: MinutesPreviewContentProps) {
             {/* Arrivals/departures */}
             {data.attendanceChanges.length > 0 && (
                 <AttendanceChangesSection changes={data.attendanceChanges} />
+            )}
+
+            {/* Discussion order (only when non-natural) */}
+            {data.discussionOrderLabel && (
+                <p className="text-sm mt-2">
+                    <span className="font-bold">Σειρά συζήτησης: </span>
+                    {data.discussionOrderLabel}
+                </p>
             )}
 
             {/* Table of Contents */}
@@ -167,16 +175,13 @@ function AttendanceChangesSection({ changes }: { changes: MinutesAttendanceChang
         <div className="mt-4 space-y-2">
             {arrivals.length > 0 && (
                 <div>
-                    <p className="font-bold text-sm">ΑΦΙΞΕΙΣ</p>
+                    <p className="font-bold text-sm">Προσελεύσεις</p>
                     <ul className="list-disc pl-5 text-sm">
                         {arrivals.map((change, i) => (
                             <li key={i}>
                                 {change.name}
                                 <span className="text-muted-foreground">
-                                    {' — παρών/παρούσα από το '}
-                                    {change.atSubject.agendaItemIndex
-                                        ? `${change.atSubject.agendaItemIndex}ο θέμα`
-                                        : change.atSubject.name}
+                                    {` — από το ${formatSubjectLabel(change.atSubject)}`}
                                 </span>
                             </li>
                         ))}
@@ -185,16 +190,13 @@ function AttendanceChangesSection({ changes }: { changes: MinutesAttendanceChang
             )}
             {departures.length > 0 && (
                 <div>
-                    <p className="font-bold text-sm">ΑΝΑΧΩΡΗΣΕΙΣ</p>
+                    <p className="font-bold text-sm">Αποχωρήσεις</p>
                     <ul className="list-disc pl-5 text-sm">
                         {departures.map((change, i) => (
                             <li key={i}>
                                 {change.name}
                                 <span className="text-muted-foreground">
-                                    {' — απουσίαζε από το '}
-                                    {change.atSubject.agendaItemIndex
-                                        ? `${change.atSubject.agendaItemIndex}ο θέμα`
-                                        : change.atSubject.name}
+                                    {` — από το ${formatSubjectLabel(change.atSubject)}`}
                                 </span>
                             </li>
                         ))}

--- a/src/components/meetings/admin/MinutesPreviewContent.tsx
+++ b/src/components/meetings/admin/MinutesPreviewContent.tsx
@@ -11,6 +11,7 @@ import {
     MinutesMember,
     MinutesCouncilComposition,
     MinutesTranscriptEntry,
+    MinutesAttendanceChange,
 } from '@/lib/minutes/types';
 import { interleaveSubstitutes } from '@/lib/minutes/builders';
 import { getWithdrawnLabel } from '@/lib/utils/subjects';
@@ -53,6 +54,11 @@ export function MinutesPreviewContent({ data }: MinutesPreviewContentProps) {
             {/* Council Composition + Absent Members */}
             {data.councilComposition && (
                 <CouncilCompositionSection composition={data.councilComposition} absentMembers={data.absentMembers} adminBody={data.administrativeBody} />
+            )}
+
+            {/* Arrivals/departures */}
+            {data.attendanceChanges.length > 0 && (
+                <AttendanceChangesSection changes={data.attendanceChanges} />
             )}
 
             {/* Table of Contents */}
@@ -149,6 +155,52 @@ function CouncilCompositionSection({ composition, absentMembers, adminBody }: {
             )}
 
             <hr className="my-8 border-gray-300" />
+        </div>
+    );
+}
+
+function AttendanceChangesSection({ changes }: { changes: MinutesAttendanceChange[] }) {
+    const arrivals = changes.filter(c => c.type === 'arrival');
+    const departures = changes.filter(c => c.type === 'departure');
+
+    return (
+        <div className="mt-4 space-y-2">
+            {arrivals.length > 0 && (
+                <div>
+                    <p className="font-bold text-sm">ΑΦΙΞΕΙΣ</p>
+                    <ul className="list-disc pl-5 text-sm">
+                        {arrivals.map((change, i) => (
+                            <li key={i}>
+                                {change.name}
+                                <span className="text-muted-foreground">
+                                    {' — παρών/παρούσα από το '}
+                                    {change.atSubject.agendaItemIndex
+                                        ? `${change.atSubject.agendaItemIndex}ο θέμα`
+                                        : change.atSubject.name}
+                                </span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+            {departures.length > 0 && (
+                <div>
+                    <p className="font-bold text-sm">ΑΝΑΧΩΡΗΣΕΙΣ</p>
+                    <ul className="list-disc pl-5 text-sm">
+                        {departures.map((change, i) => (
+                            <li key={i}>
+                                {change.name}
+                                <span className="text-muted-foreground">
+                                    {' — απουσίαζε από το '}
+                                    {change.atSubject.agendaItemIndex
+                                        ? `${change.atSubject.agendaItemIndex}ο θέμα`
+                                        : change.atSubject.name}
+                                </span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/meetings/admin/MinutesPreviewContent.tsx
+++ b/src/components/meetings/admin/MinutesPreviewContent.tsx
@@ -374,9 +374,7 @@ function SubjectSection({ subject }: { subject: MinutesSubject }) {
 }
 
 function formatMemberList(members: MinutesMember[]) {
-    return members
-        .map(m => m.party ? `${m.name} (${m.party}${m.isPartyHead ? ', Επικεφαλής' : ''})` : m.name)
-        .join(', ');
+    return members.map(m => m.name).join(', ');
 }
 
 function SubjectFooter({ subject }: { subject: MinutesSubject }) {

--- a/src/components/meetings/admin/MinutesPreviewContent.tsx
+++ b/src/components/meetings/admin/MinutesPreviewContent.tsx
@@ -12,6 +12,7 @@ import {
     MinutesCouncilComposition,
     MinutesTranscriptEntry,
 } from '@/lib/minutes/types';
+import { interleaveSubstitutes } from '@/lib/minutes/builders';
 import { getWithdrawnLabel } from '@/lib/utils/subjects';
 
 interface MinutesPreviewContentProps {
@@ -168,7 +169,7 @@ function CommitteeAttendanceSection({ composition, absentMembers }: {
     const substituteIds = new Set(composition.substituteMembers.map(m => m.personId));
     const absentPersonIds = new Set(absentMembers?.map(m => m.personId) ?? []);
 
-    const allMembers = [...composition.members, ...composition.substituteMembers];
+    const allMembers = interleaveSubstitutes(composition.members, composition.substituteMembers);
     const presentMembers = allMembers.filter(m => !absentPersonIds.has(m.personId));
     const absentMembersList = allMembers.filter(m => absentPersonIds.has(m.personId));
 

--- a/src/components/meetings/docx/MinutesDocx.ts
+++ b/src/components/meetings/docx/MinutesDocx.ts
@@ -746,8 +746,7 @@ function createSubjectSection(subject: MinutesSubject): (Paragraph | Table)[] {
         ];
         for (const { label, members } of voteCategories) {
             if (members.length === 0) continue;
-            const names = members
-                .map(m => m.party ? `${m.name} (${m.party}${m.isPartyHead ? ', Επικεφαλής' : ''})` : m.name).join(', ');
+            const names = members.map(m => m.name).join(', ');
             paragraphs.push(new Paragraph({
                 spacing: { before: 60, after: 40 },
                 children: [

--- a/src/components/meetings/docx/MinutesDocx.ts
+++ b/src/components/meetings/docx/MinutesDocx.ts
@@ -13,6 +13,7 @@ import { formatGapDuration } from '@/lib/formatters/time';
 import { getAbsentLabel, extractFirstName } from '@/lib/formatters/name';
 import { markdownToDocxParagraphs } from '@/lib/minutes/markdownToDocx';
 import { getWithdrawnLabel } from '@/lib/utils/subjects';
+import { interleaveSubstitutes } from '@/lib/minutes/builders';
 import {
     MinutesData,
     MinutesSubject,
@@ -413,7 +414,7 @@ function createCouncilCompositionSection(
         // Committee: ΠΑΡΟΝΤΑ ΜΕΛΗ and ΑΠΟΝΤΑ ΜΕΛΗ as bullet lists
         const substituteIds = new Set(composition.substituteMembers.map(m => m.personId));
         const absentPersonIds = new Set(absentMembers.map(m => m.personId));
-        const allMembers = [...composition.members, ...composition.substituteMembers];
+        const allMembers = interleaveSubstitutes(composition.members, composition.substituteMembers);
 
         const presentList = allMembers.filter(m => !absentPersonIds.has(m.personId));
         const absentList = allMembers.filter(m => absentPersonIds.has(m.personId));

--- a/src/components/meetings/docx/MinutesDocx.ts
+++ b/src/components/meetings/docx/MinutesDocx.ts
@@ -20,6 +20,7 @@ import {
     MinutesMember,
     MinutesCouncilComposition,
     MinutesTranscriptEntry,
+    MinutesAttendanceChange,
 } from '@/lib/minutes/types';
 
 const FONT_SIZE = {
@@ -466,6 +467,62 @@ function createCouncilCompositionSection(
     return paragraphs;
 }
 
+/**
+ * Creates the ΑΦΙΞΕΙΣ / ΑΝΑΧΩΡΗΣΕΙΣ section listing mid-meeting attendance changes.
+ */
+function createAttendanceChangesSection(
+    changes: MinutesAttendanceChange[],
+): Paragraph[] {
+    if (changes.length === 0) return [];
+
+    const paragraphs: Paragraph[] = [];
+
+    const arrivals = changes.filter(c => c.type === 'arrival');
+    const departures = changes.filter(c => c.type === 'departure');
+
+    if (arrivals.length > 0) {
+        paragraphs.push(new Paragraph({
+            spacing: { before: 200, after: 100 },
+            children: [new TextRun({ text: 'ΑΦΙΞΕΙΣ', bold: true, size: FONT_SIZE.BODY })],
+        }));
+        for (const change of arrivals) {
+            const subjectLabel = change.atSubject.agendaItemIndex
+                ? `${change.atSubject.agendaItemIndex}ο θέμα`
+                : change.atSubject.name;
+            paragraphs.push(new Paragraph({
+                bullet: { level: 0 },
+                spacing: { before: 40, after: 40 },
+                children: [
+                    new TextRun({ text: `${change.name}`, size: FONT_SIZE.BODY }),
+                    new TextRun({ text: ` — παρών/παρούσα από το ${subjectLabel}`, size: FONT_SIZE.BODY, color: '666666' }),
+                ],
+            }));
+        }
+    }
+
+    if (departures.length > 0) {
+        paragraphs.push(new Paragraph({
+            spacing: { before: 200, after: 100 },
+            children: [new TextRun({ text: 'ΑΝΑΧΩΡΗΣΕΙΣ', bold: true, size: FONT_SIZE.BODY })],
+        }));
+        for (const change of departures) {
+            const subjectLabel = change.atSubject.agendaItemIndex
+                ? `${change.atSubject.agendaItemIndex}ο θέμα`
+                : change.atSubject.name;
+            paragraphs.push(new Paragraph({
+                bullet: { level: 0 },
+                spacing: { before: 40, after: 40 },
+                children: [
+                    new TextRun({ text: `${change.name}`, size: FONT_SIZE.BODY }),
+                    new TextRun({ text: ` — απουσίαζε από το ${subjectLabel}`, size: FONT_SIZE.BODY, color: '666666' }),
+                ],
+            }));
+        }
+    }
+
+    return paragraphs;
+}
+
 // --- TOC ---
 
 function tocCell(text: string, bold: boolean): TableCell {
@@ -728,6 +785,11 @@ export async function renderMinutesDocx(data: MinutesData): Promise<Blob> {
     // Council composition + absent members
     if (data.councilComposition) {
         children.push(...createCouncilCompositionSection(data.councilComposition, data.absentMembers, data.administrativeBody));
+    }
+
+    // Arrivals/departures
+    if (data.attendanceChanges.length > 0) {
+        children.push(...createAttendanceChangesSection(data.attendanceChanges));
     }
 
     // Table of contents (split into ΕΚΤΟΣ ΗΔ + ΗΔ tables)

--- a/src/components/meetings/docx/MinutesDocx.ts
+++ b/src/components/meetings/docx/MinutesDocx.ts
@@ -13,7 +13,7 @@ import { formatGapDuration } from '@/lib/formatters/time';
 import { getAbsentLabel, extractFirstName } from '@/lib/formatters/name';
 import { markdownToDocxParagraphs } from '@/lib/minutes/markdownToDocx';
 import { getWithdrawnLabel } from '@/lib/utils/subjects';
-import { interleaveSubstitutes } from '@/lib/minutes/builders';
+import { interleaveSubstitutes, formatSubjectLabel } from '@/lib/minutes/builders';
 import {
     MinutesData,
     MinutesSubject,
@@ -468,7 +468,7 @@ function createCouncilCompositionSection(
 }
 
 /**
- * Creates the ΑΦΙΞΕΙΣ / ΑΝΑΧΩΡΗΣΕΙΣ section listing mid-meeting attendance changes.
+ * Creates the Προσελεύσεις / Αποχωρήσεις section listing mid-meeting attendance changes.
  */
 function createAttendanceChangesSection(
     changes: MinutesAttendanceChange[],
@@ -483,18 +483,15 @@ function createAttendanceChangesSection(
     if (arrivals.length > 0) {
         paragraphs.push(new Paragraph({
             spacing: { before: 200, after: 100 },
-            children: [new TextRun({ text: 'ΑΦΙΞΕΙΣ', bold: true, size: FONT_SIZE.BODY })],
+            children: [new TextRun({ text: 'Προσελεύσεις', bold: true, size: FONT_SIZE.BODY })],
         }));
         for (const change of arrivals) {
-            const subjectLabel = change.atSubject.agendaItemIndex
-                ? `${change.atSubject.agendaItemIndex}ο θέμα`
-                : change.atSubject.name;
             paragraphs.push(new Paragraph({
                 bullet: { level: 0 },
                 spacing: { before: 40, after: 40 },
                 children: [
-                    new TextRun({ text: `${change.name}`, size: FONT_SIZE.BODY }),
-                    new TextRun({ text: ` — παρών/παρούσα από το ${subjectLabel}`, size: FONT_SIZE.BODY, color: '666666' }),
+                    new TextRun({ text: change.name, size: FONT_SIZE.BODY }),
+                    new TextRun({ text: ` — από το ${formatSubjectLabel(change.atSubject)}`, size: FONT_SIZE.BODY, color: '666666' }),
                 ],
             }));
         }
@@ -503,18 +500,15 @@ function createAttendanceChangesSection(
     if (departures.length > 0) {
         paragraphs.push(new Paragraph({
             spacing: { before: 200, after: 100 },
-            children: [new TextRun({ text: 'ΑΝΑΧΩΡΗΣΕΙΣ', bold: true, size: FONT_SIZE.BODY })],
+            children: [new TextRun({ text: 'Αποχωρήσεις', bold: true, size: FONT_SIZE.BODY })],
         }));
         for (const change of departures) {
-            const subjectLabel = change.atSubject.agendaItemIndex
-                ? `${change.atSubject.agendaItemIndex}ο θέμα`
-                : change.atSubject.name;
             paragraphs.push(new Paragraph({
                 bullet: { level: 0 },
                 spacing: { before: 40, after: 40 },
                 children: [
-                    new TextRun({ text: `${change.name}`, size: FONT_SIZE.BODY }),
-                    new TextRun({ text: ` — απουσίαζε από το ${subjectLabel}`, size: FONT_SIZE.BODY, color: '666666' }),
+                    new TextRun({ text: change.name, size: FONT_SIZE.BODY }),
+                    new TextRun({ text: ` — από το ${formatSubjectLabel(change.atSubject)}`, size: FONT_SIZE.BODY, color: '666666' }),
                 ],
             }));
         }
@@ -789,6 +783,17 @@ export async function renderMinutesDocx(data: MinutesData): Promise<Blob> {
     // Arrivals/departures
     if (data.attendanceChanges.length > 0) {
         children.push(...createAttendanceChangesSection(data.attendanceChanges));
+    }
+
+    // Discussion order (only when subjects were discussed out of natural order)
+    if (data.discussionOrderLabel) {
+        children.push(new Paragraph({
+            spacing: { before: 200, after: 200 },
+            children: [
+                new TextRun({ text: 'Σειρά συζήτησης: ', bold: true, size: FONT_SIZE.BODY }),
+                new TextRun({ text: data.discussionOrderLabel, size: FONT_SIZE.BODY }),
+            ],
+        }));
     }
 
     // Table of contents (split into ΕΚΤΟΣ ΗΔ + ΗΔ tables)

--- a/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
+++ b/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
@@ -19,6 +19,7 @@ function makeMinutesData(overrides: Partial<MinutesData> = {}): MinutesData {
         councilComposition: null,
         absentMembers: null,
         preambleEntries: [],
+        attendanceChanges: [],
         subjects: [],
         epilogueEntries: [],
         ...overrides,

--- a/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
+++ b/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
@@ -20,6 +20,7 @@ function makeMinutesData(overrides: Partial<MinutesData> = {}): MinutesData {
         absentMembers: null,
         preambleEntries: [],
         attendanceChanges: [],
+        discussionOrderLabel: null,
         subjects: [],
         epilogueEntries: [],
         ...overrides,

--- a/src/components/meetings/subject/VotingSection.tsx
+++ b/src/components/meetings/subject/VotingSection.tsx
@@ -38,7 +38,7 @@ interface VotingUtterance {
 
 interface Vote {
     voteType: VoteType;
-    person: { id: string; name: string; roles: { electedOrder: number | null }[] };
+    person: { id: string; name: string; roles: { electedOrder: number | null; administrativeBodyId: string | null }[] };
 }
 
 interface VotingSectionProps {
@@ -46,10 +46,12 @@ interface VotingSectionProps {
     votes: Vote[];
 }
 
-function sortVotesByElectedOrder(votes: Vote[]): Vote[] {
+function sortVotesByElectedOrder(votes: Vote[], administrativeBodyId: string | null): Vote[] {
     return [...votes].sort((a, b) => {
-        const aOrder = a.person.roles[0]?.electedOrder ?? null;
-        const bOrder = b.person.roles[0]?.electedOrder ?? null;
+        const aRole = a.person.roles.find(r => r.administrativeBodyId === administrativeBodyId);
+        const bRole = b.person.roles.find(r => r.administrativeBodyId === administrativeBodyId);
+        const aOrder = aRole?.electedOrder ?? null;
+        const bOrder = bRole?.electedOrder ?? null;
         const orderCompare = compareRanks(aOrder, bOrder);
         if (orderCompare !== 0) return orderCompare;
         return a.person.name.localeCompare(b.person.name);
@@ -58,13 +60,15 @@ function sortVotesByElectedOrder(votes: Vote[]): Vote[] {
 
 function VoteBreakdown({ votes }: { votes: Vote[] }) {
     const t = useTranslations('Subject');
+    const { meeting } = useCouncilMeetingData();
+    const administrativeBodyId = meeting.administrativeBodyId ?? null;
     const result = useMemo(() => calculateVoteResult(votes), [votes]);
 
-    const forVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'FOR')), [votes]);
-    const againstVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'AGAINST')), [votes]);
-    const abstainVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'ABSTAIN')), [votes]);
-    const presentVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'PRESENT')), [votes]);
-    const didNotVoteVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'DID_NOT_VOTE')), [votes]);
+    const forVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'FOR'), administrativeBodyId), [votes, administrativeBodyId]);
+    const againstVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'AGAINST'), administrativeBodyId), [votes, administrativeBodyId]);
+    const abstainVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'ABSTAIN'), administrativeBodyId), [votes, administrativeBodyId]);
+    const presentVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'PRESENT'), administrativeBodyId), [votes, administrativeBodyId]);
+    const didNotVoteVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'DID_NOT_VOTE'), administrativeBodyId), [votes, administrativeBodyId]);
 
     return (
         <div className="p-4 space-y-3">

--- a/src/components/meetings/subject/VotingSection.tsx
+++ b/src/components/meetings/subject/VotingSection.tsx
@@ -3,9 +3,10 @@ import { useState, useEffect, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { useCouncilMeetingData } from '../CouncilMeetingDataContext';
 import { UtteranceMiniTranscript } from './UtteranceMiniTranscript';
-import { calculateVoteResult } from '@/lib/utils/votes';
+import { calculateVoteResult, getAbsentNonVoterIds } from '@/lib/utils/votes';
 import { compareRanks } from '@/lib/sorting/people';
 import { formatSurnameFirst } from '@/lib/formatters/name';
+import { isMayorRole, isRoleActiveAt } from '@/lib/utils/roles';
 import { VoteType } from '@prisma/client';
 import { Loader2 } from 'lucide-react';
 
@@ -41,34 +42,62 @@ interface Vote {
     person: { id: string; name: string; roles: { electedOrder: number | null; administrativeBodyId: string | null }[] };
 }
 
+interface AttendanceRecord {
+    status: 'PRESENT' | 'ABSENT';
+    person: { id: string; name: string; roles: { electedOrder: number | null; administrativeBodyId: string | null }[] };
+}
+
 interface VotingSectionProps {
     subjectId: string;
     votes: Vote[];
+    attendance?: AttendanceRecord[];
 }
 
-function sortVotesByElectedOrder(votes: Vote[], administrativeBodyId: string | null): Vote[] {
-    return [...votes].sort((a, b) => {
+function sortByElectedOrder<T extends { person: { name: string; roles: { electedOrder: number | null; administrativeBodyId: string | null }[] } }>(
+    items: T[], administrativeBodyId: string | null,
+): T[] {
+    return [...items].sort((a, b) => {
         const aRole = a.person.roles.find(r => r.administrativeBodyId === administrativeBodyId);
         const bRole = b.person.roles.find(r => r.administrativeBodyId === administrativeBodyId);
-        const aOrder = aRole?.electedOrder ?? null;
-        const bOrder = bRole?.electedOrder ?? null;
-        const orderCompare = compareRanks(aOrder, bOrder);
+        const orderCompare = compareRanks(aRole?.electedOrder ?? null, bRole?.electedOrder ?? null);
         if (orderCompare !== 0) return orderCompare;
         return a.person.name.localeCompare(b.person.name);
     });
 }
 
-function VoteBreakdown({ votes }: { votes: Vote[] }) {
+function VoteBreakdown({ votes, attendance }: { votes: Vote[]; attendance: AttendanceRecord[] }) {
     const t = useTranslations('Subject');
-    const { meeting } = useCouncilMeetingData();
+    const { meeting, people } = useCouncilMeetingData();
     const administrativeBodyId = meeting.administrativeBodyId ?? null;
     const result = useMemo(() => calculateVoteResult(votes), [votes]);
 
-    const forVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'FOR'), administrativeBodyId), [votes, administrativeBodyId]);
-    const againstVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'AGAINST'), administrativeBodyId), [votes, administrativeBodyId]);
-    const abstainVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'ABSTAIN'), administrativeBodyId), [votes, administrativeBodyId]);
-    const presentVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'PRESENT'), administrativeBodyId), [votes, administrativeBodyId]);
-    const didNotVoteVoters = useMemo(() => sortVotesByElectedOrder(votes.filter(v => v.voteType === 'DID_NOT_VOTE'), administrativeBodyId), [votes, administrativeBodyId]);
+    const mayorPersonId = useMemo(() => {
+        const meetingDate = new Date(meeting.dateTime);
+        return people.find(p =>
+            p.roles.some(r => isRoleActiveAt(r, meetingDate) && isMayorRole(r))
+        )?.id ?? null;
+    }, [people, meeting.dateTime]);
+
+    const forVoters = useMemo(() => sortByElectedOrder(votes.filter(v => v.voteType === 'FOR'), administrativeBodyId), [votes, administrativeBodyId]);
+    const againstVoters = useMemo(() => sortByElectedOrder(votes.filter(v => v.voteType === 'AGAINST'), administrativeBodyId), [votes, administrativeBodyId]);
+    const abstainVoters = useMemo(() => sortByElectedOrder(votes.filter(v => v.voteType === 'ABSTAIN'), administrativeBodyId), [votes, administrativeBodyId]);
+    const presentVoters = useMemo(() => sortByElectedOrder(votes.filter(v => v.voteType === 'PRESENT'), administrativeBodyId), [votes, administrativeBodyId]);
+    const didNotVoteVoters = useMemo(() => sortByElectedOrder(votes.filter(v => v.voteType === 'DID_NOT_VOTE'), administrativeBodyId), [votes, administrativeBodyId]);
+
+    // Absent members: those in attendance with ABSENT status who didn't vote (excluding mayor)
+    const absentMembers = useMemo(() => {
+        if (!attendance || attendance.length === 0) return [];
+        const voterIds = new Set(votes.map(v => v.person.id));
+        const absentIds = getAbsentNonVoterIds(
+            attendance.map(a => ({ personId: a.person.id, status: a.status })),
+            voterIds,
+            mayorPersonId,
+        );
+        return sortByElectedOrder(
+            attendance.filter(a => absentIds.has(a.person.id)),
+            administrativeBodyId,
+        );
+    }, [attendance, votes, administrativeBodyId, mayorPersonId]);
 
     return (
         <div className="p-4 space-y-3">
@@ -136,6 +165,16 @@ function VoteBreakdown({ votes }: { votes: Vote[] }) {
                             </td>
                         </tr>
                     )}
+                    {absentMembers.length > 0 && (
+                        <tr>
+                            <td className="py-1.5 pr-4 text-muted-foreground font-medium whitespace-nowrap align-top">
+                                {t('voteAbsent')} ({absentMembers.length})
+                            </td>
+                            <td className="py-1.5">
+                                {absentMembers.map(a => formatSurnameFirst(a.person.name)).join(', ')}
+                            </td>
+                        </tr>
+                    )}
                 </tbody>
             </table>
         </div>
@@ -167,7 +206,7 @@ function VotingUtterancesDisplay({ utterancesBySegment, getSpeakerSegmentById, c
     );
 }
 
-export function VotingSection({ subjectId, votes }: VotingSectionProps) {
+export function VotingSection({ subjectId, votes, attendance }: VotingSectionProps) {
     const [votingUtterances, setVotingUtterances] = useState<VotingUtterance[] | null>(null);
     const [loading, setLoading] = useState(true);
     const { meeting, getSpeakerSegmentById } = useCouncilMeetingData();
@@ -219,7 +258,7 @@ export function VotingSection({ subjectId, votes }: VotingSectionProps) {
     if (hasExtractedVotes) {
         return (
             <div>
-                <VoteBreakdown votes={votes} />
+                <VoteBreakdown votes={votes} attendance={attendance ?? []} />
                 {hasUtterances && (
                     <div className="border-t border-border p-4 space-y-3">
                         <p className="text-xs text-muted-foreground">

--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -406,7 +406,7 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                     }
                     defaultOpen={false}
                 >
-                    <VotingSection subjectId={subject.id} votes={subject.votes} />
+                    <VotingSection subjectId={subject.id} votes={subject.votes} attendance={subject.attendance} />
                 </CollapsibleCard>}
 
                 {/* Decision Section (skip for beforeAgenda and withdrawn subjects) */}

--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -409,8 +409,8 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                     <VotingSection subjectId={subject.id} votes={subject.votes} />
                 </CollapsibleCard>}
 
-                {/* Decision Section (skip for withdrawn subjects) */}
-                {agendaItemIndex != null && !subject.withdrawn && (
+                {/* Decision Section (skip for beforeAgenda and withdrawn subjects) */}
+                {subject.nonAgendaReason !== 'beforeAgenda' && !subject.withdrawn && (
                     <CollapsibleCard
                         id="decision"
                         icon={<Landmark className="w-4 h-4" />}

--- a/src/hooks/useSpeakerSegmentEditor.ts
+++ b/src/hooks/useSpeakerSegmentEditor.ts
@@ -83,11 +83,8 @@ export function useSpeakerSegmentEditor(segment: TranscriptType[number]) {
                 }
             });
 
-            // Validate summary if provided
-            if (data.summary) {
-                if (!data.summary.text || typeof data.summary.text !== 'string' || data.summary.text.trim().length === 0) {
-                    errors.push('Summary text cannot be empty if summary is provided');
-                }
+            // Validate summary if provided (treat empty text as null/no summary)
+            if (data.summary && data.summary.text && data.summary.text.trim().length > 0) {
                 if (!['procedural', 'substantive'].includes(data.summary.type)) {
                     errors.push('Summary type must be either "procedural" or "substantive"');
                 }

--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -525,6 +525,12 @@ export interface PollDecisionsResult {
         initialAttendance?: { personId: string; status: 'PRESENT' | 'ABSENT' }[];
         /** Names from the initial roll call that couldn't be matched to any person in the database */
         unmatchedInitialAttendance?: string[];
+        /** Effective attendance for subjects WITHOUT linked decisions */
+        nonDecisionSubjectAttendance?: Array<{
+            subjectId: string;
+            presentMemberIds: string[];
+            absentMemberIds: string[];
+        }>;
     } | null;
     costs: {
         input_tokens: number;

--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -480,6 +480,7 @@ export interface PollDecisionsRequest extends TaskRequest {
         subjectId: string;
         name: string;
         agendaItemIndex: number | null;
+        nonAgendaReason: string | null;
         existingDecision?: {
             ada: string;
             decisionTitle: string;

--- a/src/lib/db/chat-mock-data.ts
+++ b/src/lib/db/chat-mock-data.ts
@@ -86,7 +86,8 @@ function subjectToSearchResult(
         introducedBy: null,
         discussedIn: null,
         decision: null,
-        votes: []
+        votes: [],
+        attendance: []
     };
 
     // Create the search result

--- a/src/lib/db/roles.ts
+++ b/src/lib/db/roles.ts
@@ -68,26 +68,29 @@ export async function updateRoleRankings(
 }
 
 /**
- * Updates elected order for roles belonging to a specific city.
- * Validates that all roles belong to people in the specified city before updating.
+ * Updates elected order for roles belonging to a specific administrative body within a city.
+ * Validates that all roles belong to the specified administrative body and city before updating.
  *
  * @param cityId - The city ID that all roles must belong to
+ * @param administrativeBodyId - The administrative body ID that all roles must belong to
  * @param rankings - Array of elected order rankings to update
  * @throws Error if validation fails or update fails
  */
 export async function updateElectedOrder(
     cityId: string,
+    administrativeBodyId: string,
     rankings: ElectedOrderRanking[]
 ): Promise<void> {
     const roleIds = rankings.map(r => r.roleId);
 
-    // Verify all roles exist and belong to people in the specified city
+    // Verify all roles exist and belong to the specified administrative body
     const roles = await prisma.role.findMany({
         where: {
             id: { in: roleIds }
         },
         select: {
             id: true,
+            administrativeBodyId: true,
             person: { select: { cityId: true } }
         }
     });
@@ -96,9 +99,12 @@ export async function updateElectedOrder(
         throw new Error('One or more roles not found');
     }
 
-    const invalidRoles = roles.filter(role => role.person.cityId !== cityId);
+    const invalidRoles = roles.filter(
+        role => role.administrativeBodyId !== administrativeBodyId
+            || role.person.cityId !== cityId
+    );
     if (invalidRoles.length > 0) {
-        throw new Error('One or more roles do not belong to people in the specified city');
+        throw new Error('One or more roles do not belong to the specified administrative body');
     }
 
     // Update roles in a transaction

--- a/src/lib/db/speakerSegments.ts
+++ b/src/lib/db/speakerSegments.ts
@@ -755,9 +755,9 @@ export async function updateSpeakerSegmentData(
         }
     }
 
-    // Validate summary if provided
+    // Normalize summary: treat empty text as no summary
     if (data.summary && (!data.summary.text || data.summary.text.trim().length === 0)) {
-        throw new Error('Summary text cannot be empty if summary is provided');
+        data.summary = null;
     }
 
     // Validate that all referenced subject IDs exist

--- a/src/lib/db/subject.ts
+++ b/src/lib/db/subject.ts
@@ -33,22 +33,32 @@ const introducedByInclude = {
     },
 } satisfies Prisma.PersonDefaultArgs;
 
+/** Person select with elected order — shared by votes and attendance queries */
+const personWithElectedOrderSelect = {
+    select: {
+        id: true,
+        name: true,
+        roles: {
+            select: { electedOrder: true, administrativeBodyId: true },
+            where: { electedOrder: { not: null } },
+        },
+    },
+} satisfies Prisma.PersonDefaultArgs;
+
 const votesInclude = {
     select: {
         voteType: true,
-        person: {
-            select: {
-                id: true,
-                name: true,
-                roles: {
-                    select: { electedOrder: true, administrativeBodyId: true },
-                    where: { electedOrder: { not: null } },
-                },
-            },
-        },
+        person: personWithElectedOrderSelect,
     },
     orderBy: { person: { name: 'asc' as const } },
 } satisfies Prisma.SubjectVoteFindManyArgs;
+
+const attendanceInclude = {
+    select: {
+        status: true,
+        person: personWithElectedOrderSelect,
+    },
+} satisfies Prisma.SubjectAttendanceFindManyArgs;
 
 // Type for location with coordinates
 export type LocationWithCoordinates = Location & {
@@ -73,6 +83,7 @@ export type SubjectWithRelations = Subject & {
     discussedIn: (Subject & { topic: Topic | null }) | null;
     decision: Decision | null;
     votes: { voteType: VoteType; person: { id: string; name: string; roles: { electedOrder: number | null; administrativeBodyId: string | null }[] } }[];
+    attendance: { status: 'PRESENT' | 'ABSENT'; person: { id: string; name: string; roles: { electedOrder: number | null; administrativeBodyId: string | null }[] } }[];
 };
 
 export async function getAllSubjects(): Promise<SubjectWithRelations[]> {
@@ -96,6 +107,7 @@ export async function getAllSubjects(): Promise<SubjectWithRelations[]> {
                     },
                 },
                 votes: votesInclude,
+                attendance: attendanceInclude,
             },
         });
         return subjects;
@@ -136,6 +148,7 @@ export async function getSubjectsForMeeting(cityId: string, councilMeetingId: st
                     },
                 },
                 votes: votesInclude,
+                attendance: attendanceInclude,
             },
         });
 
@@ -201,6 +214,7 @@ export async function getSubject(subjectId: string): Promise<SubjectWithRelation
                     },
                 },
                 votes: votesInclude,
+                attendance: attendanceInclude,
             },
         });
 

--- a/src/lib/db/subject.ts
+++ b/src/lib/db/subject.ts
@@ -41,9 +41,8 @@ const votesInclude = {
                 id: true,
                 name: true,
                 roles: {
-                    select: { electedOrder: true },
+                    select: { electedOrder: true, administrativeBodyId: true },
                     where: { electedOrder: { not: null } },
-                    take: 1,
                 },
             },
         },
@@ -73,7 +72,7 @@ export type SubjectWithRelations = Subject & {
     introducedBy: PersonWithRelations | null;
     discussedIn: (Subject & { topic: Topic | null }) | null;
     decision: Decision | null;
-    votes: { voteType: VoteType; person: { id: string; name: string; roles: { electedOrder: number | null }[] } }[];
+    votes: { voteType: VoteType; person: { id: string; name: string; roles: { electedOrder: number | null; administrativeBodyId: string | null }[] } }[];
 };
 
 export async function getAllSubjects(): Promise<SubjectWithRelations[]> {

--- a/src/lib/minutes/__tests__/builders.test.ts
+++ b/src/lib/minutes/__tests__/builders.test.ts
@@ -474,19 +474,19 @@ describe('sortSubjectsByDiscussionOrder', () => {
         expect(result).toEqual([]);
     });
 
-    it('child with own transcript uses own timestamp over parent', () => {
+    it('child always inherits parent timestamp, sorted after parent', () => {
         const subjects = [
             makeSubject('child', 2, { discussedIn: { id: 'parent' } }),
             makeSubject('parent', 1),
             makeSubject('other', 3),
         ];
-        // child has its own timestamp (discussed separately even though linked)
+        // child has its own timestamp at 50, but inherits parent's (100)
         const timestamps = new Map([['parent', 100], ['child', 50], ['other', 200]]);
 
         const result = sortSubjectsByDiscussionOrder(subjects, timestamps);
 
-        // child at 50, parent at 100, other at 200
-        expect(result.map(s => s.id)).toEqual(['child', 'parent', 'other']);
+        // child inherits parent's timestamp (100), sorts after parent, then other at 200
+        expect(result.map(s => s.id)).toEqual(['parent', 'child', 'other']);
     });
 });
 

--- a/src/lib/minutes/builders.ts
+++ b/src/lib/minutes/builders.ts
@@ -213,6 +213,10 @@ export function buildCouncilComposition(
  * Computes mid-meeting attendance changes by diffing per-subject attendance
  * across consecutive subjects in discussion order.
  *
+ * Also compares the initial roll call against the first subject's attendance
+ * to catch arrivals/departures that happen during the first discussed subject
+ * (which have no preceding subject to diff against).
+ *
  * A person who is present in subject N but absent in subject N+1 is a departure
  * (detected at subject N+1). A person absent in N but present in N+1 is an arrival.
  */
@@ -221,48 +225,81 @@ export function buildAttendanceChanges(
         subjectId: string;
         name: string;
         agendaItemIndex: number | null;
+        nonAgendaReason: 'beforeAgenda' | 'outOfAgenda' | null;
         attendance: MinutesAttendance | null;
     }>,
+    /** Initial roll call — absent members at session start. Used to detect changes at the first discussed subject. */
+    initialAbsentMembers: MinutesMember[] | null,
 ): MinutesAttendanceChange[] {
     const changes: MinutesAttendanceChange[] = [];
 
+    // Pre-compute OA sequential indices (1-based)
+    const oaIndexMap = new Map<string, number>();
+    let oaCounter = 0;
+    for (const s of subjects) {
+        if (s.nonAgendaReason === 'outOfAgenda') {
+            oaCounter++;
+            oaIndexMap.set(s.subjectId, oaCounter);
+        }
+    }
+
+    const buildAtSubject = (s: typeof subjects[number]) => ({
+        id: s.subjectId,
+        name: s.name,
+        agendaItemIndex: s.agendaItemIndex,
+        nonAgendaReason: s.nonAgendaReason,
+        outOfAgendaIndex: oaIndexMap.get(s.subjectId) ?? null,
+    });
+
+    // Compare initial roll call against first subject's attendance.
+    // Catches arrivals (initially absent → present) and departures
+    // (initially present → absent) during the first discussed subject.
+    const firstWithAttendance = subjects.find(s => s.attendance);
+    if (firstWithAttendance?.attendance && initialAbsentMembers) {
+        const initialAbsentIds = new Set(initialAbsentMembers.map(m => m.personId));
+        const atSubject = buildAtSubject(firstWithAttendance);
+
+        // Arrivals: initially absent → present at first subject
+        for (const member of firstWithAttendance.attendance.present) {
+            if (initialAbsentIds.has(member.personId)) {
+                changes.push({ personId: member.personId, name: member.name, type: 'arrival', atSubject });
+            }
+        }
+
+        // Departures: initially present (not in absent list) → absent at first subject
+        for (const member of firstWithAttendance.attendance.absent) {
+            if (!initialAbsentIds.has(member.personId)) {
+                changes.push({ personId: member.personId, name: member.name, type: 'departure', atSubject });
+            }
+        }
+    }
+
+    // Diff consecutive subjects
     for (let i = 1; i < subjects.length; i++) {
         const prev = subjects[i - 1];
         const curr = subjects[i];
-        if (!prev.attendance || !curr.attendance) continue;
+        if (!prev.attendance || !curr.attendance) {
+            if (prev.attendance || curr.attendance) {
+                console.warn(`[buildAttendanceChanges] Gap in attendance data at subject "${curr.name}"`);
+            }
+            continue;
+        }
 
         const currAbsentIds = new Set(curr.attendance.absent.map(m => m.personId));
         const currPresentIds = new Set(curr.attendance.present.map(m => m.personId));
+        const atSubject = buildAtSubject(curr);
 
         // Departures: present in prev, absent in curr
         for (const member of prev.attendance.present) {
             if (currAbsentIds.has(member.personId)) {
-                changes.push({
-                    personId: member.personId,
-                    name: member.name,
-                    type: 'departure',
-                    atSubject: {
-                        id: curr.subjectId,
-                        name: curr.name,
-                        agendaItemIndex: curr.agendaItemIndex,
-                    },
-                });
+                changes.push({ personId: member.personId, name: member.name, type: 'departure', atSubject });
             }
         }
 
         // Arrivals: absent in prev, present in curr
         for (const member of prev.attendance.absent) {
             if (currPresentIds.has(member.personId)) {
-                changes.push({
-                    personId: member.personId,
-                    name: member.name,
-                    type: 'arrival',
-                    atSubject: {
-                        id: curr.subjectId,
-                        name: curr.name,
-                        agendaItemIndex: curr.agendaItemIndex,
-                    },
-                });
+                changes.push({ personId: member.personId, name: member.name, type: 'arrival', atSubject });
             }
         }
     }

--- a/src/lib/minutes/builders.ts
+++ b/src/lib/minutes/builders.ts
@@ -7,6 +7,7 @@ import {
     MinutesAttendance,
     MinutesVoteResult,
     MinutesCouncilComposition,
+    MinutesAttendanceChange,
 } from './types';
 
 // --- Dependency types for testability ---
@@ -207,6 +208,67 @@ export function buildCouncilComposition(
 }
 
 
+
+/**
+ * Computes mid-meeting attendance changes by diffing per-subject attendance
+ * across consecutive subjects in discussion order.
+ *
+ * A person who is present in subject N but absent in subject N+1 is a departure
+ * (detected at subject N+1). A person absent in N but present in N+1 is an arrival.
+ */
+export function buildAttendanceChanges(
+    subjects: Array<{
+        subjectId: string;
+        name: string;
+        agendaItemIndex: number | null;
+        attendance: MinutesAttendance | null;
+    }>,
+): MinutesAttendanceChange[] {
+    const changes: MinutesAttendanceChange[] = [];
+
+    for (let i = 1; i < subjects.length; i++) {
+        const prev = subjects[i - 1];
+        const curr = subjects[i];
+        if (!prev.attendance || !curr.attendance) continue;
+
+        const currAbsentIds = new Set(curr.attendance.absent.map(m => m.personId));
+        const currPresentIds = new Set(curr.attendance.present.map(m => m.personId));
+
+        // Departures: present in prev, absent in curr
+        for (const member of prev.attendance.present) {
+            if (currAbsentIds.has(member.personId)) {
+                changes.push({
+                    personId: member.personId,
+                    name: member.name,
+                    type: 'departure',
+                    atSubject: {
+                        id: curr.subjectId,
+                        name: curr.name,
+                        agendaItemIndex: curr.agendaItemIndex,
+                    },
+                });
+            }
+        }
+
+        // Arrivals: absent in prev, present in curr
+        for (const member of prev.attendance.absent) {
+            if (currPresentIds.has(member.personId)) {
+                changes.push({
+                    personId: member.personId,
+                    name: member.name,
+                    type: 'arrival',
+                    atSubject: {
+                        id: curr.subjectId,
+                        name: curr.name,
+                        agendaItemIndex: curr.agendaItemIndex,
+                    },
+                });
+            }
+        }
+    }
+
+    return changes;
+}
 
 interface SortableSubject {
     id: string;

--- a/src/lib/minutes/builders.ts
+++ b/src/lib/minutes/builders.ts
@@ -357,3 +357,14 @@ export function sortSubjectsByDiscussionOrder<T extends SortableSubject>(
         return (a.agendaItemIndex ?? 0) - (b.agendaItemIndex ?? 0);
     });
 }
+
+/** Formats a subject reference for display in attendance change sections. */
+export function formatSubjectLabel(atSubject: MinutesAttendanceChange['atSubject']): string {
+    if (atSubject.nonAgendaReason === 'outOfAgenda' && atSubject.outOfAgendaIndex != null) {
+        return `${atSubject.outOfAgendaIndex}ο εκτός ημερήσιας`;
+    }
+    if (atSubject.agendaItemIndex != null) {
+        return `${atSubject.agendaItemIndex}ο θέμα`;
+    }
+    return atSubject.name;
+}

--- a/src/lib/minutes/builders.ts
+++ b/src/lib/minutes/builders.ts
@@ -327,10 +327,10 @@ export function sortSubjectsByDiscussionOrder<T extends SortableSubject>(
     firstUtteranceBySubject: Map<string, number>,
 ): T[] {
     function getDiscussionTime(s: T): number | undefined {
-        const own = firstUtteranceBySubject.get(s.id);
-        if (own !== undefined) return own;
+        // Child subjects always inherit their parent's timestamp — their own
+        // utterances (e.g., procedural votes) don't determine discussion position.
         if (s.discussedIn) return firstUtteranceBySubject.get(s.discussedIn.id);
-        return undefined;
+        return firstUtteranceBySubject.get(s.id);
     }
 
     return [...subjects].sort((a, b) => {

--- a/src/lib/minutes/builders.ts
+++ b/src/lib/minutes/builders.ts
@@ -30,6 +30,51 @@ export function sortByElectedOrder(
     return a.name.localeCompare(b.name);
 }
 
+/**
+ * Merge regular and substitute members so each substitute appears right after
+ * the last regular member of the same party. Substitutes whose party doesn't
+ * match any regular member are appended at the end.
+ */
+export function interleaveSubstitutes(
+    members: MinutesMember[],
+    substituteMembers: MinutesMember[],
+): MinutesMember[] {
+    if (substituteMembers.length === 0) return members;
+
+    const result: MinutesMember[] = [];
+    // Group substitutes by party
+    const subsByParty = new Map<string | null, MinutesMember[]>();
+    for (const sub of substituteMembers) {
+        const key = sub.party;
+        const list = subsByParty.get(key) || [];
+        list.push(sub);
+        subsByParty.set(key, list);
+    }
+
+    // Track which parties we've already flushed substitutes for
+    const flushed = new Set<string | null>();
+
+    for (let i = 0; i < members.length; i++) {
+        result.push(members[i]);
+        const party = members[i].party;
+        // Check if next member has a different party (or this is the last member)
+        const isLastOfParty = i === members.length - 1 || members[i + 1].party !== party;
+        if (isLastOfParty && subsByParty.has(party) && !flushed.has(party)) {
+            result.push(...subsByParty.get(party)!);
+            flushed.add(party);
+        }
+    }
+
+    // Append any substitutes whose party didn't match any regular member
+    for (const [party, subs] of subsByParty) {
+        if (!flushed.has(party)) {
+            result.push(...subs);
+        }
+    }
+
+    return result;
+}
+
 // --- Builders ---
 
 /**

--- a/src/lib/minutes/builders.ts
+++ b/src/lib/minutes/builders.ts
@@ -1,7 +1,7 @@
 import { AttendanceStatus, VoteType } from '@prisma/client';
 import { compareRanks } from '@/lib/sorting/people';
 import { formatSurnameFirst } from '@/lib/formatters/name';
-import { calculateVoteResult } from '@/lib/utils/votes';
+import { calculateVoteResult, getAbsentNonVoterIds } from '@/lib/utils/votes';
 import {
     MinutesMember,
     MinutesAttendance,
@@ -151,8 +151,9 @@ export function buildVoteResult(
     }
 
     // Absent members: those in attendance who are absent and didn't vote (excluding mayor)
+    const absentIds = getAbsentNonVoterIds(attendance, voterIds, mayorPersonId);
     const absentMembers = attendance
-        .filter(a => a.status !== 'PRESENT' && !voterIds.has(a.personId) && a.personId !== mayorPersonId)
+        .filter(a => absentIds.has(a.personId))
         .sort((a, b) =>
             compareRanks(getElectedOrder(a.personId), getElectedOrder(b.personId))
             || a.personName.localeCompare(b.personName)

--- a/src/lib/minutes/getMinutesData.ts
+++ b/src/lib/minutes/getMinutesData.ts
@@ -200,10 +200,15 @@ export async function getMinutesData(
         };
     };
 
+    const adminBodyId = meeting.administrativeBody?.id ?? null;
+
     const getElectedOrder: ElectedOrderGetter = (personId) => {
         const person = peopleMap.get(personId);
         if (!person) return null;
-        const role = person.roles.find(r => r.electedOrder != null);
+        if (!adminBodyId) return null;
+        const role = person.roles.find(
+            r => r.administrativeBodyId === adminBodyId && r.electedOrder != null
+        );
         return role?.electedOrder ?? null;
     };
 
@@ -364,8 +369,6 @@ export async function getMinutesData(
     // Council composition: all members sorted by elected order,
     // plus mayor and president of the administrative body.
     // Built from roles — no attendance dependency.
-    const adminBodyId = meeting.administrativeBody?.id ?? null;
-
     const mayorPerson = mayorPersonId ? people.find(p => p.id === mayorPersonId) : null;
     const mayor = mayorPerson ? { personId: mayorPerson.id, name: mayorPerson.name } : null;
 

--- a/src/lib/minutes/getMinutesData.ts
+++ b/src/lib/minutes/getMinutesData.ts
@@ -17,6 +17,7 @@ import {
     buildAttendance,
     buildVoteResult,
     buildCouncilComposition,
+    buildAttendanceChanges,
     sortSubjectsByDiscussionOrder,
     sortByElectedOrder,
     MemberResolver,
@@ -426,6 +427,11 @@ export async function getMinutesData(
     }
 
 
+    // Compute mid-meeting attendance changes from per-subject attendance diffs
+    const attendanceChanges = buildAttendanceChanges(
+        minutesSubjects.filter(s => !s.withdrawn),
+    );
+
     return {
         city: {
             name: city.name,
@@ -445,6 +451,7 @@ export async function getMinutesData(
         councilComposition: councilCompositionResult,
         absentMembers,
         preambleEntries,
+        attendanceChanges,
         subjects: minutesSubjects,
         epilogueEntries,
     };

--- a/src/lib/minutes/getMinutesData.ts
+++ b/src/lib/minutes/getMinutesData.ts
@@ -229,11 +229,32 @@ export async function getMinutesData(
         });
     }
 
-    // Sort subjects by discussion order (first utterance timestamp)
+    // Sort subjects by discussion order (first utterance timestamp).
+    // Include PROCEDURAL_VOTE utterances for timestamp computation so subjects
+    // with only procedural votes (e.g., OA κατεπείγον votes) get sorted correctly,
+    // even though their content is rendered as orphaned/preamble text.
     const firstUtteranceBySubject = new Map<string, number>();
     for (const [subjectId, utterances] of utterancesBySubject) {
         if (utterances.length > 0) {
             firstUtteranceBySubject.set(subjectId, utterances[0].startTimestamp);
+        }
+    }
+
+    // Check for subjects missing a timestamp — they may have PROCEDURAL_VOTE utterances only
+    const subjectsWithoutTimestamp = subjectIds.filter(id => !firstUtteranceBySubject.has(id));
+    if (subjectsWithoutTimestamp.length > 0) {
+        const proceduralUtterances = await prisma.utterance.findMany({
+            where: {
+                discussionSubjectId: { in: subjectsWithoutTimestamp },
+                discussionStatus: 'PROCEDURAL_VOTE',
+            },
+            select: { discussionSubjectId: true, startTimestamp: true },
+            orderBy: { startTimestamp: 'asc' },
+        });
+        for (const u of proceduralUtterances) {
+            if (u.discussionSubjectId && !firstUtteranceBySubject.has(u.discussionSubjectId)) {
+                firstUtteranceBySubject.set(u.discussionSubjectId, u.startTimestamp);
+            }
         }
     }
 
@@ -426,7 +447,34 @@ export async function getMinutesData(
     // Compute mid-meeting attendance changes from per-subject attendance diffs
     const attendanceChanges = buildAttendanceChanges(
         minutesSubjects.filter(s => !s.withdrawn),
+        absentMembers,
     );
+
+    // Build discussion order label if subjects were discussed out of natural order.
+    // Natural order: OA subjects first (sorted), then regular subjects (sorted by agendaItemIndex).
+    const nonWithdrawn = minutesSubjects.filter(s => !s.withdrawn);
+    const naturalOrder = [
+        ...nonWithdrawn.filter(s => s.nonAgendaReason === 'outOfAgenda'),
+        ...nonWithdrawn.filter(s => s.nonAgendaReason !== 'outOfAgenda'),
+    ].sort((a, b) => {
+        const aIsOA = a.nonAgendaReason === 'outOfAgenda';
+        const bIsOA = b.nonAgendaReason === 'outOfAgenda';
+        if (aIsOA !== bIsOA) return aIsOA ? -1 : 1;
+        return (a.agendaItemIndex ?? 0) - (b.agendaItemIndex ?? 0);
+    });
+    const isNaturalOrder = nonWithdrawn.every((s, i) => s.subjectId === naturalOrder[i]?.subjectId);
+
+    let discussionOrderLabel: string | null = null;
+    if (!isNaturalOrder && nonWithdrawn.length > 0) {
+        let oaCounter = 0;
+        discussionOrderLabel = nonWithdrawn.map(s => {
+            if (s.nonAgendaReason === 'outOfAgenda') {
+                oaCounter++;
+                return `ΕΗΔ${oaCounter}`;
+            }
+            return `${s.agendaItemIndex}ο`;
+        }).join(', ');
+    }
 
     return {
         city: {
@@ -448,6 +496,7 @@ export async function getMinutesData(
         absentMembers,
         preambleEntries,
         attendanceChanges,
+        discussionOrderLabel,
         subjects: minutesSubjects,
         epilogueEntries,
     };

--- a/src/lib/minutes/getMinutesData.ts
+++ b/src/lib/minutes/getMinutesData.ts
@@ -3,6 +3,7 @@ import { getSubjectsForMeeting } from '@/lib/db/subject';
 import { getExtractedDataForMeeting, getMeetingAttendance, SubjectExtractedData } from '@/lib/db/decisions';
 import { getPeopleForCity } from '@/lib/db/people';
 import { getCity } from '@/lib/db/cities';
+import { getElectedOrderForBody } from '@/lib/sorting/people';
 import { getSpeakerDisplayInfo, isRoleActiveAt, isMayorRole, simplifyRoleName } from '@/lib/utils/roles';
 import { PersonWithRelations } from '@/lib/db/people';
 import prisma from '@/lib/db/prisma';
@@ -205,12 +206,7 @@ export async function getMinutesData(
 
     const getElectedOrder: ElectedOrderGetter = (personId) => {
         const person = peopleMap.get(personId);
-        if (!person) return null;
-        if (!adminBodyId) return null;
-        const role = person.roles.find(
-            r => r.administrativeBodyId === adminBodyId && r.electedOrder != null
-        );
-        return role?.electedOrder ?? null;
+        return getElectedOrderForBody(person, adminBodyId);
     };
 
     function buildTranscriptEntries(subjectId: string): MinutesTranscriptEntry[] {

--- a/src/lib/minutes/types.ts
+++ b/src/lib/minutes/types.ts
@@ -86,6 +86,9 @@ export interface MinutesAttendanceChange {
         id: string;
         name: string;
         agendaItemIndex: number | null;
+        nonAgendaReason: 'beforeAgenda' | 'outOfAgenda' | null;
+        /** Sequential number among out-of-agenda subjects (1-based), null for regular items */
+        outOfAgendaIndex: number | null;
     };
 }
 
@@ -110,6 +113,8 @@ export interface MinutesData {
     preambleEntries: MinutesTranscriptEntry[];
     /** Mid-meeting arrivals and departures derived from per-subject attendance diffs */
     attendanceChanges: MinutesAttendanceChange[];
+    /** Discussion order summary, only set when subjects were discussed out of natural order */
+    discussionOrderLabel: string | null;
     subjects: MinutesSubject[];
     /** Orphaned utterances after the last subject (closing remarks) */
     epilogueEntries: MinutesTranscriptEntry[];

--- a/src/lib/minutes/types.ts
+++ b/src/lib/minutes/types.ts
@@ -77,6 +77,18 @@ export interface MinutesSubject {
     transcriptEntries: MinutesTranscriptEntry[];
 }
 
+export interface MinutesAttendanceChange {
+    personId: string;
+    name: string;
+    type: 'arrival' | 'departure';
+    /** The agenda item where this change is first observed (subject immediately after the change) */
+    atSubject: {
+        id: string;
+        name: string;
+        agendaItemIndex: number | null;
+    };
+}
+
 export interface MinutesData {
     city: {
         name: string;
@@ -96,6 +108,8 @@ export interface MinutesData {
     absentMembers: MinutesMember[] | null;
     /** Orphaned utterances before the first subject (opening remarks, procedural content) */
     preambleEntries: MinutesTranscriptEntry[];
+    /** Mid-meeting arrivals and departures derived from per-subject attendance diffs */
+    attendanceChanges: MinutesAttendanceChange[];
     subjects: MinutesSubject[];
     /** Orphaned utterances after the last subject (closing remarks) */
     epilogueEntries: MinutesTranscriptEntry[];

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -257,7 +257,8 @@ export async function search(request: SearchRequest): Promise<SearchResponse> {
                     score: hit._score || 0,
                     matchedSpeakerSegmentIds,
                     councilMeeting: subject.councilMeeting,
-                    votes: []
+                    votes: [],
+                    attendance: []
                 };
 
                 // If detailed results are requested, add speaker segment text

--- a/src/lib/sorting/people.ts
+++ b/src/lib/sorting/people.ts
@@ -4,6 +4,21 @@ import { PeopleOrdering } from '@prisma/client';
 import { getActivePartyRole } from '@/lib/utils';
 
 /**
+ * Get the elected order for a person within a specific administrative body.
+ * Returns null if the person has no role with elected order in that body.
+ */
+export function getElectedOrderForBody(
+    person: PersonWithRelations | undefined,
+    administrativeBodyId: string | null,
+): number | null {
+    if (!person || !administrativeBodyId) return null;
+    const role = person.roles.find(
+        r => r.administrativeBodyId === administrativeBodyId && r.electedOrder != null
+    );
+    return role?.electedOrder ?? null;
+}
+
+/**
  * Sorts an array of Person objects by the last word in their name (typically last name)
  */
 export const sortPersonsByLastName = (persons: PersonWithRelations[]): PersonWithRelations[] => {

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -4,6 +4,7 @@ import { PollDecisionsRequest, PollDecisionsResult, ExtractedDecisionData } from
 import { startTask } from "./tasks";
 import prisma from "../db/prisma";
 import { AttendanceStatus, DataSource, Prisma, VoteType } from "@prisma/client";
+import { sortSubjectsByDiscussionOrder } from "../minutes/builders";
 
 /** Subjects eligible for decision polling: agenda + out-of-agenda, excluding withdrawn */
 const POLL_ELIGIBLE_SUBJECT_WHERE = {
@@ -68,6 +69,7 @@ export async function pollDecisionsForMeeting(
                     name: true,
                     agendaItemIndex: true,
                     nonAgendaReason: true,
+                    discussedIn: { select: { id: true } },
                     decision: { select: { ada: true, title: true, pdfUrl: true, excerpt: true } },
                 },
                 where: POLL_ELIGIBLE_SUBJECT_WHERE,
@@ -96,6 +98,25 @@ export async function pollDecisionsForMeeting(
         p.roles.some(r => isMayorRole(r) && isRoleActiveAt(r, councilMeeting.dateTime))
     );
 
+    // Sort subjects by discussion order (transcript timestamps) so OA subjects
+    // are in the correct sequence. Uses the same sortSubjectsByDiscussionOrder
+    // used by the minutes renderer.
+    const subjectIds = councilMeeting.subjects.map(s => s.id);
+    const firstUtteranceBySubject = new Map<string, number>();
+    if (subjectIds.length > 0) {
+        const firstUtterances = await prisma.utterance.groupBy({
+            by: ['discussionSubjectId'],
+            where: { discussionSubjectId: { in: subjectIds } },
+            _min: { startTimestamp: true },
+        });
+        for (const u of firstUtterances) {
+            if (u.discussionSubjectId && u._min.startTimestamp != null) {
+                firstUtteranceBySubject.set(u.discussionSubjectId, u._min.startTimestamp);
+            }
+        }
+    }
+    const sortedSubjects = sortSubjectsByDiscussionOrder(councilMeeting.subjects, firstUtteranceBySubject);
+
     const body: Omit<PollDecisionsRequest, 'callbackUrl'> = {
         meetingDate: councilMeeting.dateTime.toISOString().split('T')[0],
         diavgeiaUid: councilMeeting.city.diavgeiaUid,
@@ -105,7 +126,7 @@ export async function pollDecisionsForMeeting(
         mayorId: mayorPerson?.id,
         forceExtract: options?.forceExtract || undefined,
         people: peopleForRequest,
-        subjects: councilMeeting.subjects.map(s => ({
+        subjects: sortedSubjects.map(s => ({
             subjectId: s.id,
             name: s.name,
             agendaItemIndex: s.agendaItemIndex,

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -1306,6 +1306,58 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
             }
         }
 
+        // --- Store SubjectAttendance for subjects without decisions ---
+        // These subjects have no PDF but their effective attendance was computed
+        // using the complete discussion order and aggregated attendance changes.
+        if (result.extractions.nonDecisionSubjectAttendance && result.extractions.nonDecisionSubjectAttendance.length > 0) {
+            let storedCount = 0;
+            for (const subjectAttendance of result.extractions.nonDecisionSubjectAttendance) {
+                if (!validSubjectIdSet.has(subjectAttendance.subjectId)) {
+                    console.warn(`Poll decisions: skipping invalid subjectId ${subjectAttendance.subjectId} in nonDecisionSubjectAttendance for task ${taskId}`);
+                    continue;
+                }
+                if (subjectAttendance.presentMemberIds.length === 0 && subjectAttendance.absentMemberIds.length === 0) continue;
+
+                try {
+                    await prisma.$transaction(async (tx) => {
+                        const attendanceByPerson = new Map<string, AttendanceStatus>(
+                            [
+                                ...subjectAttendance.presentMemberIds.map(id => [id, 'PRESENT' as const] as const),
+                                ...subjectAttendance.absentMemberIds.map(id => [id, 'ABSENT' as const] as const),
+                            ]
+                        );
+
+                        // Include mayor attendance if known
+                        if (mayorId && result.extractions!.initialAttendance) {
+                            const mayorInitial = result.extractions!.initialAttendance.find(a => a.personId === mayorId);
+                            if (mayorInitial && !attendanceByPerson.has(mayorId)) {
+                                attendanceByPerson.set(mayorId, mayorInitial.status);
+                            }
+                        }
+
+                        await tx.subjectAttendance.deleteMany({
+                            where: { subjectId: subjectAttendance.subjectId, source: DataSource.decision },
+                        });
+                        await tx.subjectAttendance.createMany({
+                            data: [...attendanceByPerson].map(([personId, status]) => ({
+                                subjectId: subjectAttendance.subjectId,
+                                personId,
+                                status,
+                                source: DataSource.decision,
+                                taskId,
+                            })),
+                        });
+                    });
+                    storedCount++;
+                } catch (error) {
+                    console.error(`Failed to store attendance for subject ${subjectAttendance.subjectId}:`, error);
+                }
+            }
+            if (storedCount > 0) {
+                console.log(`Stored effective attendance for ${storedCount} non-decision subjects`);
+            }
+        }
+
         if (result.extractions.warnings.length > 0) {
             console.log(`Extraction warnings (${result.extractions.warnings.length}):`);
             for (const w of result.extractions.warnings) {

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -109,6 +109,7 @@ export async function pollDecisionsForMeeting(
             subjectId: s.id,
             name: s.name,
             agendaItemIndex: s.agendaItemIndex,
+            nonAgendaReason: s.nonAgendaReason,
             ...(s.decision?.ada ? {
                 existingDecision: {
                     ada: s.decision.ada,

--- a/src/lib/utils/votes.ts
+++ b/src/lib/utils/votes.ts
@@ -1,4 +1,4 @@
-import { VoteType } from '@prisma/client';
+import { AttendanceStatus, VoteType } from '@prisma/client';
 
 export interface VoteResultSummary {
     forCount: number;
@@ -46,4 +46,23 @@ export function calculateVoteResult(votes: { voteType: VoteType }[]): VoteResult
     const isUnanimous = totalVotes > 0 && againstCount === 0 && abstainCount === 0;
 
     return { forCount, againstCount, abstainCount, presentCount, didNotVoteCount, totalVotes, isUnanimous, passed };
+}
+
+/**
+ * Get person IDs of members who were absent during a vote.
+ * Absent = marked ABSENT in attendance AND didn't cast a vote AND not the mayor.
+ * The mayor is excluded because they're displayed separately in the composition.
+ */
+export function getAbsentNonVoterIds(
+    attendance: Array<{ personId: string; status: AttendanceStatus }>,
+    voterIds: Set<string>,
+    mayorPersonId: string | null,
+): Set<string> {
+    const result = new Set<string>();
+    for (const a of attendance) {
+        if (a.status === 'ABSENT' && !voterIds.has(a.personId) && a.personId !== mayorPersonId) {
+            result.add(a.personId);
+        }
+    }
+    return result;
 }


### PR DESCRIPTION
## Summary

Addresses items `#1`, `#2`, `#3`, and `#4` from #173 (Phase 2 follow-ups), plus elected order scoping for administrative bodies.

### Effective attendance & arrivals/departures (#173 items 1-3)

- **Store attendance for all subjects**: handles `nonDecisionSubjectAttendance` from the tasks server for subjects without linked decisions
- **Προσελεύσεις/Αποχωρήσεις section**: computes mid-meeting attendance changes by diffing consecutive subjects' attendance, rendered in both DOCX and HTML preview. Includes initial-state diff (catches changes during the first discussed subject)
- **Discussion order label**: shown in minutes when subjects were discussed out of natural order (e.g., `Σειρά συζήτησης: 1ο, ΕΗΔ1, ΕΗΔ2, 9ο, ...`)
- **PROCEDURAL_VOTE timestamp fix**: subjects with only procedural votes now sort correctly in discussion order instead of sinking to the end
- **Pass `nonAgendaReason` and sort by discussion order** in the pollDecisions request so the tasks server can identify OA subjects and assign correct sequential indices

### Vote breakdown improvements (#173 item 4)

- Remove party annotations from per-subject vote breakdown names
- Show absent members in subject voting section

### Elected order scoping

- Scope elected order API, UI, and minutes rendering to the meeting's administrative body (council vs committee have different election orders)
- Add administrative body selector in ElectedOrderSheet
- Extract `getElectedOrderForBody` into shared sorting utility

### Other fixes

- Fix: allow editing speaker segments with empty summary
- Fix: show decision section for out-of-agenda subjects
- Fix: child subjects inherit parent's discussion order position

Companion PR: schemalabz/opencouncil-tasks#40

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds effective attendance tracking, mid-meeting arrivals/departures (Προσελεύσεις/Αποχωρήσεις), discussion order labels, and scopes elected-order sorting/API to the meeting's administrative body. It also stores attendance for non-decision subjects received from the tasks server, adds absent members to the per-subject vote breakdown, and fixes child-subject discussion-order inheritance and the speaker-segment empty-summary editing bug.

- **Effective attendance & attendance changes**: `buildAttendanceChanges` diffs consecutive per-subject attendance (plus an initial-state diff) to compute mid-meeting arrivals/departures; these are rendered in both HTML preview and DOCX output. Storing `nonDecisionSubjectAttendance` from the tasks server gives subjects without PDFs their own attendance records.
- **Elected-order scoping**: `getElectedOrderForBody` replaces the "first role with any elected order" lookup, scoping sorting to the meeting's administrative body in the minutes renderer, voting section, and admin UI; the `ElectedOrderSheet` now requires selecting a body from a dropdown before opening.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are well-scoped, consistently applied across the renderer/DOCX/preview/API layers, and backed by updated tests.

The attendance-change diffing, elected-order scoping, and discussion-order label are applied consistently in both HTML preview and DOCX output. The tasks-server interaction (sorting subjects before sending, storing non-decision attendance on return) is correctly guarded with subject-ID validation. The AttendanceStatus enum only has PRESENT/ABSENT, so the === 'ABSENT' predicate in getAbsentNonVoterIds is equivalent to the old !== 'PRESENT' check. The sortSubjectsByDiscussionOrder child-timestamp change is covered by an updated test. No data-integrity or auth regressions detected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/minutes/builders.ts | Adds buildAttendanceChanges (initial-state diff + consecutive diffs), interleaveSubstitutes, formatSubjectLabel, and updates sortSubjectsByDiscussionOrder to always use parent timestamp for child subjects. |
| src/lib/minutes/getMinutesData.ts | Adds PROCEDURAL_VOTE fallback timestamp query, computes attendanceChanges and discussionOrderLabel, and moves adminBodyId up in scope for use in getElectedOrder. |
| src/lib/tasks/pollDecisions.ts | Sorts subjects by discussion order before sending to tasks server, passes nonAgendaReason, and stores nonDecisionSubjectAttendance from the tasks response. |
| src/components/admin/people/ElectedOrderSheet.tsx | Now requires administrativeBodyId prop; filters displayed members to only those with a role in that body; includes administrativeBodyId in all API and export payloads. |
| src/lib/db/roles.ts | updateElectedOrder now validates that roles belong to the specified administrativeBodyId in addition to the city. |
| src/components/meetings/subject/VotingSection.tsx | Adds absent member display to VoteBreakdown, scopes elected-order sorting to the meeting's administrativeBodyId, and adds mayorPersonId exclusion. |
| src/components/meetings/docx/MinutesDocx.ts | Adds createAttendanceChangesSection, renders discussionOrderLabel paragraph, switches to interleaveSubstitutes, and removes party annotations from vote breakdown names. |
| src/components/meetings/admin/DecisionsPanel.tsx | Adds elected-order sorting to the initial roll call display, filters mayor from attendance counts, and extends the expand chevron to non-decision subjects with attendance data. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getMinutesData] --> B[Sort subjects by discussion order\nincl. PROCEDURAL_VOTE fallback]
    B --> C[buildAttendanceChanges\nminutes subjects + absentMembers]
    C --> D{initialAbsentMembers?}
    D -- yes --> E[Initial diff:\nfirstSubject vs roll call\narrivals & departures]
    D -- no --> F[Skip initial diff]
    E --> G[Consecutive diff loop\ni=1..N]
    F --> G
    G --> H{both prev & curr\nhave attendance?}
    H -- no --> I[console.warn if gap\ncontinue]
    H -- yes --> J[Emit arrival / departure\nat curr subject]
    J --> G
    G --> K[attendanceChanges array]
    K --> L[MinutesData output\nattendanceChanges + discussionOrderLabel]
    L --> M[MinutesDocx\nΠροσελεύσεις/Αποχωρήσεις section]
    L --> N[MinutesPreviewContent\nAttendanceChangesSection]

    P[pollDecisions] --> Q[groupBy ALL utterance types\nfor first timestamps]
    Q --> R[sortSubjectsByDiscussionOrder\nchild inherits parent timestamp]
    R --> S[Send sorted subjects + nonAgendaReason\nto tasks server]
    S --> T{nonDecisionSubjectAttendance\nin response?}
    T -- yes --> U[Store SubjectAttendance\nper non-decision subject]
    T -- no --> V[Done]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/lib/minutes/getMinutesData.ts:456-464
The `naturalOrder` array is first split into two groups via spread, then immediately re-sorted with the same OA-first predicate. The spread already guarantees OA subjects precede non-OA subjects, so the `if (aIsOA !== bIsOA)` branch of the sort can never fire. Only the within-group `agendaItemIndex` comparison is actually needed. Removing the redundant OA/non-OA guard slightly clarifies intent and avoids confusing future readers.

```suggestion
    const naturalOrder = [
        ...nonWithdrawn.filter(s => s.nonAgendaReason === 'outOfAgenda'),
        ...nonWithdrawn.filter(s => s.nonAgendaReason !== 'outOfAgenda'),
    ].sort((a, b) => (a.agendaItemIndex ?? 0) - (b.agendaItemIndex ?? 0));
```

### Issue 2 of 2
src/components/admin/people/ElectedOrderSheet.tsx:246-247
The import handler uses the current `administrativeBodyId` prop even when the uploaded file was exported for a different body. If the bodies don't match, the API will throw "One or more roles do not belong to the specified administrative body" — a cryptic error. A quick pre-flight check against the `administrativeBodyId` field embedded in the export JSON would surface a clear message before the round-trip.

```suggestion
            const data = JSON.parse(text);
            if (!Array.isArray(data?.members)) throw new Error('Invalid format');
            if (data.administrativeBodyId && data.administrativeBodyId !== administrativeBodyId) {
                toast({ title: t('importError'), description: 'This file was exported for a different administrative body.', variant: 'destructive' });
                return;
            }
```

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["feat: sort subjects by discussion order ..."](https://github.com/schemalabz/opencouncil/commit/f80cdd2b9b685206036f03460cea6901849764b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32536548)</sub>

<!-- /greptile_comment -->