### PR TITLE
feat(people/page): replace the speakerSegments with contributions

### DIFF
--- a/messages/el.json
+++ b/messages/el.json
@@ -401,7 +401,7 @@
         "loading": "Φόρτωση...",
         "loadMore": "Περισσότερα",
         "changeMemberOrdering": "Αλλαγή Ταξινόμησης Μελών",
-        "recentSegments": "Πρόσφατες τοποθετήσεις",
+        "recentContributions": "Περιλήψεις Τοποθετήσεων",
         "leaderLabel": "Επικεφαλής: ",
         "breadcrumbHome": "Αρχική",
         "tabPeople": "Πρόσωπα",

--- a/messages/el.json
+++ b/messages/el.json
@@ -379,7 +379,7 @@
         "noSegmentsFound": "Δεν βρέθηκαν τοποθετήσεις",
         "loading": "Φόρτωση...",
         "loadMore": "Περισσότερα",
-        "recentSegments": "Πρόσφατες τοποθετήσεις",
+        "recentContributions": "Περιλήψεις Τοποθετήσεων",
         "tryDifferentFilter": "Προσπαθήστε να αλλάξετε τα φίλτρα"
     },
     "Party": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -653,7 +653,7 @@
         "noSegmentsFound": "No statements found",
         "loading": "Loading...",
         "loadMore": "Load more",
