### PR TITLE
Feat/fisheye transcript

### DIFF
--- a/messages/el.json
+++ b/messages/el.json
@@ -895,5 +895,6 @@
         "successSummary": "Εστάλησαν: {sent}, απέτυχαν: {failed}.",
         "failedListWithCount": "Διευθύνσεις που απέτυχαν ({count})",
         "errorTitle": "Η αποστολή απέτυχε"
-    }
+    },
+    "transcript": {}
 }

--- a/messages/el/transcript.json
+++ b/messages/el/transcript.json
@@ -76,5 +76,15 @@
         "button": "Αντιγραφή τμήματος",
         "segmentCopied": "Το τμήμα αντιγράφηκε",
         "copySourceAttribution": "Αντιγράφηκε από το OpenCouncil · opencouncil.gr"
+    },
+    "viewModes": {
+        "toggleLabel": "Εναλλαγή προβολής fish-eye",
+        "default": "Προεπιλεγμένη προβολή",
+        "fisheye": "Προβολή fish-eye",
+        "expand": "Επέκταση τμήματος",
+        "collapse": "Σύμπτυξη",
+        "seekHere": "Αναπαραγωγή από εδώ",
+        "seekHereDetailed": "Αναπαραγωγή από {speaker} στις {time}",
+        "aiSummary": "Περίληψη από ΤΝ"
     }
 }

--- a/messages/el/transcript.json
+++ b/messages/el/transcript.json
@@ -83,8 +83,8 @@
         "fisheye": "Προβολή fish-eye",
         "expand": "Επέκταση τμήματος",
         "collapse": "Σύμπτυξη",
-        "seekHere": "Αναπαραγωγή από εδώ",
-        "seekHereDetailed": "Αναπαραγωγή από {speaker} στις {time}",
+        "seekHere": "Μετάβαση εδώ",
+        "seekHereDetailed": "Μετάβαση σε {speaker} στις {time}",
         "aiSummary": "Περίληψη από ΤΝ"
     }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -895,5 +895,6 @@
         "successSummary": "Sent: {sent}, failed: {failed}.",
         "failedListWithCount": "Failed addresses ({count})",
         "errorTitle": "Send failed"
-    }
+    },
+    "transcript": {}
 }

--- a/messages/en/transcript.json
+++ b/messages/en/transcript.json
@@ -76,5 +76,15 @@
     "button": "Copy segment",
     "segmentCopied": "Segment copied",
     "copySourceAttribution": "Copied from OpenCouncil · opencouncil.gr"
+  },
+  "viewModes": {
+    "toggleLabel": "Toggle fish-eye view",
+    "default": "Default view",
+    "fisheye": "Fish-eye view",
+    "expand": "Expand segment",
+    "collapse": "Collapse",
+    "seekHere": "Play from here",
+    "seekHereDetailed": "Play from {speaker} at {time}",
+    "aiSummary": "AI-generated summary"
   }
 }

--- a/messages/en/transcript.json
+++ b/messages/en/transcript.json
@@ -83,8 +83,8 @@
     "fisheye": "Fish-eye view",
     "expand": "Expand segment",
     "collapse": "Collapse",
-    "seekHere": "Play from here",
-    "seekHereDetailed": "Play from {speaker} at {time}",
+    "seekHere": "Go to here",
+    "seekHereDetailed": "Go to {speaker} at {time}",
     "aiSummary": "AI-generated summary"
   }
 }

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/transcript/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/transcript/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 import CurrentTimeButton from "@/components/meetings/current-time-button";
 import Transcript from "@/components/meetings/transcript/Transcript";
+import FisheyeToggle from "@/components/meetings/transcript/FisheyeToggle";
 
 export default function TranscriptPage() {
     return <>
         <Transcript />
         <CurrentTimeButton />
+        <FisheyeToggle />
     </>
 }

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/transcript/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/transcript/page.tsx
@@ -1,12 +1,10 @@
 "use client";
 import CurrentTimeButton from "@/components/meetings/current-time-button";
 import Transcript from "@/components/meetings/transcript/Transcript";
-import FisheyeToggle from "@/components/meetings/transcript/FisheyeToggle";
 
 export default function TranscriptPage() {
     return <>
         <Transcript />
         <CurrentTimeButton />
-        <FisheyeToggle />
     </>
 }

--- a/src/components/meetings/CouncilMeetingWrapper.tsx
+++ b/src/components/meetings/CouncilMeetingWrapper.tsx
@@ -21,11 +21,22 @@ type CouncilMeetingWrapperProps = {
     children: React.ReactNode
 }
 
