### PR TITLE
fix(analytics): exclude embed iframe routes from Plausible tracking

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "./globals.css"
 import { cn } from "../lib/utils"
 import React from "react"
-import PlausibleProvider from 'next-plausible'
+import PlausibleAnalytics from "@/components/analytics/PlausibleAnalytics"
 import { SessionProvider } from "next-auth/react"
 import { Toaster } from "@/components/ui/toaster";
 import { routing } from "@/i18n/routing";
@@ -77,10 +77,10 @@ export default async function RootLayout({
                     {t("skipToContent")}
                 </a>
                 <SessionProvider>
-                    <PlausibleProvider domain="opencouncil.gr">
+                    <PlausibleAnalytics>
                         {children}
                         <Toaster />
-                    </PlausibleProvider>
+                    </PlausibleAnalytics>
                 </SessionProvider>
             </body>
         </html>

--- a/src/components/analytics/PlausibleAnalytics.tsx
+++ b/src/components/analytics/PlausibleAnalytics.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import React from "react";
+import PlausibleProvider from "next-plausible";
+import { usePathname } from "next/navigation";
+
+// Matches embed routes with or without a locale prefix, e.g.
+// /embed/meetings, /en/embed/meetings. These are loaded inside iframes
+// on third-party sites and must not be counted as pageviews.
+const EMBED_PATH = /^\/(?:en\/|el\/)?embed(?:\/|$)/;
+
+export default function PlausibleAnalytics({ children }: { children: React.ReactNode }) {
+    const pathname = usePathname();
+    const isEmbed = EMBED_PATH.test(pathname ?? "");
+
+    // On embed routes force the script off; otherwise pass undefined so
+    // next-plausible applies its own default (production-only) behaviour.
+    return (
+        <PlausibleProvider domain="opencouncil.gr" enabled={isEmbed ? false : undefined}>
+            {children}
+        </PlausibleProvider>
+    );
+}

--- a/src/components/analytics/PlausibleAnalytics.tsx
+++ b/src/components/analytics/PlausibleAnalytics.tsx
@@ -2,12 +2,12 @@
 
 import React from "react";
 import PlausibleProvider from "next-plausible";
-import { usePathname } from "next/navigation";
+import { usePathname } from "@/i18n/routing";
 
-// Matches embed routes with or without a locale prefix, e.g.
-// /embed/meetings, /en/embed/meetings. These are loaded inside iframes
-// on third-party sites and must not be counted as pageviews.
-const EMBED_PATH = /^\/(?:en\/|el\/)?embed(?:\/|$)/;
+// Matches embed routes (locale prefix already stripped by next-intl), e.g.
+// /embed/meetings. These are loaded inside iframes on third-party sites
+// and must not be counted as pageviews.
+const EMBED_PATH = /^\/embed(?:\/|$)/;
 
 export default function PlausibleAnalytics({ children }: { children: React.ReactNode }) {
     const pathname = usePathname();


### PR DESCRIPTION
## Summary

Plausible was counting embed iframe loads as pageviews — `/embed/meetings` was showing up as the #2 page in the dashboard (2.1k visitors) because the root layout wraps every route, including `[locale]/(embed)/embed/meetings`, in `<PlausibleProvider>`. Each iframe load on a third-party site fired a pageview.

- Add `src/components/analytics/PlausibleAnalytics.tsx`, a client wrapper that reads the pathname and forces `enabled={false}` on `/embed/...` (with or without locale prefix). Everywhere else it passes `enabled={undefined}` so `next-plausible` applies its existing default (production + non-Vercel-preview), preserving current tracking behaviour exactly.
- Swap `<PlausibleProvider>` for `<PlausibleAnalytics>` in `src/app/layout.tsx`. No `usePlausible()` consumers exist, so nothing else depends on the provider.

This stops the analytics script from loading inside iframes entirely — stronger than `next-plausible`'s `exclude` prop, which still loads the script and only suppresses the pageview.

## Test plan

- [ ] In production: load a page on `opencouncil.gr`, confirm the Plausible script tag is present and a pageview is recorded.
- [ ] In production: load `/embed/meetings?cityId=athens` (and `/en/embed/meetings`), confirm no Plausible script tag is injected and no pageview is recorded.
- [ ] Verify regex doesn't false-match: `/embedded`, `/ending`, `/en/embedded` should still be tracked normally.
- [ ] Verify dev behaviour unchanged (Plausible disabled everywhere by `next-plausible` default).

https://claude.ai/code/session_01NUXgwF1FWGkt9GffmwfiKq

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUXgwF1FWGkt9GffmwfiKq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change with no impact on auth, data, or user-facing app behavior beyond measurement on embed URLs.
> 
> **Overview**
> **Stops Plausible from loading on embed iframe routes** so third-party iframe loads no longer inflate pageview stats (e.g. `/embed/meetings`).
> 
> The root layout no longer wraps the app in `next-plausible` directly. It uses a new client component **`PlausibleAnalytics`** that reads `usePathname()` and sets `enabled={false}` when the path matches `/embed/...` (optional `en/` or `el/` prefix). On all other routes it leaves `enabled` **undefined** so `next-plausible` keeps its existing production-only behavior.
> 
> This disables the analytics script entirely on embed pages rather than only suppressing pageviews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52fb4db5239a72a9a21b2e0ed65aa0f6ce71315a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces a thin client component (`PlausibleAnalytics`) to prevent the Plausible analytics script from loading on embed iframe routes, stopping `/embed/meetings` (and similar paths) from inflating pageview counts.

- Replaces the direct `<PlausibleProvider>` in the root layout with `<PlausibleAnalytics>`, which reads the locale-stripped pathname via `@/i18n/routing`'s `usePathname` and sets `enabled={false}` on embed routes, while passing `enabled={undefined}` everywhere else to preserve the existing production-only default.
- The regex `^\\/embed(?:\\/|$)` correctly excludes `/embed/meetings` and `/embed/` without false-matching `/embedded`, `/ending`, or similar paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — analytics-only change with no impact on auth, data, or user-facing behaviour beyond correcting pageview counts on embed routes.

The change is narrow: a two-file swap that adds a client wrapper around the existing Plausible provider. The locale-stripping usePathname from @/i18n/routing is correctly used so the regex requires no locale handling. enabled={undefined} on non-embed routes preserves the existing production-only default without any behaviour change for regular visitors. No auth, data, or routing logic is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/analytics/PlausibleAnalytics.tsx | New client component that conditionally disables Plausible on embed routes using locale-stripped usePathname and a regex guard; logic is correct and the regex handles all edge cases. |
| src/app/layout.tsx | Swaps the direct PlausibleProvider for the new PlausibleAnalytics wrapper; domain prop is preserved inside the component and the change is minimal. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Request hits root layout] --> B[PlausibleAnalytics renders]
    B --> C[usePathname - locale prefix stripped by next-intl]
    C --> D{Path starts with /embed/}
    D -- Yes, embed iframe route --> E[enabled=false\nNo Plausible script injected]
    D -- No, regular route --> F[enabled=undefined\nPlausible uses its own default]
    F --> G{Environment}
    G -- Production --> H[Script injected, pageview tracked]
    G -- Dev or Vercel Preview --> I[Script suppressed by next-plausible default]
```

<sub>Reviews (2): Last reviewed commit: ["fix(plausible): remove hardcoded locale ..."](https://github.com/schemalabz/opencouncil/commit/848cb558d5ada2fc23eafc055268aec11a8aa25c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34553488)</sub>

<!-- /greptile_comment -->