### PR TITLE
perf(server): parallelize independent awaits in city/meeting pages

### DIFF
--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
@@ -128,20 +128,21 @@ export default async function CouncilMeetingPage(
         children
     } = props;
 
-    const currentUser = await getCurrentUser();
-    const editable = await isUserAuthorizedToEdit({ cityId });
-
-    const data = await getMeetingDataCached(cityId, meetingId);
+    const currentUserPromise = getCurrentUser();
+    const [currentUser, editable, data, notificationPreference] = await Promise.all([
+        currentUserPromise,
+        isUserAuthorizedToEdit({ cityId }),
+        getMeetingDataCached(cityId, meetingId),
+        currentUserPromise.then(user =>
+            user ? getNotificationPreferenceForCity(user.id, cityId) : null
+        ),
+    ]);
 
     if (!data || !data.city) {
         notFound();
     }
 
     console.log(`Got meeting data for ${cityId} ${meetingId}: ${data.meeting.updatedAt}`);
-
-    const notificationPreference = currentUser
-        ? await getNotificationPreferenceForCity(currentUser.id, cityId)
-        : null;
 
     const meetingData = (data.transcriptHiddenForReview && !editable)
         ? { ...data, transcript: [], speakerTags: [] }

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/parties/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/parties/page.tsx
@@ -14,16 +14,17 @@ export default async function PartiesPage(
         cityId
     } = params;
 
-    const people = await getPeopleForCityCached(cityId);
-    const partiesWithPersons = await getPartiesForCityCached(cityId);
-
-    const peopleWithoutParties = people.filter(person => !partiesWithPersons.some(party => party.people.some(p => p.id === person.id)));
+    const [people, partiesWithPersons, canEdit] = await Promise.all([
+        getPeopleForCityCached(cityId),
+        getPartiesForCityCached(cityId),
+        isUserAuthorizedToEdit({ cityId }),
+    ]);
 
     if (!partiesWithPersons) {
         notFound();
     }
 
