### PR TITLE
chore(valkey): add pingInterval keep-alive to silence idle-socket churn

### DIFF
--- a/cache-handler.mjs
+++ b/cache-handler.mjs
@@ -20,6 +20,10 @@ CacheHandler.onCreation(async ({ buildId }) => {
 
     client = createClient({
       url: normalizedUrl,
+      // Keep the connection warm — DO managed Valkey closes idle TCP sockets
+      // around the 300s mark, producing periodic "Socket closed unexpectedly"
+      // errors and adding reconnect latency to the first request after each.
+      pingInterval: 60_000,
     });
 
     client.on('error', (error) => {

--- a/src/app/api/admin/cache/stats/route.ts
+++ b/src/app/api/admin/cache/stats/route.ts
@@ -25,7 +25,9 @@ async function getClient() {
     }
     // The `redis` npm package uses rediss:// for TLS; DO Valkey uses valkeys://
     const normalizedUrl = cacheUrl.replace(/^valkeys:\/\//, 'rediss://');
-    client = createClient({ url: normalizedUrl });
+    // pingInterval keeps the TCP connection warm against DO Valkey's ~300s
+    // idle timeout — same reasoning as cache-handler.mjs.
+    client = createClient({ url: normalizedUrl, pingInterval: 60_000 });
     client.on('error', (error) => {
       console.error('[cache-stats] Valkey client error:', error.message);
     });


### PR DESCRIPTION
## Summary

Production logs were filling with periodic "Socket closed unexpectedly" errors from both Valkey clients, at exact 5-minute intervals:

\`\`\`
19:24:24  [cache-stats]   Valkey client error: Socket closed unexpectedly
19:26:53  [cache-handler] Valkey client error: Socket closed unexpectedly
19:29:24  [cache-stats]   Valkey client error: Socket closed unexpectedly
19:31:53  [cache-handler] Valkey client error: Socket closed unexpectedly
19:34:24  [cache-stats]   Valkey client error: Socket closed unexpectedly
\`\`\`

The clean 5-minute cadence is the fingerprint of **DigitalOcean Managed Valkey's idle TCP timeout** (~300s). The \`redis\` npm client auto-reconnects with exponential backoff, so this was functionally noise — but:

- The first request after each timeout pays a reconnect penalty (TLS handshake + auth).
- During the 2026-05-27 incident triage, these errors were misleading and made it harder to spot the actual cache-pollution problem.

## Change

Add \`pingInterval: 60_000\` to both Valkey \`createClient\` calls. The redis client sends a lightweight \`PING\` every 60s, keeping the TCP connection well below the 300s idle threshold.

- [cache-handler.mjs](https://github.com/schemalabz/opencouncil/blob/main/cache-handler.mjs) — Next.js cache backend
- [src/app/api/admin/cache/stats/route.ts](https://github.com/schemalabz/opencouncil/blob/main/src/app/api/admin/cache/stats/route.ts) — admin cache observability endpoint

Single option, no behavioral change beyond eliminating the periodic disconnect/reconnect cycle.

## Test plan

- [ ] \`npx tsc --noEmit\` passes (verified locally).
- [ ] After deploy, the periodic \`[cache-handler]\` / \`[cache-stats] Valkey client error: Socket closed unexpectedly\` log entries should stop appearing every 5 minutes.
- [ ] Admin cache stats panel (\`/admin/cache\`) should still report connected and serve fresh stats.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small connection tuning on cache and admin observability paths; no auth, data model, or API contract changes.
> 
> **Overview**
> Adds **`pingInterval: 60_000`** to both Valkey **`redis`** clients so they send periodic **PING**s and stay under DigitalOcean’s ~**300s** idle TCP close.
> 
> **`cache-handler.mjs`** (Next.js cache) and **`src/app/api/admin/cache/stats/route.ts`** (admin stats) previously saw recurring **“Socket closed unexpectedly”** logs and reconnect latency after idle periods; behavior is otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f17bc8ba1e1bac5bd72b3ce86a71898b15a58eb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `pingInterval: 60_000` to both Valkey `createClient` calls (`cache-handler.mjs` and the admin cache-stats route) to prevent DigitalOcean Managed Valkey's ~300 s idle TCP timeout from triggering periodic "Socket closed unexpectedly" errors. The change is minimal, well-commented, and consistent across both clients.

- **`cache-handler.mjs`**: `pingInterval: 60_000` added to the Next.js cache backend's `createClient` call, keeping the connection warm with a PING every 60 s.
- **`src/app/api/admin/cache/stats/route.ts`**: Identical option added to the module-level singleton client, with a cross-reference comment pointing back to `cache-handler.mjs` for the rationale.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single well-understood option added to two client constructors with no behavioral side effects beyond eliminating the periodic reconnect cycle.

Both changes are identical in intent: a single, recognized node-redis client option (pingInterval) set to a conservative 60 s interval against a 300 s idle threshold. TypeScript compilation is verified, the option is applied consistently across both clients, comments explain the reasoning, and there are no logic changes anywhere in the files.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cache-handler.mjs | Adds `pingInterval: 60_000` to the Valkey `createClient` call to keep the TCP connection alive below DigitalOcean's ~300 s idle timeout. No logic changes. |
| src/app/api/admin/cache/stats/route.ts | Same `pingInterval: 60_000` addition to the module-level singleton client in the admin cache-stats route. Change is consistent with cache-handler.mjs and well-commented. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Next.js App
    participant RC as redis Client (node-redis)
    participant DO as DO Managed Valkey

    Note over App,DO: On startup
    App->>RC: "createClient({ pingInterval: 60_000 })"
    App->>RC: client.connect()
    RC->>DO: TCP + TLS handshake + AUTH

    loop Every 60 seconds (pingInterval)
        RC->>DO: PING
        DO-->>RC: PONG
        Note over RC,DO: TCP kept warm — below 300s idle timeout
    end

    Note over App,DO: Without pingInterval (before this PR)
    Note over RC,DO: After ~300s idle, DO closes socket
    RC-->>App: Socket closed unexpectedly
    RC->>DO: reconnect (TLS + AUTH penalty)
```

<sub>Reviews (1): Last reviewed commit: ["chore(valkey): add pingInterval keep-ali..."](https://github.com/schemalabz/opencouncil/commit/f17bc8ba1e1bac5bd72b3ce86a71898b15a58eb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34231046)</sub>

<!-- /greptile_comment -->