### PR TITLE
fix(cache): cap HTML s-maxage at 30s and namespace Valkey keys by buildId

### DIFF
--- a/cache-handler.mjs
+++ b/cache-handler.mjs
@@ -66,9 +66,13 @@ CacheHandler.onCreation(async ({ buildId }) => {
       console.warn('[cache-handler] Deploy flush check failed:', error.message);
     }
 
+    // Namespace by buildId so old-build instances during a rolling deploy can't
+    // pollute the new build's cache (and vice-versa). Without this, an old
+    // instance writes HTML referencing its own chunk hashes into the shared
+    // cache, then new instances serve it and 404 on the chunks they don't have.
     const handler = createRedisHandler({
       client,
-      keyPrefix: 'oc:',
+      keyPrefix: `oc:${buildId ?? 'nobuild'}:`,
       timeoutMs: 1000,
       keyExpirationStrategy: 'EXAT',
       sharedTagsKey: '__oc_tags__',

--- a/cache-handler.mjs
+++ b/cache-handler.mjs
@@ -70,12 +70,15 @@ CacheHandler.onCreation(async ({ buildId }) => {
     // pollute the new build's cache (and vice-versa). Without this, an old
     // instance writes HTML referencing its own chunk hashes into the shared
     // cache, then new instances serve it and 404 on the chunks they don't have.
+    // sharedTagsKey is also namespaced so a revalidateTag from an old-build
+    // instance doesn't delete the new build's entries through the shared tag map.
+    const namespace = buildId || 'nobuild';
     const handler = createRedisHandler({
       client,
-      keyPrefix: `oc:${buildId ?? 'nobuild'}:`,
+      keyPrefix: `oc:${namespace}:`,
       timeoutMs: 1000,
       keyExpirationStrategy: 'EXAT',
-      sharedTagsKey: '__oc_tags__',
+      sharedTagsKey: `__oc_tags__:${namespace}`,
       revalidateTagQuerySize: 100,
     });
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -43,7 +43,7 @@ const nextConfig = {
             {
                 // Cap edge cache on HTML so a broken deploy can't be served by Cloudflare for a year.
                 // Excludes _next/* (immutable hashed assets), api/*, files with extensions, and the embed rule above.
-                source: '/((?!_next/|api/|.*\\..*|[^/]+/embed/).*)',
+                source: '/((?!_next/|api/|[^/]*\\.[^/]*|[^/]+/embed/).*)',
                 headers: [
                     { key: 'Cache-Control', value: 'public, max-age=0, s-maxage=30, stale-while-revalidate=60' },
                 ],

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -40,6 +40,14 @@ const nextConfig = {
                     { key: 'Cache-Control', value: 'public, s-maxage=300, stale-while-revalidate=3600' },
                 ],
             },
+            {
+                // Cap edge cache on HTML so a broken deploy can't be served by Cloudflare for a year.
+                // Excludes _next/* (immutable hashed assets), api/*, files with extensions, and the embed rule above.
+                source: '/((?!_next/|api/|.*\\..*|[^/]+/embed/).*)',
+                headers: [
+                    { key: 'Cache-Control', value: 'public, max-age=0, s-maxage=30, stale-while-revalidate=60' },
+                ],
+            },
         ];
     },
     async redirects() {


### PR DESCRIPTION
## Summary

Permanent fix for the stale-HTML-after-deploy outage class — original incident [INC-2026-04-14-001](https://github.com/schemalabz/engineering/blob/main/incidents/2026-04-14-stale-html-chunks.md) and recurrence on 2026-05-27 (incident writeup PR coming in `schemalabz/engineering`).

> **Note**: This change was applied to the production branch directly during the 2026-05-27 incident and is already running in prod. This PR brings `main` in sync.

Two changes addressing the two layers that compounded the outage:

### 1. `next.config.mjs` — cap HTML edge cache at 30s

HTML pages now respond with `Cache-Control: public, max-age=0, s-maxage=30, stale-while-revalidate=60`. Static assets under `_next/`, API routes, files-with-extensions, and the existing `/:locale/embed/` rule are excluded so they keep their original cache headers.

**Before**: a single broken deploy could cache at Cloudflare for `s-maxage=31536000` (1 year). Recovery required a manual CDN purge — which DO App Platform doesn't directly expose, often requiring a support ticket.

**After**: worst-case blast radius is ≤30s.

### 2. `cache-handler.mjs` — namespace Valkey keys by buildId

`keyPrefix` is now `oc:${buildId}:` instead of `oc:`. During a rolling deploy, old-build instances writing to shared Valkey under their own buildId can no longer pollute the new build's keyspace.

This addresses a previously-undocumented multi-instance race that defeated the existing auto-flush logic ([cache-handler.mjs:48-67](https://github.com/schemalabz/opencouncil/blob/main/cache-handler.mjs#L48-L67)) — the auto-flush runs on new-instance boot, but old instances still serving traffic during the deploy window were re-populating the shared cache with HTML referencing their own (soon-to-be-removed) chunk hashes. New instances then read that polluted entry from Valkey and served HTML referencing chunks they didn't have on disk.

The sentinel key (`oc:__build_id__`) is unaffected — it uses direct `client.get/set` and doesn't go through the handler prefix.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] After deploy, verify HTML response: `curl -sI https://opencouncil.gr/ | grep -i cache-control` shows `s-maxage=30`
- [ ] Verify static assets still cache as expected: `curl -sI https://opencouncil.gr/_next/static/chunks/<any>.js` retains the immutable cache header
- [ ] Verify embed routes still get the longer cache: `curl -sI https://opencouncil.gr/el/embed/...`
- [ ] After a deploy, check that Valkey keys are prefixed with the new buildId (admin cache stats panel)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global HTML edge caching and all production Valkey key/tag layout; behavior is intentional for deploy safety but affects cache hit rates and invalidation until instances converge on one buildId.
> 
> **Overview**
> Limits how long bad HTML can stick at the edge and stops rolling deploys from mixing Next.js build artifacts in shared Valkey.
> 
> **`next.config.mjs`** adds a catch-all `headers()` rule so HTML routes get `Cache-Control: public, max-age=0, s-maxage=30, stale-while-revalidate=60`, while `_next/`, `api/`, extension paths, and `/:locale/embed/` stay on their existing rules.
> 
> **`cache-handler.mjs`** scopes Redis cache keys and the tag-invalidation map to the current `buildId` (`oc:${namespace}:` and `__oc_tags__:${namespace}`), so old instances during deploy no longer write or revalidate against the new build’s entries in the shared store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34f34ecf99a711a4e1d177cc61fd7bad952f2042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Permanently fixes two compounding layers of the stale-HTML-after-deploy outage: HTML edge cache is now capped at `s-maxage=30` (down from `s-maxage=31536000`) and Valkey cache keys are namespaced per `buildId` so rolling-deploy instances can no longer cross-contaminate each other's keyspace.

- **`next.config.mjs`**: Adds a catch-all `headers()` rule that sets `public, max-age=0, s-maxage=30, stale-while-revalidate=60` on all HTML routes, with correct exclusions for `_next/`, `api/`, extension paths, and embed routes (which keep their 300s TTL).
- **`cache-handler.mjs`**: Scopes both `keyPrefix` (`oc:${buildId}:`) and `sharedTagsKey` (`__oc_tags__:${buildId}`) to the current build, so old-build instances writing to shared Valkey during a rolling deploy can't serve stale chunk-hashed HTML to new-build instances.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are targeted fixes that reduce cache blast radius and eliminate cross-build Valkey contamination, with no regressions introduced.

The Valkey namespacing correctly scopes both keyPrefix and sharedTagsKey to the current build, and the sentinel-based flush logic is unaffected. The next.config.mjs regex correctly excludes static assets, API routes, and embed paths from the 30s cap.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cache-handler.mjs | Namespaces both keyPrefix and sharedTagsKey by buildId (falling back to 'nobuild'), effectively isolating each deployment's Valkey keyspace. The sentinel key for the auto-flush logic is intentionally left un-namespaced so cross-build detection still works. |
| next.config.mjs | Adds a catch-all headers() rule that caps HTML edge cache at s-maxage=30, stale-while-revalidate=60. The negative-lookahead regex correctly excludes _next/, api/, extension-bearing paths, and /:locale/embed/ routes. Worst-case stale window is technically 90s due to the SWR window. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
next.config.mjs:48
The `stale-while-revalidate=60` window means the worst-case stale content window is **90 seconds** (30s `s-maxage` + 60s SWR), not 30s as the PR description claims. During the SWR window (30–90s post-deploy), Cloudflare may serve the previously-cached HTML to users while revalidating in the background — meaning broken chunk-hash references from a bad deploy could reach users for up to 90s. If the 30s claim is being used to set incident-response expectations (e.g., "wait 30 seconds before incident is resolved"), consider reducing or removing `stale-while-revalidate`.

```suggestion
                    { key: 'Cache-Control', value: 'public, max-age=0, s-maxage=30, stale-while-revalidate=30' },
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(cache): address review comments — ti..."](https://github.com/schemalabz/opencouncil/commit/34f34ecf99a711a4e1d177cc61fd7bad952f2042) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34214094)</sub>

<!-- /greptile_comment -->