-    const canEdit = await isUserAuthorizedToEdit({ cityId });
+    const peopleWithoutParties = people.filter(person => !partiesWithPersons.some(party => party.people.some(p => p.id === person.id)));
 
     return (
         <CityParties

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/people/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/people/page.tsx
@@ -87,18 +87,17 @@ export default async function PeoplePage(
         cityId
     } = params;
 
-    const [partiesWithPersons, administrativeBodies, allPeople, city] = await Promise.all([
+    const [partiesWithPersons, administrativeBodies, allPeople, city, canEdit] = await Promise.all([
         getPartiesForCityCached(cityId),
         getAdministrativeBodiesForCityCached(cityId),
         getPeopleForCityCached(cityId),
-        getCityCached(cityId)
+        getCityCached(cityId),
+        isUserAuthorizedToEdit({ cityId })
     ]);
 
     if (!partiesWithPersons) {
         notFound();
     }
-
-    const canEdit = await isUserAuthorizedToEdit({ cityId });
 
     return (
         <CityPeople

--- a/src/app/__tests__/parallelize-server-awaits.test.ts
+++ b/src/app/__tests__/parallelize-server-awaits.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Verifies independent server-side data fetches in three page/layout files
+ * are kicked off concurrently rather than sequentially. Each mock returns a
+ * deferred promise so we can assert all dependencies were *invoked* before any
+ * of them resolve — the signature of a Promise.all / parallel pattern.
+ */
+
+type Deferred<T> = {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
+jest.mock('next/navigation', () => ({
+    notFound: jest.fn(() => {
+        throw new Error('notFound called');
+    }),
+}));
+
+jest.mock('next-intl/server', () => ({
+    getTranslations: jest.fn(async () => (key: string) => key),
+}));
+
+jest.mock('@/lib/cache', () => ({
+    getPartiesForCityCached: jest.fn(),
+    getPeopleForCityCached: jest.fn(),
+    getAdministrativeBodiesForCityCached: jest.fn(),
+    getCityCached: jest.fn(),
+}));
+
+jest.mock('@/lib/auth', () => ({
+    isUserAuthorizedToEdit: jest.fn(),
+    getCurrentUser: jest.fn(),
+}));
+
+jest.mock('@/lib/getMeetingData', () => ({
+    getMeetingDataCached: jest.fn(),
+}));
+
+jest.mock('@/lib/db/notifications', () => ({
+    getNotificationPreferenceForCity: jest.fn(),
+}));
+
+// Mock heavy React component trees — we only care about the data-fetch ordering.
+jest.mock('@/components/cities/CityParties', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/cities/CityPeople', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/meetings/CouncilMeetingWrapper', () => ({ __esModule: true, default: ({ children }: any) => children }));
+jest.mock('@/components/meetings/sidebar', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/meetings/TranscriptControls', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/layout/Header', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/meetings/EditButton', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/meetings/PresentationViewButton', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/meetings/ShareDropdown', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/meetings/NavigationEvents', () => ({ NavigationEvents: () => null }));
+jest.mock('@/components/meetings/HighlightModeBar', () => ({ HighlightModeBar: () => null }));
+jest.mock('@/components/meetings/CreateHighlightButton', () => ({ CreateHighlightButton: () => null }));
+jest.mock('@/components/meetings/HighlightContext', () => ({ HighlightProvider: ({ children }: any) => children }));
+jest.mock('@/components/meetings/EditingModeBar', () => ({ EditingModeBar: () => null }));
+jest.mock('@/contexts/ShareContext', () => ({ ShareProvider: ({ children }: any) => children }));
+jest.mock('@/contexts/SubjectHeaderContext', () => ({ SubjectHeaderProvider: ({ children }: any) => children }));
+jest.mock('@/contexts/NotificationPreferenceContext', () => ({ NotificationPreferenceProvider: ({ children }: any) => children }));
+jest.mock('@/components/ui/sidebar', () => ({ SidebarProvider: ({ children }: any) => children }));
+jest.mock('@/env.mjs', () => ({ env: { NEXTAUTH_URL: 'http://localhost' } }));
+
+// Tick the microtask queue a few times so any chained .then(...) handlers run
+// before we assert on which mocks have been invoked.
+async function flushMicrotasks(times = 5) {
+    for (let i = 0; i < times; i++) {
+        await Promise.resolve();
+    }
+}
+
+describe('PR1: server-side awaits run concurrently', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('parties/page.tsx kicks off people + parties + auth concurrently', async () => {
+        const cache = require('@/lib/cache');
+        const auth = require('@/lib/auth');
+
+        const peopleD = deferred<any[]>();
+        const partiesD = deferred<any[]>();
+        const authD = deferred<boolean>();
+
+        cache.getPeopleForCityCached.mockReturnValue(peopleD.promise);
+        cache.getPartiesForCityCached.mockReturnValue(partiesD.promise);
+        auth.isUserAuthorizedToEdit.mockReturnValue(authD.promise);
+
+        const { default: PartiesPage } = require('@/app/[locale]/(city)/[cityId]/(other)/(tabs)/parties/page');
+
+        const pending = PartiesPage({ params: { cityId: 'athens' } });
+
+        await flushMicrotasks();
+
+        expect(cache.getPeopleForCityCached).toHaveBeenCalledTimes(1);
+        expect(cache.getPartiesForCityCached).toHaveBeenCalledTimes(1);
+        expect(auth.isUserAuthorizedToEdit).toHaveBeenCalledTimes(1);
+
+        peopleD.resolve([]);
+        partiesD.resolve([{ id: 'p1', people: [] }]);
+        authD.resolve(false);
+
+        await pending;
+    });
+
+    it('meeting layout.tsx kicks off currentUser + auth + meetingData concurrently', async () => {
+        const auth = require('@/lib/auth');
+        const meetingData = require('@/lib/getMeetingData');
+        const notifications = require('@/lib/db/notifications');
+
+        const userD = deferred<any>();
+        const authD = deferred<boolean>();
+        const dataD = deferred<any>();
+
+        auth.getCurrentUser.mockReturnValue(userD.promise);
+        auth.isUserAuthorizedToEdit.mockReturnValue(authD.promise);
+        meetingData.getMeetingDataCached.mockReturnValue(dataD.promise);
+        notifications.getNotificationPreferenceForCity.mockResolvedValue(null);
+
+        const mod = require('@/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout');
+        const Layout = mod.default;
+
+        const pending = Layout({
+            params: { meetingId: 'm1', cityId: 'athens', locale: 'el' },
+            children: null,
+        });
+
+        await flushMicrotasks();
+
+        expect(auth.getCurrentUser).toHaveBeenCalledTimes(1);
+        expect(auth.isUserAuthorizedToEdit).toHaveBeenCalledTimes(1);
+        expect(meetingData.getMeetingDataCached).toHaveBeenCalledTimes(1);
+
+        userD.resolve(null);
+        authD.resolve(false);
+        dataD.resolve({
+            city: { id: 'athens', name: 'Athens', highlightCreationPermission: 'ADMIN' },
+            meeting: { name: 'm', updatedAt: new Date(), administrativeBody: null, muxPlaybackId: null },
+            transcriptHiddenForReview: false,
+            transcript: [],
+            speakerTags: [],
+        });
+
+        await pending;
+    });
+
+    it('people/page.tsx folds isUserAuthorizedToEdit into the Promise.all batch', async () => {
+        const cache = require('@/lib/cache');
+        const auth = require('@/lib/auth');
+
+        const partiesD = deferred<any[]>();
+        const adminD = deferred<any[]>();
+        const peopleD = deferred<any[]>();
+        const cityD = deferred<any>();
+        const authD = deferred<boolean>();
+
+        cache.getPartiesForCityCached.mockReturnValue(partiesD.promise);
+        cache.getAdministrativeBodiesForCityCached.mockReturnValue(adminD.promise);
+        cache.getPeopleForCityCached.mockReturnValue(peopleD.promise);
+        cache.getCityCached.mockReturnValue(cityD.promise);
+        auth.isUserAuthorizedToEdit.mockReturnValue(authD.promise);
+
+        const { default: PeoplePage } = require('@/app/[locale]/(city)/[cityId]/(other)/(tabs)/people/page');
+
+        const pending = PeoplePage({ params: { cityId: 'athens' } });
+
+        await flushMicrotasks();
+
+        // The crucial assertion: auth must be invoked BEFORE the Promise.all batch resolves.
+        expect(auth.isUserAuthorizedToEdit).toHaveBeenCalledTimes(1);
+        expect(cache.getPartiesForCityCached).toHaveBeenCalledTimes(1);
+        expect(cache.getAdministrativeBodiesForCityCached).toHaveBeenCalledTimes(1);
+        expect(cache.getPeopleForCityCached).toHaveBeenCalledTimes(1);
+        expect(cache.getCityCached).toHaveBeenCalledTimes(1);
+
+        partiesD.resolve([{ id: 'p', people: [] }]);
+        adminD.resolve([]);
+        peopleD.resolve([]);
+        cityD.resolve({ id: 'athens', name: 'Athens' });
+        authD.resolve(false);
+
+        await pending;
+    });
+});

--- a/src/app/__tests__/parallelize-server-awaits.test.ts
+++ b/src/app/__tests__/parallelize-server-awaits.test.ts
@@ -152,6 +152,59 @@ describe('PR1: server-side awaits run concurrently', () => {
         await pending;
     });
 
+    it('meeting layout.tsx: notification preference starts in parallel with auth/data once user resolves', async () => {
+        const auth = require('@/lib/auth');
+        const meetingData = require('@/lib/getMeetingData');
+        const notifications = require('@/lib/db/notifications');
+
+        const userD = deferred<any>();
+        const authD = deferred<boolean>();
+        const dataD = deferred<any>();
+        const notifD = deferred<any>();
+
+        auth.getCurrentUser.mockReturnValue(userD.promise);
+        auth.isUserAuthorizedToEdit.mockReturnValue(authD.promise);
+        meetingData.getMeetingDataCached.mockReturnValue(dataD.promise);
+        notifications.getNotificationPreferenceForCity.mockReturnValue(notifD.promise);
+
+        const mod = require('@/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout');
+        const Layout = mod.default;
+
+        const pending = Layout({
+            params: { meetingId: 'm1', cityId: 'athens', locale: 'el' },
+            children: null,
+        });
+
+        await flushMicrotasks();
+
+        // Top-level awaits started, but notification cannot fire until the user resolves.
+        expect(auth.getCurrentUser).toHaveBeenCalledTimes(1);
+        expect(auth.isUserAuthorizedToEdit).toHaveBeenCalledTimes(1);
+        expect(meetingData.getMeetingDataCached).toHaveBeenCalledTimes(1);
+        expect(notifications.getNotificationPreferenceForCity).not.toHaveBeenCalled();
+
+        // Resolve the user; the .then() handler should fire and kick off the notification fetch
+        // while authD and dataD are still pending.
+        userD.resolve({ id: 'user-42' });
+        await flushMicrotasks();
+
+        expect(notifications.getNotificationPreferenceForCity).toHaveBeenCalledTimes(1);
+        expect(notifications.getNotificationPreferenceForCity).toHaveBeenCalledWith('user-42', 'athens');
+
+        // Now resolve the remaining promises so the layout can finish.
+        authD.resolve(false);
+        dataD.resolve({
+            city: { id: 'athens', name: 'Athens', highlightCreationPermission: 'ADMIN' },
+            meeting: { name: 'm', updatedAt: new Date(), administrativeBody: null, muxPlaybackId: null },
+            transcriptHiddenForReview: false,
+            transcript: [],
+            speakerTags: [],
+        });
+        notifD.resolve(null);
+
+        await pending;
+    });
+
     it('people/page.tsx folds isUserAuthorizedToEdit into the Promise.all batch', async () => {
         const cache = require('@/lib/cache');
         const auth = require('@/lib/auth');


### PR DESCRIPTION
## Summary

Three server-rendered pages were issuing independent data fetches sequentially. Each added a round-trip to TTFB for no good reason — the calls don't depend on each other.

- `parties/page.tsx`: people + parties + auth check
- meeting `layout.tsx`: current user + auth + meeting data + notification preference. The notification call branches off the user promise (`currentUserPromise.then(...)`), so it still starts in parallel with auth/meeting data and resolves once the user is in.
- `people/page.tsx`: the auth check ran after the existing 4-way `Promise.all`. Folded it in.

A note on the auth call: `isUserAuthorizedToEdit` internally calls `getCurrentUser`. Auth.js wraps `auth()` in React `cache()`, so the duplicate session read in the meeting layout dedupes — running them in parallel does not double-fetch.

## Test plan

Added `src/app/__tests__/parallelize-server-awaits.test.ts` — 3 tests, one per file. Each one mocks the data dependencies as deferred promises and asserts every mock was invoked before any of them resolves. That assertion fails against the old sequential code and passes after the change.

- [x] `npx jest src/app/__tests__/parallelize-server-awaits.test.ts` — 3/3 pass
- [x] `npm test` — 41 suites / 691 tests pass, no regressions
- [x] `npx tsc --noEmit` — clean
- [ ] Manual smoke: confirm pages still render for anonymous, authorized, and unauthorized users

Refs #242

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR parallelizes independent data fetches on three server-rendered pages that were previously issuing sequential `await` calls, reducing TTFB by the sum of the serialized round-trips. The notification preference fetch in the meeting layout is chained off the user promise via `.then()`, so it starts as soon as the session resolves while auth and meeting data are still in flight.

- **`layout.tsx`**: `getCurrentUser`, `isUserAuthorizedToEdit`, `getMeetingDataCached`, and the notification preference are now batched in a single `Promise.all`; the session dedup via React `cache()` ensures no double-fetch.
- **`parties/page.tsx`**: People, parties, and auth run concurrently; moving `peopleWithoutParties` after the `notFound()` guard also fixes a pre-existing null-dereference path.
- **`people/page.tsx`**: `isUserAuthorizedToEdit` is folded into the existing four-way `Promise.all` as a fifth member; tests cover all three pages with deferred-promise assertions, including the logged-in notification branch.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change restructures fetch ordering without altering any data processing or error-handling logic, and the test suite validates the new parallel execution pattern including the logged-in notification branch.

All three refactors are mechanical: sequential awaits replaced by Promise.all with identical result destructuring. The one non-trivial pattern — the .then() chain for notification preference — is correctly scoped and explicitly tested. The session dedup claim (React cache()) is a well-established Next.js/Auth.js guarantee. No new error paths, no changed data contracts, no missing guards.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx | Parallelizes getCurrentUser, isUserAuthorizedToEdit, getMeetingDataCached, and notification preference via Promise.all with a .then() chain; logic and error handling are equivalent to the original sequential code. |
| src/app/[locale]/(city)/[cityId]/(other)/(tabs)/parties/page.tsx | Folds getPeopleForCityCached, getPartiesForCityCached, and isUserAuthorizedToEdit into a single Promise.all; also incidentally fixes a pre-existing crash risk by moving the peopleWithoutParties filter after the notFound guard. |
| src/app/[locale]/(city)/[cityId]/(other)/(tabs)/people/page.tsx | Adds isUserAuthorizedToEdit as a 5th member of the existing Promise.all; change is minimal and correct. |
| src/app/__tests__/parallelize-server-awaits.test.ts | Four deferred-promise tests cover all three pages; the third test specifically verifies the logged-in-user notification branch that was flagged in a prior review round. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(server): cover logged-in branch of ..."](https://github.com/schemalabz/opencouncil/commit/27207573f18a0c96c4dc268ca5eb567f7c4d913b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33585267)</sub>

<!-- /greptile_comment -->