### PR TITLE
Add text copy and range selection to transcript context menu

### DIFF
--- a/messages/el/transcript.json
+++ b/messages/el/transcript.json
@@ -10,6 +10,8 @@
     },
     "contextMenu": {
       "copyText": "Αντιγραφή κειμένου",
+      "selectFromHere": "Επιλογή από εδώ",
+      "selectUntilHere": "Επιλογή έως εδώ",
       "startHighlightFromHere": "Ξεκινήστε Στιγμιότυπο από εδώ",
       "moveToPreviousSegment": "Μετακίνηση στο προηγούμενο τμήμα",
       "moveToNextSegment": "Μετακίνηση στο επόμενο τμήμα",

--- a/messages/el/transcript.json
+++ b/messages/el/transcript.json
@@ -9,6 +9,7 @@
       "setEndTime": "Ορισμός στην τρέχουσα ώρα βίντεο (])"
     },
     "contextMenu": {
+      "copyText": "Αντιγραφή κειμένου",
       "startHighlightFromHere": "Ξεκινήστε Στιγμιότυπο από εδώ",
       "moveToPreviousSegment": "Μετακίνηση στο προηγούμενο τμήμα",
       "moveToNextSegment": "Μετακίνηση στο επόμενο τμήμα",
@@ -26,6 +27,7 @@
       "error": "Σφάλμα",
       "createHighlightError": "Αποτυχία δημιουργίας στιγμιότυπου. Παρακαλώ δοκιμάστε ξανά.",
       "editError": "Αποτυχία αποθήκευσης αλλαγών. Παρακαλώ δοκιμάστε ξανά.",
+      "copyError": "Αποτυχία αντιγραφής κειμένου",
       "deleteUtterance": "Διαγραφή φράσης;",
       "deleteUtteranceDescription": "Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.",
       "utteranceDeletedSuccessfully": "Η φράση διαγράφηκε επιτυχώς",

--- a/messages/en/transcript.json
+++ b/messages/en/transcript.json
@@ -10,6 +10,8 @@
     },
     "contextMenu": {
       "copyText": "Copy text",
+      "selectFromHere": "Select from here",
+      "selectUntilHere": "Select until here",
       "startHighlightFromHere": "Start Highlight from here",
       "moveToPreviousSegment": "Move to previous segment",
       "moveToNextSegment": "Move to next segment",

--- a/messages/en/transcript.json
+++ b/messages/en/transcript.json
@@ -9,6 +9,7 @@
       "setEndTime": "Set to current video time (])"
     },
     "contextMenu": {
+      "copyText": "Copy text",
       "startHighlightFromHere": "Start Highlight from here",
       "moveToPreviousSegment": "Move to previous segment",
       "moveToNextSegment": "Move to next segment",
@@ -26,6 +27,7 @@
       "error": "Error",
       "createHighlightError": "Failed to create highlight. Please try again.",
       "editError": "Failed to save changes. Please try again.",
+      "copyError": "Failed to copy text",
       "deleteUtterance": "Delete utterance?",
       "deleteUtteranceDescription": "This action cannot be undone.",
       "utteranceDeletedSuccessfully": "Utterance deleted successfully",

--- a/src/components/meetings/HighlightContext.tsx
+++ b/src/components/meetings/HighlightContext.tsx
@@ -41,6 +41,7 @@ interface HighlightContextType {
   isEditingDisabled: boolean;
   enterEditMode: (highlight: HighlightWithUtterances) => void;
   updateHighlightUtterances: (utteranceId: string, action: 'add' | 'remove', modifiers?: { shift: boolean }) => void;
+  addUtteranceRangeToHighlight: (fromUtteranceId: string, toUtteranceId: string) => boolean;
   resetToOriginal: () => void;
   exitEditMode: () => void;
   exitEditModeAndRedirectToHighlight: () => void;
@@ -428,6 +429,48 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     setIsDirty(true);
   }, []);
 