-        "recentContributions": "Recent contributions",
+        "recentContributions": "Recent Contributions",
         "tryDifferentFilter": "Try changing the filters"
     },
     "Party": {
@@ -675,7 +675,7 @@
         "loading": "Loading...",
         "loadMore": "Load more",
         "changeMemberOrdering": "Change Member Ordering",
-        "recentSegments": "Recent Segments",
+        "recentContributions": "Recent Contributions",
         "leaderLabel": "Leader: ",
         "breadcrumbHome": "Home",
         "tabPeople": "People",

--- a/messages/en.json
+++ b/messages/en.json
@@ -653,7 +653,7 @@
         "noSegmentsFound": "No statements found",
         "loading": "Loading...",
         "loadMore": "Load more",
-        "recentSegments": "Recent Statements",
+        "recentContributions": "Recent contributions",
         "tryDifferentFilter": "Try changing the filters"
     },
     "Party": {

--- a/src/app/[locale]/(city)/[cityId]/(other)/parties/[partyId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/parties/[partyId]/page.tsx
@@ -4,11 +4,8 @@ import { getCity } from "@/lib/db/cities";
 import { getParty } from "@/lib/db/parties";
 import { notFound } from "next/navigation";
 import { getAdministrativeBodiesForCity } from "@/lib/db/administrativeBodies";
-import { isUserAuthorizedToEdit } from "@/lib/auth";
 
 export default async function PartyPage({ params }: { params: { locale: string, partyId: string, cityId: string } }) {
-    const includeUnreleased = await isUserAuthorizedToEdit({ cityId: params.cityId });
-
     const [party, city, administrativeBodies] = await Promise.all([
         getParty(params.partyId),
         getCity(params.cityId),
@@ -19,5 +16,5 @@ export default async function PartyPage({ params }: { params: { locale: string, 
         notFound();
     }
 
-    return <PartyC party={party} city={city} administrativeBodies={administrativeBodies} includeUnreleased={includeUnreleased} />
+    return <PartyC party={party} city={city} administrativeBodies={administrativeBodies} />
 }

--- a/src/app/[locale]/(city)/[cityId]/(other)/people/[personId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/people/[personId]/page.tsx
@@ -2,6 +2,7 @@
 import { getPerson } from "@/lib/db/people";
 import { getPartiesForCity } from "@/lib/db/parties";
 import { getAdministrativeBodiesForCity } from "@/lib/db/administrativeBodies";
+import { getDistinctTopicsForSpeakerContributions } from "@/lib/db/contributions";
 import { notFound } from "next/navigation";
 import Person from "@/components/persons/Person";
 import { getCity } from "@/lib/db/cities";
@@ -90,12 +91,13 @@ export async function generateMetadata({ params }: { params: { locale: string, p
 export default async function PersonPage({ params }: { params: { locale: string, personId: string, cityId: string } }) {
     const includeUnreleased = await isUserAuthorizedToEdit({ cityId: params.cityId });
 
-    const [person, city, parties, administrativeBodies, statistics] = await Promise.all([
+    const [person, city, parties, administrativeBodies, statistics, contributionTopics] = await Promise.all([
         getPerson(params.personId),
         getCity(params.cityId),
         getPartiesForCity(params.cityId),
         getAdministrativeBodiesForCity(params.cityId),
-        getStatisticsFor({ personId: params.personId, cityId: params.cityId, includeUnreleased }, ['topic'])
+        getStatisticsFor({ personId: params.personId, cityId: params.cityId, includeUnreleased }, ['topic']),
+        getDistinctTopicsForSpeakerContributions(params.personId),
     ]);
 
     if (!person || !city) {
@@ -108,6 +110,6 @@ export default async function PersonPage({ params }: { params: { locale: string,
         parties={parties}
         administrativeBodies={administrativeBodies}
         statistics={statistics}
-        includeUnreleased={includeUnreleased}
+        contributionTopics={contributionTopics}
     />;
 }

--- a/src/components/FormattedTextDisplay.tsx
+++ b/src/components/FormattedTextDisplay.tsx
@@ -12,6 +12,11 @@ interface FormattedTextDisplayProps {
     meetingId?: string;
     cityId?: string;
     linkColor?: 'blue' | 'black'; // Optional link color override
+    /**
+     * Use on pages that aren't inside a CouncilMeetingDataProvider (e.g. the Person page),
+     * where the expansion mini-transcript cannot resolve utterance data.
+     */
+    disableUtteranceExpansion?: boolean;
 }
 
 export const FormattedTextDisplay = memo(function FormattedTextDisplay({
@@ -19,7 +24,8 @@ export const FormattedTextDisplay = memo(function FormattedTextDisplay({
     onUtteranceClick,
     meetingId,
     cityId,
-    linkColor = 'blue'
+    linkColor = 'blue',
+    disableUtteranceExpansion = false,
 }: FormattedTextDisplayProps) {
     const linkClassName = linkColor === 'black'
         ? 'text-foreground underline hover:opacity-80'
@@ -70,7 +76,13 @@ export const FormattedTextDisplay = memo(function FormattedTextDisplay({
 
                         switch (refType) {
                             case 'utterance':
-                                // Use UtteranceReferenceLink for inline mini transcript
+                                if (disableUtteranceExpansion) {
+                                    return (
+                                        <span className={`${linkClassName} inline`} style={linkStyle}>
+                                            {children}
+                                        </span>
+                                    );
+                                }
                                 return (
                                     <UtteranceReferenceLink
                                         utteranceId={id}

--- a/src/components/meetings/subject/ContributionCard.tsx
+++ b/src/components/meetings/subject/ContributionCard.tsx
@@ -39,6 +39,10 @@ interface ContributionCardProps {
     };
     /** Render the in-page play button. Disable on pages without a VideoProvider (e.g. Person page). */
     showPlayButton?: boolean;
+    /**
+     * Suppress navigation on the speaker badge.
+     */
+    disableSpeakerNavigation?: boolean;
 }
 
 export const ContributionCard = memo(function ContributionCard({
@@ -48,6 +52,7 @@ export const ContributionCard = memo(function ContributionCard({
     speaker,
     contextHeader,
     showPlayButton = true,
+    disableSpeakerNavigation = false,
 }: ContributionCardProps) {
     const t = useTranslations("Subject");
 
@@ -126,7 +131,7 @@ export const ContributionCard = memo(function ContributionCard({
                 <div className="flex flex-col md:flex-row md:items-center gap-4">
                     {/* Speaker Badge */}
                     {speaker ? (
-                        <PersonBadge person={speaker} disableNavigation={!!contextHeader} />
+                        <PersonBadge person={speaker} disableNavigation={disableSpeakerNavigation} />
                     ) : contribution.speakerName ? (
                         <span className="text-sm font-medium">
                             {contribution.speakerName}

--- a/src/components/meetings/subject/ContributionCard.tsx
+++ b/src/components/meetings/subject/ContributionCard.tsx
@@ -2,16 +2,19 @@
 
 import { memo } from "react";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
 import { FileText, Clock } from "lucide-react";
+import Icon from "@/components/icon";
 import { PersonBadge } from "@/components/persons/PersonBadge";
 import { Link } from "@/i18n/routing";
 import { FormattedTextDisplay } from "@/components/FormattedTextDisplay";
 import { AIGeneratedBadge } from "@/components/AIGeneratedBadge";
-import { useCouncilMeetingData } from "@/components/meetings/CouncilMeetingDataContext";
 import { useTranslations } from "next-intl";
 import { SpeakerContribution } from "@/lib/apiTypes";
 import { PlayPauseButton } from "@/components/meetings/PlayPauseButton";
-import { formatTimestamp } from "@/lib/formatters/time";
+import { formatTimestamp, formatDate } from "@/lib/formatters/time";
+import { PersonWithRelations } from "@/lib/db/people";
+import { getPartyFromRoles } from "@/lib/utils";
 import useSWR from "swr";
 
 interface UtteranceTimeRange {
@@ -24,21 +27,30 @@ const fetcher = (url: string) => fetch(url).then(res => res.ok ? res.json() : nu
 interface ContributionCardProps {
     contribution: SpeakerContribution & { id: string };
     subjectId: string;
+    meeting: { id: string; cityId: string };
+    speaker: PersonWithRelations | null;
+    /** Optional admin-body + meeting + subject header shown above the card body (used on the Person page). */
+    contextHeader?: {
+        meetingName: string;
+        adminBodyName: string | null;
+        meetingDate: Date;
+        subjectName: string;
+        topic: { name: string; colorHex: string; icon: string | null } | null;
+    };
+    /** Render the in-page play button. Disable on pages without a VideoProvider (e.g. Person page). */
+    showPlayButton?: boolean;
 }
 
 export const ContributionCard = memo(function ContributionCard({
     contribution,
     subjectId,
+    meeting,
+    speaker,
+    contextHeader,
+    showPlayButton = true,
 }: ContributionCardProps) {
-    const { getPerson, meeting } = useCouncilMeetingData();
     const t = useTranslations("Subject");
 
-    const speaker = contribution.speakerId
-        ? getPerson(contribution.speakerId)
-        : null;
-
-    // Fetch the time range for this speaker's discussion of this subject
-    // Uses the discussionSubjectId index for efficient lookup
     const { data: utteranceInfo } = useSWR<UtteranceTimeRange>(
         contribution.speakerId
             ? `/api/subject/${subjectId}/first-utterance/${contribution.speakerId}`
@@ -46,74 +58,149 @@ export const ContributionCard = memo(function ContributionCard({
         fetcher
     );
 
-    // Build transcript URL using the utterance's start timestamp
     const transcriptUrl = utteranceInfo
         ? `/${meeting.cityId}/${meeting.id}/transcript?t=${Math.floor(utteranceInfo.startTimestamp)}`
         : null;
 
-    return (
-        <div className="p-4 space-y-4">
-            {/* Header: Speaker Badge + Action Buttons */}
-            <div className="flex flex-col md:flex-row md:items-center gap-4">
-                {/* Speaker Badge */}
-                {speaker ? (
-                    <PersonBadge person={speaker} />
-                ) : contribution.speakerName ? (
-                    <span className="text-sm font-medium">
-                        {contribution.speakerName}
-                    </span>
-                ) : (
-                    <span className="text-sm text-muted-foreground italic">
-                        {t("unknownSpeaker")}
-                    </span>
-                )}
+    const subjectUrl = contextHeader
+        ? `/${meeting.cityId}/${meeting.id}/subjects/${subjectId}`
+        : null;
 
-                {/* Timestamp and Action Buttons - only show if we have utterance info */}
-                {utteranceInfo && (
-                    <div className="flex items-center gap-2 md:ml-auto">
-                        {/* Timestamp */}
-                        <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                            <Clock className="w-3 h-3" />
-                            <span>{formatTimestamp(utteranceInfo.startTimestamp)}</span>
+    // Party color for the colored left bar — matches the old Result/SpeakerSegment styling.
+    // Only used when the card is rendered on a non-meeting page (i.e. contextHeader is set).
+    const party = speaker ? getPartyFromRoles(speaker.roles) : null;
+    const sideBarColor = party?.colorHex || '#D3D3D3';
+
+    const headerLeft = contextHeader
+        ? (contextHeader.adminBodyName
+            ? `${contextHeader.adminBodyName} (${contextHeader.meetingName})`
+            : contextHeader.meetingName)
+        : null;
+    const headerRight = contextHeader ? formatDate(contextHeader.meetingDate) : null;
+
+    const body = (
+        <div className={contextHeader ? "p-4 space-y-4 relative" : "p-4 space-y-4"}>
+            {contextHeader && (
+                <div
+                    className="absolute left-0 top-0 bottom-0 w-[3px] sm:w-1"
+                    style={{
+                        backgroundColor: sideBarColor,
+                        borderTopLeftRadius: 'calc(0.5rem - 1.5px)',
+                        borderBottomLeftRadius: 'calc(0.5rem - 1.5px)',
+                    }}
+                />
+            )}
+            <div className={contextHeader ? "pl-3 sm:pl-4 space-y-4" : "contents"}>
+                {contextHeader && (
+                    <div className="space-y-2">
+                        <div className="grid grid-cols-1 sm:grid-cols-[1fr_auto] sm:items-baseline gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
+                            <span className="break-words">{headerLeft}</span>
+                            <span className="sm:text-right">{headerRight}</span>
                         </div>
-                        {/* Action Buttons */}
-                        <div className="flex gap-2">
-                            <PlayPauseButton
-                                startTimestamp={utteranceInfo.startTimestamp}
-                                endTimestamp={utteranceInfo.endTimestamp}
-                            />
-                            {transcriptUrl && (
-                                <Button
-                                    asChild
-                                    variant="outline"
-                                    size="sm"
-                                    className="transition-colors hover:bg-primary hover:text-primary-foreground"
-                                >
-                                    <Link href={transcriptUrl}>
-                                        <FileText className="h-4 w-4 mr-1.5" />
-                                        {t("transcript")}
-                                    </Link>
-                                </Button>
-                            )}
-                        </div>
+                        <Link
+                            href={subjectUrl!}
+                            className="inline-flex items-center gap-2 group"
+                        >
+                            <div
+                                className="p-1.5 rounded-full"
+                                style={{
+                                    backgroundColor: contextHeader.topic?.colorHex
+                                        ? contextHeader.topic.colorHex + "20"
+                                        : "#e5e7eb",
+                                }}
+                            >
+                                <Icon
+                                    name={contextHeader.topic?.icon || "hash"}
+                                    color={contextHeader.topic?.colorHex || "#9ca3af"}
+                                    size={20}
+                                />
+                            </div>
+                            <span className="text-lg sm:text-xl font-semibold leading-tight group-hover:underline">
+                                {contextHeader.subjectName}
+                            </span>
+                        </Link>
                     </div>
                 )}
-            </div>
 
-            {/* Formatted Text with References */}
-            <div className="text-sm text-muted-foreground text-justify">
-                <FormattedTextDisplay
-                    text={contribution.text}
-                    meetingId={meeting.id}
-                    cityId={meeting.cityId}
-                    linkColor="black"
-                />
-            </div>
+                {/* Header: Speaker Badge + Action Buttons */}
+                <div className="flex flex-col md:flex-row md:items-center gap-4">
+                    {/* Speaker Badge */}
+                    {speaker ? (
+                        <PersonBadge person={speaker} disableNavigation={!!contextHeader} />
+                    ) : contribution.speakerName ? (
+                        <span className="text-sm font-medium">
+                            {contribution.speakerName}
+                        </span>
+                    ) : (
+                        <span className="text-sm text-muted-foreground italic">
+                            {t("unknownSpeaker")}
+                        </span>
+                    )}
 
-            {/* AI Generated Badge */}
-            <div className="flex justify-end">
-                <AIGeneratedBadge />
+                    {/* Timestamp and Action Buttons - only show if we have utterance info */}
+                    {utteranceInfo && (
+                        <div className="flex items-center gap-2 md:ml-auto">
+                            {/* Timestamp */}
+                            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                                <Clock className="w-3 h-3" />
+                                <span>{formatTimestamp(utteranceInfo.startTimestamp)}</span>
+                            </div>
+                            {/* Action Buttons */}
+                            <div className="flex gap-2">
+                                {showPlayButton && (
+                                    <PlayPauseButton
+                                        startTimestamp={utteranceInfo.startTimestamp}
+                                        endTimestamp={utteranceInfo.endTimestamp}
+                                    />
+                                )}
+                                {transcriptUrl && (
+                                    <Button
+                                        asChild
+                                        variant="outline"
+                                        size="sm"
+                                        className="h-auto min-h-9 py-1.5 whitespace-normal text-left transition-colors hover:bg-primary hover:text-primary-foreground"
+                                    >
+                                        <Link href={transcriptUrl}>
+                                            <FileText className="h-4 w-4 mr-1.5 shrink-0" />
+                                            <span className="break-words">{t("transcript")}</span>
+                                        </Link>
+                                    </Button>
+                                )}
+                            </div>
+                        </div>
+                    )}
+                </div>
+
+                {/* Formatted Text with References */}
+                <div className="text-sm text-muted-foreground text-justify">
+                    <FormattedTextDisplay
+                        text={contribution.text}
+                        meetingId={meeting.id}
+                        cityId={meeting.cityId}
+                        linkColor="black"
+                        disableUtteranceExpansion={!!contextHeader}
+                    />
+                </div>
+
+                {/* AI Generated Badge */}
+                <div className="flex justify-end">
+                    <AIGeneratedBadge />
+                </div>
             </div>
         </div>
+    );
+
+    if (!contextHeader) {
+        return body;
+    }
+
+    // Same `Card` wrapping used by the old SpeakerSegment Result card —
+    // subtle gradient border at rest, brand-colored animation on hover.
+    return (
+        <Card className="hover:shadow-md transition-shadow">
+            <CardContent className="p-0">
+                {body}
+            </CardContent>
+        </Card>
     );
 });

--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -313,7 +313,12 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                                 {contributions.map((contribution, index) => (
                                     <div key={contribution.id}>
                                         {index > 0 && <div className="border-t border-border" />}
-                                        <ContributionCard contribution={contribution} subjectId={subject.id} />
+                                        <ContributionCard
+                                            contribution={contribution}
+                                            subjectId={subject.id}
+                                            meeting={meeting}
+                                            speaker={contribution.speakerId ? getPerson(contribution.speakerId) ?? null : null}
+                                        />
                                     </div>
                                 ))}
                             </>

--- a/src/components/parties/Party.tsx
+++ b/src/components/parties/Party.tsx
@@ -13,8 +13,9 @@ import { Search, Users, FileText } from "lucide-react";
 import { Input } from '../ui/input';
 import { Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from '@/components/ui/breadcrumb';
 import { Link } from '@/i18n/routing';
-import { getLatestSegmentsForParty, SegmentWithRelations } from '@/lib/db/speakerSegments';
-import { Result } from '../search/Result';
+import { getLatestContributionsForParty } from '@/lib/db/contributions';
+import { ContributionForPerson } from '@/lib/db/types';
+import { ContributionCard } from '@/components/meetings/subject/ContributionCard';
 import { isUserAuthorizedToEdit } from '@/lib/auth';
 import { getAdministrativeBodyTypesForPeople, filterPersonByAdminBodyTypes } from '@/lib/utils/administrativeBodies';
 import { motion } from 'framer-motion';
@@ -211,13 +212,12 @@ function PartyMembersTab({
 
 // Segments Tab Component
 function SegmentsTab({
-    city,
     party,
     typeOptions,
     selectedType,
     onSelectType,
-    latestSegments,
-    isLoadingSegments,
+    contributions,
+    isLoadingContributions,
     totalCount,
     setPage,
     searchQuery,
@@ -225,13 +225,12 @@ function SegmentsTab({
     handleSearch,
     allLabel
 }: {
-    city: City,
     party: PartyWithPersons,
     typeOptions: { value: AdministrativeBodyType; label: string }[],
     selectedType: AdministrativeBodyType | null,
     onSelectType: (type: AdministrativeBodyType | null) => void,
-    latestSegments: SegmentWithRelations[],
-    isLoadingSegments: boolean,
+    contributions: ContributionForPerson[],
+    isLoadingContributions: boolean,
     totalCount: number,
     setPage: (updater: (prev: number) => number) => void,
     searchQuery: string,
@@ -283,9 +282,9 @@ function SegmentsTab({
                 transition={{ delay: 0.4 }}
                 className="relative"
             >
-                <h2 className="text-lg sm:text-xl font-semibold mb-4">{t('recentSegments')}</h2>
+                <h2 className="text-lg sm:text-xl font-semibold mb-4">{t('recentContributions')}</h2>
 
-                {isLoadingSegments && latestSegments.length === 0 ? (
+                {isLoadingContributions && contributions.length === 0 ? (
                     <div className="flex justify-center items-center py-12 border rounded-lg bg-card/50">
                         <div className="flex flex-col items-center space-y-4">
                             <div className="h-6 w-6 sm:h-8 sm:w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
@@ -294,18 +293,40 @@ function SegmentsTab({
                     </div>
                 ) : (
                     <div className="space-y-3 sm:space-y-4">
-                        {latestSegments.map((segment, index) => (
+                        {contributions.map((contribution, index) => (
                             <motion.div
-                                key={index}
+                                key={contribution.id}
                                 initial={{ opacity: 0, y: 20 }}
                                 animate={{ opacity: 1, y: 0 }}
                                 transition={{ delay: 0.1 * index }}
                             >
-                                <Result result={segment} />
+                                <ContributionCard
+                                    contribution={contribution}
+                                    subjectId={contribution.subject.id}
+                                    meeting={{
+                                        id: contribution.subject.councilMeetingId,
+                                        cityId: contribution.subject.cityId,
+                                    }}
+                                    speaker={contribution.speaker}
+                                    contextHeader={{
+                                        meetingName: contribution.subject.councilMeeting.name,
+                                        adminBodyName: contribution.subject.councilMeeting.administrativeBody?.name ?? null,
+                                        meetingDate: contribution.subject.councilMeeting.dateTime,
+                                        subjectName: contribution.subject.name,
+                                        topic: contribution.subject.topic
+                                            ? {
+                                                name: contribution.subject.topic.name,
+                                                colorHex: contribution.subject.topic.colorHex,
+                                                icon: contribution.subject.topic.icon,
+                                            }
+                                            : null,
+                                    }}
+                                    showPlayButton={false}
+                                />
                             </motion.div>
                         ))}
 
-                        {latestSegments.length === 0 && !isLoadingSegments && (
+                        {contributions.length === 0 && !isLoadingContributions && (
                             <div className="text-center py-8 border rounded-lg bg-card/50">
                                 <p className="text-muted-foreground text-sm sm:text-base">{t('noSegmentsFound')}</p>
                             </div>
@@ -313,20 +334,20 @@ function SegmentsTab({
                     </div>
                 )}
 
-                {isLoadingSegments && latestSegments.length > 0 && (
+                {isLoadingContributions && contributions.length > 0 && (
                     <div className="flex justify-center items-center py-4">
                         <div className="h-6 w-6 sm:h-8 sm:w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
                     </div>
                 )}
 
-                {!isLoadingSegments && latestSegments.length < totalCount && (
+                {!isLoadingContributions && contributions.length < totalCount && (
                     <Button
                         onClick={() => setPage(prevPage => prevPage + 1)}
                         variant="outline"
                         className="mt-6 w-full sm:w-auto"
-                        disabled={isLoadingSegments}
+                        disabled={isLoadingContributions}
                     >
-                        {isLoadingSegments ? (
+                        {isLoadingContributions ? (
                             <>
                                 <div className="h-4 w-4 mr-2 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
                                 {t('loading')}
@@ -339,22 +360,21 @@ function SegmentsTab({
     );
 }
 
-export default function PartyC({ city, party, administrativeBodies, includeUnreleased }: {
+export default function PartyC({ city, party, administrativeBodies }: {
     city: City,
     party: PartyWithPersons,
     administrativeBodies: AdministrativeBody[],
-    includeUnreleased?: boolean
 }) {
     const t = useTranslations('Party');
     const tCommon = useTranslations('Common');
     const router = useRouter();
     const [searchQuery, setSearchQuery] = useState("");
-    const [latestSegments, setLatestSegments] = useState<SegmentWithRelations[]>([]);
+    const [contributions, setContributions] = useState<ContributionForPerson[]>([]);
     const [page, setPage] = useState(1);
     const [totalCount, setTotalCount] = useState(0);
     const [canEdit, setCanEdit] = useState(false);
     const [selectedAdminBodyType, setSelectedAdminBodyType] = useState<AdministrativeBodyType | null>(null);
-    const [isLoadingSegments, setIsLoadingSegments] = useState(false);
+    const [isLoadingContributions, setIsLoadingContributions] = useState(false);
 
     // Use people directly from the party object
     const persons = useMemo(() => party.people, [party.people]);
@@ -393,50 +413,48 @@ export default function PartyC({ city, party, administrativeBodies, includeUnrel
     }, [party.id]);
 
     useEffect(() => {
-        const fetchLatestSegments = async () => {
+        const fetchLatestContributions = async () => {
             try {
-                setIsLoadingSegments(true);
-                setLatestSegments([]);
+                setIsLoadingContributions(true);
+                setContributions([]);
                 setPage(1);
-                const { results, totalCount } = await getLatestSegmentsForParty(
+                const { results, totalCount } = await getLatestContributionsForParty(
                     party.id,
                     1,
                     5,
-                    includeUnreleased,
                     selectedAdminBodyType
                 );
-                setLatestSegments(results);
+                setContributions(results);
                 setTotalCount(totalCount);
             } catch (error) {
-                console.error('Error fetching segments:', error);
+                console.error('Error fetching contributions:', error);
             } finally {
-                setIsLoadingSegments(false);
+                setIsLoadingContributions(false);
             }
         };
-        fetchLatestSegments();
-    }, [party.id, selectedAdminBodyType, includeUnreleased]);
+        fetchLatestContributions();
+    }, [party.id, selectedAdminBodyType]);
 
     useEffect(() => {
-        const loadMoreSegments = async () => {
+        const loadMoreContributions = async () => {
             if (page === 1) return;
             try {
-                setIsLoadingSegments(true);
-                const { results } = await getLatestSegmentsForParty(
+                setIsLoadingContributions(true);
+                const { results } = await getLatestContributionsForParty(
                     party.id,
                     page,
                     5,
-                    includeUnreleased,
                     selectedAdminBodyType
                 );
-                setLatestSegments(prevSegments => [...prevSegments, ...results]);
+                setContributions(prev => [...prev, ...results]);
             } catch (error) {
-                console.error('Error loading more segments:', error);
+                console.error('Error loading more contributions:', error);
             } finally {
-                setIsLoadingSegments(false);
+                setIsLoadingContributions(false);
             }
         };
-        loadMoreSegments();
-    }, [party.id, page, selectedAdminBodyType, includeUnreleased]);
+        loadMoreContributions();
+    }, [party.id, page, selectedAdminBodyType]);
 
     const handleSearch = (e: React.FormEvent) => {
         e.preventDefault();
@@ -589,7 +607,7 @@ export default function PartyC({ city, party, administrativeBodies, includeUnrel
                                     <span className="hidden xs:inline">{t('tabPeople')}</span>
                                     <span className="xs:hidden">{t('tabPeopleShort')}</span>
                                 </TabsTrigger>
-                                <TabsTrigger value="segments" className="text-xs sm:text-sm py-2 px-3">
+                                <TabsTrigger value="contributions" className="text-xs sm:text-sm py-2 px-3">
                                     <FileText className="h-4 w-4 mr-1 sm:mr-2" />
                                     <span className="hidden sm:inline">{t('tabSegments')}</span>
                                     <span className="sm:hidden">{t('tabSegmentsShort')}</span>
@@ -607,15 +625,14 @@ export default function PartyC({ city, party, administrativeBodies, includeUnrel
                             />
                         </TabsContent>
 
-                        <TabsContent value="segments" className="mt-6">
+                        <TabsContent value="contributions" className="mt-6">
                             <SegmentsTab
-                                city={city}
                                 party={party}
                                 typeOptions={typeOptions}
                                 selectedType={selectedAdminBodyType}
                                 onSelectType={handleAdminBodyTypeSelect}
-                                latestSegments={latestSegments}
-                                isLoadingSegments={isLoadingSegments}
+                                contributions={contributions}
+                                isLoadingContributions={isLoadingContributions}
                                 totalCount={totalCount}
                                 setPage={setPage}
                                 searchQuery={searchQuery}

--- a/src/components/persons/Person.tsx
+++ b/src/components/persons/Person.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useTranslations } from 'next-intl';
-import { City, Party, AdministrativeBody, AdministrativeBodyType } from '@prisma/client';
+import { City, Party, AdministrativeBody, Topic } from '@prisma/client';
 import { Button } from '../ui/button';
 import FormSheet from '../FormSheet';
 import PersonForm from './PersonForm';
@@ -12,53 +12,42 @@ import { useState, useEffect, useMemo } from 'react';
 import { Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from '@/components/ui/breadcrumb';
 import { Link } from '@/i18n/routing';
 import { Statistics } from "@/lib/statistics";
-import { getLatestSegmentsForSpeaker, SegmentWithRelations } from '@/lib/db/speakerSegments';
-import { Result } from '@/components/search/Result';
+import { getLatestContributionsForSpeaker } from '@/lib/db/contributions';
+import { ContributionForPerson } from '@/lib/db/types';
+import { ContributionCard } from '@/components/meetings/subject/ContributionCard';
 import { isUserAuthorizedToEdit } from '@/lib/auth';
 import { motion } from 'framer-motion';
 import { ImageOrInitials } from '@/components/ImageOrInitials';
 import { PersonWithRelations } from '@/lib/db/people';
 import { filterActiveRoles, filterInactiveRoles, formatDateRange } from '@/lib/utils';
-import { getAdministrativeBodyTypesForPeople } from '@/lib/utils/administrativeBodies';
-import { BadgePicker } from '../ui/badge-picker';
 import { RoleDisplay } from './RoleDisplay';
 import { TopicFilter } from '@/components/TopicFilter';
 import { RoleWithRelations } from '@/lib/db/types';
 import { useSession } from 'next-auth/react';
 import { DebugMetadataButton } from '../ui/debug-metadata-button';
 
-export default function PersonC({ city, person, parties, administrativeBodies, statistics, includeUnreleased }: {
+export default function PersonC({ city, person, parties, administrativeBodies, statistics, contributionTopics }: {
     city: City,
     person: PersonWithRelations,
     parties: Party[],
     administrativeBodies: AdministrativeBody[],
     statistics: Statistics,
-    includeUnreleased?: boolean
+    contributionTopics: Topic[],
 }) {
     const t = useTranslations('Person');
-    const tCommon = useTranslations('Common');
     const router = useRouter();
     const [searchQuery, setSearchQuery] = useState("");
-    const [latestSegments, setLatestSegments] = useState<SegmentWithRelations[]>([]);
+    const [contributions, setContributions] = useState<ContributionForPerson[]>([]);
     const [page, setPage] = useState(1);
     const [totalCount, setTotalCount] = useState(0);
     const [canEdit, setCanEdit] = useState(false);
-    const [selectedAdminBodyType, setSelectedAdminBodyType] = useState<AdministrativeBodyType | null>(null);
     const [selectedTopicId, setSelectedTopicId] = useState<string | null>(null);
-    const [isLoadingSegments, setIsLoadingSegments] = useState(false);
+    const [isLoadingContributions, setIsLoadingContributions] = useState(false);
     const { data: session } = useSession();
     const isSuperAdmin = session?.user?.isSuperAdmin ?? false;
 
-    // Get admin body type options from person's roles
-    const typeOptions = useMemo(() =>
-        getAdministrativeBodyTypesForPeople([person], tCommon),
-        [person, tCommon]);
-
-    // Filter topics to only show ones relevant to this person based on statistics
-    const relevantTopics = useMemo(() => {
-        if (!statistics?.topics) return [];
-        return statistics.topics.map(t => t.item).sort((a, b) => a.name.localeCompare(b.name));
-    }, [statistics?.topics]);
+    // Topic chips reflect the actual contributions list (already sorted server-side).
+    const relevantTopics = contributionTopics;
 
     // Check if person is an independent council member
     const isIndependentCouncilMember = useMemo(() => {
@@ -81,52 +70,48 @@ export default function PersonC({ city, person, parties, administrativeBodies, s
     }, [person.id]);
 
     useEffect(() => {
-        const fetchLatestSegments = async () => {
+        const fetchLatestContributions = async () => {
             try {
-                setIsLoadingSegments(true);
-                setLatestSegments([]);
-                const { results, totalCount } = await getLatestSegmentsForSpeaker(
+                setIsLoadingContributions(true);
+                setContributions([]);
+                const { results, totalCount } = await getLatestContributionsForSpeaker(
                     person.id,
                     1,
                     5,
                     selectedTopicId,
-                    includeUnreleased,
-                    selectedAdminBodyType
                 );
-                setLatestSegments(results);
+                setContributions(results);
                 setTotalCount(totalCount);
                 setPage(1);
             } catch (error) {
-                console.error('Error fetching segments:', error);
+                console.error('Error fetching contributions:', error);
             } finally {
-                setIsLoadingSegments(false);
+                setIsLoadingContributions(false);
             }
         };
-        fetchLatestSegments();
-    }, [person.id, selectedAdminBodyType, selectedTopicId, includeUnreleased]);
+        fetchLatestContributions();
+    }, [person.id, selectedTopicId]);
 
     useEffect(() => {
-        const loadMoreSegments = async () => {
+        const loadMoreContributions = async () => {
             if (page === 1) return;
             try {
-                setIsLoadingSegments(true);
-                const { results } = await getLatestSegmentsForSpeaker(
+                setIsLoadingContributions(true);
+                const { results } = await getLatestContributionsForSpeaker(
                     person.id,
                     page,
                     5,
                     selectedTopicId,
-                    includeUnreleased,
-                    selectedAdminBodyType
                 );
-                setLatestSegments(prevSegments => [...prevSegments, ...results]);
+                setContributions(prev => [...prev, ...results]);
             } catch (error) {
-                console.error('Error loading more segments:', error);
+                console.error('Error loading more contributions:', error);
             } finally {
-                setIsLoadingSegments(false);
+                setIsLoadingContributions(false);
             }
         };
-        loadMoreSegments();
-    }, [person.id, page, selectedAdminBodyType, selectedTopicId, includeUnreleased]);
+        loadMoreContributions();
+    }, [person.id, page, selectedTopicId]);
 
     const handleSearch = (e: React.FormEvent) => {
         e.preventDefault();
@@ -159,11 +144,6 @@ export default function PersonC({ city, person, parties, administrativeBodies, s
             });
         }
     }
-
-    // Handler for admin body type selection
-    const handleAdminBodyTypeChange = (values: AdministrativeBodyType[]) => {
-        setSelectedAdminBodyType(values.length > 0 ? values[0] : null);
-    };
 
     // Handler for topic selection
     const handleTopicSelect = (topicId: string | null) => {
@@ -323,17 +303,6 @@ export default function PersonC({ city, person, parties, administrativeBodies, s
                         />
                     </motion.form>
 
-                    {/* Administrative Body Type Filter - only show if there's more than one type */}
-                    {typeOptions.length > 1 && (
-                        <BadgePicker
-                            options={typeOptions}
-                            selectedValues={selectedAdminBodyType ? [selectedAdminBodyType] : []}
-                            onSelectionChange={handleAdminBodyTypeChange}
-                            allLabel={tCommon('allMeetings')}
-                            className="items-center my-6 sm:my-8 px-2 sm:px-6"
-                        />
-                    )}
-
                     {/* History Section - only show if there are inactive roles */}
                     {filterInactiveRoles(person.roles).length > 0 && (
                         <motion.div
@@ -384,7 +353,7 @@ export default function PersonC({ city, person, parties, administrativeBodies, s
                         transition={{ delay: 0.8 }}
                         className="relative"
                     >
-                        <h2 className="text-lg sm:text-xl font-semibold mb-4">{t('recentSegments', { fallback: 'Πρόσφατες τοποθετήσεις' })}</h2>
+                        <h2 className="text-lg sm:text-xl font-semibold mb-4">{t('recentContributions')}</h2>
 
                         {/* Topic Filter */}
                         {relevantTopics.length > 0 && (
@@ -395,7 +364,7 @@ export default function PersonC({ city, person, parties, administrativeBodies, s
                             />
                         )}
 
-                        {isLoadingSegments && latestSegments.length === 0 ? (
+                        {isLoadingContributions && contributions.length === 0 ? (
                             <div className="flex justify-center items-center py-12 border rounded-lg bg-card/50">
                                 <div className="flex flex-col items-center space-y-4">
                                     <div className="h-6 w-6 sm:h-8 sm:w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
@@ -404,18 +373,40 @@ export default function PersonC({ city, person, parties, administrativeBodies, s
                             </div>
                         ) : (
                             <div className="space-y-3 sm:space-y-4">
-                                {latestSegments.map((segment, index) => (
+                                {contributions.map((contribution, index) => (
                                     <motion.div
-                                        key={index}
+                                        key={contribution.id}
                                         initial={{ opacity: 0, y: 20 }}
                                         animate={{ opacity: 1, y: 0 }}
                                         transition={{ delay: 0.1 * index }}
                                     >
-                                        <Result result={segment} />
+                                        <ContributionCard
+                                            contribution={contribution}
+                                            subjectId={contribution.subject.id}
+                                            meeting={{
+                                                id: contribution.subject.councilMeetingId,
+                                                cityId: contribution.subject.cityId,
+                                            }}
+                                            speaker={contribution.speaker}
+                                            contextHeader={{
+                                                meetingName: contribution.subject.councilMeeting.name,
+                                                adminBodyName: contribution.subject.councilMeeting.administrativeBody?.name ?? null,
+                                                meetingDate: contribution.subject.councilMeeting.dateTime,
+                                                subjectName: contribution.subject.name,
+                                                topic: contribution.subject.topic
+                                                    ? {
+                                                        name: contribution.subject.topic.name,
+                                                        colorHex: contribution.subject.topic.colorHex,
+                                                        icon: contribution.subject.topic.icon,
+                                                    }
+                                                    : null,
+                                            }}
+                                            showPlayButton={false}
+                                        />
                                     </motion.div>
                                 ))}
 
-                                {latestSegments.length === 0 && !isLoadingSegments && (
+                                {contributions.length === 0 && !isLoadingContributions && (
                                     <div className="flex flex-col items-center justify-center py-12 px-4 border rounded-lg bg-card/50">
                                         <FileText className="w-8 h-8 sm:w-12 sm:h-12 text-muted-foreground mb-4" />
                                         <div className="text-muted-foreground text-center space-y-2">
@@ -427,20 +418,20 @@ export default function PersonC({ city, person, parties, administrativeBodies, s
                             </div>
                         )}
 
-                        {isLoadingSegments && latestSegments.length > 0 && (
+                        {isLoadingContributions && contributions.length > 0 && (
                             <div className="flex justify-center items-center py-4">
                                 <div className="h-6 w-6 sm:h-8 sm:w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
                             </div>
                         )}
 
-                        {!isLoadingSegments && latestSegments.length < totalCount && (
+                        {!isLoadingContributions && contributions.length < totalCount && (
                             <Button
                                 onClick={() => setPage(prevPage => prevPage + 1)}
                                 variant="outline"
                                 className="mt-6 w-full sm:w-auto"
-                                disabled={isLoadingSegments}
+                                disabled={isLoadingContributions}
                             >
-                                {isLoadingSegments ? (
+                                {isLoadingContributions ? (
                                     <>
                                         <div className="h-4 w-4 mr-2 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
                                         {t('loading')}

--- a/src/components/persons/Person.tsx
+++ b/src/components/persons/Person.tsx
@@ -402,6 +402,7 @@ export default function PersonC({ city, person, parties, administrativeBodies, s
                                                     : null,
                                             }}
                                             showPlayButton={false}
+                                            disableSpeakerNavigation
                                         />
                                     </motion.div>
                                 ))}

--- a/src/components/persons/PersonBadge.tsx
+++ b/src/components/persons/PersonBadge.tsx
@@ -25,10 +25,11 @@ interface PersonDisplayProps {
     size?: 'sm' | 'md' | 'lg' | 'xl';
     editable?: boolean;
     onClick?: () => void;
+    nonInteractive?: boolean;
 }
 
 // A simpler version of PersonBadge used in search results
-function PersonDisplay({ person, speakerTag, segmentCount, short = false, preferFullName = false, size = 'md', editable = false, onClick }: PersonDisplayProps) {
+function PersonDisplay({ person, speakerTag, segmentCount, short = false, preferFullName = false, size = 'md', editable = false, onClick, nonInteractive = false }: PersonDisplayProps) {
     const activeRoles = person ? filterActiveRoles(person.roles) : [];
     const party = person ? getPartyFromRoles(person.roles) : null;
     const partyColor = party?.colorHex || 'gray';
@@ -54,12 +55,12 @@ function PersonDisplay({ person, speakerTag, segmentCount, short = false, prefer
                     size === 'md' && "w-10 h-10 sm:w-12 sm:h-12",
                     size === 'lg' && "w-12 h-12 sm:w-16 sm:h-16",
                     size === 'xl' && "w-16 h-16 sm:w-24 sm:h-24",
-                    !editable && "cursor-pointer"
+                    !editable && !nonInteractive && "cursor-pointer"
                 )}
-                onClick={onClick}
-                role="button"
-                tabIndex={0}
-                onKeyPress={(e) => {
+                onClick={nonInteractive ? undefined : onClick}
+                role={nonInteractive ? undefined : "button"}
+                tabIndex={nonInteractive ? undefined : 0}
+                onKeyPress={nonInteractive ? undefined : (e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                         onClick?.();
                     }
@@ -119,6 +120,8 @@ interface PersonBadgeProps extends PersonDisplayProps {
     availablePeople?: PersonWithRelations[];
     nextUnknownLabel?: string;
     variant?: 'default' | 'inline';
+    /** When true, the badge does not navigate or behave like a button (useful on the person's own page). */
+    disableNavigation?: boolean;
 }
 
 function PersonBadge({
@@ -137,6 +140,7 @@ function PersonBadge({
     preferFullName = false,
     size = 'md',
     variant = 'default',
+    disableNavigation = false,
 }: PersonBadgeProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
@@ -159,7 +163,7 @@ function PersonBadge({
     const handlePersonClick = () => {
         if (editable) {
             setIsOpen(true);
-        } else if (person) {
+        } else if (person && !disableNavigation) {
             router.push(`/${person.cityId}/people/${person.id}`);
         }
     };
@@ -187,6 +191,7 @@ function PersonBadge({
         );
     }
 
+    const isInteractive = editable || !disableNavigation;
     const badge = (
         <div
             className={cn(
@@ -194,17 +199,17 @@ function PersonBadge({
                 withBorder && "border",
                 isSelected && "bg-accent",
                 editable && "cursor-pointer hover:bg-accent/50",
-                !editable && "cursor-pointer hover:bg-accent/20",
+                !editable && !disableNavigation && "cursor-pointer hover:bg-accent/20",
                 className
             )}
-            onClick={handlePersonClick}
-            role="button"
-            tabIndex={0}
-            onKeyPress={(e) => {
+            onClick={isInteractive ? handlePersonClick : undefined}
+            role={isInteractive ? "button" : undefined}
+            tabIndex={isInteractive ? 0 : undefined}
+            onKeyPress={isInteractive ? (e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                     handlePersonClick();
                 }
-            }}
+            } : undefined}
         >
             <PersonDisplay
                 person={person}
@@ -214,6 +219,7 @@ function PersonBadge({
                 preferFullName={preferFullName}
                 size={size}
                 editable={editable}
+                nonInteractive={disableNavigation && !editable}
             />
             {editable && (
                 <Button

--- a/src/lib/db/contributions.ts
+++ b/src/lib/db/contributions.ts
@@ -1,0 +1,109 @@
+"use server";
+import prisma from './prisma';
+import { Prisma, Topic } from '@prisma/client';
+import { isUserAuthorizedToEdit } from '../auth';
+import { ContributionForPerson, roleWithRelationsInclude } from './types';
+
+async function shouldIncludeUnreleasedForPerson(personId: string): Promise<boolean> {
+    const person = await prisma.person.findUnique({
+        where: { id: personId },
+        select: { cityId: true },
+    });
+    if (!person) return false;
+    return isUserAuthorizedToEdit({ cityId: person.cityId });
+}
+
+/**
+ * Shared `CouncilMeeting` filter for contribution queries.
+ * Keeps the released / admin-body / human-review gating in one place so the
+ * different query functions can't drift.
+ */
+function buildMeetingFilter(includeUnreleased: boolean): Prisma.CouncilMeetingWhereInput {
+    return {
+        ...(includeUnreleased ? {} : { released: true }),
+        // Hide meetings whose admin body hides unreviewed transcripts and
+        // that haven't passed human review.
+        NOT: {
+            administrativeBody: { showUnreviewedTranscript: false },
+            taskStatuses: { none: { type: 'humanReview', status: 'succeeded' } },
+        },
+    };
+}
+
+/**
+ * Returns the distinct topics across all subjects this person has contributed to.
+ * Used to populate the topic-filter chips on the Person page so the list always
+ * reflects what can actually be filtered (vs. segment-derived statistics).
+ */
+export async function getDistinctTopicsForSpeakerContributions(
+    personId: string,
+): Promise<Topic[]> {
+    const includeUnreleased = await shouldIncludeUnreleasedForPerson(personId);
+    const meetingFilter = buildMeetingFilter(includeUnreleased);
+
+    const subjects = await prisma.subject.findMany({
+        where: {
+            contributions: { some: { speakerId: personId } },
+            councilMeeting: meetingFilter,
+            topicId: { not: null },
+        },
+        select: { topic: true },
+        distinct: ['topicId'],
+    });
+
+    return subjects
+        .map(s => s.topic)
+        .filter((t): t is Topic => t !== null)
+        .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getLatestContributionsForSpeaker(
+    personId: string,
+    page: number = 1,
+    pageSize: number = 5,
+    topicId?: string | null,
+): Promise<{ results: ContributionForPerson[]; totalCount: number }> {
+    const skip = (page - 1) * pageSize;
+    const includeUnreleased = await shouldIncludeUnreleasedForPerson(personId);
+    const meetingFilter = buildMeetingFilter(includeUnreleased);
+
+    const whereClause: Prisma.SpeakerContributionWhereInput = {
+        speakerId: personId,
+        subject: {
+            councilMeeting: meetingFilter,
+            ...(topicId ? { topicId } : {}),
+        },
+    };
+
+    const [contributions, totalCount] = await Promise.all([
+        prisma.speakerContribution.findMany({
+            where: whereClause,
+            include: {
+                speaker: {
+                    include: { roles: roleWithRelationsInclude },
+                },
+                subject: {
+                    select: {
+                        id: true,
+                        name: true,
+                        cityId: true,
+                        councilMeetingId: true,
+                        topic: true,
+                        councilMeeting: {
+                            include: { administrativeBody: true },
+                        },
+                    },
+                },
+            },
+            orderBy: [
+                { subject: { councilMeeting: { dateTime: 'desc' } } },
+                { order: 'asc' },
+            ],
+            take: pageSize,
+            skip,
+        }),
+        prisma.speakerContribution.count({ where: whereClause }),
+    ]);
+
+    return { results: contributions, totalCount };
+}

--- a/src/lib/db/contributions.ts
+++ b/src/lib/db/contributions.ts
@@ -1,6 +1,6 @@
 "use server";
 import prisma from './prisma';
-import { Prisma, Topic } from '@prisma/client';
+import { AdministrativeBodyType, Prisma, Topic } from '@prisma/client';
 import { isUserAuthorizedToEdit } from '../auth';
 import { ContributionForPerson, roleWithRelationsInclude } from './types';
 
@@ -13,14 +13,27 @@ async function shouldIncludeUnreleasedForPerson(personId: string): Promise<boole
     return isUserAuthorizedToEdit({ cityId: person.cityId });
 }
 
+async function shouldIncludeUnreleasedForParty(partyId: string): Promise<boolean> {
+    const party = await prisma.party.findUnique({
+        where: { id: partyId },
+        select: { cityId: true },
+    });
+    if (!party) return false;
+    return isUserAuthorizedToEdit({ cityId: party.cityId });
+}
+
 /**
  * Shared `CouncilMeeting` filter for contribution queries.
  * Keeps the released / admin-body / human-review gating in one place so the
  * different query functions can't drift.
  */
-function buildMeetingFilter(includeUnreleased: boolean): Prisma.CouncilMeetingWhereInput {
+function buildMeetingFilter(
+    includeUnreleased: boolean,
+    administrativeBodyType?: AdministrativeBodyType | null,
+): Prisma.CouncilMeetingWhereInput {
     return {
         ...(includeUnreleased ? {} : { released: true }),
+        ...(administrativeBodyType ? { administrativeBody: { type: administrativeBodyType } } : {}),
         // Hide meetings whose admin body hides unreviewed transcripts and
         // that haven't passed human review.
         NOT: {
@@ -72,6 +85,61 @@ export async function getLatestContributionsForSpeaker(
         subject: {
             councilMeeting: meetingFilter,
             ...(topicId ? { topicId } : {}),
+        },
+    };
+
+    const [contributions, totalCount] = await Promise.all([
+        prisma.speakerContribution.findMany({
+            where: whereClause,
+            include: {
+                speaker: {
+                    include: { roles: roleWithRelationsInclude },
+                },
+                subject: {
+                    select: {
+                        id: true,
+                        name: true,
+                        cityId: true,
+                        councilMeetingId: true,
+                        topic: true,
+                        councilMeeting: {
+                            include: { administrativeBody: true },
+                        },
+                    },
+                },
+            },
+            orderBy: [
+                { subject: { councilMeeting: { dateTime: 'desc' } } },
+                { order: 'asc' },
+            ],
+            take: pageSize,
+            skip,
+        }),
+        prisma.speakerContribution.count({ where: whereClause }),
+    ]);
+
+    return { results: contributions, totalCount };
+}
+
+export async function getLatestContributionsForParty(
+    partyId: string,
+    page: number = 1,
+    pageSize: number = 5,
+    administrativeBodyType?: AdministrativeBodyType | null,
+): Promise<{ results: ContributionForPerson[]; totalCount: number }> {
+    const skip = (page - 1) * pageSize;
+    const includeUnreleased = await shouldIncludeUnreleasedForParty(partyId);
+    const meetingFilter = buildMeetingFilter(includeUnreleased, administrativeBodyType);
+
+    // A contribution belongs to the party if its speaker holds any role linking
+    // them to the party. Mirrors getLatestSegmentsForParty (no date-bounded role
+    // check — historical members are included).
+    const whereClause: Prisma.SpeakerContributionWhereInput = {
+        speaker: {
+            roles: { some: { partyId } },
+        },
+        subject: {
+            councilMeeting: meetingFilter,
         },
     };
 

--- a/src/lib/db/types/contribution.ts
+++ b/src/lib/db/types/contribution.ts
@@ -1,0 +1,16 @@
+import { AdministrativeBody, CouncilMeeting, SpeakerContribution, Topic } from '@prisma/client';
+import type { PersonWithRelations } from '../people';
+
+export type ContributionForPerson = SpeakerContribution & {
+    speaker: PersonWithRelations | null;
+    subject: {
+        id: string;
+        name: string;
+        cityId: string;
+        councilMeetingId: string;
+        topic: Topic | null;
+        councilMeeting: CouncilMeeting & {
+            administrativeBody: AdministrativeBody | null;
+        };
+    };
+};

--- a/src/lib/db/types/index.ts
+++ b/src/lib/db/types/index.ts
@@ -15,6 +15,7 @@ import { CouncilMeetingWithAdminBodyAndSubjects } from '../meetings';
 
 // Re-export db types
 export * from './roles';
+export * from './contribution';
 
 // Pagination
 export interface PaginationParams {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the old `speakerSegments`-based display on the Person and Party pages with `SpeakerContribution` records, surfacing AI-generated contribution summaries instead of raw transcript segments. Authorization is now resolved server-side inside each server action rather than being passed as a client-trusted prop.

- **`contributions.ts`** (new): two server actions (`getLatestContributionsForSpeaker`, `getLatestContributionsForParty`) and one topic-query helper, sharing a `buildMeetingFilter` helper to keep release/review gating consistent; authorization is re-derived from the entity's `cityId` on every invocation.
- **`ContributionCard.tsx`**: decoupled from `CouncilMeetingDataContext`; accepts explicit `meeting`/`speaker` props and an optional `contextHeader` to render the meeting/subject header with a colored party sidebar, enabling reuse on the Person and Party pages.
- **`PersonBadge.tsx`**: new `disableNavigation` prop suppresses routing and interactive styling when the badge appears on the subject person's own page.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the auth and DRY concerns flagged in earlier review rounds are both addressed in this revision.

Auth is now resolved server-side in every server action call using the entity's own cityId — the client can no longer influence the includeUnreleased decision. The shared buildMeetingFilter helper keeps release/review gating consistent across both query functions. The ContributionForPerson type is correctly housed in the shared types directory. The ContributionCard decoupling is clean and the PersonBadge navigation suppression works correctly for the on-page speaker use case.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/db/contributions.ts | New server-action file; auth is now resolved server-side via shouldIncludeUnreleasedForPerson/Party; buildMeetingFilter addresses the previous DRY concern; each server-action call adds an extra prisma round-trip to resolve cityId |
| src/lib/db/types/contribution.ts | ContributionForPerson type correctly placed in the shared types directory per CLAUDE.md guidelines and re-exported from the index |
| src/components/meetings/subject/ContributionCard.tsx | Significant refactor: meeting and speaker are now explicit props instead of context-derived; contextHeader enables the Person/Party page layout with a colored sidebar bar, subject link, and meeting metadata |
| src/components/persons/Person.tsx | Replaces segment fetching with contribution fetching; removes includeUnreleased prop (now auth-resolved server-side); topic chips now driven by contributionTopics instead of statistics-derived topics |
| src/components/parties/Party.tsx | Replaces getLatestSegmentsForParty with getLatestContributionsForParty; removes includeUnreleased from component props; tab value renamed from segments to contributions (defaultValue stays people so no user-visible breakage) |
| src/components/persons/PersonBadge.tsx | Adds disableNavigation prop to suppress routing and interactive styling when the badge is shown on the person's own page |
| src/app/[locale]/(city)/[cityId]/(other)/people/[personId]/page.tsx | Adds getDistinctTopicsForSpeakerContributions to the parallel fetch; drops includeUnreleased from PersonC props (auth now server-action internal) |
| src/app/[locale]/(city)/[cityId]/(other)/parties/[partyId]/page.tsx | Removes includeUnreleased computation and prop; auth is now entirely server-action internal |
| src/components/FormattedTextDisplay.tsx | Adds disableUtteranceExpansion prop to render utterance references as plain spans on pages without a CouncilMeetingDataProvider |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser as Browser (Client)
    participant PersonPage as PersonPage (Server)
    participant PersonC as PersonC (Client)
    participant SA as contributions.ts (Server Action)
    participant DB as Prisma / DB

    PersonPage->>DB: getPerson, getCity, getStatisticsFor, getDistinctTopicsForSpeakerContributions
    DB-->>PersonPage: person, city, statistics, contributionTopics
    PersonPage->>Browser: render PersonC(contributionTopics)

    Browser->>SA: getLatestContributionsForSpeaker(personId, page, topicId)
    SA->>DB: person.findUnique → cityId
    SA->>SA: isUserAuthorizedToEdit(cityId)
    SA->>DB: speakerContribution.findMany + count
    DB-->>SA: contributions, totalCount
    SA-->>Browser: "{ results, totalCount }"

    Browser->>PersonC: render ContributionCards
```

<sub>Reviews (3): Last reviewed commit: ["feat(party/page): replace the speakerSeg..."](https://github.com/schemalabz/opencouncil/commit/fed283abf80a345227db8804c75c47b03df98611) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34174792)</sub>

<!-- /greptile_comment -->