### PR TITLE
fix(webhooks/bird): verify signature before freshness; widen replay window to 24h

### DIFF
--- a/src/app/api/webhooks/bird/route.ts
+++ b/src/app/api/webhooks/bird/route.ts
@@ -19,7 +19,12 @@ import type { Prisma } from '@prisma/client';
 
 const SIGNATURE_HEADER = 'messagebird-signature';
 const TIMESTAMP_HEADER = 'messagebird-request-timestamp';
-const REPLAY_WINDOW_SECONDS = 300;
+// Wide sanity ceiling, not the primary replay defense. Bird's retry queue
+// re-delivers webhooks with the original event timestamp (observed: 3–4h
+// stale), which the previous 300s window was silently rejecting and losing
+// real user messages. Proper replay protection should come from id-based
+// dedupe — see follow-up ticket.
+const REPLAY_WINDOW_SECONDS = 24 * 60 * 60;
 
 function verifyBirdSignature(opts: {
     rawBody: string;
@@ -34,9 +39,10 @@ function verifyBirdSignature(opts: {
 
     const ts = Number(timestampHeader);
     if (!Number.isFinite(ts)) return { ok: false, reason: 'invalid timestamp' };
-    const skew = Math.abs(Math.floor(Date.now() / 1000) - ts);
-    if (skew > REPLAY_WINDOW_SECONDS) return { ok: false, reason: `timestamp skew ${skew}s` };
 
+    // Verify HMAC first. The signature binds timestamp + url + body, so a
+    // passing check already proves the request came from Bird untampered;
+    // the freshness check below is only a sanity ceiling.
     const bodyHash = createHash('sha256').update(rawBody, 'utf8').digest();
     const expected = createHmac('sha256', secret)
         .update(`${timestampHeader}\n${url}\n`, 'utf8')
@@ -48,6 +54,10 @@ function verifyBirdSignature(opts: {
     if (!timingSafeEqual(new Uint8Array(provided), new Uint8Array(expected))) {
         return { ok: false, reason: 'signature mismatch' };
     }
+
+    const skew = Math.abs(Math.floor(Date.now() / 1000) - ts);
+    if (skew > REPLAY_WINDOW_SECONDS) return { ok: false, reason: `timestamp skew ${skew}s` };
+
     return { ok: true };
 }
 

--- a/src/app/api/webhooks/bird/route.ts
+++ b/src/app/api/webhooks/bird/route.ts
@@ -15,7 +15,7 @@ import {
 import { normalizePhone } from '@/lib/notifications/phone';
 import type { VerifyRequestResult, VerifySignatureResult } from '@/lib/notifications/types';
 import { extractMessageFields, type ExtractedMessageFields } from './extract';
-import type { Prisma } from '@prisma/client';
+import type { MessageStatus, Prisma } from '@prisma/client';
 
 const SIGNATURE_HEADER = 'messagebird-signature';
 const TIMESTAMP_HEADER = 'messagebird-request-timestamp';
@@ -110,6 +110,22 @@ async function verifyRequest(request: Request): Promise<VerifyRequestResult> {
 }
 
 
+// Lifecycle rank: pending → sent → {delivered | failed}. Terminal statuses
+// (delivered, failed) absorb. Used to reject replayed webhooks that would
+// otherwise regress a message's status — see PR #389 / issue #391. Also
+// makes the handler tolerant of out-of-order webhook delivery.
+const STATUS_RANK: Record<MessageStatus, number> = {
+    pending: 0,
+    sent: 1,
+    delivered: 2,
+    failed: 2,
+};
+
+function isForwardProgression(current: MessageStatus, next: MessageStatus): boolean {
+    if (current === 'delivered' || current === 'failed') return false;
+    return STATUS_RANK[next] > STATUS_RANK[current];
+}
+
 async function updateOutboundMessage(fields: ExtractedMessageFields): Promise<boolean> {
     if (!fields.birdMessageId) return false;
     const existing = await prisma.message.findUnique({
@@ -117,7 +133,7 @@ async function updateOutboundMessage(fields: ExtractedMessageFields): Promise<bo
     });
     if (!existing) return false;
 
-    if (existing.status !== fields.status) {
+    if (existing.status !== fields.status && isForwardProgression(existing.status, fields.status)) {
         await prisma.message.update({
             where: { id: existing.id },
             data: {


### PR DESCRIPTION
## Summary

Stop silently dropping inbound user messages (including \`STOP\` unsubscribe requests). Bird's retry queue re-delivers webhooks with the **original event timestamp**, not the current time. Observed 3–4h stale timestamps on real traffic — the previous 300s freshness window was rejecting every retry as \`timestamp skew\` before signature verification ever ran.

## Symptoms

From production logs:
\`\`\`
19:26:29  Bird webhook: signature verification failed — timestamp skew 13618s
19:26:33  Bird webhook: signature verification failed — timestamp skew 13608s
19:28:21  Bird webhook: signature verification failed — timestamp skew 13729s
19:28:44  Bird webhook: signature verification failed — timestamp skew 13613s
19:29:31  Bird webhook: signature verification failed — timestamp skew 13683s
19:35:30  Bird webhook: signature verification failed — timestamp skew 11879s
19:35:34  Bird webhook: signature verification failed — timestamp skew 11845s
\`\`\`

Skews cluster into tight batches (15:39–15:41 EEST and 16:17–16:18 EEST original events), which is the fingerprint of a retry queue re-using the original timestamp, not random late traffic. Verified production server clock is correct (1s drift via Date header), so the staleness is on Bird's side.

## Changes

1. **Reorder**: verify HMAC signature before checking the freshness window. The signature cryptographically binds \`timestamp + url + body\`, so a passing signature already proves the request came from Bird untampered. The ordering swap doesn't weaken anything — it just makes intent clear.
2. **Widen window**: \`REPLAY_WINDOW_SECONDS\` 300 → \`24 * 60 * 60\` (24h). Wide ceiling rather than tight gating, since:
   - HMAC signature is still doing the real authentication + integrity work.
   - Bird's own (deprecated) Node SDK uses 100s in [lib/signature.js](https://github.com/messagebird/messagebird-nodejs/blob/master/lib/signature.js); neither 300s nor 24h matches their docs. The 24h ceiling exists only to bound replay risk for the interim before id-based dedupe lands.

## What this does NOT do

Real replay protection should be **id-based dedupe** — persist Bird's per-event \`id\` and reject duplicates. That makes replay rejection exact and independent of any time window. Tracked as a separate follow-up ticket — intentionally out of scope here to keep the hotfix small.

## Test plan

- [ ] \`npx tsc --noEmit\` passes (verified locally).
- [ ] After deploy, inbound webhook traffic stops logging \`timestamp skew\` for retries; legitimate forged-signature attempts still log \`signature mismatch\`.
- [ ] Send a real \`STOP\` from a test number and confirm the unsubscribe path runs end-to-end (was previously dropped on retry).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes webhook acceptance (wider timestamp window) and outbound status persistence; HMAC still gates authenticity, but replay/id dedupe for outbound paths is still incomplete per follow-up work.
> 
> **Overview**
> Fixes **silent loss of Bird webhook traffic** (including inbound `STOP` / unsubscribe) when retries arrive with the **original event timestamp** hours later. The handler now **verifies HMAC before the timestamp skew check** (signature already binds timestamp + URL + body) and widens **`REPLAY_WINDOW_SECONDS` from 300s to 24h** as an interim sanity ceiling; **id-based dedupe** remains called out as follow-up.
> 
> For **outbound delivery updates**, status writes only apply on **forward lifecycle progression** (`pending` → `sent` → `delivered` / `failed`), so replays or out-of-order events cannot regress a message that is already terminal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e152fff205498dfcd365fb22ad611e22ba22eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes Bird inbound webhooks being silently rejected when retry deliveries carry the original (hours-old) event timestamp, which was causing real user messages — including STOP/unsubscribe flows — to be permanently dropped by the previous 300s freshness window.

- **Signature-before-freshness reorder**: HMAC verification now runs first; the freshness check is demoted to a wide sanity ceiling (24h). Since the HMAC binds `timestamp + url + body`, a passing signature already proves authenticity and integrity.
- **`REPLAY_WINDOW_SECONDS` widened to 86 400s**: accommodates Bird's retry queue, which re-delivers events with the original timestamp (observed 3–4h lag in production).
- **`isForwardProgression` guard on outbound status updates**: replaces the bare `existing.status !== fields.status` check, ensuring replayed or out-of-order \"pending\"/\"sent\" webhooks cannot regress a message that has already reached a terminal or later state.

<h3>Confidence Score: 5/5</h3>

Safe to merge — HMAC authentication is intact, and the new isForwardProgression guard directly addresses the outbound-status-regression risk introduced by the wider replay window.

The signature reorder does not weaken authentication — HMAC is still required and verified on every request. The 24h window is a deliberate trade-off and is mitigated for the outbound path by isForwardProgression; the inbound path is naturally idempotent via the P2002 unique constraint on birdMessageId.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/api/webhooks/bird/route.ts | Reorders HMAC check before freshness window, widens REPLAY_WINDOW_SECONDS from 300s to 86400s, and adds STATUS_RANK/isForwardProgression to prevent replayed webhooks from regressing outbound message status back to a prior state. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(webhooks/bird): guard outbound statu..."](https://github.com/schemalabz/opencouncil/commit/c7e152fff205498dfcd365fb22ad611e22ba22eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34230541)</sub>

<!-- /greptile_comment -->