+  // Add a range of utterances (inclusive) to the highlight. Used by the
+  // "select from here" / "select until here" context menu actions, which need
+  // an explicit range-add independent of the shift-click anchor. Returns
+  // true if anything was actually added (lets callers distinguish a real
+  // commit from a no-op so they can decide whether to clear UI state).
+  const addUtteranceRangeToHighlight = useCallback((fromUtteranceId: string, toUtteranceId: string): boolean => {
+    if (isEditingDisabledRef.current) return false;
+    const current = editingHighlightRef.current;
+    if (!current) return false;
+
+    const utteranceIds = calculateUtteranceRange(allUtterancesRef.current, fromUtteranceId, toUtteranceId);
+    const map = utteranceMapRef.current;
+    const now = new Date();
+    const newHighlightedUtterances = utteranceIds
+      .filter(id => !current.highlightedUtterances.some(hu => hu.utteranceId === id))
+      .map(id => {
+        const utterance = map.get(id);
+        if (!utterance) return null;
+        return {
+          id: `temp-${Date.now()}-${Math.random()}`,
+          utteranceId: id,
+          highlightId: current.id,
+          createdAt: now,
+          updatedAt: now,
+          utterance,
+        };
+      })
+      .filter((hu): hu is NonNullable<typeof hu> => hu !== null);
+
+    if (newHighlightedUtterances.length === 0) return false;
+
+    setEditingHighlight({
+      ...current,
+      highlightedUtterances: [
+        ...current.highlightedUtterances,
+        ...newHighlightedUtterances,
+      ],
+    });
+    setIsDirty(true);
+    return true;
+  }, []);
+
   const resetToOriginal = useCallback(() => {
     if (originalHighlight) {
       setEditingHighlight(originalHighlight);
@@ -574,6 +617,7 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     isEditingDisabled,
     enterEditMode,
     updateHighlightUtterances,
+    addUtteranceRangeToHighlight,
     resetToOriginal,
     exitEditMode,
     exitEditModeAndRedirectToHighlight,
@@ -600,6 +644,7 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
     isEditingDisabled,
     enterEditMode,
     updateHighlightUtterances,
+    addUtteranceRangeToHighlight,
     resetToOriginal,
     exitEditMode,
     exitEditModeAndRedirectToHighlight,

--- a/src/components/meetings/transcript/Utterance.tsx
+++ b/src/components/meetings/transcript/Utterance.tsx
@@ -93,11 +93,18 @@ const UtteranceC: React.FC<{
             "underline decoration-blue-500 decoration-2": isTaskModified,
             "decoration-green-500 underline decoration-2": isUserModified,
             "text-red-500 font-bold": isUncertain,
-            "select-none": options.editable || editingHighlight, // Prevent text selection in modes with range selection
         }
     );
 
     const handleClick = (e: React.MouseEvent) => {
+        // Shift-click extends the browser's native text selection in
+        // addition to firing onClick. In modes where shift/ctrl/meta mean
+        // "extend the utterance range", clear that parallel text selection
+        // so the user only sees the app's selection state.
+        const isModifiedClick = e.shiftKey || e.ctrlKey || e.metaKey;
+        if (isModifiedClick && (editingHighlight || options.editable)) {
+            window.getSelection()?.removeAllRanges();
+        }
         // If we're in highlight editing mode, handle highlight toggling and seek to utterance
         if (editingHighlight) {
             // Pass shift modifier for range selection

--- a/src/components/meetings/transcript/UtteranceContextMenu.tsx
+++ b/src/components/meetings/transcript/UtteranceContextMenu.tsx
@@ -1,7 +1,7 @@
 "use client";
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { ArrowLeftToLine, ArrowRightToLine, ClipboardCopy, Copy, Loader2, Scissors, Star } from 'lucide-react';
+import { ArrowLeftToLine, ArrowRightToLine, ClipboardCopy, Copy, ListEnd, ListStart, Loader2, Scissors, Star } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -48,9 +48,16 @@ export function UtteranceContextMenu({ children }: { children: React.ReactNode }
     const [open, setOpen] = useState(false);
     const [target, setTarget] = useState<ContextTarget | null>(null);
     const pendingShareRef = useRef<number | null>(null);
+    // Tracks whether handleContextMenu applied a temp utterance selection
+    // for visual feedback, so the close handler only clears what it added.
+    const didTempSelectRef = useRef(false);
+    // "Select from here" anchor for range-add via the context menu. Lives
+    // only here — independent of the shift-click anchor in HighlightContext
+    // so it isn't overwritten by stray clicks between "from" and "until".
+    const [rangeAnchorId, setRangeAnchorId] = useState<string | null>(null);
 
     const { options } = useTranscriptOptions();
-    const { editingHighlight, createHighlight } = useHighlight();
+    const { editingHighlight, createHighlight, addUtteranceRangeToHighlight } = useHighlight();
     const { selectedUtteranceIds, isProcessing, toggleSelection, clearSelection, extractSelectedSegment } = useEditing();
     const { moveUtterancesToPrevious, moveUtterancesToNext } = useCouncilMeetingActions();
     const { openShareDropdownAndCopy } = useShare();
@@ -59,8 +66,16 @@ export function UtteranceContextMenu({ children }: { children: React.ReactNode }
 
     const canStartHighlight = options.canCreateHighlights && !editingHighlight && !options.editable;
     const canShare = !editingHighlight && !options.editable;
+    const canRangeSelect = Boolean(editingHighlight);
     // "Copy text" is universally available, so the menu always opens on an
-    // utterance — no `hasAnyAction` gate needed.
+    // utterance. The original `hasAnyAction` gate is no longer needed.
+
+    // Clear the range anchor whenever the user switches highlights or exits
+    // highlight-edit mode — a stale anchor from a previous highlight would
+    // produce nonsensical ranges.
+    useEffect(() => {
+        setRangeAnchorId(null);
+    }, [editingHighlight?.id]);
 
     const handleContextMenu = useCallback((e: React.MouseEvent) => {
         const span = (e.target as HTMLElement | null)?.closest<HTMLElement>('[data-utterance-id]');
@@ -80,13 +95,18 @@ export function UtteranceContextMenu({ children }: { children: React.ReactNode }
         setTarget({ id, segmentId, startTimestamp, x: e.clientX, y: e.clientY, selectedText, utteranceText });
         setOpen(true);
 
-        // Mirror the original per-utterance behavior: temporarily select the
-        // right-clicked utterance for visual feedback unless it's already in
-        // the user's deliberate selection.
-        if (!selectedUtteranceIds.has(id)) {
+        // Temp-select the right-clicked utterance for visual feedback —
+        // but skip it when the user already has a text selection (which is
+        // their own feedback; bolding only the clicked utterance would
+        // misrepresent a multi-utterance selection), when this utterance is
+        // already deliberately selected, or in highlight-edit mode (where
+        // font-semibold would stack on font-bold and EditingContext state
+        // would mutate for no visible reason).
+        if (!selectedText && !editingHighlight && !selectedUtteranceIds.has(id)) {
             toggleSelection(id, { shift: false, ctrl: false });
+            didTempSelectRef.current = true;
         }
-    }, [selectedUtteranceIds, toggleSelection]);
+    }, [editingHighlight, selectedUtteranceIds, toggleSelection]);
 
     const handleOpenChange = useCallback((next: boolean) => {
         setOpen(next);
@@ -96,14 +116,11 @@ export function UtteranceContextMenu({ children }: { children: React.ReactNode }
             openShareDropdownAndCopy(pendingShareRef.current);
             pendingShareRef.current = null;
         }
-        if (selectedUtteranceIds.size === 1) {
+        if (didTempSelectRef.current) {
             clearSelection();
+            didTempSelectRef.current = false;
         }
-        // Depend on the full Set, not just `.size`. Each selection change
-        // produces a new Set identity, so we recreate this callback even when
-        // size stays the same (e.g., right-clicking utterance B while A was
-        // the lone selection swaps the contents but keeps size = 1).
-    }, [clearSelection, openShareDropdownAndCopy, selectedUtteranceIds]);
+    }, [clearSelection, openShareDropdownAndCopy]);
 
     const targetSelected = target ? selectedUtteranceIds.has(target.id) : false;
 
@@ -139,6 +156,21 @@ export function UtteranceContextMenu({ children }: { children: React.ReactNode }
             }),
         });
     }, [target, createHighlight, toast, t]);
