### PR TITLE
fix(seo): repair sitemap routes, add hreflang/canonical, robots.txt, llms.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ scripts/clear_advisory_locks.sh
 
 *.csv
 *.txt
+!public/llms.txt
 *.swp
 
 # Logs

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,23 @@
+# OpenCouncil
+
+> OpenCouncil uses AI to monitor Greek municipal (city) council meetings and make them simple and understandable. It transcribes council meeting recordings, breaks them into discrete agenda subjects, summarizes them, and links statements to the councillors and parties who made them. Content is primarily in Greek (el); an English (en) translation of the interface is served under `/en`.
+
+## How content is organized
+
+- Cities (municipalities) each have a page at `https://opencouncil.gr/{cityId}` listing their council meetings, councillors, and parties.
+- Meetings live at `https://opencouncil.gr/{cityId}/{meetingId}` and contain the video, full transcript, and a list of agenda subjects.
+- Subjects (individual agenda items) live at `https://opencouncil.gr/{cityId}/{meetingId}/subjects/{subjectId}` and carry an AI summary plus the relevant transcript segments. These are the most citation-worthy units of content.
+- People (councillors) live at `https://opencouncil.gr/{cityId}/people/{personId}`.
+
+## Key entry points
+
+- [Homepage](https://opencouncil.gr/): overview of supported municipalities.
+- [About](https://opencouncil.gr/about): what OpenCouncil is, who runs it, and how it works.
+- [Search](https://opencouncil.gr/search): full-text search across all transcribed council meetings, filterable by city, person, party, topic, location, and date.
+- [Chat](https://opencouncil.gr/chat): an AI assistant for questions about council meetings and local government.
+- [Sitemap](https://opencouncil.gr/sitemap.xml): the authoritative list of all indexable cities, meetings, and subjects.
+
+## Notes
+
+- OpenCouncil is open source: https://github.com/schemalabz/opencouncil
+- Raw `/transcript` pages duplicate content that is better structured on the subject pages; prefer linking to subject pages when citing specific statements.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,7 @@
 User-agent: *
 Allow: /
 
-# Prevent indexing of transcript pages
-Disallow: */meetings/*/transcript
+# Prevent indexing of raw transcript pages (content is surfaced via subject pages)
+Disallow: /*/*/transcript
 
-Sitemap: https://opencouncil.co/sitemap.xml
+Sitemap: https://opencouncil.gr/sitemap.xml

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
@@ -23,6 +23,7 @@ import { HighlightCreationPermission } from '@prisma/client';
 import { SubjectHeaderProvider } from '@/contexts/SubjectHeaderContext';
 import { NotificationPreferenceProvider } from '@/contexts/NotificationPreferenceContext';
 import { getTranslations } from 'next-intl/server';
+import { buildHreflangAlternates } from '@/lib/utils/hreflang';
 
 export async function generateImageMetadata({
     params: { meetingId, cityId }
@@ -54,9 +55,9 @@ export async function generateImageMetadata({
 }
 
 export async function generateMetadata({
-    params: { meetingId, cityId }
+    params: { meetingId, cityId, locale }
 }: {
-    params: { meetingId: string; cityId: string }
+    params: { meetingId: string; cityId: string; locale: string }
 }) {
     const data = await getMeetingDataCached(cityId, meetingId);
 
@@ -77,6 +78,7 @@ export async function generateMetadata({
     return {
         title: optimizedTitle,
         description,
+        alternates: buildHreflangAlternates(`/${cityId}/${meetingId}`, locale),
         openGraph: {
             title: optimizedTitle,
             description,

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
@@ -2,11 +2,12 @@ import { Metadata } from "next";
 import Subject from "@/components/meetings/subject/subject";
 import { getMeetingDataCached, getSubjectFromMeetingCached } from "@/lib/getMeetingData";
 import { notFound } from "next/navigation";
+import { buildHreflangAlternates } from "@/lib/utils/hreflang";
 
 export async function generateMetadata({
     params,
 }: {
-    params: { cityId: string; meetingId: string; subjectId: string };
+    params: { cityId: string; meetingId: string; subjectId: string; locale: string };
 }): Promise<Metadata> {
     // First try to get the subject from the cached meeting data
     const subject = await getSubjectFromMeetingCached(params.cityId, params.meetingId, params.subjectId);
@@ -33,6 +34,10 @@ export async function generateMetadata({
     return {
         title,
         description,
+        alternates: buildHreflangAlternates(
+            `/${params.cityId}/${params.meetingId}/subjects/${params.subjectId}`,
+            params.locale
+        ),
         openGraph: {
             title,
             description,

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/consultations/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/consultations/page.tsx
@@ -5,9 +5,10 @@ import CityConsultations from "@/components/cities/CityConsultations";
 import { getCityCached } from "@/lib/cache";
 import { getAllConsultationsForCity, isConsultationActive } from "@/lib/db/consultations";
 import { env } from "@/env.mjs";
+import { buildHreflangAlternates } from '@/lib/utils/hreflang';
 
 interface PageProps {
-    params: { cityId: string };
+    params: { cityId: string; locale: string };
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
@@ -75,9 +76,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
             description,
             images: [ogImageUrl],
         },
-        alternates: {
-            canonical: `/${params.cityId}/consultations`,
-        },
+        alternates: buildHreflangAlternates(`/${params.cityId}/consultations`, params.locale),
         other: {
             'consultations:total': totalConsultationsCount.toString(),
             'consultations:active': activeConsultationsCount.toString(),

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/page.tsx
@@ -1,7 +1,19 @@
 import { notFound } from "next/navigation";
+import { Metadata } from "next";
 import { isUserAuthorizedToEdit } from "@/lib/auth";
 import CityMeetings from "@/components/cities/CityMeetings";
 import { getCityCached, getCouncilMeetingsForCityCached } from "@/lib/cache";
+import { buildHreflangAlternates } from "@/lib/utils/hreflang";
+
+export async function generateMetadata({
+    params: { cityId, locale }
+}: {
+    params: { cityId: string; locale: string }
+}): Promise<Metadata> {
+    return {
+        alternates: buildHreflangAlternates(`/${cityId}`, locale),
+    };
+}
 
 export default async function MeetingsPage({
     params: { cityId },

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/people/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/people/page.tsx
@@ -4,8 +4,9 @@ import CityPeople from "@/components/cities/CityPeople";
 import { getPartiesForCityCached, getPeopleForCityCached, getAdministrativeBodiesForCityCached, getCityCached } from "@/lib/cache";
 import { Metadata } from "next";
 import { env } from '@/env.mjs';
+import { buildHreflangAlternates } from '@/lib/utils/hreflang';
 
-export async function generateMetadata({ params }: { params: { cityId: string } }): Promise<Metadata> {
+export async function generateMetadata({ params }: { params: { cityId: string; locale: string } }): Promise<Metadata> {
     const [city, people, parties] = await Promise.all([
         getCityCached(params.cityId),
         getPeopleForCityCached(params.cityId),
@@ -65,9 +66,7 @@ export async function generateMetadata({ params }: { params: { cityId: string } 
             description,
             images: [ogImageUrl],
         },
-        alternates: {
-            canonical: `/${params.cityId}/people`,
-        },
+        alternates: buildHreflangAlternates(`/${params.cityId}/people`, params.locale),
         other: {
             'people:count': peopleCount.toString(),
             'people:parties': partiesCount.toString(),

--- a/src/app/[locale]/(city)/[cityId]/(other)/people/[personId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/people/[personId]/page.tsx
@@ -9,6 +9,7 @@ import { getStatisticsFor } from "@/lib/statistics";
 import { isUserAuthorizedToEdit } from "@/lib/auth";
 import { Metadata } from "next";
 import { env } from '@/env.mjs';
+import { buildHreflangAlternates } from '@/lib/utils/hreflang';
 
 export async function generateMetadata({ params }: { params: { locale: string, personId: string, cityId: string } }): Promise<Metadata> {
     const [person, city] = await Promise.all([
@@ -75,9 +76,7 @@ export async function generateMetadata({ params }: { params: { locale: string, p
             description,
             images: [ogImageUrl],
         },
-        alternates: {
-            canonical: `/${params.cityId}/people/${params.personId}`,
-        },
+        alternates: buildHreflangAlternates(`/${params.cityId}/people/${params.personId}`, params.locale),
         other: {
             'person:name': person.name,
             'person:city': city.name,

--- a/src/app/[locale]/(city)/[cityId]/consultation/[id]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/consultation/[id]/page.tsx
@@ -6,9 +6,10 @@ import { ConsultationViewer } from "@/components/consultations";
 import { auth } from "@/auth";
 import { env } from "@/env.mjs";
 import { Suspense } from "react";
+import { buildHreflangAlternates } from '@/lib/utils/hreflang';
 
 interface PageProps {
-    params: { cityId: string; id: string };
+    params: { cityId: string; id: string; locale: string };
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
@@ -77,9 +78,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
             description,
             images: [ogImageUrl],
         },
-        alternates: {
-            canonical: `/${params.cityId}/consultation/${params.id}`,
-        },
+        alternates: buildHreflangAlternates(`/${params.cityId}/consultation/${params.id}`, params.locale),
         other: {
             'consultation:status': isActive ? 'active' : 'expired',
             'consultation:endDate': consultation.endDate.toISOString(),

--- a/src/app/[locale]/(interfaces)/chat/page.tsx
+++ b/src/app/[locale]/(interfaces)/chat/page.tsx
@@ -2,54 +2,59 @@ import { ChatInterface } from "@/components/chat/ChatInterface";
 import { Suspense } from "react";
 import { Metadata } from "next";
 import { env } from '@/env.mjs';
+import { buildHreflangAlternates } from '@/lib/utils/hreflang';
 
-export const metadata: Metadata = {
-    title: "OpenCouncil AI | Συνομιλήστε για τα Δημοτικά Συμβούλια",
-    description: "Συνομιλήστε με την τεχνητή νοημοσύνη του OpenCouncil για να μάθετε για δημοτικά συμβούλια, θέματα πολιτικής και την τοπική αυτοδιοίκηση. Κάντε ερωτήσεις και λάβετε εξατομικευμένες απαντήσεις.",
-    keywords: [
-        'OpenCouncil AI',
-        'τεχνητή νοημοσύνη',
-        'chatbot',
-        'δημοτικά συμβούλια',
-        'πολιτική',
-        'τοπική αυτοδιοίκηση',
-        'ερωτήσεις',
-        'απαντήσεις',
-        'διαδραστικότητα'
-    ],
-    authors: [{ name: 'OpenCouncil' }],
-    openGraph: {
-        title: "OpenCouncil AI",
-        description: "Συνομιλήστε με την τεχνητή νοημοσύνη για να μάθετε για δημοτικά συμβούλια και θέματα πολιτικής",
-        type: 'website',
-        siteName: 'OpenCouncil',
-        images: [
-            {
-                url: `${env.NEXTAUTH_URL}/api/og?pageType=chat`,
-                width: 1200,
-                height: 630,
-                alt: "OpenCouncil AI - Συνομιλήστε για τα Δημοτικά Συμβούλια",
-            }
+export async function generateMetadata({
+    params: { locale }
+}: {
+    params: { locale: string }
+}): Promise<Metadata> {
+    return {
+        title: "OpenCouncil AI | Συνομιλήστε για τα Δημοτικά Συμβούλια",
+        description: "Συνομιλήστε με την τεχνητή νοημοσύνη του OpenCouncil για να μάθετε για δημοτικά συμβούλια, θέματα πολιτικής και την τοπική αυτοδιοίκηση. Κάντε ερωτήσεις και λάβετε εξατομικευμένες απαντήσεις.",
+        keywords: [
+            'OpenCouncil AI',
+            'τεχνητή νοημοσύνη',
+            'chatbot',
+            'δημοτικά συμβούλια',
+            'πολιτική',
+            'τοπική αυτοδιοίκηση',
+            'ερωτήσεις',
+            'απαντήσεις',
+            'διαδραστικότητα'
         ],
-        locale: 'el_GR',
-    },
-    twitter: {
-        card: 'summary_large_image',
-        title: "OpenCouncil AI",
-        description: "Συνομιλήστε με την τεχνητή νοημοσύνη για να μάθετε για δημοτικά συμβούλια και θέματα πολιτικής",
-        images: [`${env.NEXTAUTH_URL}/api/og?pageType=chat`],
-        creator: '@opencouncil',
-        site: '@opencouncil'
-    },
-    alternates: {
-        canonical: '/chat',
-    },
-    other: {
-        'chat:type': 'ai-assistant',
-        'chat:domain': 'municipal-politics',
-        'chat:interactive': 'true',
-    }
-};
+        authors: [{ name: 'OpenCouncil' }],
+        openGraph: {
+            title: "OpenCouncil AI",
+            description: "Συνομιλήστε με την τεχνητή νοημοσύνη για να μάθετε για δημοτικά συμβούλια και θέματα πολιτικής",
+            type: 'website',
+            siteName: 'OpenCouncil',
+            images: [
+                {
+                    url: `${env.NEXTAUTH_URL}/api/og?pageType=chat`,
+                    width: 1200,
+                    height: 630,
+                    alt: "OpenCouncil AI - Συνομιλήστε για τα Δημοτικά Συμβούλια",
+                }
+            ],
+            locale: 'el_GR',
+        },
+        twitter: {
+            card: 'summary_large_image',
+            title: "OpenCouncil AI",
+            description: "Συνομιλήστε με την τεχνητή νοημοσύνη για να μάθετε για δημοτικά συμβούλια και θέματα πολιτικής",
+            images: [`${env.NEXTAUTH_URL}/api/og?pageType=chat`],
+            creator: '@opencouncil',
+            site: '@opencouncil'
+        },
+        alternates: buildHreflangAlternates('/chat', locale),
+        other: {
+            'chat:type': 'ai-assistant',
+            'chat:domain': 'municipal-politics',
+            'chat:interactive': 'true',
+        }
+    };
+}
 
 export default function ChatPage() {
     return <Suspense fallback={<div>Loading...</div>}>

--- a/src/app/[locale]/(interfaces)/search/page.tsx
+++ b/src/app/[locale]/(interfaces)/search/page.tsx
@@ -3,8 +3,13 @@ import { default as SearchPageComponent } from "@/components/search/SearchPage";
 import { Suspense } from "react";
 import { Metadata } from "next";
 import { env } from '@/env.mjs';
+import { buildHreflangAlternates } from '@/lib/utils/hreflang';
 
-export async function generateMetadata(): Promise<Metadata> {
+export async function generateMetadata({
+    params: { locale }
+}: {
+    params: { locale: string }
+}): Promise<Metadata> {
     const description = "Αναζητήστε στα δημοτικά συμβούλια του OpenCouncil. Βρείτε αναφορές σε θέματα, τοποθετήσεις συμβούλων, στατιστικά και πολλά άλλα χρησιμοποιώντας την έξυπνη αναζήτηση του OpenCouncil.";
 
     const ogImageUrl = `${env.NEXTAUTH_URL}/api/og?pageType=search`;
@@ -47,9 +52,7 @@ export async function generateMetadata(): Promise<Metadata> {
             creator: '@opencouncil',
             site: '@opencouncil'
         },
-        alternates: {
-            canonical: '/search',
-        },
+        alternates: buildHreflangAlternates('/search', locale),
         other: {
             'search:type': 'intelligent',
             'search:scope': 'municipal-councils',

--- a/src/app/[locale]/(other)/about/page.tsx
+++ b/src/app/[locale]/(other)/about/page.tsx
@@ -3,8 +3,13 @@ import { Metadata } from "next"
 import { getTranslations } from 'next-intl/server'
 import { env } from '@/env.mjs'
 import { getSupportedCitiesWithLogosCached, getAboutPageStatsCached, getGitHubStatsCached } from '@/lib/cache/queries'
+import { buildHreflangAlternates } from '@/lib/utils/hreflang'
 
-export async function generateMetadata(): Promise<Metadata> {
+export async function generateMetadata({
+    params: { locale }
+}: {
+    params: { locale: string }
+}): Promise<Metadata> {
     const t = await getTranslations('about.metadata')
 
     const title = t('title')
@@ -40,9 +45,7 @@ export async function generateMetadata(): Promise<Metadata> {
             creator: '@opencouncil',
             site: '@opencouncil'
         },
-        alternates: {
-            canonical: '/about',
-        },
+        alternates: buildHreflangAlternates('/about', locale),
         other: {
             'about:mission': 'transparency',
             'about:technology': 'artificial-intelligence',

--- a/src/app/[locale]/(other)/page.tsx
+++ b/src/app/[locale]/(other)/page.tsx
@@ -1,6 +1,18 @@
+import { Metadata } from "next";
 import { Landing } from "@/components/landing/landing";
 import { LandingCity } from "@/lib/db/landing";
 import { fetchLatestSubstackPostCached, getAllCitiesMinimalCached, getCouncilMeetingsForCityPublicCached } from "@/lib/cache/queries";
+import { buildHreflangAlternates } from "@/lib/utils/hreflang";
+
+export async function generateMetadata({
+    params: { locale }
+}: {
+    params: { locale: string }
+}): Promise<Metadata> {
+    return {
+        alternates: buildHreflangAlternates('', locale),
+    };
+}
 
 export default async function HomePage({
     params: { locale }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -84,20 +84,20 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
     const meetingEntries: MetadataRoute.Sitemap = cities.flatMap(city =>
         city.councilMeetings.map(meeting => ({
-            url: `${baseUrl}/${city.id}/meetings/${meeting.id}`,
+            url: `${baseUrl}/${city.id}/${meeting.id}`,
             changeFrequency: 'weekly',
             priority: 0.7,
-            alternates: buildAlternates(`/${city.id}/meetings/${meeting.id}`)
+            alternates: buildAlternates(`/${city.id}/${meeting.id}`)
         }))
     )
 
     const subjectEntries: MetadataRoute.Sitemap = cities.flatMap(city =>
         city.councilMeetings.flatMap(meeting =>
             meeting.subjects.map(subject => ({
-                url: `${baseUrl}/${city.id}/meetings/${meeting.id}/subjects/${subject.id}`,
+                url: `${baseUrl}/${city.id}/${meeting.id}/subjects/${subject.id}`,
                 changeFrequency: 'weekly',
                 priority: 0.6,
-                alternates: buildAlternates(`/${city.id}/meetings/${meeting.id}/subjects/${subject.id}`)
+                alternates: buildAlternates(`/${city.id}/${meeting.id}/subjects/${subject.id}`)
             }))
         )
     )

--- a/src/lib/utils/hreflang.ts
+++ b/src/lib/utils/hreflang.ts
@@ -1,0 +1,29 @@
+import { Metadata } from 'next';
+import { env } from '@/env.mjs';
+
+const baseUrl = env.NEXTAUTH_URL;
+
+/**
+ * Builds canonical + hreflang alternates for a page.
+ *
+ * Greek is the default locale and served unprefixed (`/path`); English lives at
+ * `/en/path`. `x-default` points at the Greek URL so search engines surface the
+ * Greek variant by default. Each locale self-references its own canonical to
+ * avoid sending Google a canonical signal that contradicts the hreflang cluster.
+ *
+ * @param path locale-agnostic path beginning with `/`, or `''` for the homepage
+ * @param locale current request locale (`'el'` | `'en'`)
+ */
+export function buildHreflangAlternates(path: string, locale: string): Metadata['alternates'] {
+    const elUrl = `${baseUrl}${path || '/'}`;
+    const enUrl = `${baseUrl}/en${path}`;
+
+    return {
+        canonical: locale === 'en' ? enUrl : elUrl,
+        languages: {
+            el: elUrl,
+            en: enUrl,
+            'x-default': elUrl,
+        },
+    };
+}

--- a/src/lib/utils/hreflang.ts
+++ b/src/lib/utils/hreflang.ts
@@ -15,7 +15,7 @@ const baseUrl = env.NEXTAUTH_URL;
  * @param locale current request locale (`'el'` | `'en'`)
  */
 export function buildHreflangAlternates(path: string, locale: string): Metadata['alternates'] {
-    const elUrl = `${baseUrl}${path || '/'}`;
+    const elUrl = `${baseUrl}${path}`;
     const enUrl = `${baseUrl}/en${path}`;
 
     return {


### PR DESCRIPTION
## Summary

A bundle of SEO fixes addressing the mass de-indexing in Google Search Console plus LLM discoverability. Four atomic changes:

1. **Sitemap pointed at real routes** — the sitemap emitted a phantom `/meetings/` path segment (`/{city}/meetings/{meeting}` and `/{city}/meetings/{meeting}/subjects/...`). Those URLs 404 in production; the real routes are `/{city}/{meeting}` and `/{city}/{meeting}/subjects/...`. This made ~99.8% of the 6,958 sitemap URLs 404, which is the root cause of the de-indexing (GSC: 2,062 "Not found 404" + 6,296 "Discovered – not indexed"). Confirmed via production curl: 404 with `/meetings/`, 200 without.

2. **hreflang + locale-aware canonical (Closes #281)** — adds a shared `buildHreflangAlternates(path, locale)` helper (`src/lib/utils/hreflang.ts`) and wires it into every public page type (homepage, about, search, chat, city home, people, person, consultations, consultation, meeting, subject). Greek is the default/unprefixed locale (`/`), English lives at `/en`. Each locale is self-referentially canonical, with `x-default` → Greek. The homepage and city-home pages previously emitted **no** metadata at all.

3. **robots.txt** — fixed the sitemap URL domain to `https://opencouncil.gr/sitemap.xml` and added a `Disallow: /*/*/transcript` rule (raw transcript pages duplicate the subject pages that already surface that content).

4. **llms.txt** — new `public/llms.txt` describing the site, its URL structure, and key entry points for LLM crawlers (llmstxt.org convention). Required a `!public/llms.txt` negation in `.gitignore` since `*.txt` was ignoring it.

Supersedes #325 (which used an always-Greek canonical that conflicts with hreflang and risks de-indexing `/en`).

## Test plan

- [ ] Verify the homepage and `/en` render `<link rel="alternate" hreflang="...">` and self-referential `<link rel="canonical">` tags (live verification — dev server was down during authoring)
- [ ] Verify `/sitemap.xml` URLs no longer contain the `/meetings/` segment
- [ ] Verify `/robots.txt` references `https://opencouncil.gr/sitemap.xml` and the transcript disallow rule
- [ ] Verify `/llms.txt` is served (not 404)
- [ ] After deploy: resubmit sitemap in Google Search Console and monitor indexing recovery

Closes #281

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and static SEO assets only; no auth, data, or runtime business logic changes. Wrong canonical/hreflang could still affect indexing until verified in production.
> 
> **Overview**
> Fixes mass de-indexing by correcting **sitemap** meeting and subject URLs: removes the phantom `/meetings/` segment so entries match live routes (`/{city}/{meeting}` and `.../subjects/...`).
> 
> Adds **`buildHreflangAlternates`** and wires locale-aware **canonical** plus **hreflang** (`el`, `en`, `x-default` → Greek) across public pages (home, about, search, chat, city, people, consultations, meetings, subjects), including new metadata where it was missing. Replaces prior path-only canonicals on several routes.
> 
> Updates **`robots.txt`**: sitemap host to `opencouncil.gr`, transcript disallow pattern `/*/*/transcript`. Adds **`public/llms.txt`** and a `.gitignore` exception so it is not ignored by `*.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 898b1ea7472f0b329787506968245d0cd468088d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the root cause of mass Google de-indexing by correcting sitemap URLs (removing the phantom `/meetings/` segment so ~6,900 URLs stop 404ing), and adds locale-aware canonical + hreflang tags across all public page types via a new `buildHreflangAlternates` helper. It also repairs `robots.txt` (correct domain, updated transcript disallow pattern) and adds `public/llms.txt` for LLM crawler discoverability.

- **Sitemap**: `/{city}/meetings/{meeting}` → `/{city}/{meeting}` and `/{city}/meetings/{meeting}/subjects/...` → `/{city}/{meeting}/subjects/...`, matching production routes.
- **hreflang/canonical**: New `src/lib/utils/hreflang.ts` utility wired into homepage, about, search, chat, city home, people, person, consultations, consultation, meeting, and subject pages; Greek is the default unprefixed locale with `x-default` pointing to it, English lives under `/en`.
- **robots.txt + llms.txt**: Sitemap URL corrected to `opencouncil.gr`; transcript pages disallowed via `/*/*/transcript`; new `llms.txt` documents URL structure for AI crawlers with a `.gitignore` negation to un-hide it.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive metadata fixes that align sitemap URLs with live routes and add standard hreflang/canonical signals.

The sitemap path fix is a straight string correction confirmed against production routes, the hreflang utility is straightforward and well-structured, and the static files (robots.txt, llms.txt) are well-formed. No logic paths were removed or altered in a way that could regress existing behavior.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/utils/hreflang.ts | New utility that builds locale-aware canonical + hreflang alternates; Greek is the default unprefixed locale, English lives at /en, x-default points to Greek. |
| src/app/sitemap.ts | Removes phantom /meetings/ segment from meeting and subject URLs; hreflang alternates already emit el + en but lack x-default (noted in prior review). |
| public/robots.txt | Corrects sitemap domain from opencouncil.co to opencouncil.gr and updates Disallow pattern for transcript pages to match actual route structure. |
| public/llms.txt | New file documenting site structure for LLM crawlers; accurately describes URL patterns and key entry points per the llmstxt.org convention. |
| src/app/[locale]/(other)/page.tsx | Adds a generateMetadata function that was previously absent; returns only alternates (title/description come from parent layout). |
| src/app/[locale]/(interfaces)/chat/page.tsx | Converts static metadata export to async generateMetadata function so locale param is accessible; wires hreflang alternates for /chat. |
| src/app/[locale]/(city)/[cityId]/(other)/(tabs)/page.tsx | Adds generateMetadata (previously absent) emitting hreflang alternates for the city home page. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["generateMetadata(params)"] --> B["buildHreflangAlternates(path, locale)"]
    B --> C{"locale === 'en'?"}
    C -- "Yes" --> D["canonical = baseUrl + '/en' + path"]
    C -- "No (el / default)" --> E["canonical = baseUrl + path"]
    B --> F["languages.el = baseUrl + path"]
    B --> G["languages.en = baseUrl + '/en' + path"]
    B --> H["languages['x-default'] = baseUrl + path (Greek)"]
    D --> I["Metadata returned to Next.js"]
    E --> I
    F --> I
    G --> I
    H --> I

    J["sitemap.ts buildAlternates(path)"] --> K["languages.el = baseUrl + path"]
    J --> L["languages.en = baseUrl + '/en' + path"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/sitemap.ts`, line 15-22 ([link](https://github.com/schemalabz/opencouncil/blob/540ecd4f8bf2cb367dde9005b25fa674eb6ca682/src/app/sitemap.ts#L15-L22)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Sitemap `x-default` hreflang absent**

   The per-page `buildHreflangAlternates` utility emits `x-default` → Greek, but the sitemap's local `buildAlternates` only emits `el` and `en`. Google's documentation recommends including the `x-default` value in sitemap hreflang clusters as well, so that crawlers know which page to serve for unmatched locales. Without it, the sitemap cluster is inconsistent with the in-page hreflang tags already added by this PR.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/sitemap.ts
   Line: 15-22

   Comment:
   **Sitemap `x-default` hreflang absent**

   The per-page `buildHreflangAlternates` utility emits `x-default` → Greek, but the sitemap's local `buildAlternates` only emits `el` and `en`. Google's documentation recommends including the `x-default` value in sitemap hreflang clusters as well, so that crawlers know which page to serve for unmatched locales. Without it, the sitemap cluster is inconsistent with the in-page hreflang tags already added by this PR.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fixup! fix(seo): add hreflang and locale..."](https://github.com/schemalabz/opencouncil/commit/898b1ea7472f0b329787506968245d0cd468088d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34542619)</sub>

<!-- /greptile_comment -->