### PR TITLE
feat: add metadata to city and party pages

### DIFF
--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/page.tsx
@@ -4,13 +4,58 @@ import { isUserAuthorizedToEdit } from "@/lib/auth";
 import CityMeetings from "@/components/cities/CityMeetings";
 import { getCityCached, getCouncilMeetingsForCityCached } from "@/lib/cache";
 import { buildHreflangAlternates } from "@/lib/utils/hreflang";
+import { env } from "@/env.mjs";
 
 export async function generateMetadata({
     params: { cityId, locale }
 }: {
     params: { cityId: string; locale: string }
 }): Promise<Metadata> {
+    const city = await getCityCached(cityId);
+
+    if (!city) {
+        return {
+            title: "Δήμος δεν βρέθηκε | OpenCouncil",
+            description: "Ο δήμος που αναζητάτε δεν είναι διαθέσιμος.",
+            alternates: buildHreflangAlternates(`/${cityId}`, locale),
+        };
+    }
+
+    const description = `Συνεδριάσεις του Δήμου ${city.name}: βίντεο, απομαγνητοφωνήσεις, θέματα ημερήσιας διάταξης και αποφάσεις, εξηγημένα απλά.`;
+    const ogImageUrl = `${env.NEXTAUTH_URL}/api/og?cityId=${cityId}`;
+
     return {
+        title: `${city.name} | OpenCouncil`,
+        description,
+        keywords: [
+            city.name,
+            "δημοτικό συμβούλιο",
+            "συνεδριάσεις",
+            "τοπική αυτοδιοίκηση",
+            "OpenCouncil",
+        ],
+        authors: [{ name: `Δήμος ${city.name}` }],
+        openGraph: {
+            title: `${city.name} | OpenCouncil`,
+            description,
+            type: "website",
+            siteName: "OpenCouncil",
+            images: [
+                {
+                    url: ogImageUrl,
+                    width: 1200,
+                    height: 630,
+                    alt: `OpenCouncil — Συνεδριάσεις του Δήμου ${city.name}`,
+                },
+            ],
+            locale: locale === "en" ? "en_US" : "el_GR",
+        },
+        twitter: {
+            card: "summary_large_image",
+            title: `${city.name} | OpenCouncil`,
+            description,
+            images: [ogImageUrl],
+        },
         alternates: buildHreflangAlternates(`/${cityId}`, locale),
     };
 }