+
+    const handleSelectFromHere = useCallback(() => {
+        if (!target) return;
+        setRangeAnchorId(target.id);
+    }, [target]);
+
+    const handleSelectUntilHere = useCallback(() => {
+        if (!target || !rangeAnchorId) return;
+        // Only clear the anchor when the range actually committed — if the
+        // call no-ops (e.g. every utterance in the range is already in the
+        // highlight), preserve the anchor so the user isn't forced to
+        // re-set it just to try a different "until here".
+        const added = addUtteranceRangeToHighlight(rangeAnchorId, target.id);
+        if (added) setRangeAnchorId(null);
+    }, [target, rangeAnchorId, addUtteranceRangeToHighlight]);
 
     const handleMoveToPrevious = useCallback(() => {
         if (!target) return;
@@ -212,6 +244,19 @@ export function UtteranceContextMenu({ children }: { children: React.ReactNode }
                             <ClipboardCopy className="h-4 w-4 mr-2" />
                             {t('contextMenu.copyText')}
                         </DropdownMenuItem>
+                    )}
+                    {target && canRangeSelect && (
+                        <>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem onClick={handleSelectFromHere}>
+                                <ListStart className="h-4 w-4 mr-2" />
+                                {t('contextMenu.selectFromHere')}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={handleSelectUntilHere} disabled={!rangeAnchorId}>
+                                <ListEnd className="h-4 w-4 mr-2" />
+                                {t('contextMenu.selectUntilHere')}
+                            </DropdownMenuItem>
+                        </>
                     )}
                     {target && canStartHighlight && (
                         <>

--- a/src/components/meetings/transcript/UtteranceContextMenu.tsx
+++ b/src/components/meetings/transcript/UtteranceContextMenu.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useCallback, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { ArrowLeftToLine, ArrowRightToLine, Copy, Loader2, Scissors, Star } from 'lucide-react';
+import { ArrowLeftToLine, ArrowRightToLine, ClipboardCopy, Copy, Loader2, Scissors, Star } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -25,6 +25,10 @@ interface ContextTarget {
     startTimestamp: number;
     x: number;
     y: number;
+    // Captured at right-click time so the menu's open/focus changes don't
+    // collapse the selection before "Copy text" runs.
+    selectedText: string;
+    utteranceText: string;
 }
 
 /**
@@ -55,10 +59,10 @@ export function UtteranceContextMenu({ children }: { children: React.ReactNode }
 
     const canStartHighlight = options.canCreateHighlights && !editingHighlight && !options.editable;
     const canShare = !editingHighlight && !options.editable;
-    const hasAnyAction = canStartHighlight || options.editable || canShare;
+    // "Copy text" is universally available, so the menu always opens on an
+    // utterance — no `hasAnyAction` gate needed.
 
     const handleContextMenu = useCallback((e: React.MouseEvent) => {
-        if (!hasAnyAction) return;
         const span = (e.target as HTMLElement | null)?.closest<HTMLElement>('[data-utterance-id]');
         if (!span) return; // outside an utterance — let the system menu show
         const id = span.dataset.utteranceId;
@@ -66,8 +70,14 @@ export function UtteranceContextMenu({ children }: { children: React.ReactNode }
         if (!id || !segmentId) return;
         const startTimestamp = parseFloat(span.dataset.startTimestamp || '0');
 
+        // Capture the user's text selection BEFORE preventDefault / state
+        // updates that might collapse it. `getSelection()` is global; if the
+        // user has nothing selected, this is an empty string.
+        const selectedText = window.getSelection()?.toString() ?? '';
+        const utteranceText = (span.textContent ?? '').trim();
+
         e.preventDefault();
-        setTarget({ id, segmentId, startTimestamp, x: e.clientX, y: e.clientY });
+        setTarget({ id, segmentId, startTimestamp, x: e.clientX, y: e.clientY, selectedText, utteranceText });
         setOpen(true);
 
         // Mirror the original per-utterance behavior: temporarily select the
@@ -76,7 +86,7 @@ export function UtteranceContextMenu({ children }: { children: React.ReactNode }
         if (!selectedUtteranceIds.has(id)) {
             toggleSelection(id, { shift: false, ctrl: false });
         }
-    }, [hasAnyAction, selectedUtteranceIds, toggleSelection]);
+    }, [selectedUtteranceIds, toggleSelection]);
 
     const handleOpenChange = useCallback((next: boolean) => {
         setOpen(next);
@@ -96,6 +106,23 @@ export function UtteranceContextMenu({ children }: { children: React.ReactNode }
     }, [clearSelection, openShareDropdownAndCopy, selectedUtteranceIds]);
 
     const targetSelected = target ? selectedUtteranceIds.has(target.id) : false;
+
+    const handleCopyText = useCallback(async () => {
+        if (!target) return;
+        // Prefer the user's manual selection; fall back to the utterance's
+        // full text. Matches what native "Copy" would have produced.
+        const text = target.selectedText.trim() || target.utteranceText;
+        if (!text) return;
+        try {
+            await navigator.clipboard.writeText(text);
+        } catch (err) {
+            toast({
+                title: t('common.error'),
+                description: t('toasts.copyError'),
+                variant: 'destructive',
+            });
+        }
+    }, [target, toast, t]);
 
     const handleStartHighlight = useCallback(async () => {
         if (!target) return;
@@ -180,15 +207,24 @@ export function UtteranceContextMenu({ children }: { children: React.ReactNode }
                     />
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
-                    {target && canStartHighlight && (
-                        <DropdownMenuItem onClick={handleStartHighlight}>
-                            <Star className="h-4 w-4 mr-2" />
-                            {t('contextMenu.startHighlightFromHere')}
+                    {target && (
+                        <DropdownMenuItem onClick={handleCopyText}>
+                            <ClipboardCopy className="h-4 w-4 mr-2" />
+                            {t('contextMenu.copyText')}
                         </DropdownMenuItem>
+                    )}
+                    {target && canStartHighlight && (
+                        <>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem onClick={handleStartHighlight}>
+                                <Star className="h-4 w-4 mr-2" />
+                                {t('contextMenu.startHighlightFromHere')}
+                            </DropdownMenuItem>
+                        </>
                     )}
                     {target && options.editable && (
                         <>
-                            {canStartHighlight && <DropdownMenuSeparator />}
+                            <DropdownMenuSeparator />
                             <DropdownMenuItem
                                 onClick={() => extractSelectedSegment()}
                                 disabled={isProcessing || (!targetSelected && selectedUtteranceIds.size > 0)}
@@ -211,10 +247,13 @@ export function UtteranceContextMenu({ children }: { children: React.ReactNode }
                         </>
                     )}
                     {target && canShare && (
-                        <DropdownMenuItem onClick={handleShareFromHere}>
-                            <Copy className="h-4 w-4 mr-2" />
-                            {t('contextMenu.shareFromHere')}
-                        </DropdownMenuItem>
+                        <>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem onClick={handleShareFromHere}>
+                                <Copy className="h-4 w-4 mr-2" />
+                                {t('contextMenu.shareFromHere')}
+                            </DropdownMenuItem>
+                        </>
                     )}
                 </DropdownMenuContent>
             </DropdownMenu>


### PR DESCRIPTION
## Summary
Enhances the utterance context menu in transcripts with new text manipulation features: direct text copying and range-based utterance selection for highlights.

## Key Changes

- **Copy text action**: Added "Copy text" menu item that copies either the user's manual selection or the full utterance text to clipboard, with error handling via toast notifications
- **Range selection for highlights**: Implemented "Select from here" / "Select until here" context menu actions that allow users to build highlight ranges without relying on shift-click behavior
  - Maintains an independent `rangeAnchorId` state in `UtteranceContextMenu` to avoid conflicts with the shift-click anchor in `HighlightContext`
  - Automatically clears the anchor when switching highlights or exiting edit mode
- **Capture selection state**: Captures user's text selection and utterance text at right-click time (before state updates that might collapse the selection)
- **New hook method**: Added `addUtteranceRangeToHighlight()` to `HighlightContext` for explicit range-add operations independent of shift-click behavior
- **Menu reorganization**: Restructured dropdown menu with separators to group related actions (copy, range selection, highlight creation, editing, sharing)
- **Internationalization**: Added translation keys for new menu items and error messages in English and Greek

## Implementation Details

- Removed the `hasAnyAction` gate that prevented menu opening; "Copy text" is now universally available
- Text selection is captured via `window.getSelection()?.toString()` before `preventDefault()` to ensure it's not lost
- Range selection uses the existing `calculateUtteranceRange()` utility to handle utterance ordering
- New highlighted utterances created by range selection follow the same temporary ID pattern as single-utterance highlights

https://claude.ai/code/session_01MoPJC2ygoWLHKLQoxhG8t7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes that add clipboard copying and highlight range-selection actions; main risk is small UX regressions around selection/clipboard permissions.
> 
> **Overview**
> Adds a universal transcript utterance context-menu action to **copy text** (copies the user’s current selection when present, otherwise the full utterance) with a destructive toast on clipboard failure.
> 
> In highlight edit mode, introduces **range-based highlight building** via "Select from here" / "Select until here" using a new `addUtteranceRangeToHighlight()` API in `HighlightContext`, with independent anchor state and auto-reset when switching highlights.
> 
> Adjusts utterance click behavior to allow normal text selection while clearing native browser selection on modifier-clicks, and updates i18n strings (EN/EL) for the new menu items and copy-error toast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a736b37eaaee5dcaf4db49ba2f2a19a46866d3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new features to the utterance right-click context menu: a \"Copy text\" action (using the current browser selection or the full utterance as fallback) and a two-step \"Select from here / Select until here\" range-selector for building highlight utterance sets without relying on shift-click. It also removes the `select-none` CSS guard from edit/highlight-edit modes, replacing it with an imperative `removeAllRanges()` call on modified clicks.

- **Copy text** captures `window.getSelection()` at right-click time (before `preventDefault` collapses it), stores it in `ContextTarget`, and writes it to the clipboard via `navigator.clipboard`, toasting on failure.
- **Range selection** introduces a local `rangeAnchorId` state in `UtteranceContextMenu` (independent of the shift-click anchor in `HighlightContext`) and a new `addUtteranceRangeToHighlight()` callback that appends non-duplicate utterances in the specified range, returning `true` when anything was actually committed.
- **Menu structure** is reorganised with `DropdownMenuSeparator` groups so that each capability cluster (copy, range, highlight-create, editing, share) is visually separated; the old `hasAnyAction` gate is removed since \"Copy text\" is now universally available.

<h3>Confidence Score: 5/5</h3>

Safe to merge; changes are confined to the right-click context menu and do not touch data persistence or auth paths.

The new clipboard path has robust error handling, the range-add callback uses the same ref-backed pattern as existing stable callbacks, the didTempSelectRef approach correctly scopes temp-selection cleanup, and the addUtteranceRangeToHighlight return value lets the caller decide whether to clear the anchor. No new data-loss or incorrect-state scenarios were found beyond the issues already documented in the existing review threads.

No files require special attention. The shift-click text-selection behaviour in Utterance.tsx and the range-anchor lifecycle were flagged in prior review threads and are handled in the current code.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/meetings/transcript/UtteranceContextMenu.tsx | Core change: adds copy-text, range-anchor state, and associated handlers; replaces size-based temp-selection cleanup with a ref-tracked flag. Logic is sound; anchor-cleared-on-commit behaviour is correct in the current HEAD. |
| src/components/meetings/HighlightContext.tsx | Adds addUtteranceRangeToHighlight(), a stable useCallback that reads exclusively from render-time-synced refs and returns a boolean to distinguish real commits from no-ops. Pattern is consistent with existing callbacks in the file. |
| src/components/meetings/transcript/Utterance.tsx | Removes select-none CSS on edit/highlight-edit modes and adds removeAllRanges() on modified clicks to prevent parallel native text-selection artifacts during range operations. |
| messages/en/transcript.json | Adds copyText, selectFromHere, selectUntilHere context-menu keys and a copyError toast key; all referenced paths are consistent with the useTranslations namespace used in UtteranceContextMenu. |
| messages/el/transcript.json | Greek translations for the four new keys; structure mirrors the English file correctly. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/meetings/transcript/Utterance.tsx`, line 99-132 ([link](https://github.com/schemalabz/opencouncil/blob/8777f2def98a516595b15012f34afa1ee56578bc/src/components/meetings/transcript/Utterance.tsx#L99-L132)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Shift-click now causes browser text selection in edit / highlight-edit modes**

   `handleClick` never calls `e.preventDefault()`. Before this PR, the `select-none` CSS was the only thing stopping the browser from building a native text selection on shift-click. With that guard removed, shift-clicking to select utterance ranges (in both `editingHighlight` and `options.editable` modes) now simultaneously triggers the utterance-selection logic AND highlights a span of visible text between the previous and new click points. This is a direct regression of the shift-range-select workflow that `select-none` was explicitly protecting (the removed line even had a comment: `// Prevent text selection in modes with range selection`). A call to `window.getSelection()?.removeAllRanges()` after the utterance-selection branches, or a targeted `e.preventDefault()` when a shift modifier is present, would restore the pre-PR behaviour without blocking plain left-clicks needed for copy.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/meetings/transcript/Utterance.tsx
   Line: 99-132

   Comment:
   **Shift-click now causes browser text selection in edit / highlight-edit modes**

   `handleClick` never calls `e.preventDefault()`. Before this PR, the `select-none` CSS was the only thing stopping the browser from building a native text selection on shift-click. With that guard removed, shift-clicking to select utterance ranges (in both `editingHighlight` and `options.editable` modes) now simultaneously triggers the utterance-selection logic AND highlights a span of visible text between the previous and new click points. This is a direct regression of the shift-range-select workflow that `select-none` was explicitly protecting (the removed line even had a comment: `// Prevent text selection in modes with range selection`). A call to `window.getSelection()?.removeAllRanges()` after the utterance-selection branches, or a targeted `e.preventDefault()` when a shift modifier is present, would restore the pre-PR behaviour without blocking plain left-clicks needed for copy.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["feat(transcript): add range-select actio..."](https://github.com/schemalabz/opencouncil/commit/1a736b37eaaee5dcaf4db49ba2f2a19a46866d3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32620434)</sub>

<!-- /greptile_comment -->