### PR TITLE
feat(search): show administrative body on search result cards

### DIFF
--- a/src/components/subject-card.tsx
+++ b/src/components/subject-card.tsx
@@ -1,9 +1,9 @@
-import { City, CouncilMeeting, Party } from "@prisma/client";
+import { AdministrativeBody, City, CouncilMeeting, Party } from "@prisma/client";
 import { Statistics } from "@/lib/statistics";
 import { SubjectWithRelations } from "@/lib/db/subject";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "./ui/card";
 import Icon from "./icon";
-import { MapPin, ScrollText, Calendar, Loader2, Clock, MessageSquare } from "lucide-react";
+import { MapPin, ScrollText, Calendar, Loader2, Clock, MessageSquare, Landmark } from "lucide-react";
 import { cn, getPartyFromRoles } from "@/lib/utils";
 import { getNonAgendaLabel, getWithdrawnLabel } from "@/lib/utils/subjects";
 import { Link, useRouter } from "@/i18n/routing";
@@ -18,7 +18,7 @@ import { usePathname } from "next/navigation";
 interface SubjectCardProps {
     subject: SubjectWithRelations & { statistics?: Statistics };
     city: City;
-    meeting: CouncilMeeting;
+    meeting: CouncilMeeting & { administrativeBody?: AdministrativeBody | null };
     parties: Party[];
     persons: PersonWithRelations[];
     fullWidth?: boolean;
@@ -101,10 +101,16 @@ export function SubjectCard({ subject, city, meeting, parties, persons, fullWidt
                 {/* Header: topic icon + title + meta */}
                 <CardHeader className="flex flex-col gap-1.5 pb-2">
                     {showContext && (
-                        <div className="flex items-center gap-1 text-[10px] text-muted-foreground/70 -mt-1 -mb-1">
-                            <span className="truncate">
+                        <div className="flex flex-col gap-0.5 -mt-1 -mb-1">
+                            <span className="text-[10px] text-muted-foreground/70 truncate">
                                 {city.name} • {meeting.name}
                             </span>
+                            {meeting.administrativeBody && (
+                                <span className="flex items-center gap-1 text-[10px] font-medium text-muted-foreground min-w-0">
+                                    <Landmark className="w-3 h-3 shrink-0" />
+                                    <span className="truncate">{meeting.administrativeBody.name}</span>
+                                </span>
+                            )}
                         </div>
                     )}
                     <div className="flex flex-row items-center gap-1.5">

--- a/src/components/subject-card.tsx
+++ b/src/components/subject-card.tsx
@@ -101,22 +101,19 @@ export function SubjectCard({ subject, city, meeting, parties, persons, fullWidt
 
                 {/* Header: topic icon + title + meta */}
                 <CardHeader className="flex flex-col gap-1.5 pb-2">
-                    {showContext && (
-                        <div className="flex flex-col gap-0.5 text-[10px] text-muted-foreground/70 -mt-1 -mb-1 min-w-0">
-                            <span className="truncate min-w-0">
-                                {[city.name, meeting.administrativeBody?.name, meeting.name]
-                                    .filter(Boolean)
-                                    .join(" › ")}
-                            </span>
-                            <span className="truncate">{formatDate(new Date(meeting.dateTime))}</span>
-                        </div>
-                    )}
                     <div className="flex flex-row items-center gap-1.5">
                         <div className="p-1.5 rounded-full shrink-0 transition-colors duration-300" style={{ backgroundColor: subject.topic?.colorHex ? subject.topic.colorHex + "20" : "#e5e7eb" }}>
                             <Icon name={subject.topic?.icon || "hash"} color={subject.topic?.colorHex || "#9ca3af"} size={16} />
                         </div>
                         <CardTitle className="text-sm sm:text-base line-clamp-2 flex-1 group-hover/card:text-accent-foreground transition-colors duration-300">{subject.name}</CardTitle>
                     </div>
+                    {showContext && (
+                        <div className="text-[10px] text-muted-foreground/70">
+                            {[city.name, meeting.administrativeBody?.name, formatDate(new Date(meeting.dateTime))]
+                                .filter(Boolean)
+                                .join(" · ")}
+                        </div>
+                    )}
                     <div className="flex flex-row justify-between gap-2 text-xs text-muted-foreground">
                         <div className="flex items-center gap-1 min-w-0 flex-1">
                             <MapPin className="w-3.5 h-3.5 shrink-0" />

--- a/src/components/subject-card.tsx
+++ b/src/components/subject-card.tsx
@@ -108,10 +108,13 @@ export function SubjectCard({ subject, city, meeting, parties, persons, fullWidt
                         <CardTitle className="text-sm sm:text-base line-clamp-2 flex-1 group-hover/card:text-accent-foreground transition-colors duration-300">{subject.name}</CardTitle>
                     </div>
                     {showContext && (
-                        <div className="text-[10px] text-muted-foreground/70">
-                            {[city.name, meeting.administrativeBody?.name, formatDate(new Date(meeting.dateTime))]
-                                .filter(Boolean)
-                                .join(" · ")}
+                        <div className="flex flex-col gap-0.5">
+                            <span className="text-[10px] text-muted-foreground/70">
+                                {[city.name, meeting.administrativeBody?.name, formatDate(new Date(meeting.dateTime))]
+                                    .filter(Boolean)
+                                    .join(" · ")}
+                            </span>
+                            <span className="text-xs font-medium text-foreground/90">{meeting.name}</span>
                         </div>
                     )}
                     <div className="flex flex-row justify-between gap-2 text-xs text-muted-foreground">

--- a/src/components/subject-card.tsx
+++ b/src/components/subject-card.tsx
@@ -3,7 +3,7 @@ import { Statistics } from "@/lib/statistics";
 import { SubjectWithRelations } from "@/lib/db/subject";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "./ui/card";
 import Icon from "./icon";
-import { MapPin, ScrollText, Calendar, Loader2, Clock, MessageSquare, Landmark } from "lucide-react";
+import { MapPin, ScrollText, Loader2, Clock, MessageSquare } from "lucide-react";
 import { cn, getPartyFromRoles } from "@/lib/utils";
 import { getNonAgendaLabel, getWithdrawnLabel } from "@/lib/utils/subjects";
 import { Link, useRouter } from "@/i18n/routing";
@@ -12,6 +12,7 @@ import { PersonWithRelations } from '@/lib/db/people';
 import { HighlightVideo } from "./meetings/HighlightVideo";
 import { HighlightWithUtterances } from "@/lib/db/highlights";
 import { stripMarkdown } from "@/lib/formatters/markdown";
+import { formatDate } from "@/lib/formatters/time";
 import { useState, useEffect } from "react";
 import { usePathname } from "next/navigation";
 
@@ -101,16 +102,13 @@ export function SubjectCard({ subject, city, meeting, parties, persons, fullWidt
                 {/* Header: topic icon + title + meta */}
                 <CardHeader className="flex flex-col gap-1.5 pb-2">
                     {showContext && (
-                        <div className="flex flex-col gap-0.5 -mt-1 -mb-1">
-                            <span className="text-[10px] text-muted-foreground/70 truncate">
-                                {city.name} • {meeting.name}
+                        <div className="flex flex-col gap-0.5 text-[10px] text-muted-foreground/70 -mt-1 -mb-1 min-w-0">
+                            <span className="truncate min-w-0">
+                                {[city.name, meeting.administrativeBody?.name, meeting.name]
+                                    .filter(Boolean)
+                                    .join(" › ")}
                             </span>
-                            {meeting.administrativeBody && (
-                                <span className="flex items-center gap-1 text-[10px] font-medium text-muted-foreground min-w-0">
-                                    <Landmark className="w-3 h-3 shrink-0" />
-                                    <span className="truncate">{meeting.administrativeBody.name}</span>
-                                </span>
-                            )}
+                            <span className="truncate">{formatDate(new Date(meeting.dateTime))}</span>
                         </div>
                     )}
                     <div className="flex flex-row items-center gap-1.5">
@@ -198,14 +196,6 @@ export function SubjectCard({ subject, city, meeting, parties, persons, fullWidt
                                 autoScroll
                                 isHovered={isCardHovered}
                             />
-                        </div>
-                    )}
-                    {showContext && (
-                        <div className="flex justify-end w-full mt-auto">
-                            <span className="text-[10px] text-muted-foreground/70 flex items-center gap-1">
-                                <Calendar className="w-3 h-3" />
-                                {new Date(meeting.dateTime).toLocaleDateString('el-GR', { year: 'numeric', month: 'long', day: 'numeric' })}
-                            </span>
                         </div>
                     )}
                 </CardFooter>

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -157,7 +157,8 @@ export async function search(request: SearchRequest): Promise<SearchResponse> {
                 topic: true,
                 councilMeeting: {
                     include: {
-                        city: true
+                        city: true,
+                        administrativeBody: true
                     }
                 },
                 introducedBy: {

--- a/src/lib/search/types.ts
+++ b/src/lib/search/types.ts
@@ -1,4 +1,4 @@
-import { City, CouncilMeeting } from "@prisma/client";
+import { AdministrativeBody, City, CouncilMeeting } from "@prisma/client";
 import { SubjectWithRelations } from "@/lib/db/subject";
 import { SegmentWithRelations } from "@/lib/db/speakerSegments";
 
@@ -43,6 +43,7 @@ export type SearchResultLight = SubjectWithRelations & {
     matchedSpeakerSegmentIds?: string[];
     councilMeeting: CouncilMeeting & {
         city: City;
+        administrativeBody: AdministrativeBody | null;
     };
 };
 


### PR DESCRIPTION
## Summary

Each search result now cleanly lists which administrative body the subject was discussed in (e.g. `Δημοτικό Συμβούλιο`, `1η Δημοτική Κοινότητα`).

- `src/lib/search/index.ts`: include `administrativeBody` when enriching search results from the DB.
- `src/lib/search/types.ts`: add `administrativeBody: AdministrativeBody | null` to `SearchResultLight.councilMeeting`.
- `src/components/subject-card.tsx`: render the admin body name with a `Landmark` icon below the city/meeting line. The `meeting` prop's admin body is optional, so existing non-search usages (meeting page, highlights) are unaffected and just don't render the line.

The label only appears when `showContext` is set (i.e. on the search page and similar list contexts where the meeting isn't already implied).

## Notes

- Display-only change, as requested. No admin-body **filter** was added — a working filter would require adding `administrative_body_id` to the Elasticsearch index (`elasticsearch/schema.json`) plus a coordinated reindex via `opencouncil-tasks`, so it was intentionally left out of this PR.

## Test plan

- [x] `npx tsc --noEmit` — no type errors in `src/`
- [ ] Manual: run a search and confirm each result card shows the admin body name under the city/meeting line (requires Elasticsearch + indexed data; not exercised in CI sandbox)

https://claude.ai/code/session_015uBbguksbftgS7JiMLJDdp

---
_Generated by [Claude Code](https://claude.ai/code/session_015uBbguksbftgS7JiMLJDdp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only threading of an extra Prisma relation and optional UI field; no auth, writes, or index changes.
> 
> **Overview**
> Search result cards (and other `showContext` lists) now show **which administrative body** held the meeting, by loading `administrativeBody` on `councilMeeting` in `search()` and typing it on `SearchResultLight`.
> 
> **`SubjectCard`** context UI is reworked when `showContext` is on: a muted breadcrumb line (`city · administrative body · meeting date` via `formatDate`, omitting the body when missing) sits above the **meeting title** on its own line. The old single-line `city • meeting.name` header and the footer calendar row are removed so date/body live in one place. The `meeting` prop accepts optional `administrativeBody`, so callers that do not pass it behave as before (no extra segment in the breadcrumb).
> 
> No Elasticsearch schema or admin-body filtering changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2cdf1489a506b70392cfebfcb8fdbc646055a84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Search result cards now display the administrative body (e.g. `Δημοτικό Συμβούλιο`) alongside city and formatted meeting date in a compact muted header line, with the meeting name on a second line below it.

- **`src/lib/search/index.ts`**: adds a read-only `administrativeBody` Prisma include on `councilMeeting` — no writes or index changes.
- **`src/lib/search/types.ts`**: types the new relation as `AdministrativeBody | null` on `SearchResultLight.councilMeeting`.
- **`src/components/subject-card.tsx`**: renders the admin body name in the `showContext` header block; the prop is optional so all non-search call-sites are untouched. The old footer calendar date is replaced by `formatDate` in the header line.

<h3>Confidence Score: 5/5</h3>

Display-only change — read-only Prisma relation include plus an optional UI field; no writes, no auth changes, no index modifications.

All three files make additive, backwards-compatible changes: a new nullable relation is included in the Prisma query, typed accordingly, and rendered behind an existing `showContext` guard. Callers that don't pass `administrativeBody` are unaffected. No data mutations, no schema changes, and the PR author explicitly notes that filtering was intentionally left out.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/search/index.ts | Adds `administrativeBody: true` to the Prisma include for councilMeeting — a read-only relation include with no side-effects. |
| src/lib/search/types.ts | Adds `administrativeBody: AdministrativeBody | null` (required, non-optional) to `SearchResultLight.councilMeeting`, matching the Prisma relation which can be null. |
| src/components/subject-card.tsx | Renders administrative body name in the card header context line; `administrativeBody` is optional on the prop type so existing non-search callers are unaffected. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant SearchAPI as search() [index.ts]
    participant Prisma
    participant SubjectCard

    Client->>SearchAPI: SearchRequest
    SearchAPI->>Prisma: findMany with councilMeeting include city + administrativeBody
    Prisma-->>SearchAPI: SearchResultLight[] with administrativeBody AdministrativeBody or null
    SearchAPI-->>Client: SearchResponse

    Client->>SubjectCard: meeting with optional administrativeBody
    Note over SubjectCard: showContext=true
    SubjectCard-->>Client: renders city · body · date + meeting.name
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/components/subject-card.tsx:110-119
`formatDate` defaults to the Greek locale regardless of the active app locale. The component can obtain the current locale via `useLocale` from `next-intl` (already a transitive dependency through `@/i18n/routing`). Without it, users viewing in English will still see dates formatted in Greek.

```suggestion
                    {showContext && (
                        <div className="flex flex-col gap-0.5">
                            <span className="text-[10px] text-muted-foreground/70">
                                {[city.name, meeting.administrativeBody?.name, formatDate(new Date(meeting.dateTime), undefined, locale)]
                                    .filter(Boolean)
                                    .join(" · ")}
                            </span>
                            <span className="text-xs font-medium text-foreground/90">{meeting.name}</span>
                        </div>
                    )}
```

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fixup! feat(search): show administrative..."](https://github.com/schemalabz/opencouncil/commit/f2cdf1489a506b70392cfebfcb8fdbc646055a84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34144445)</sub>

<!-- /greptile_comment -->