--- a/src/app/[locale]/(city)/[cityId]/(other)/parties/[partyId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/parties/[partyId]/page.tsx
@@ -1,14 +1,87 @@
 "use server";
+import { cache } from "react";
 import PartyC from "@/components/parties/Party";
-import { getCity } from "@/lib/db/cities";
+import { getCityCached } from "@/lib/cache";
 import { getParty } from "@/lib/db/parties";
 import { notFound } from "next/navigation";
 import { getAdministrativeBodiesForCity } from "@/lib/db/administrativeBodies";
+import { Metadata } from "next";
+import { env } from "@/env.mjs";
+import { buildHreflangAlternates } from "@/lib/utils/hreflang";
+
+// Request-scoped dedup so generateMetadata and PartyPage share a single fetch.
+const getPartyCached = cache(getParty);
+
+export async function generateMetadata({
+    params,
+}: {
+    params: { locale: string; partyId: string; cityId: string };
+}): Promise<Metadata> {
+    const [party, city] = await Promise.all([
+        getPartyCached(params.partyId),
+        getCityCached(params.cityId),
+    ]);
+
+    if (!party || !city) {
+        return {
+            title: "Παράταξη δεν βρέθηκε | OpenCouncil",
+            description: "Η παράταξη που αναζητάτε δεν είναι διαθέσιμη.",
+        };
+    }
+
+    const description = `Η παράταξη ${party.name} στο Δημοτικό Συμβούλιο του Δήμου ${city.name}. Δείτε τα μέλη, τις τοποθετήσεις και τη δραστηριότητά της στις συνεδριάσεις.`;
+    const ogImageUrl = `${env.NEXTAUTH_URL}/api/og?cityId=${params.cityId}`;
+
+    return {
+        title: `${party.name} | ${city.name} | OpenCouncil`,
+        description,
+        keywords: [
+            party.name,
+            party.name_short,
+            "παράταξη",
+            "δημοτικό συμβούλιο",
+            "τοπική αυτοδιοίκηση",
+            city.name,
+            "OpenCouncil",
+        ],
+        authors: [{ name: `Δήμος ${city.name}` }],
+        openGraph: {
+            title: `${party.name} | ${city.name}`,
+            description,
+            type: "website",
+            siteName: "OpenCouncil",
+            images: [
+                {
+                    url: ogImageUrl,
+                    width: 1200,
+                    height: 630,
+                    alt: `${party.name} — Δήμος ${city.name}`,
+                },
+            ],
+            locale: params.locale === "en" ? "en_US" : "el_GR",
+        },
+        twitter: {
+            card: "summary_large_image",
+            title: `${party.name} | ${city.name}`,
+            description,
+            images: [ogImageUrl],
+        },
+        alternates: buildHreflangAlternates(
+            `/${params.cityId}/parties/${params.partyId}`,
+            params.locale,
+        ),
+        other: {
+            "party:name": party.name,
+            "party:short": party.name_short,
+            "party:city": city.name,
+        },
+    };
+}
 
 export default async function PartyPage({ params }: { params: { locale: string, partyId: string, cityId: string } }) {
     const [party, city, administrativeBodies] = await Promise.all([
-        getParty(params.partyId),
-        getCity(params.cityId),
+        getPartyCached(params.partyId),
+        getCityCached(params.cityId),
         getAdministrativeBodiesForCity(params.cityId)
     ]);
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds rich `generateMetadata` exports to the city and party pages, covering page title, description, keywords, Open Graph, and Twitter card metadata. The party page also introduces a `react.cache()` wrapper so `generateMetadata` and the page component share a single DB fetch per request.

- **City page** (`(tabs)/page.tsx`): adds full metadata with city-specific OG image, hreflang alternates, and a graceful not-found fallback.
- **Party page** (`parties/[partyId]/page.tsx`): adds full metadata with parallel `getPartyCached`/`getCityCached` calls, switches from uncached `getCity` to `getCityCached`, and adds `alternates` for hreflang support. Also includes a non-standard `other` block with `party:*` meta keys that no crawler recognizes.

<h3>Confidence Score: 5/5</h3>

The changes are additive metadata-only additions with no effect on runtime rendering or data mutations; safe to merge.

Both files only introduce `generateMetadata` functions and improve existing DB call patterns. No rendering logic, auth, or data mutations are touched, and the existing page components are unchanged.

No files require special attention beyond the minor suggestions on the non-standard `other` meta tags and the hreflang alternates on the not-found path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/(city)/[cityId]/(other)/(tabs)/page.tsx | Adds full generateMetadata with title, description, keywords, OG, and Twitter tags for the city page; uses the existing getCityCached helper and correctly handles the not-found case. |
| src/app/[locale]/(city)/[cityId]/(other)/parties/[partyId]/page.tsx | Adds generateMetadata with rich metadata for party pages; introduces react.cache() wrapper to deduplicate getParty calls between metadata and page render. Includes non-standard other meta tags whose value is unclear. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Crawler as Social Crawler / Bot
    participant Next as Next.js (generateMetadata)
    participant Cache as react.cache() / getCityCached
    participant DB as Database

    Crawler->>Next: GET /el/athens (city page)
    Next->>Cache: getCityCached("athens")
    Cache->>DB: "SELECT city WHERE id="athens""
    DB-->>Cache: city row
    Cache-->>Next: city data
    Note over Next: Build OG title, description,<br/>Twitter card, hreflang alternates
    Next-->>Crawler: head with full metadata

    Crawler->>Next: GET /el/athens/parties/party-1
    par Parallel fetch
        Next->>Cache: getPartyCached("party-1")
        Cache->>DB: "SELECT party WHERE id="party-1""
        DB-->>Cache: party row
    and
        Next->>Cache: getCityCached("athens")
        Note over Cache: Cache hit — no DB round-trip
    end
    Cache-->>Next: party + city data
    Note over Next: Build OG title, description,<br/>Twitter card, hreflang alternates
    Next-->>Crawler: head with full metadata
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/app/[locale]/(city)/[cityId]/(other)/parties/[partyId]/page.tsx:73-77
The `other` block emits three non-standard `<meta>` tags (`party:name`, `party:short`, `party:city`). These keys don't belong to any recognized protocol (Open Graph uses `og:`, Twitter uses `twitter:`, Schema.org uses JSON-LD), so search engines and social crawlers will silently ignore them. The same structured data is already expressed via the title, description, and `openGraph` fields, making these tags redundant noise in the `<head>`.

```suggestion
        // No custom `other` block needed — party name, short name, and city
        // are already surfaced via title, description, and openGraph fields.
```

### Issue 2 of 2
src/app/[locale]/(city)/[cityId]/(other)/(tabs)/page.tsx:16-22
The not-found fallback returns `alternates` with hreflang links that point to a city route that doesn't exist. This tells search engines there are valid Greek/English variants of a 404 page. The party page's not-found handler correctly omits `alternates`; the city page should do the same.

```suggestion
    if (!city) {
        return {
            title: "Δήμος δεν βρέθηκε | OpenCouncil",
            description: "Ο δήμος που αναζητάτε δεν είναι διαθέσιμος.",
        };
    }
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat: add metadata to city and party pag..."](https://github.com/schemalabz/opencouncil/commit/9db0fd817ad22ae8896b9e240d3711851f19f845) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34552643)</sub>

<!-- /greptile_comment -->