### PR TITLE
Improve conversations display and flow

### DIFF
--- a/src/app/[locale]/(other)/admin/conversations/page.tsx
+++ b/src/app/[locale]/(other)/admin/conversations/page.tsx
@@ -19,6 +19,7 @@ import { FaWhatsapp } from 'react-icons/fa';
 import { ReplyForm } from '@/components/admin/conversations/ReplyForm';
 import { SendTemplateDialog } from '@/components/admin/conversations/SendTemplateDialog';
 import { ScrollableThread } from '@/components/admin/conversations/ScrollableThread';
+import { ConversationsPagination } from '@/components/admin/conversations/ConversationsPagination';
 
 export const metadata: Metadata = {
     title: 'Conversations - Admin',
@@ -26,6 +27,7 @@ export const metadata: Metadata = {
 };
 
 const PREVIEW_MAX = 120;
+const PAGE_SIZE = 50;
 
 function truncate(s: string, max = PREVIEW_MAX) {
     return s.length <= max ? s : `${s.slice(0, max).trimEnd()}…`;
@@ -266,7 +268,7 @@ function ThreadDetail({
 }
 
 interface PageProps {
-    searchParams: { all?: string };
+    searchParams: { all?: string; page?: string };
 }
 
 export default async function ConversationsPage({ searchParams }: PageProps) {
@@ -274,7 +276,14 @@ export default async function ConversationsPage({ searchParams }: PageProps) {
     // failed deliveries) so the admin can focus on conversations that need
     // attention. `?all=1` opts back into the full unfiltered list.
     const showAll = searchParams.all === '1';
-    const conversations = await getConversationSummaries({ onlyWithInbound: !showAll });
+    const requestedPage = Number.parseInt(searchParams.page ?? '', 10);
+    const page = Number.isFinite(requestedPage) && requestedPage > 0 ? requestedPage : 1;
+    const { conversations, total } = await getConversationSummaries({
+        onlyWithInbound: !showAll,
+        page,
+        pageSize: PAGE_SIZE,
+    });
+    const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
     return (
         <div className="container mx-auto py-8">
@@ -282,7 +291,7 @@ export default async function ConversationsPage({ searchParams }: PageProps) {
                 <div className="flex items-baseline gap-3">
                     <h1 className="text-3xl font-bold">Conversations</h1>
                     <p className="text-sm text-muted-foreground">
-                        {conversations.length} {conversations.length === 1 ? 'thread' : 'threads'}
+                        {total} {total === 1 ? 'thread' : 'threads'}
                         {!showAll && ' with replies'}
                     </p>
                 </div>
@@ -400,6 +409,7 @@ export default async function ConversationsPage({ searchParams }: PageProps) {
                                     </TableBody>
                                 </Table>
                             </div>
+                            <ConversationsPagination currentPage={page} totalPages={totalPages} pageSize={PAGE_SIZE} />
                         </>
                     )}
                 </CardContent>

--- a/src/app/[locale]/(other)/admin/conversations/page.tsx
+++ b/src/app/[locale]/(other)/admin/conversations/page.tsx
@@ -20,6 +20,7 @@ import { ReplyForm } from '@/components/admin/conversations/ReplyForm';
 import { SendTemplateDialog } from '@/components/admin/conversations/SendTemplateDialog';
 import { ScrollableThread } from '@/components/admin/conversations/ScrollableThread';
 import { ConversationsPagination } from '@/components/admin/conversations/ConversationsPagination';
+import { RefreshButton } from '@/components/admin/conversations/RefreshButton';
 
 export const metadata: Metadata = {
     title: 'Conversations - Admin',
@@ -302,6 +303,7 @@ export default async function ConversationsPage({ searchParams }: PageProps) {
                     >
                         {showAll ? 'Only with replies' : 'Show all threads'}
                     </Link>
+                    <RefreshButton />
                     <SendTemplateDialog />
                 </div>
             </div>

--- a/src/app/api/webhooks/bird/route.ts
+++ b/src/app/api/webhooks/bird/route.ts
@@ -12,6 +12,7 @@ import {
     unsubscribeUserPhoneFromAllCities,
     verifyUnsubscribeIntent,
 } from '@/lib/notifications/unsubscribe';
+import { sendUnsupportedReply } from '@/lib/notifications/autoReply';
 import { normalizePhone } from '@/lib/notifications/phone';
 import type { VerifyRequestResult, VerifySignatureResult } from '@/lib/notifications/types';
 import { extractMessageFields, type ExtractedMessageFields } from './extract';
@@ -187,31 +188,36 @@ async function persistMessageRow(
  * resolved delivery link:
  *   1. Regex keyword match (STOP / ΣΤΟΠ / απεγγραφή / etc.)
  *   2. LLM intent verification (rules out e.g. "stop the meeting")
+ *
+ * Returns true when the message was handled as an unsubscribe (action taken
+ * or an unsubscribe-related reply sent), so the caller can skip the generic
+ * "replies not supported" auto-reply. A keyword match that the LLM rejects
+ * (e.g. "stop the meeting") is NOT an unsubscribe and returns false.
  */
 async function handleUnsubscribeIfApplicable(
     fields: ExtractedMessageFields,
     notificationDeliveryId: string | null,
-): Promise<void> {
+): Promise<boolean> {
     if (
         fields.direction !== 'inbound' ||
         fields.channel !== 'whatsapp' ||
         !notificationDeliveryId ||
         !isUnsubscribeMessage(fields.body)
-    ) return;
+    ) return false;
 
     const user = await findUserByNotificationDeliveryId(notificationDeliveryId);
     if (!user) {
         console.warn(
             `Bird webhook: unsubscribe keyword matched but no user resolved (delivery ${notificationDeliveryId})`,
         );
-        return;
+        return false;
     }
 
     if (normalizePhone(user.phone) !== normalizePhone(fields.phone)) {
         console.warn(
             `Bird webhook: unsubscribe phone mismatch — inbound from ${fields.phone}, user.phone ${user.phone} (user ${user.id}, delivery ${notificationDeliveryId}); ignoring`,
         );
-        return;
+        return false;
     }
 
     const intent = await verifyUnsubscribeIntent(fields.body);
@@ -220,7 +226,7 @@ async function handleUnsubscribeIfApplicable(
         console.log(
             `Bird webhook: unsubscribe keyword matched but LLM rejected intent (user ${user.id}, delivery ${notificationDeliveryId})`,
         );
-        return;
+        return false;
     }
 
     if (intent === 'failed') {
@@ -235,7 +241,7 @@ async function handleUnsubscribeIfApplicable(
                 text: UNSUBSCRIBE_RETRY_TEXT,
             });
         }
-        return;
+        return true;
     }
 
     const { changedCount } = await unsubscribeUserPhoneFromAllCities(user.id);
@@ -253,6 +259,36 @@ async function handleUnsubscribeIfApplicable(
             text: replyText,
         });
     }
+    return true;
+}
+
+/**
+ * For inbound WhatsApp messages we didn't otherwise act on, reply that we
+ * don't support conversational replies yet (and how to unsubscribe).
+ *
+ * Unsubscribe-keyword messages are excluded even when `handleUnsubscribeIf-
+ * Applicable` returned false (null delivery link, unresolved user, phone
+ * mismatch). Telling someone who just sent "STOP" that replies aren't
+ * supported would be the wrong message; those edge cases get no reply, as
+ * before this feature.
+ */
+async function sendUnsupportedReplyIfApplicable(
+    fields: ExtractedMessageFields,
+    notificationDeliveryId: string | null,
+): Promise<void> {
+    if (
+        fields.direction !== 'inbound' ||
+        fields.channel !== 'whatsapp' ||
+        !fields.conversationId ||
+        isUnsubscribeMessage(fields.body)
+    ) return;
+
+    await sendUnsupportedReply({
+        conversationId: fields.conversationId,
+        channel: fields.channel,
+        phone: normalizePhone(fields.phone),
+        notificationDeliveryId,
+    });
 }
 
 export async function POST(request: Request) {
@@ -276,7 +312,10 @@ export async function POST(request: Request) {
 
     try {
         await persistMessageRow(fields, notificationDeliveryId);
-        await handleUnsubscribeIfApplicable(fields, notificationDeliveryId);
+        const handledAsUnsubscribe = await handleUnsubscribeIfApplicable(fields, notificationDeliveryId);
+        if (!handledAsUnsubscribe) {
+            await sendUnsupportedReplyIfApplicable(fields, notificationDeliveryId);
+        }
     } catch (error) {
         const code = (error as Prisma.PrismaClientKnownRequestError | undefined)?.code;
         if (code !== 'P2002') {

--- a/src/components/admin/conversations/ConversationsPagination.tsx
+++ b/src/components/admin/conversations/ConversationsPagination.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+import { Pagination } from '@/components/ui/pagination';
+
+/**
+ * Drives the conversations list pagination via the `?page=N` search param,
+ * preserving any other params (e.g. `?all=1`). Page 1 omits the param to keep
+ * the default URL clean.
+ */
+export function ConversationsPagination({
+    currentPage,
+    totalPages,
+    pageSize,
+}: {
+    currentPage: number;
+    totalPages: number;
+    pageSize: number;
+}) {
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    const onPageChange = (page: number) => {
+        const params = new URLSearchParams(searchParams.toString());
+        if (page <= 1) {
+            params.delete('page');
+        } else {
+            params.set('page', String(page));
+        }
+        const query = params.toString();
+        router.push(query ? `${pathname}?${query}` : pathname);
+    };
+
+    return (
+        <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            pageSize={pageSize}
+            onPageChange={onPageChange}
+        />
+    );
+}

--- a/src/components/admin/conversations/RefreshButton.tsx
+++ b/src/components/admin/conversations/RefreshButton.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+/**
+ * Re-fetches the server component's data via `router.refresh()`. The
+ * transition's pending flag drives the spinner so the page stays interactive
+ * while the refresh is in flight.
+ */
+export function RefreshButton() {
+    const router = useRouter();
+    const [isPending, startTransition] = useTransition();
+
+    return (
+        <Button
+            onClick={() => startTransition(() => router.refresh())}
+            variant="outline"
+            disabled={isPending}
+        >
+            <RefreshCw className={`h-4 w-4 mr-2 ${isPending ? 'animate-spin' : ''}`} />
+            Refresh
+        </Button>
+    );
+}

--- a/src/lib/db/conversations.ts
+++ b/src/lib/db/conversations.ts
@@ -15,6 +15,15 @@ export interface ConversationSummary {
 }
 
 /**
+ * A page of conversation summaries plus the total number of conversations
+ * matching the filter, so the admin page can render pagination controls.
+ */
+export interface ConversationSummariesPage {
+    conversations: ConversationSummary[];
+    total: number;
+}
+
+/**
  * v0 implementation: fetch a recent window of messages, then group by
  * (phone, channel) in JS. Sorted by latest message first.
  *
@@ -27,18 +36,24 @@ export interface ConversationSummary {
  * participant. Outbound-only threads (e.g. broadcasts no one answered, failed
  * deliveries) are noise for the admin view whose purpose is triaging replies.
  * Pass false to include every thread.
+ *
+ * Pagination (`page`/`pageSize`) is applied over the grouped, filtered, and
+ * sorted conversation list — not over raw messages — so a page always holds
+ * whole threads. `total` is the full count before slicing, for page controls.
  */
 export async function getConversationSummaries(
     {
-        limit = 50,
+        page = 1,
+        pageSize = 50,
         recentMessageWindow = 1000,
         onlyWithInbound = true,
     }: {
-        limit?: number;
+        page?: number;
+        pageSize?: number;
         recentMessageWindow?: number;
         onlyWithInbound?: boolean;
     } = {},
-): Promise<ConversationSummary[]> {
+): Promise<ConversationSummariesPage> {
     // Fetch newest-first so the window is the *recent* slice, not the oldest;
     // otherwise once the table exceeds `recentMessageWindow` rows, fresh
     // conversations would silently drop off the admin view. We reverse each
@@ -78,5 +93,9 @@ export async function getConversationSummaries(
             return bLast - aLast;
         });
 
-    return ordered.slice(0, limit);
+    const start = Math.max(0, (page - 1) * pageSize);
+    return {
+        conversations: ordered.slice(start, start + pageSize),
+        total: ordered.length,
+    };
 }

--- a/src/lib/notifications/autoReply.ts
+++ b/src/lib/notifications/autoReply.ts
@@ -1,0 +1,37 @@
+import type { MessageChannel } from '@prisma/client';
+import { sendConversationMessage } from '@/lib/notifications/bird';
+import { sendAndPersistOutbound } from '@/lib/notifications/outbound';
+
+// Canned reply for inbound messages we don't act on. We don't support
+// conversational replies yet, so we tell the user that and point them at the
+// only inbound action we do support — unsubscribing.
+export const UNSUPPORTED_REPLY_TEXT =
+    'Δεν υποστηρίζεται ακόμα η απάντηση σε μηνύματα. Όμως, μπορείτε να απεγγραφείτε από τις ειδοποιήσεις στέλνοντας "ΣΤΟΠ", "Θέλω να απεγγραφώ" κλπ.';
+
+/**
+ * Sends the "replies not supported" auto-reply on the conversation the
+ * inbound message arrived on. Mirrors `sendUnsubscribeReply`: `reconcile:
+ * false` because the inbound webhook reconciles the row when Bird emits the
+ * delivery-status event.
+ */
+export async function sendUnsupportedReply(input: {
+    conversationId: string;
+    channel: MessageChannel;
+    phone: string;
+    notificationDeliveryId: string | null;
+}): Promise<void> {
+    await sendAndPersistOutbound({
+        channel: input.channel,
+        phone: input.phone,
+        body: UNSUPPORTED_REPLY_TEXT,
+        conversationId: input.conversationId,
+        notificationDeliveryId: input.notificationDeliveryId,
+        send: () => sendConversationMessage({
+            conversationId: input.conversationId,
+            channel: input.channel,
+            text: UNSUPPORTED_REPLY_TEXT,
+            recipientPhone: input.phone,
+        }),
+        reconcile: false,
+    });
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds pagination and a refresh button to the admin conversations view, and introduces an auto-reply for inbound WhatsApp messages that aren't unsubscribe attempts.

- **Pagination**: `getConversationSummaries` now accepts `page`/`pageSize` instead of `limit`, returns a `{ conversations, total }` page object, and the admin page threads `?page=N` through a new `ConversationsPagination` client component.
- **Auto-reply**: A new `sendUnsupportedReplyIfApplicable` function fires for every non-unsubscribe inbound WhatsApp message, telling users replies aren't supported; unsubscribe-keyword messages are explicitly excluded even when `handleUnsubscribeIfApplicable` returns `false`.
- **Refresh button**: A `RefreshButton` client component calls `router.refresh()` with a pending spinner to re-fetch server-side data on demand.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changes are admin-only UI improvements or a benign auto-reply addition with no impact on data mutations or auth paths.

The auto-reply logic is correctly guarded, pagination arithmetic is straightforward, and the only noteworthy issues are a router.push/router.replace UX nit and the pre-existing recentMessageWindow cap on total count — neither affects correctness or data integrity.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/(other)/admin/conversations/page.tsx | Adds pagination (PAGE_SIZE=50, ?page=N param) and a Refresh button to the admin conversations view; total count now reflects all conversations in the message window rather than just the current page. |
| src/app/api/webhooks/bird/route.ts | Adds sendUnsupportedReplyIfApplicable auto-reply for non-unsubscribe inbound WhatsApp messages; correctly guards unsubscribe-keyword messages to avoid the wrong reply. |
| src/lib/db/conversations.ts | Replaces the old limit parameter with proper page/pageSize pagination and returns a total count; total is bounded by recentMessageWindow (1000), which becomes more visible now that pagination controls are exposed in the UI. |
| src/components/admin/conversations/ConversationsPagination.tsx | New client component for ?page=N pagination; uses router.push which pollutes browser history on each page change — should be router.replace. |
| src/components/admin/conversations/RefreshButton.tsx | New client component that triggers router.refresh() with a spinner while in-flight; straightforward and correct. |
| src/lib/notifications/autoReply.ts | New module exposing sendUnsupportedReply; uses sendAndPersistOutbound with reconcile: false, consistent with the existing unsubscribe reply pattern. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fcomponents%2Fadmin%2Fconversations%2FConversationsPagination.tsx%3A32%0APagination%20should%20use%20%60router.replace%60%20rather%20than%20%60router.push%60.%20Every%20page-change%20click%20currently%20adds%20an%20entry%20to%20the%20browser%20history%2C%20so%20pressing%20the%20Back%20button%20steps%20through%20every%20page%20the%20admin%20visited%20instead%20of%20navigating%20to%20the%20previous%20page.%20%60replace%60%20updates%20the%20URL%20without%20growing%20the%20history%20stack%2C%20which%20is%20the%20standard%20behaviour%20for%20pagination%20controls.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20router.replace%28query%20%3F%20%60%24%7Bpathname%7D%3F%24%7Bquery%7D%60%20%3A%20pathname%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Fdb%2Fconversations.ts%3A99%0A%60total%60%20is%20bounded%20by%20%60recentMessageWindow%60%20%281000%20messages%29%2C%20not%20the%20true%20database%20row%20count.%20Once%20the%20messages%20table%20grows%20past%201000%20rows%2C%20some%20older%20conversations%20fall%20outside%20the%20window%20and%20%60total%60%20under-reports%20the%20real%20conversation%20count.%20With%20pagination%20now%20surfaced%20in%20the%20UI%2C%20admins%20will%20see%20a%20total%20that%20quietly%20truncates%20old%20threads%2C%20and%20there%20is%20no%20way%20for%20them%20to%20navigate%20to%20conversations%20outside%20the%20window.%20The%20existing%20comment%20already%20calls%20this%20a%20v0%20limitation%20%E2%80%94%20it's%20worth%20revisiting%20when%20the%20table%20starts%20filling%20up.%0A%0A&repo=schemalabz%2Fopencouncil&pr=398&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/components/admin/conversations/ConversationsPagination.tsx:32
Pagination should use `router.replace` rather than `router.push`. Every page-change click currently adds an entry to the browser history, so pressing the Back button steps through every page the admin visited instead of navigating to the previous page. `replace` updates the URL without growing the history stack, which is the standard behaviour for pagination controls.

```suggestion
        router.replace(query ? `${pathname}?${query}` : pathname);
```

### Issue 2 of 2
src/lib/db/conversations.ts:99
`total` is bounded by `recentMessageWindow` (1000 messages), not the true database row count. Once the messages table grows past 1000 rows, some older conversations fall outside the window and `total` under-reports the real conversation count. With pagination now surfaced in the UI, admins will see a total that quietly truncates old threads, and there is no way for them to navigate to conversations outside the window. The existing comment already calls this a v0 limitation — it's worth revisiting when the table starts filling up.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["feat(admin/conversations): add refresh b..."](https://github.com/schemalabz/opencouncil/commit/77f723a516f776602f809288989600ed75f02cf7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34585570)</sub>

<!-- /greptile_comment -->