### PR TITLE
feat(api): add utterance context endpoint

### DIFF
--- a/src/app/api/utterance/[utteranceId]/context/route.ts
+++ b/src/app/api/utterance/[utteranceId]/context/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getUtteranceContext } from '@/lib/db/utteranceContext';
+
+const DEFAULT_WINDOW = 10;
+const MAX_WINDOW = 50;
+
+function parseWindow(raw: string | null, fallback: number): number | null {
+    if (raw === null) return fallback;
+    if (!/^\d+$/.test(raw)) return null;
+    const n = Number(raw);
+    if (n > MAX_WINDOW) return null;
+    return n;
+}
+
+export async function GET(
+    request: NextRequest,
+    { params }: { params: { utteranceId: string } }
+) {
+    const { searchParams } = new URL(request.url);
+
+    const before = parseWindow(searchParams.get('before'), DEFAULT_WINDOW);
+    const after = parseWindow(searchParams.get('after'), DEFAULT_WINDOW);
+
+    if (before === null || after === null) {
+        return NextResponse.json(
+            { error: `before/after must be integers in [0, ${MAX_WINDOW}]` },
+            { status: 400 }
+        );
+    }
+
+    try {
+        const result = await getUtteranceContext(params.utteranceId, before, after);
+        if (!result) {
+            return NextResponse.json({ error: 'Utterance not found' }, { status: 404 });
+        }
+        return NextResponse.json(result);
+    } catch (error) {
+        console.error('Error fetching utterance context:', error);
+        return NextResponse.json(
+            { error: 'Internal server error' },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/utterance/[utteranceId]/context/route.ts
+++ b/src/app/api/utterance/[utteranceId]/context/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getUtteranceContext } from '@/lib/db/utteranceContext';
+import { handleApiError } from '@/lib/api/errors';
 
 const DEFAULT_WINDOW = 10;
 const MAX_WINDOW = 50;
@@ -29,16 +30,12 @@ export async function GET(
     }
 
     try {
-        const result = await getUtteranceContext(params.utteranceId, before, after);
+        const result = await getUtteranceContext(request, params.utteranceId, before, after);
         if (!result) {
             return NextResponse.json({ error: 'Utterance not found' }, { status: 404 });
         }
         return NextResponse.json(result);
     } catch (error) {
-        console.error('Error fetching utterance context:', error);
-        return NextResponse.json(
-            { error: 'Internal server error' },
-            { status: 500 }
-        );
+        return handleApiError(error, 'Internal server error');
     }
 }

--- a/src/lib/db/utteranceContext.ts
+++ b/src/lib/db/utteranceContext.ts
@@ -1,0 +1,118 @@
+import { Prisma } from '@prisma/client';
+import prisma from './prisma';
+import { isUserAuthorizedToEdit } from '../auth';
+
+const neighborSelect = {
+    id: true,
+    text: true,
+    startTimestamp: true,
+    endTimestamp: true,
+    speakerSegment: { select: { speakerTagId: true } },
+} satisfies Prisma.UtteranceSelect;
+
+type NeighborRow = Prisma.UtteranceGetPayload<{ select: typeof neighborSelect }>;
+
+export type UtteranceContextNeighbor = {
+    id: string;
+    text: string;
+    start: number;
+    end: number;
+    speakerTagId: string;
+};
+
+export type UtteranceContext = {
+    meeting: { id: string; cityId: string; name: string; dateTime: string };
+    before: UtteranceContextNeighbor[];
+    after: UtteranceContextNeighbor[];
+};
+
+const toNeighbor = (u: NeighborRow): UtteranceContextNeighbor => ({
+    id: u.id,
+    text: u.text,
+    start: u.startTimestamp,
+    end: u.endTimestamp,
+    speakerTagId: u.speakerSegment.speakerTagId,
+});
+
+export async function getUtteranceContext(
+    utteranceId: string,
+    before: number,
+    after: number
+): Promise<UtteranceContext | null> {
+    const target = await prisma.utterance.findUnique({
+        where: { id: utteranceId },
+        select: {
+            id: true,
+            startTimestamp: true,
+            speakerSegment: {
+                select: {
+                    meetingId: true,
+                    cityId: true,
+                    meeting: {
+                        select: { name: true, dateTime: true, released: true },
+                    },
+                },
+            },
+        },
+    });
+
+    if (!target) return null;
+
+    const { meetingId, cityId, meeting } = target.speakerSegment;
+
+    if (!meeting.released && !(await isUserAuthorizedToEdit({ cityId }))) {
+        return null;
+    }
+
+    const segmentFilter = {
+        speakerSegment: { is: { meetingId, cityId } },
+    };
+
+    const [beforeRows, afterRows] = await Promise.all<NeighborRow[]>([
+        before === 0
+            ? Promise.resolve([])
+            : prisma.utterance.findMany({
+                where: {
+                    ...segmentFilter,
+                    OR: [
+                        { startTimestamp: { lt: target.startTimestamp } },
+                        {
+                            startTimestamp: target.startTimestamp,
+                            id: { lt: target.id },
+                        },
+                    ],
+                },
+                orderBy: [{ startTimestamp: 'desc' }, { id: 'desc' }],
+                take: before,
+                select: neighborSelect,
+            }),
+        after === 0
+            ? Promise.resolve([])
+            : prisma.utterance.findMany({
+                where: {
+                    ...segmentFilter,
+                    OR: [
+                        { startTimestamp: { gt: target.startTimestamp } },
+                        {
+                            startTimestamp: target.startTimestamp,
+                            id: { gt: target.id },
+                        },
+                    ],
+                },
+                orderBy: [{ startTimestamp: 'asc' }, { id: 'asc' }],
+                take: after,
+                select: neighborSelect,
+            }),
+    ]);
+
+    return {
+        meeting: {
+            id: meetingId,
+            cityId,
+            name: meeting.name,
+            dateTime: meeting.dateTime.toISOString(),
+        },
+        before: beforeRows.slice().reverse().map(toNeighbor),
+        after: afterRows.map(toNeighbor),
+    };
+}

--- a/src/lib/db/utteranceContext.ts
+++ b/src/lib/db/utteranceContext.ts
@@ -1,6 +1,7 @@
+import { NextRequest } from 'next/server';
 import { Prisma } from '@prisma/client';
 import prisma from './prisma';
-import { isUserAuthorizedToEdit } from '../auth';
+import { isUserAuthorizedToEdit, validateBearerAuth } from '../auth';
 
 const neighborSelect = {
     id: true,
@@ -35,6 +36,7 @@ const toNeighbor = (u: NeighborRow): UtteranceContextNeighbor => ({
 });
 
 export async function getUtteranceContext(
+    request: NextRequest,
     utteranceId: string,
     before: number,
     after: number
@@ -60,8 +62,11 @@ export async function getUtteranceContext(
 
     const { meetingId, cityId, meeting } = target.speakerSegment;
 
-    if (!meeting.released && !(await isUserAuthorizedToEdit({ cityId }))) {
-        return null;
+    if (!meeting.released) {
+        const bearer = await validateBearerAuth(request);
+        if (!bearer && !(await isUserAuthorizedToEdit({ cityId }))) {
+            return null;
+        }
     }
 
     const segmentFilter = {

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -197,6 +197,51 @@ paths:
         '500':
           description: Failed to fetch person
 
+  # Utterances
+  /api/utterance/{utteranceId}/context:
+    get:
+      summary: Get utterance context (neighbors)
+      description: |
+        Returns N utterances immediately before and after the target utterance within
+        the same meeting, crossing speaker segments. Designed for transcript review
+        tools that already have the target utterance locally and only need surrounding
+        context to judge the flow of speech.
+      parameters:
+        - name: utteranceId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: before
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 50
+            default: 10
+        - name: after
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 50
+            default: 10
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UtteranceContext'
+        '400':
+          description: Invalid before/after parameter
+        '404':
+          description: Utterance not found
+        '500':
+          description: Internal server error
+
   # Search
   /api/search:
     post:
@@ -418,6 +463,47 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Word'
+
+    UtteranceContextNeighbor:
+      type: object
+      required: [id, text, start, end, speakerTagId]
+      properties:
+        id:
+          type: string
+        text:
+          type: string
+        start:
+          type: number
+        end:
+          type: number
+        speakerTagId:
+          type: string
+
+    UtteranceContext:
+      type: object
+      required: [meeting, before, after]
+      properties:
+        meeting:
+          type: object
+          required: [id, cityId, name, dateTime]
+          properties:
+            id:
+              type: string
+            cityId:
+              type: string
+            name:
+              type: string
+            dateTime:
+              type: string
+              format: date-time
+        before:
+          type: array
+          items:
+            $ref: '#/components/schemas/UtteranceContextNeighbor'
+        after:
+          type: array
+          items:
+            $ref: '#/components/schemas/UtteranceContextNeighbor'
 
     Word:
       type: object


### PR DESCRIPTION
## Summary
Adds `GET /api/utterance/[id]/context` — returns N utterances before and after a target utterance within the same meeting, crossing speaker segments.

For transcript review tools (correction QA, fine-tuning UI) that already have the target utterance locally and only need surrounding context to judge whether an edit fits the flow of speech.

Defaults: 10 before + 10 after. Max 50 each. When two utterances share a `startTimestamp`, ordering tie-breaks on `id`.

Response:
```json
{
  "meeting": { "id", "cityId", "name", "dateTime" },
  "before": [{ "id", "text", "start", "end", "speakerTagId" }],
  "after":  [{ "id", "text", "start", "end", "speakerTagId" }]
}
```

The existing `/api/utterance/[id]` redirect is untouched. 
`swagger.yaml` is updated with the new path and the `UtteranceContext` / `UtteranceContextNeighbor` schemas.

## Test plan
- [ ] No params returns 10+10
- [ ] `before=0&after=5` returns empty `before`, 5 `after`
- [ ] `before=51` returns 400
- [ ] Unknown id returns 404
- [ ] First utterance of a meeting returns empty `before`; last returns empty `after`
- [ ] Window spans multiple speaker segments

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `GET /api/utterance/[id]/context` — a new endpoint that returns N utterances before and after a target utterance within the same meeting, designed for transcript QA and fine-tuning tools. All issues raised in previous review threads (missing try/catch, hex-input parsing, unreleased-meeting auth gate, and service-key support via `validateBearerAuth`) have been addressed.

- **Route handler** (`route.ts`): validates `before`/`after` with a decimal-only regex, enforces the `MAX_WINDOW=50` cap, and wraps the DB call in a try/catch that routes errors through `handleApiError`.
- **DB helper** (`utteranceContext.ts`): fetches the target utterance first, checks `meeting.released`, then gates access via `validateBearerAuth` (service keys) or `isUserAuthorizedToEdit` (session users); neighbor rows are fetched in a single `Promise.all` and the `before` window is correctly reversed to chronological order before returning.
- **Swagger** (`swagger.yaml`): documents the new path plus `UtteranceContext` / `UtteranceContextNeighbor` schemas; a `401` status code (reachable when an invalid Bearer token is used against an unreleased meeting) is missing from the documented responses.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the auth gate correctly guards unreleased meetings for both session users and service API keys, and the DB queries are properly scoped by the composite meetingId+cityId key.

The three changed files introduce a well-contained read-only endpoint. The auth logic mirrors established patterns in the codebase, the query scoping is correct, and error handling is consistent with sibling routes. The only gap is a missing 401 entry in the swagger spec, which does not affect runtime behaviour.

No files require special attention; swagger.yaml has a minor documentation gap for the 401 status code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/api/utterance/[utteranceId]/context/route.ts | New GET handler with clean input validation, try/catch with handleApiError, and request forwarding to getUtteranceContext; all prior-thread concerns (missing try/catch, hex input parsing, auth forwarding) are fully addressed. |
| src/lib/db/utteranceContext.ts | DB helper now checks meeting.released before queries, calls validateBearerAuth for service keys and isUserAuthorizedToEdit for session users; neighborSelect is correctly typed with NeighborRow; before-window reversal logic is correct. |
| swagger.yaml | Adds /api/utterance/{utteranceId}/context path and UtteranceContext/UtteranceContextNeighbor schemas; documents 400/404/500 but omits 401, which is reachable when an invalid Bearer token is supplied against an unreleased meeting. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Route as GET /api/utterance/[id]/context
    participant DB as getUtteranceContext
    participant Prisma

    Client->>Route: "GET ?before=N&after=M"
    Route->>Route: parseWindow(before, after)
    alt invalid params
        Route-->>Client: 400 Bad Request
    end
    Route->>DB: getUtteranceContext(request, utteranceId, N, M)
    DB->>Prisma: findUnique(utteranceId) → target + meeting
    alt target not found
        DB-->>Route: null
        Route-->>Client: 404 Not Found
    end
    alt "meeting.released === false"
        DB->>DB: validateBearerAuth(request)
        alt invalid Bearer token
            DB-->>Route: throws UnauthorizedError
            Route-->>Client: 401 Unauthorized
        end
        DB->>DB: "isUserAuthorizedToEdit({cityId})"
        alt no auth
            DB-->>Route: null
            Route-->>Client: 404 Not Found
        end
    end
    DB->>Prisma: findMany(before utterances, desc)
    DB->>Prisma: findMany(after utterances, asc)
    DB->>DB: reverse(beforeRows).map(toNeighbor)
    DB-->>Route: UtteranceContext
    Route-->>Client: "200 { meeting, before[], after[] }"
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
swagger.yaml:238-243
The `401` status is reachable but undocumented. When a caller passes `Authorization: Bearer <invalid-key>` against an unreleased meeting, `validateBearerAuth` throws `UnauthorizedError`, which the route's catch block converts to a 401. Swagger clients that enumerate possible status codes will miss this branch.

```suggestion
        '400':
          description: Invalid before/after parameter
        '401':
          description: Invalid or revoked API key
        '404':
          description: Utterance not found or not accessible
        '500':
          description: Internal server error
```

`````

</details>

<sub>Reviews (10): Last reviewed commit: ["fix(api): accept service API keys on utt..."](https://github.com/schemalabz/opencouncil/commit/cf1ef5ef59e3922bd09e95fe8d653c3ce4ae96b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34127363)</sub>

<!-- /greptile_comment -->