### PR TITLE
fix(admin): avoid Next Link prefetch on open-in-new-tab links

### DIFF
--- a/src/components/admin/notifications/NotificationMeetingRow.tsx
+++ b/src/components/admin/notifications/NotificationMeetingRow.tsx
@@ -29,7 +29,6 @@ import {
     ExternalLink,
     Trash2
 } from "lucide-react";
-import Link from "next/link";
 import { useToast } from "@/hooks/use-toast";
 import { MeetingNotificationStats, NotificationStatusCounts } from "@/lib/db/notifications";
 import { createMeetingKey } from "./utils";
@@ -149,7 +148,7 @@ function NotificationCard({ notification }: { notification: NotificationData }) 
                         {notification.type === 'beforeMeeting' ? 'Before' : 'After'}
                     </Badge>
                 </div>
-                <Link
+                <a
                     href={`/el/notifications/${notification.id}`}
                     target="_blank"
                     rel="noopener noreferrer"
@@ -157,7 +156,7 @@ function NotificationCard({ notification }: { notification: NotificationData }) 
                 >
                     <ExternalLink className="h-3 w-3" />
                     View
-                </Link>
+                </a>
             </div>
             <div className="text-xs text-muted-foreground mb-2">
                 {notification.subjects.length} subject{notification.subjects.length !== 1 ? 's' : ''}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces a Next.js `<Link>` component with a plain `<a>` tag for the "View" link in `NotificationCard`, which always opens in a new tab via `target="_blank"`. Using `<Link>` for new-tab links unnecessarily triggers Next.js prefetching and client-side route handling, neither of which applies when the browser opens a separate tab.

- Removes the `next/link` import and swaps the `<Link>` wrapper to `<a>` in `NotificationCard`, preserving `href`, `target="_blank"`, `rel="noopener noreferrer"`, and all styling classes intact.

<h3>Confidence Score: 5/5</h3>

This is a safe, minimal change that replaces a Next.js Link with a plain anchor tag for a new-tab link, preserving all security attributes and styling.

The change is narrowly scoped to a single link element in an admin notification card. The rel="noopener noreferrer" security attribute is preserved, the href, target, and class props are unchanged, and the removed next/link import was the only usage in the file. No logic, state, or data flow is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/admin/notifications/NotificationMeetingRow.tsx | Removes unused next/link import and replaces <Link> with <a> for the new-tab "View" link; all security attributes (rel="noopener noreferrer") and styles are preserved. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks View link] --> B{Link type}
    B -->|Before: Next Link| C[Next.js router intercepts]
    C --> D[Prefetch triggered]
    D --> E[Opens in new tab]
    B -->|After: plain a tag| F[Browser handles natively]
    F --> G[No prefetch]
    G --> E
```

<sub>Reviews (1): Last reviewed commit: ["fix(admin): use &lt;a&gt; instead of &lt;Link&gt; fo..."](https://github.com/schemalabz/opencouncil/commit/479ddd27816b30685e674a0b538e6c419f739c0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34575126)</sub>

<!-- /greptile_comment -->