-const LayoutContext = createContext<{ isWide: boolean }>({ isWide: false });
+const LayoutContext = createContext<{
+    isWide: boolean;
+    isControlsVisible: boolean;
+    setIsControlsVisible: (next: boolean | ((prev: boolean) => boolean)) => void;
+}>({
+    isWide: false,
+    isControlsVisible: true,
+    setIsControlsVisible: () => { },
+});
 export const useLayout = () => useContext(LayoutContext);
 
 export default function CouncilMeetingWrapper({ meetingData, editable, canCreateHighlights, children }: CouncilMeetingWrapperProps) {
     const [isWide, setIsWide] = useState(false);
+    // Lifted from TranscriptControls so other floating buttons (e.g. FisheyeToggle)
+    // can position themselves relative to the show/hide-bar toggle on mobile.
+    const [isControlsVisible, setIsControlsVisible] = useState(false);
     const [loading, setLoading] = useState(true);
 
     const memoizedUtterances = useMemo(() => {
@@ -36,7 +47,13 @@ export default function CouncilMeetingWrapper({ meetingData, editable, canCreate
 
     useEffect(() => {
         const checkSize = () => {
-            setIsWide(window.innerWidth > window.innerHeight)
+            const wide = window.innerWidth > window.innerHeight;
+            setIsWide(wide);
+            // Wide (landscape) viewports show the controls; narrow viewports
+            // keep the user's current choice (default `false` on first mount).
+            // Resize never force-collapses — incidental height changes (soft
+            // keyboard, DevTools) would otherwise hide a bar the user opened.
+            if (wide) setIsControlsVisible(true);
         }
 
         checkSize()
@@ -58,7 +75,7 @@ export default function CouncilMeetingWrapper({ meetingData, editable, canCreate
     )
 
     return (
-        <LayoutContext.Provider value={{ isWide }}>
+        <LayoutContext.Provider value={{ isWide, isControlsVisible, setIsControlsVisible }}>
             <CouncilMeetingDataProvider data={meetingData}>
                 <TranscriptOptionsProvider editable={editable} canCreateHighlights={canCreateHighlights}>
                     <VideoProvider meeting={memoizedMeeting} utterances={memoizedUtterances}>

--- a/src/components/meetings/CouncilMeetingWrapper.tsx
+++ b/src/components/meetings/CouncilMeetingWrapper.tsx
@@ -34,8 +34,8 @@ export const useLayout = () => useContext(LayoutContext);
 
 export default function CouncilMeetingWrapper({ meetingData, editable, canCreateHighlights, children }: CouncilMeetingWrapperProps) {
     const [isWide, setIsWide] = useState(false);
-    // Lifted from TranscriptControls so other floating buttons (e.g. FisheyeToggle)
-    // can position themselves relative to the show/hide-bar toggle on mobile.
+    // Lifted from TranscriptControls so other floating buttons can position
+    // themselves relative to the show/hide-bar toggle on mobile.
     const [isControlsVisible, setIsControlsVisible] = useState(false);
     const [loading, setLoading] = useState(true);
 

--- a/src/components/meetings/TranscriptControls.tsx
+++ b/src/components/meetings/TranscriptControls.tsx
@@ -6,8 +6,9 @@ import { cn, formatTimestamp } from "@/lib/utils";
 import { useCouncilMeetingData } from "./CouncilMeetingDataContext";
 import { useTranscriptOptions } from "./options/OptionsContext";
 import { useHighlight } from "./HighlightContext";
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useCallback } from "react";
 import { Video } from "./Video";
+import { useLayout } from "./CouncilMeetingWrapper";
 
 export default function TranscriptControls({ className }: { className?: string }) {
     const { transcript: speakerSegments } = useCouncilMeetingData();
@@ -18,26 +19,9 @@ export default function TranscriptControls({ className }: { className?: string }
     const [isSliderHovered, setIsSliderHovered] = useState(false);
     const [isTouchActive, setIsTouchActive] = useState(false);
     const sliderRef = useRef<HTMLDivElement>(null);
-    const [isWide, setIsWide] = useState(false);
-    const [isControlsVisible, setIsControlsVisible] = useState(false);
+    const { isWide, isControlsVisible, setIsControlsVisible } = useLayout();
     const [hoveredSpeaker, setHoveredSpeaker] = useState<{ name: string, color: string } | null>(null);
     const [cursorPosition, setCursorPosition] = useState({ x: 0, y: 0 }); // Track cursor position
-
-    useEffect(() => {
-        const checkSize = () => {
-            const wide = window.innerWidth > window.innerHeight;
-            setIsWide(wide);
-            // If it's desktop (wide), make controls visible by default
-            if (wide) {
-                setIsControlsVisible(true);
-            }
-        }
-
-        checkSize()
-        window.addEventListener('resize', checkSize)
-
-        return () => window.removeEventListener('resize', checkSize)
-    }, [])
 
 
     const handleSeek = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/src/components/meetings/VideoProvider.tsx
+++ b/src/components/meetings/VideoProvider.tsx
@@ -62,6 +62,7 @@ interface VideoActionsContextType {
     seekTo: (time: number) => void;
     seekToWithoutScroll: (time: number) => void;
     togglePlayPause: () => void;
+    setIsPlaying: (isPlaying: boolean) => void;
 }
 
 const VideoActionsContext = createContext<VideoActionsContextType | undefined>(undefined);
@@ -480,7 +481,8 @@ export const VideoProvider: React.FC<VideoProviderProps> = ({ children, meeting,
         seekTo: stableSeekTo,
         seekToWithoutScroll: stableSeekToWithoutScroll,
         togglePlayPause: stableTogglePlayPause,
-    }), [stableSeekTo, stableSeekToWithoutScroll, stableTogglePlayPause]);
+        setIsPlaying: stableSetIsPlaying,
+    }), [stableSeekTo, stableSeekToWithoutScroll, stableTogglePlayPause, stableSetIsPlaying]);
 
     // Memoize the value so it only invalidates when the reactive fields it
     // exposes actually change. The function fields are now all stable refs,

--- a/src/components/meetings/transcript/FisheyeToggle.tsx
+++ b/src/components/meetings/transcript/FisheyeToggle.tsx
@@ -3,13 +3,10 @@ import { Button } from "@/components/ui/button";
 import { ScanEye, AlignJustify } from "lucide-react";
 import { useTranslations } from 'next-intl';
 import { useViewMode } from "@/hooks/useViewMode";
-import { useLayout } from "@/components/meetings/CouncilMeetingWrapper";
 import { useTranscriptOptions } from "@/components/meetings/options/OptionsContext";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 
 export default function FisheyeToggle() {
     const [mode, setMode] = useViewMode();
-    const { isWide, isControlsVisible } = useLayout();
     const { options } = useTranscriptOptions();
     const t = useTranslations('transcript.viewModes');
 
@@ -19,35 +16,20 @@ export default function FisheyeToggle() {
     if (options.editable) return null;
 
     const isFisheye = mode === 'fisheye';
-    const tooltipText = isFisheye ? t('default') : t('fisheye');
-
-    // Mobile: stack just above the orange show/hide-controls toggle so the
-    // pair animates together when the user opens/closes the video bar.
-    // Desktop: top-right of the horizontal video controls.
-    const position = isWide
-        ? 'bottom-24 right-4'
-        : `bottom-16 ${isControlsVisible ? 'right-[4.5rem]' : 'right-2'}`;
+    // Label and icon describe what clicking switches TO.
+    const label = isFisheye ? t('default') : t('fisheye');
+    const Icon = isFisheye ? AlignJustify : ScanEye;
 
     return (
-        <TooltipProvider>
-            <Tooltip>
-                <TooltipTrigger asChild>
-                    <Button
-                        onClick={() => setMode(isFisheye ? 'default' : 'fisheye')}
-                        variant="outline"
-                        size="icon"
-                        aria-pressed={isFisheye}
-                        aria-label={tooltipText}
-                        title={tooltipText}
-                        className={`fixed ${position} z-50 bg-background shadow-md hover:shadow-lg transition-all duration-200`}
-                    >
-                        {isFisheye ? <AlignJustify className="w-4 h-4" /> : <ScanEye className="w-4 h-4" />}
-                    </Button>
-                </TooltipTrigger>
-                <TooltipContent side={isWide ? 'top' : 'left'}>
-                    {tooltipText}
-                </TooltipContent>
-            </Tooltip>
-        </TooltipProvider>
+        <Button
+            onClick={() => setMode(isFisheye ? 'default' : 'fisheye')}
+            variant="outline"
+            size="sm"
+            aria-pressed={isFisheye}
+            className="gap-2"
+        >
+            <Icon className="w-4 h-4" />
+            {label}
+        </Button>
     );
 }

--- a/src/components/meetings/transcript/FisheyeToggle.tsx
+++ b/src/components/meetings/transcript/FisheyeToggle.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import { ScanEye, AlignJustify } from "lucide-react";
+import { useTranslations } from 'next-intl';
+import { useViewMode } from "@/hooks/useViewMode";
+import { useLayout } from "@/components/meetings/CouncilMeetingWrapper";
+import { useTranscriptOptions } from "@/components/meetings/options/OptionsContext";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+
+export default function FisheyeToggle() {
+    const [mode, setMode] = useViewMode();
+    const { isWide, isControlsVisible } = useLayout();
+    const { options } = useTranscriptOptions();
+    const t = useTranslations('transcript.viewModes');
+
+    // Fish-eye is suppressed in editable mode (Transcript.tsx gates it the
+    // same way), so hide the toggle there too — otherwise editors see an
+    // "active" button that does nothing and silently writes mode to storage.
+    if (options.editable) return null;
+
+    const isFisheye = mode === 'fisheye';
+    const tooltipText = isFisheye ? t('default') : t('fisheye');
+
+    // Mobile: stack just above the orange show/hide-controls toggle so the
+    // pair animates together when the user opens/closes the video bar.
+    // Desktop: top-right of the horizontal video controls.
+    const position = isWide
+        ? 'bottom-24 right-4'
+        : `bottom-16 ${isControlsVisible ? 'right-[4.5rem]' : 'right-2'}`;
+
+    return (
+        <TooltipProvider>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        onClick={() => setMode(isFisheye ? 'default' : 'fisheye')}
+                        variant="outline"
+                        size="icon"
+                        aria-pressed={isFisheye}
+                        aria-label={tooltipText}
+                        title={tooltipText}
+                        className={`fixed ${position} z-50 bg-background shadow-md hover:shadow-lg transition-all duration-200`}
+                    >
+                        {isFisheye ? <AlignJustify className="w-4 h-4" /> : <ScanEye className="w-4 h-4" />}
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent side={isWide ? 'top' : 'left'}>
+                    {tooltipText}
+                </TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
+    );
+}

--- a/src/components/meetings/transcript/SegmentContext.tsx
+++ b/src/components/meetings/transcript/SegmentContext.tsx
@@ -47,12 +47,12 @@ function buildPreview(segment: TranscriptType[number]): Preview {
 
 /**
  * Compact one-line view used for every segment outside the active 3-item
- * focus window. Click the whole row to seek+play that segment — playback
- * advance is the only way to change which segments are in focus.
+ * focus window. Click the row to move the playhead there — playback advance
+ * is what changes which segments are in focus.
  */
 const SegmentContext = React.memo(({ segment }: SegmentContextProps) => {
     const { getPerson, getSpeakerTag } = useCouncilMeetingMeta();
-    const { seekToWithoutScroll, setIsPlaying } = useVideoActions();
+    const { seekToWithoutScroll } = useVideoActions();
     const t = useTranslations('transcript.viewModes');
 
     const speakerTag = getSpeakerTag(segment.speakerTagId);
@@ -63,13 +63,11 @@ const SegmentContext = React.memo(({ segment }: SegmentContextProps) => {
     const preview = useMemo(() => buildPreview(segment), [segment]);
 
     const handleActivate = () => {
+        // Move the playhead only — never force playback. The 4Hz poll in
+        // Transcript picks up the new position and expands this row within
+        // ~250ms. If the user was already playing they continue from here;
+        // if paused, they stay paused. Expanding a row must not start audio.
         seekToWithoutScroll(segment.startTimestamp);
-        // setIsPlaying is typed as void-returning but internally awaits
-        // playerRef.current.play(), which can reject (autoplay policy, media
-        // not ready). Surface those so the user-visible "seeked but not
-        // playing" state at least leaves a console trail.
-        Promise.resolve(setIsPlaying(true) as unknown as void | Promise<void>)
-            .catch(err => console.error('Fish-eye seek: failed to start playback', err));
     };
 
     const speakerName = person?.name ?? speakerTag?.label ?? null;

--- a/src/components/meetings/transcript/SegmentContext.tsx
+++ b/src/components/meetings/transcript/SegmentContext.tsx
@@ -1,0 +1,119 @@
+"use client";
+import React, { useMemo } from 'react';
+import { useCouncilMeetingMeta } from "../CouncilMeetingDataContext";
+import { useVideoActions } from "../VideoProvider";
+import { Transcript as TranscriptType } from '@/lib/db/transcript';
+import { PersonBadge } from '@/components/persons/PersonBadge';
+import { Bot } from "lucide-react";
+import { formatTimestamp, getPartyFromRoles } from "@/lib/utils";
+import { stripMarkdown } from '@/lib/formatters/markdown';
+import { useTranslations } from 'next-intl';
+
+const SHORT_UTTERANCE_MAX_CHARS = 160;
+const SHORT_UTTERANCE_MAX_SENTENCES = 2;
+
+interface SegmentContextProps {
+    segment: TranscriptType[number];
+}
+
+interface Preview {
+    text: string;
+    isAI: boolean;
+}
+
+/**
+ * Picks what to render below the speaker name in context mode.
+ * Short speeches (≤ ~2 sentences) display verbatim — readers don't need a
+ * summary for a one-liner. Longer speeches use the AI summary when available;
+ * otherwise we clip the verbatim text to the short-speech budget and append
+ * an ellipsis so the row visually signals it's a truncated excerpt rather
+ * than a complete short utterance. The isAI flag drives a small icon so the
+ * reader can tell at a glance which rows show synthetic vs verbatim text.
+ */
+function buildPreview(segment: TranscriptType[number]): Preview {
+    const joined = segment.utterances.map(u => u.text).join(' ').trim();
+    const sentenceCount = joined ? (joined.match(/[.!?]+(?:\s|$)/g)?.length ?? 1) : 0;
+    const isShort = joined.length > 0
+        && joined.length <= SHORT_UTTERANCE_MAX_CHARS
+        && sentenceCount <= SHORT_UTTERANCE_MAX_SENTENCES;
+    if (isShort) return { text: joined, isAI: false };
+
+    const summaryText = segment.summary?.text;
+    if (summaryText) return { text: stripMarkdown(summaryText).trim(), isAI: true };
+    if (!joined) return { text: '', isAI: false };
+    const clipped = joined.slice(0, SHORT_UTTERANCE_MAX_CHARS).trimEnd();
+    return { text: `${clipped}…`, isAI: false };
+}
+
+/**
+ * Compact one-line view used for every segment outside the active 3-item
+ * focus window. Click the whole row to seek+play that segment — playback
+ * advance is the only way to change which segments are in focus.
+ */
+const SegmentContext = React.memo(({ segment }: SegmentContextProps) => {
+    const { getPerson, getSpeakerTag } = useCouncilMeetingMeta();
+    const { seekToWithoutScroll, setIsPlaying } = useVideoActions();
+    const t = useTranslations('transcript.viewModes');
+
+    const speakerTag = getSpeakerTag(segment.speakerTagId);
+    const person = speakerTag?.personId ? getPerson(speakerTag.personId) : undefined;
+    const party = person ? getPartyFromRoles(person.roles) : null;
+    const borderColor = party?.colorHex || '#D3D3D3';
+
+    const preview = useMemo(() => buildPreview(segment), [segment]);
+
+    const handleActivate = () => {
+        seekToWithoutScroll(segment.startTimestamp);
+        // setIsPlaying is typed as void-returning but internally awaits
+        // playerRef.current.play(), which can reject (autoplay policy, media
+        // not ready). Surface those so the user-visible "seeked but not
+        // playing" state at least leaves a console trail.
+        Promise.resolve(setIsPlaying(true) as unknown as void | Promise<void>)
+            .catch(err => console.error('Fish-eye seek: failed to start playback', err));
+    };
+
+    const speakerName = person?.name ?? speakerTag?.label ?? null;
+    const timestamp = formatTimestamp(segment.startTimestamp);
+    // The button's aria-label fully replaces its inner text for screen readers,
+    // so the AI indicator has to live here too — the Bot SVG below is
+    // decorative for AT.
+    const baseLabel = speakerName
+        ? t('seekHereDetailed', { speaker: speakerName, time: timestamp })
+        : t('seekHere');
+    const ariaLabel = preview.isAI ? `${baseLabel} · ${t('aiSummary')}` : baseLabel;
+
+    return (
+        <button
+            type="button"
+            onClick={handleActivate}
+            aria-label={ariaLabel}
+            className="my-1 w-full text-left rounded-r-md border-l-[3px] sm:border-l-4 bg-muted/20 hover:bg-muted/40 transition-colors px-2.5 sm:px-4 py-1.5 flex items-baseline gap-2 overflow-hidden"
+            style={{ borderLeftColor: borderColor }}
+        >
+            <PersonBadge
+                person={person}
+                speakerTag={speakerTag}
+                variant="inline"
+                lastNameOnly
+                className="shrink-0"
+            />
+            {preview.text && (
+                <span className="text-xs sm:text-sm text-muted-foreground truncate flex-1 min-w-0 flex items-center gap-1">
+                    {preview.isAI && (
+                        <Bot
+                            className="h-3 w-3 shrink-0 opacity-70"
+                            aria-hidden="true"
+                        />
+                    )}
+                    <span className="truncate">{preview.text}</span>
+                </span>
+            )}
+            <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
+                {timestamp}
+            </span>
+        </button>
+    );
+});
+SegmentContext.displayName = 'SegmentContext';
+
+export default SegmentContext;

--- a/src/components/meetings/transcript/Transcript.tsx
+++ b/src/components/meetings/transcript/Transcript.tsx
@@ -15,6 +15,7 @@ import { UtteranceContextMenu } from "./UtteranceContextMenu";
 import { useViewMode } from "@/hooks/useViewMode";
 import { useFisheyeCenter } from "@/hooks/useFisheyeCenter";
 import { fisheyeModeForDistance } from "@/lib/utils/fisheye";
+import FisheyeToggle from "./FisheyeToggle";
 
 // Helper functions for speaker segment identification and parsing
 const SPEAKER_SEGMENT_PREFIX = 'speaker-segment-';
@@ -210,6 +211,11 @@ export default function Transcript() {
                     isScrolled={isScrolled}
                     onBannerHeightChange={setBannerHeight}
                 />
+            )}
+            {!options.editable && (
+                <div className="flex justify-end pt-2 pb-1">
+                    <FisheyeToggle />
+                </div>
             )}
             <UtteranceContextMenu>
                 <div ref={containerRef} role="list" aria-label={t('transcript')}>

--- a/src/components/meetings/transcript/Transcript.tsx
+++ b/src/components/meetings/transcript/Transcript.tsx
@@ -1,7 +1,8 @@
 "use client";
 import SpeakerSegment from "./SpeakerSegment";
+import SegmentContext from "./SegmentContext";
 import { useEffect, useRef, useMemo, useState } from 'react';
-import { useVideo } from "../VideoProvider";
+import { useVideo, useVideoActions } from "../VideoProvider";
 import { debounce, joinTranscriptSegments } from '@/lib/utils';
 import { useCouncilMeetingData } from "../CouncilMeetingDataContext";
 import { Clock, ScrollText } from "lucide-react";
@@ -11,6 +12,9 @@ import { useHighlight } from "../HighlightContext";
 import { useTranslations } from 'next-intl';
 import { UnverifiedTranscriptBanner, BANNER_HEIGHT_FULL } from "./UnverifiedTranscriptBanner";
 import { UtteranceContextMenu } from "./UtteranceContextMenu";
+import { useViewMode } from "@/hooks/useViewMode";
+import { useFisheyeCenter } from "@/hooks/useFisheyeCenter";
+import { fisheyeModeForDistance } from "@/lib/utils/fisheye";
 
 // Helper functions for speaker segment identification and parsing
 const SPEAKER_SEGMENT_PREFIX = 'speaker-segment-';
@@ -38,6 +42,10 @@ export default function Transcript() {
     const [bannerHeight, setBannerHeight] = useState(BANNER_HEIGHT_FULL);
     const [isScrolled, setIsScrolled] = useState(false);
     const searchParams = useSearchParams();
+    const [viewMode] = useViewMode();
+    const isFisheye = viewMode === 'fisheye' && !options.editable;
+    const { currentTimeRef } = useVideoActions();
+    const [activeSegmentIndex, setActiveSegmentIndex] = useState<number | null>(null);
 
     // Check if transcript is unverified (humanReview not completed)
     const isUnverified = !taskStatus.humanReview && !options.editsAllowed;
@@ -46,6 +54,10 @@ export default function Transcript() {
     const displayedSegments = useMemo(() => {
         return options.editable ? speakerSegments : joinTranscriptSegments(speakerSegments);
     }, [speakerSegments, options.editable]);
+
+    // Store displayedSegments in a ref for stable callbacks
+    const displayedSegmentsRef = useRef(displayedSegments);
+    displayedSegmentsRef.current = displayedSegments;
 
     // Track scroll state for banner minimization via scroll container
     useEffect(() => {
@@ -60,6 +72,44 @@ export default function Transcript() {
         return () => container.removeEventListener('scroll', handleScroll);
     }, []);
 
+    // Track segment containing the current playback time. Polled from a ref to
+    // avoid re-rendering the transcript on every video tick. Only enabled in
+    // fisheye mode — default view doesn't read it.
+    useEffect(() => {
+        if (!isFisheye) {
+            setActiveSegmentIndex(null);
+            return;
+        }
+        const recompute = () => {
+            const now = currentTimeRef.current;
+            const segs = displayedSegmentsRef.current;
+            if (!segs.length) {
+                setActiveSegmentIndex(null);
+                return;
+            }
+            // Linear scan is fine: invoked at 4Hz, segments rarely exceed a few hundred.
+            let found: number | null = null;
+            for (let i = 0; i < segs.length; i++) {
+                if (now >= segs[i].startTimestamp && now <= segs[i].endTimestamp) {
+                    found = i;
+                    break;
+                }
+                if (segs[i].startTimestamp > now) {
+                    found = Math.max(0, i - 1);
+                    break;
+                }
+            }
+            if (found === null) found = segs.length - 1;
+            setActiveSegmentIndex(prev => (prev === found ? prev : found));
+        };
+        recompute();
+        const id = setInterval(recompute, 250);
+        return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isFisheye, displayedSegments.length]);
+
+    const centerIndex = useFisheyeCenter(activeSegmentIndex);
+
     // Handle highlight editing initialization from URL
     useEffect(() => {
         const highlightId = searchParams.get('highlight');
@@ -70,10 +120,6 @@ export default function Transcript() {
             }
         }
     }, [searchParams, getHighlight, enterEditMode, editingHighlight?.id]);
-
-    // Store displayedSegments in a ref for stable IntersectionObserver callback
-    const displayedSegmentsRef = useRef(displayedSegments);
-    displayedSegmentsRef.current = displayedSegments;
 
     // Store setCurrentScrollInterval in a ref for stable access from observer callback
     const setCurrentScrollIntervalRef = useRef(setCurrentScrollInterval);
@@ -167,19 +213,28 @@ export default function Transcript() {
             )}
             <UtteranceContextMenu>
                 <div ref={containerRef} role="list" aria-label={t('transcript')}>
-                {displayedSegments.map((segment, index: number) => (
-                    <div
-                        key={index}
-                        id={createSegmentId(index)}
-                        className="content-visibility-auto"
-                        role="listitem"
-                    >
-                        <SpeakerSegment
-                            segment={segment}
-                            isFirstSegment={index === 0}
-                        />
-                    </div>
-                ))}
+                {displayedSegments.map((segment, index: number) => {
+                    const mode = isFisheye && centerIndex !== null
+                        ? fisheyeModeForDistance(index - centerIndex)
+                        : 'focus';
+                    return (
+                        <div
+                            key={index}
+                            id={createSegmentId(index)}
+                            className="content-visibility-auto"
+                            role="listitem"
+                        >
+                            {mode === 'context' ? (
+                                <SegmentContext segment={segment} />
+                            ) : (
+                                <SpeakerSegment
+                                    segment={segment}
+                                    isFirstSegment={index === 0}
+                                />
+                            )}
+                        </div>
+                    );
+                })}
                 </div>
             </UtteranceContextMenu>
         </div>

--- a/src/components/persons/PersonBadge.tsx
+++ b/src/components/persons/PersonBadge.tsx
@@ -122,6 +122,8 @@ interface PersonBadgeProps extends PersonDisplayProps {
     variant?: 'default' | 'inline';
     /** When true, the badge does not navigate or behave like a button (useful on the person's own page). */
     disableNavigation?: boolean;
+    /** When true with variant="inline", show only the surname. */
+    lastNameOnly?: boolean;
 }
 
 function PersonBadge({
@@ -141,6 +143,7 @@ function PersonBadge({
     size = 'md',
     variant = 'default',
     disableNavigation = false,
+    lastNameOnly = false,
 }: PersonBadgeProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
@@ -182,7 +185,9 @@ function PersonBadge({
                 )}
                 <span className="text-sm font-medium truncate">
                     {person ? (
-                        preferFullName ? person.name : formatSurnameFirst(person.name)
+                        lastNameOnly
+                            ? formatSurnameFirst(person.name).split(/\s+/)[0]
+                            : preferFullName ? person.name : formatSurnameFirst(person.name)
                     ) : (
                         speakerTag?.label
                     )}

--- a/src/hooks/__tests__/useFisheyeCenter.test.tsx
+++ b/src/hooks/__tests__/useFisheyeCenter.test.tsx
@@ -1,0 +1,18 @@
+import { renderHook } from '@testing-library/react';
+import { useFisheyeCenter } from '../useFisheyeCenter';
+
+describe('useFisheyeCenter', () => {
+    it('mirrors the active segment index', () => {
+        const { result, rerender } = renderHook(({ idx }: { idx: number | null }) => useFisheyeCenter(idx), {
+            initialProps: { idx: 5 },
+        });
+        expect(result.current).toBe(5);
+        rerender({ idx: 12 });
+        expect(result.current).toBe(12);
+    });
+
+    it('returns null when no segment is active', () => {
+        const { result } = renderHook(() => useFisheyeCenter(null));
+        expect(result.current).toBeNull();
+    });
+});

--- a/src/hooks/__tests__/useViewMode.test.tsx
+++ b/src/hooks/__tests__/useViewMode.test.tsx
@@ -1,0 +1,104 @@
+import { act, renderHook } from '@testing-library/react';
+import { useViewMode, __resetViewModeStoreForTests } from '../useViewMode';
+
+const STORAGE_KEY = 'opencouncil.transcript.viewMode';
+
+function setLocation(search: string) {
+    window.history.replaceState(null, '', `/${search ? `?${search}` : ''}`);
+}
+
+describe('useViewMode', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+        setLocation('');
+        __resetViewModeStoreForTests();
+    });
+
+    it('defaults to default mode when neither URL nor storage is set', () => {
+        const { result } = renderHook(() => useViewMode());
+        expect(result.current[0]).toBe('default');
+    });
+
+    it('reads from localStorage on first mount', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'fisheye');
+        const { result } = renderHook(() => useViewMode());
+        expect(result.current[0]).toBe('fisheye');
+    });
+
+    it('URL param overrides localStorage and is mirrored to storage', () => {
+        window.localStorage.setItem(STORAGE_KEY, 'default');
+        setLocation('mode=fisheye');
+        const { result } = renderHook(() => useViewMode());
+        expect(result.current[0]).toBe('fisheye');
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe('fisheye');
+    });
+
+    it('toggle updates both URL and storage', () => {
+        const { result } = renderHook(() => useViewMode());
+        act(() => result.current[1]('fisheye'));
+        expect(result.current[0]).toBe('fisheye');
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe('fisheye');
+        expect(window.location.search).toContain('mode=fisheye');
+    });
+
+    it('toggle propagates to every consumer of the hook', () => {
+        // Two independent useViewMode() calls in different components must
+        // stay in sync — this is the bug that motivated the rewrite.
+        const { result: a } = renderHook(() => useViewMode());
+        const { result: b } = renderHook(() => useViewMode());
+        expect(a.current[0]).toBe('default');
+        expect(b.current[0]).toBe('default');
+        act(() => a.current[1]('fisheye'));
+        expect(a.current[0]).toBe('fisheye');
+        expect(b.current[0]).toBe('fisheye');
+    });
+
+    it('removes mode param from URL when reverting to default', () => {
+        setLocation('mode=fisheye&other=1');
+        const { result } = renderHook(() => useViewMode());
+        act(() => result.current[1]('default'));
+        expect(window.location.search).not.toContain('mode=');
+        expect(window.location.search).toContain('other=1');
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe('default');
+    });
+
+    it('a second mount with no URL param keeps the active mode (no storage clobber)', () => {
+        // Simulates navigating to a new transcript page after toggling fisheye.
+        // The new page has no ?mode= in its URL — the preference must persist
+        // without being reset by some lingering "default" value in storage.
+        const { result, unmount } = renderHook(() => useViewMode());
+        act(() => result.current[1]('fisheye'));
+        unmount();
+        setLocation('');
+        const { result: next } = renderHook(() => useViewMode());
+        expect(next.current[0]).toBe('fisheye');
+    });
+
+    it('a second mount with ?mode=default explicitly overrides current state', () => {
+        const { result, unmount } = renderHook(() => useViewMode());
+        act(() => result.current[1]('fisheye'));
+        unmount();
+        setLocation('mode=default');
+        const { result: next } = renderHook(() => useViewMode());
+        expect(next.current[0]).toBe('default');
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBe('default');
+    });
+
+    it('ignores unknown URL param values', () => {
+        setLocation('mode=garbage');
+        const { result } = renderHook(() => useViewMode());
+        expect(result.current[0]).toBe('default');
+    });
+
+    it('syncs to a storage event from another tab', () => {
+        const { result } = renderHook(() => useViewMode());
+        expect(result.current[0]).toBe('default');
+        act(() => {
+            window.dispatchEvent(new StorageEvent('storage', {
+                key: STORAGE_KEY,
+                newValue: 'fisheye',
+            }));
+        });
+        expect(result.current[0]).toBe('fisheye');
+    });
+});

--- a/src/hooks/useFisheyeCenter.ts
+++ b/src/hooks/useFisheyeCenter.ts
@@ -1,0 +1,12 @@
+/**
+ * The fisheye center is whatever segment is currently playing. Scroll position
+ * is intentionally ignored: the user wanted layout to change only when
+ * playback advances (naturally or via clicking a row to play it from there),
+ * never as a side-effect of scrolling.
+ *
+ * This is kept as a hook (not just `activeSegmentIndex` inline) so the rule
+ * stays documented in one place and remains easy to evolve.
+ */
+export function useFisheyeCenter(activeSegmentIndex: number | null): number | null {
+    return activeSegmentIndex;
+}

--- a/src/hooks/useViewMode.ts
+++ b/src/hooks/useViewMode.ts
@@ -92,6 +92,15 @@ function hydrate(): void {
     }
 }
 
+// Seed the store eagerly at module evaluation so getSnapshot() already returns
+// the right mode on the very first render. hydrate() is SSR-safe (no-ops while
+// window is undefined), and useSyncExternalStore applies a client snapshot that
+// differs from the server snapshot before paint — so a ?mode=fisheye link no
+// longer renders every segment full-height and then collapses (a visible layout
+// shift on long transcripts). The mount effect below stays as the
+// cross-navigation refresh; setCurrent is a no-op when the value is unchanged.
+hydrate();
+
 /**
  * Test-only: reset module state between tests. Keep it gated to NODE_ENV
  * !== 'production' so it isn't reachable from production bundles.

--- a/src/hooks/useViewMode.ts
+++ b/src/hooks/useViewMode.ts
@@ -1,0 +1,49 @@
+"use client";
+import { useCallback, useEffect, useState } from 'react';
+
+export type ViewMode = 'default' | 'fisheye';
+
+const PARAM = 'mode';
+
+function readFromUrl(): ViewMode | null {
+    if (typeof window === 'undefined') return null;
+    const p = new URLSearchParams(window.location.search).get(PARAM);
+    return p === 'fisheye' ? 'fisheye' : p === 'default' ? 'default' : null;
+}
+
+function writeToUrl(mode: ViewMode): void {
+    if (typeof window === 'undefined') return;
+    const url = new URL(window.location.href);
+    if (mode === 'default') url.searchParams.delete(PARAM);
+    else url.searchParams.set(PARAM, mode);
+    window.history.replaceState(null, '', url.toString());
+}
+
+/**
+ * Reads/writes the transcript view mode. The URL is the canonical signal for
+ * the active session, but we deliberately avoid next/navigation hooks here:
+ * `useSearchParams` in a "use client" page without a Suspense boundary can
+ * tear down React's render dispatcher during SSR error fallback and surface
+ * as a cryptic `Cannot read properties of null (reading 'useContext')` at
+ * Next.js's internal ErrorBoundary.
+ *
+ * Instead we read window.location on mount and write back with
+ * `history.replaceState`, which keeps URL state in sync without router
+ * coupling and is SSR-safe (initial state is always 'default', then hydrates
+ * cleanly to whatever the URL says).
+ */
+export function useViewMode(): [ViewMode, (next: ViewMode) => void] {
+    const [mode, setModeState] = useState<ViewMode>('default');
+
+    useEffect(() => {
+        const fromUrl = readFromUrl();
+        if (fromUrl !== null) setModeState(fromUrl);
+    }, []);
+
+    const setMode = useCallback((next: ViewMode) => {
+        setModeState(next);
+        writeToUrl(next);
+    }, []);
+
+    return [mode, setMode];
+}

--- a/src/hooks/useViewMode.ts
+++ b/src/hooks/useViewMode.ts
@@ -1,14 +1,27 @@
 "use client";
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
 
 export type ViewMode = 'default' | 'fisheye';
 
 const PARAM = 'mode';
+const STORAGE_KEY = 'opencouncil.transcript.viewMode';
+
+function parseMode(raw: string | null | undefined): ViewMode | null {
+    return raw === 'fisheye' ? 'fisheye' : raw === 'default' ? 'default' : null;
+}
 
 function readFromUrl(): ViewMode | null {
     if (typeof window === 'undefined') return null;
-    const p = new URLSearchParams(window.location.search).get(PARAM);
-    return p === 'fisheye' ? 'fisheye' : p === 'default' ? 'default' : null;
+    return parseMode(new URLSearchParams(window.location.search).get(PARAM));
+}
+
+function readFromStorage(): ViewMode | null {
+    if (typeof window === 'undefined') return null;
+    try {
+        return parseMode(window.localStorage.getItem(STORAGE_KEY));
+    } catch {
+        return null;
+    }
 }
 
 function writeToUrl(mode: ViewMode): void {
@@ -19,30 +32,122 @@ function writeToUrl(mode: ViewMode): void {
     window.history.replaceState(null, '', url.toString());
 }
 
+function writeToStorage(mode: ViewMode): void {
+    if (typeof window === 'undefined') return;
+    try {
+        window.localStorage.setItem(STORAGE_KEY, mode);
+    } catch {
+        // Storage may be unavailable (private mode, quota, disabled cookies).
+    }
+}
+
+// Module-level store, shared across every useViewMode() consumer so the
+// fisheye toggle and the transcript stay in sync (each useState would
+// otherwise give every consumer its own private cell).
+//
+// HMR caveat: during dev hot-module replacement the old module instance can
+// stay alive while the new one starts fresh, so `listeners` may briefly hold
+// stale callbacks and `current` may diverge from what a freshly-mounted
+// consumer sees. A full reload clears it. Production is unaffected — modules
+// are evaluated once. No workaround here; if it gets noisy in dev, wire up
+// `import.meta.hot` to clear `listeners` and reset `current`.
+let current: ViewMode = 'default';
+let hasInitializedFromStorage = false;
+const listeners = new Set<() => void>();
+
+function setCurrent(next: ViewMode): void {
+    if (current === next) return;
+    current = next;
+    listeners.forEach(l => l());
+}
+
+function subscribe(cb: () => void): () => void {
+    listeners.add(cb);
+    return () => { listeners.delete(cb); };
+}
+
+const getSnapshot = (): ViewMode => current;
+const getServerSnapshot = (): ViewMode => 'default';
+
 /**
- * Reads/writes the transcript view mode. The URL is the canonical signal for
- * the active session, but we deliberately avoid next/navigation hooks here:
- * `useSearchParams` in a "use client" page without a Suspense boundary can
- * tear down React's render dispatcher during SSR error fallback and surface
- * as a cryptic `Cannot read properties of null (reading 'useContext')` at
- * Next.js's internal ErrorBoundary.
+ * Re-evaluated on every mount. An explicit URL ?mode= always wins (per-link
+ * override) and is mirrored to storage; otherwise the very first init reads
+ * storage so a previously-chosen preference carries into new sessions.
+ * Subsequent mounts without a URL value leave the store alone — that way
+ * navigating between transcripts keeps the user's last toggle decision
+ * without storage ever clobbering it.
+ */
+function hydrate(): void {
+    if (typeof window === 'undefined') return;
+    const fromUrl = readFromUrl();
+    if (fromUrl !== null) {
+        writeToStorage(fromUrl);
+        setCurrent(fromUrl);
+        return;
+    }
+    if (!hasInitializedFromStorage) {
+        hasInitializedFromStorage = true;
+        const fromStorage = readFromStorage();
+        if (fromStorage !== null) setCurrent(fromStorage);
+    }
+}
+
+/**
+ * Test-only: reset module state between tests. Keep it gated to NODE_ENV
+ * !== 'production' so it isn't reachable from production bundles.
+ */
+export function __resetViewModeStoreForTests(): void {
+    if (process.env.NODE_ENV === 'production') return;
+    current = 'default';
+    hasInitializedFromStorage = false;
+    listeners.clear();
+}
+
+/**
+ * Reads/writes the transcript view mode with localStorage as the persistent
+ * source of truth and the URL as a per-link override. Backed by
+ * useSyncExternalStore so every consumer in the tree re-renders when the
+ * toggle is clicked, with no Provider plumbing.
  *
- * Instead we read window.location on mount and write back with
- * `history.replaceState`, which keeps URL state in sync without router
- * coupling and is SSR-safe (initial state is always 'default', then hydrates
- * cleanly to whatever the URL says).
+ * Deliberately avoids next/navigation hooks (useSearchParams/useRouter):
+ * useSearchParams in a "use client" page without a Suspense boundary tore
+ * down React's render dispatcher during SSR error fallback and surfaced as
+ * `Cannot read properties of null (reading 'useContext')` from Next.js's
+ * internal ErrorBoundary. Reading window.location on mount and writing back
+ * with history.replaceState is SSR-safe.
  */
 export function useViewMode(): [ViewMode, (next: ViewMode) => void] {
-    const [mode, setModeState] = useState<ViewMode>('default');
+    const mode = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
     useEffect(() => {
-        const fromUrl = readFromUrl();
-        if (fromUrl !== null) setModeState(fromUrl);
+        hydrate();
+    }, []);
+
+    // Cross-tab sync: if storage changes in another tab, mirror it here. Skip
+    // when the value matches what we already have to avoid a redundant render.
+    useEffect(() => {
+        const onStorage = (e: StorageEvent) => {
+            // key === null means another tab called localStorage.clear(),
+            // which clears every key including ours.
+            if (e.key !== null && e.key !== STORAGE_KEY) return;
+            // newValue === null means removeItem/clear — reset to default
+            // so the tab matches the new empty-storage state.
+            setCurrent(parseMode(e.newValue) ?? 'default');
+        };
+        window.addEventListener('storage', onStorage);
+        return () => window.removeEventListener('storage', onStorage);
     }, []);
 
     const setMode = useCallback((next: ViewMode) => {
-        setModeState(next);
+        if (current === next) {
+            // Still write — the URL may not yet have the param even though
+            // the in-memory value matches (e.g. seeded from storage).
+            writeToUrl(next);
+            return;
+        }
         writeToUrl(next);
+        writeToStorage(next);
+        setCurrent(next);
     }, []);
 
     return [mode, setMode];

--- a/src/lib/utils/__tests__/fisheye.test.ts
+++ b/src/lib/utils/__tests__/fisheye.test.ts
@@ -1,0 +1,22 @@
+import { fisheyeModeForDistance } from '../fisheye';
+
+describe('fisheyeModeForDistance', () => {
+    it('returns focus for the center segment and immediate neighbors', () => {
+        expect(fisheyeModeForDistance(0)).toBe('focus');
+        expect(fisheyeModeForDistance(1)).toBe('focus');
+        expect(fisheyeModeForDistance(-1)).toBe('focus');
+    });
+
+    it('returns context for everything beyond distance 1', () => {
+        expect(fisheyeModeForDistance(2)).toBe('context');
+        expect(fisheyeModeForDistance(-2)).toBe('context');
+        expect(fisheyeModeForDistance(50)).toBe('context');
+        expect(fisheyeModeForDistance(-100)).toBe('context');
+    });
+
+    it('is symmetric around zero', () => {
+        for (let d = 0; d < 10; d++) {
+            expect(fisheyeModeForDistance(d)).toBe(fisheyeModeForDistance(-d));
+        }
+    });
+});

--- a/src/lib/utils/fisheye.ts
+++ b/src/lib/utils/fisheye.ts
@@ -1,0 +1,12 @@
+export type FisheyeMode = 'focus' | 'context';
+
+const FOCUS_RADIUS = 1;
+
+/**
+ * Maps a distance-from-center to a render mode.
+ * Three segments get the focus treatment: the active segment plus one on
+ * either side. Everything else renders in the compact context mode.
+ */
+export function fisheyeModeForDistance(distance: number): FisheyeMode {
+    return Math.abs(distance) <= FOCUS_RADIUS ? 'focus' : 'context';
+}


### PR DESCRIPTION
## Summary

Adds an opt-in "fish-eye" view mode for the transcript page. When it's on, only the segment that's currently playing and its two immediate neighbors render in full; everything else collapses to a one-line row with the speaker's surname, a short preview, and a timestamp. The focus window only moves when playback moves. Scrolling never shifts it. Clicking any compact row seeks to that segment and starts playing, which is the only way to change what's in focus.

The point is to make long meetings scannable. You can see what's playing without losing the shape of the rest of the agenda below.

The preview text in compact rows is the verbatim utterance for short speeches (≤ ~2 sentences, ≤ 160 chars). For longer ones it falls back to the AI summary, with a small Bot icon so it's obvious which rows are synthetic and which are real speech.

[597261238-b65abfb3-49f2-461b-949a-528c0325117b.webm](https://github.com/user-attachments/assets/26732cee-1b92-4e0d-b613-5c60c1f72dc8)



## Changes

- New `useViewMode` hook on `useSyncExternalStore` so the toggle button and the transcript read from the same state cell. A `?mode=fisheye` URL param wins per-link; otherwise the choice is saved to localStorage and synced across tabs via the storage event.
- New `FisheyeToggle` button. On mobile it sits next to the orange show/hide-controls button and animates together with it when the controls bar collapses.
- Controls visibility moved out of `TranscriptControls` and into `LayoutContext` so the toggle can react to it.
- New pure mapper `fisheyeModeForDistance` and a `SegmentContext` compact row component.
- i18n keys added to `messages/{en,el}/transcript.json`. These override the monolithic file via the shallow merge in `src/i18n/request.ts`, so the keys go there, not in `messages/{en,el}.json`.
- `PersonBadge` gets an optional `lastNameOnly` prop for the inline variant.

## Test plan

- [ ] Turn fish-eye on. Only the active segment and one row on each side render fully; everything else is compact.
- [ ] Let playback advance across segments. Focus follows without a scroll jump.
- [ ] Scroll up and down with fish-eye on. The focus window does NOT move.
- [ ] Click a compact row. It seeks to that segment and starts playing.
- [ ] Reload the page. The chosen mode persists.
- [ ] Open a `?mode=fisheye` link in a tab where the saved mode is default. URL wins.
- [ ] Open the same page in two tabs and toggle in one. The other updates.
- [ ] A short speech shows the verbatim text. A long one shows the AI summary with a Bot icon.
- [ ] Mobile: hide and show the controls bar. The fish-eye button animates with it.
- [ ] `npm test` passes locally (703).

Closes #109

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an opt-in "fish-eye" view mode for the transcript page: the active segment and its two immediate neighbors render fully while everything else collapses to a compact one-line row. The architecture is solid — `useSyncExternalStore` with eager module-level hydration, a stable `VideoActionsContext` to avoid per-tick re-renders on compact rows, and a lifted `LayoutContext` for controls visibility.

- **`useViewMode`** is backed by a module-level store that seeds from URL/localStorage before the first render, eliminating the layout-shift on `?mode=fisheye` links, and syncs across tabs via the storage event.
- **`SegmentContext`** renders the compact row and correctly subscribes only to `useVideoActions()` (not the hot `VideoContext`), so it avoids per-frame re-renders during playback.
- **`handleActivate`** only calls `seekToWithoutScroll` — the video stays paused if it was already paused — which contradicts the PR description and test plan item 3 ("seeks to that segment and starts playing"). `setIsPlaying` was added to `VideoActionsContext` in this PR but is never invoked from the click handler.

<h3>Confidence Score: 4/5</h3>

Safe to merge after confirming whether clicking a compact row should start playback — the code explicitly keeps the user paused, while the PR description and test plan say it starts playing.

The click handler in SegmentContext only seeks without starting playback, directly contradicting test plan item 3. If the intent is 'seek only' (the code comment says so), the description and test plan need updating. If the intent is 'seek and play', setIsPlaying(true) is missing from handleActivate.

src/components/meetings/transcript/SegmentContext.tsx — the handleActivate function and whether it should call setIsPlaying(true)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/meetings/transcript/SegmentContext.tsx | New compact context-row component; now correctly uses useVideoActions() to avoid per-frame re-renders, but handleActivate does not call setIsPlaying(true) despite the PR description and test plan requiring it |
| src/hooks/useViewMode.ts | New module-level store backed by useSyncExternalStore; eagerly hydrates from URL/localStorage at module-eval time to avoid layout shift, correctly handles cross-tab sync via storage event |
| src/hooks/useFisheyeCenter.ts | Thin passthrough hook that returns activeSegmentIndex unchanged; kept as a hook so the 'center follows playback, not scroll' invariant is documented in one place |
| src/components/meetings/transcript/Transcript.tsx | Adds fisheye rendering path: 4Hz setInterval polling currentTimeRef drives activeSegmentIndex; fisheyeModeForDistance gates SpeakerSegment vs SegmentContext per row |
| src/components/meetings/VideoProvider.tsx | Adds setIsPlaying to the stable VideoActionsContext so consumers can trigger playback without subscribing to the hot VideoContext |
| src/components/meetings/CouncilMeetingWrapper.tsx | Lifts isControlsVisible/setIsControlsVisible into LayoutContext; resize handler now only forces-show controls on landscape and never force-hides on narrow, preserving the user's toggle choice |
| src/components/persons/PersonBadge.tsx | Adds optional lastNameOnly prop; correctly extracts first token of formatSurnameFirst output (which uses space, not comma, as separator) |
| src/lib/utils/fisheye.ts | Pure utility mapping distance-from-center to FisheyeMode; well-tested with symmetric and boundary cases |
| src/components/meetings/transcript/FisheyeToggle.tsx | Simple toggle button that reads/writes from useViewMode; correctly suppressed in editable mode |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/meetings/transcript/SegmentContext.tsx`, line 333-336 ([link](https://github.com/schemalabz/opencouncil/blob/f667a96960da0323e15e4869c3e46011ac9de638/src/components/meetings/transcript/SegmentContext.tsx#L333-L336)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Unhandled rejection in `handleActivate`**

   `setIsPlaying` is backed by `stableSetIsPlaying`, which is an `async` function (it `await`s `playVideoRef.current()`). The interface exposes it as `(isPlaying: boolean) => void`, hiding the async nature. If the underlying `playVideo` call rejects (e.g., media not ready, browser autoplay policy), the rejected promise is silently swallowed here — no error boundary or console output, and the seek has already been committed. This leaves the player seeked to the new position but not playing, with no feedback to the user.

   Consider wrapping in a `.catch` so failures are at least logged, or aligning the interface signature with the async reality.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/meetings/transcript/SegmentContext.tsx
   Line: 333-336

   Comment:
   **Unhandled rejection in `handleActivate`**

   `setIsPlaying` is backed by `stableSetIsPlaying`, which is an `async` function (it `await`s `playVideoRef.current()`). The interface exposes it as `(isPlaying: boolean) => void`, hiding the async nature. If the underlying `playVideo` call rejects (e.g., media not ready, browser autoplay policy), the rejected promise is silently swallowed here — no error boundary or console output, and the seek has already been committed. This leaves the player seeked to the new position but not playing, with no feedback to the user.

   Consider wrapping in a `.catch` so failures are at least logged, or aligning the interface signature with the async reality.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2Fmeetings%2Ftranscript%2FSegmentContext.tsx%3A65-71%0A**Clicking%20a%20compact%20row%20does%20not%20start%20playback**%0A%0A%60handleActivate%60%20only%20calls%20%60seekToWithoutScroll%60%20%E2%80%94%20it%20never%20calls%20%60setIsPlaying%28true%29%60.%20The%20PR%20description%20states%20%22clicking%20any%20compact%20row%20seeks%20to%20that%20segment%20and%20**starts%20playing**%22%20and%20test%20plan%20item%203%20says%20%22It%20seeks%20to%20that%20segment%20and%20**starts%20playing**.%22%20With%20this%20implementation%2C%20a%20paused%20user%20who%20clicks%20a%20row%20stays%20paused.%20The%20%60setIsPlaying%60%20function%20was%20added%20to%20%60VideoActionsContext%60%20in%20this%20same%20PR%20%28presumably%20for%20exactly%20this%20call-site%29%20but%20is%20never%20invoked%20here%20%E2%80%94%20the%20test%20plan%20check%20would%20fail%20as-written.%0A%0A&repo=schemalabz%2Fopencouncil&pr=379&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/components/meetings/transcript/SegmentContext.tsx:65-71
**Clicking a compact row does not start playback**

`handleActivate` only calls `seekToWithoutScroll` — it never calls `setIsPlaying(true)`. The PR description states "clicking any compact row seeks to that segment and **starts playing**" and test plan item 3 says "It seeks to that segment and **starts playing**." With this implementation, a paused user who clicks a row stays paused. The `setIsPlaying` function was added to `VideoActionsContext` in this same PR (presumably for exactly this call-site) but is never invoked here — the test plan check would fail as-written.


`````

</details>

<sub>Reviews (12): Last reviewed commit: ["fix(transcript): apply view mode before ..."](https://github.com/schemalabz/opencouncil/commit/359a77b032fe68350fd271a4a1d2db1158d0da5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33653311)</sub>

<!-- /greptile_comment -->