### PR TITLE
feat(admin): batch re-run tasks and version filter rework

### DIFF
--- a/src/app/[locale]/(other)/admin/tasks/page.tsx
+++ b/src/app/[locale]/(other)/admin/tasks/page.tsx
@@ -3,6 +3,7 @@ import type { TaskVersionsFilter } from "@/lib/tasks/tasks";
 import TaskVersionsTable from "@/components/admin/tasks/TaskVersionsTable";
 import { TaskFilters } from "@/components/admin/tasks/TaskFilters";
 import { BatchRerunActions, type BatchMeeting } from "@/components/admin/tasks/BatchRerunActions";
+import { ActiveTasks } from "@/components/admin/tasks/ActiveTasks";
 import { MeetingTaskType } from "@/lib/tasks/types";
 
 const DEFAULT_TASK_TYPES: MeetingTaskType[] = ['transcribe', 'processAgenda', 'summarize'];
@@ -76,6 +77,10 @@ export default async function TasksPage({ searchParams }: PageProps) {
     return (
         <div className="container mx-auto py-8 px-4">
             <h1 className="text-2xl font-bold mb-6">Task Versions Admin</h1>
+
+            <div className="mb-6">
+                <ActiveTasks />
+            </div>
 
             <div className="flex flex-col md:flex-row flex-wrap gap-4 mb-6">
                 <TaskFilters

--- a/src/app/[locale]/(other)/admin/tasks/page.tsx
+++ b/src/app/[locale]/(other)/admin/tasks/page.tsx
@@ -2,6 +2,7 @@ import { getHighestVersionsForTasks, getTaskVersionsGroupedByCity, getAvailableC
 import type { TaskVersionsFilter } from "@/lib/tasks/tasks";
 import TaskVersionsTable from "@/components/admin/tasks/TaskVersionsTable";
 import { TaskFilters } from "@/components/admin/tasks/TaskFilters";
+import { BatchRerunActions, type BatchMeeting } from "@/components/admin/tasks/BatchRerunActions";
 import { MeetingTaskType } from "@/lib/tasks/types";
 
 const DEFAULT_TASK_TYPES: MeetingTaskType[] = ['transcribe', 'processAgenda', 'summarize'];
@@ -56,6 +57,21 @@ export default async function TasksPage({ searchParams }: PageProps) {
     // Derive max version across all task types for the version filter dropdowns
     const maxVersion = Math.max(0, ...Object.values(highestVersions).map(v => v ?? 0));
 
+    // Flatten citiesData into a meeting list for batch actions
+    const allMeetings: BatchMeeting[] = Object.values(citiesData).flatMap((city: any) =>
+        city.meetings.map((meeting: any) => ({
+            meetingId: meeting.meetingId,
+            cityId: meeting.cityId,
+            cityName: city.cityNameEn,
+            dateTime: meeting.dateTime,
+            currentVersion: taskTypes.reduce((min: number | null, t: string) => {
+                const v = meeting[t] ?? null;
+                if (v === null) return min;
+                if (min === null) return v;
+                return Math.min(min, v);
+            }, null),
+        }))
+    );
 
     return (
         <div className="container mx-auto py-8 px-4">
@@ -72,6 +88,10 @@ export default async function TasksPage({ searchParams }: PageProps) {
                     maxVersion={maxVersion}
                     availableCities={availableCities}
                 />
+            </div>
+
+            <div className="mb-6">
+                <BatchRerunActions meetings={allMeetings} />
             </div>
 
             <TaskVersionsTable

--- a/src/app/[locale]/(other)/admin/tasks/page.tsx
+++ b/src/app/[locale]/(other)/admin/tasks/page.tsx
@@ -53,6 +53,10 @@ export default async function TasksPage({ searchParams }: PageProps) {
         getAvailableCities(),
     ]);
 
+    // Derive max version across all task types for the version filter dropdowns
+    const maxVersion = Math.max(0, ...Object.values(highestVersions).map(v => v ?? 0));
+
+
     return (
         <div className="container mx-auto py-8 px-4">
             <h1 className="text-2xl font-bold mb-6">Task Versions Admin</h1>
@@ -65,6 +69,7 @@ export default async function TasksPage({ searchParams }: PageProps) {
                     taskTypes={taskTypes}
                     versionMin={searchParams.versionMin}
                     versionMax={searchParams.versionMax}
+                    maxVersion={maxVersion}
                     availableCities={availableCities}
                 />
             </div>

--- a/src/components/admin/tasks/ActiveTasks.tsx
+++ b/src/components/admin/tasks/ActiveTasks.tsx
@@ -3,54 +3,146 @@
 import { useState, useEffect, useCallback } from 'react';
 import { TaskStatus } from '@prisma/client';
 import { Loader2 } from 'lucide-react';
-import { getActiveTasks } from '@/lib/db/tasks';
-import { deleteTaskStatus } from '@/lib/db/tasks';
+import { getActiveTasks, getRecentTasks, deleteTaskStatus } from '@/lib/db/tasks';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
 import TaskList from '@/components/meetings/admin/TaskList';
 
 const POLL_INTERVAL = 3000;
 
 export function ActiveTasks() {
-    const [tasks, setTasks] = useState<TaskStatus[]>([]);
-    const [loading, setLoading] = useState(true);
+    const [activeTasks, setActiveTasks] = useState<TaskStatus[]>([]);
+    const [recentTasks, setRecentTasks] = useState<TaskStatus[]>([]);
+    const [hasMore, setHasMore] = useState(false);
+    const [loadingActive, setLoadingActive] = useState(true);
+    const [loadingRecent, setLoadingRecent] = useState(false);
+    const [loadingMore, setLoadingMore] = useState(false);
+    const [recentLoaded, setRecentLoaded] = useState(false);
 
-    const fetchTasks = useCallback(async () => {
+    const fetchActiveTasks = useCallback(async () => {
         try {
-            const activeTasks = await getActiveTasks();
-            setTasks(activeTasks);
+            const tasks = await getActiveTasks();
+            setActiveTasks(tasks);
         } catch (error) {
             console.error('Failed to fetch active tasks:', error);
         } finally {
-            setLoading(false);
+            setLoadingActive(false);
         }
     }, []);
 
     useEffect(() => {
-        fetchTasks();
-        const interval = setInterval(fetchTasks, POLL_INTERVAL);
+        fetchActiveTasks();
+        const interval = setInterval(fetchActiveTasks, POLL_INTERVAL);
         return () => clearInterval(interval);
-    }, [fetchTasks]);
+    }, [fetchActiveTasks]);
+
+    const fetchRecentTasks = useCallback(async () => {
+        setLoadingRecent(true);
+        try {
+            const result = await getRecentTasks(0);
+            setRecentTasks(result.tasks);
+            setHasMore(result.hasMore);
+        } catch (error) {
+            console.error('Failed to fetch recent tasks:', error);
+        } finally {
+            setLoadingRecent(false);
+        }
+    }, []);
+
+    const handleLoadMore = async () => {
+        setLoadingMore(true);
+        try {
+            const result = await getRecentTasks(recentTasks.length);
+            setRecentTasks(prev => [...prev, ...result.tasks]);
+            setHasMore(result.hasMore);
+        } catch (error) {
+            console.error('Failed to load more tasks:', error);
+        } finally {
+            setLoadingMore(false);
+        }
+    };
+
+    const handleTabChange = (tab: string) => {
+        if (tab === 'recent' && !recentLoaded) {
+            setRecentLoaded(true);
+            fetchRecentTasks();
+        }
+    };
 
     const handleDelete = async (taskId: string) => {
         await deleteTaskStatus(taskId);
-        setTasks(prev => prev.filter(t => t.id !== taskId));
+        setActiveTasks(prev => prev.filter(t => t.id !== taskId));
+        setRecentTasks(prev => prev.filter(t => t.id !== taskId));
     };
 
-    if (loading || tasks.length === 0) {
+    if (loadingActive) {
         return null;
     }
 
     return (
         <div className="border rounded-md p-4">
-            <h2 className="text-base font-semibold flex items-center gap-2 mb-3">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Active Tasks ({tasks.length})
-            </h2>
-            <TaskList
-                tasks={tasks}
-                onDelete={handleDelete}
-                isLoading={false}
-                showMeetingInfo
-            />
+            <Tabs defaultValue="active" local onValueChange={handleTabChange}>
+                <TabsList>
+                    <TabsTrigger value="active" className="flex items-center gap-2">
+                        {activeTasks.length > 0 && <Loader2 className="h-3 w-3 animate-spin" />}
+                        Active ({activeTasks.length})
+                    </TabsTrigger>
+                    <TabsTrigger value="recent">
+                        Recent
+                    </TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="active" className="mt-3">
+                    {activeTasks.length === 0 ? (
+                        <p className="text-sm text-muted-foreground py-2">No active tasks</p>
+                    ) : (
+                        <TaskList
+                            tasks={activeTasks}
+                            onDelete={handleDelete}
+                            isLoading={false}
+                            showMeetingInfo
+                        />
+                    )}
+                </TabsContent>
+
+                <TabsContent value="recent" className="mt-3">
+                    {loadingRecent ? (
+                        <div className="flex justify-center py-4">
+                            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                        </div>
+                    ) : recentTasks.length === 0 ? (
+                        <p className="text-sm text-muted-foreground py-2">No recent tasks</p>
+                    ) : (
+                        <>
+                            <TaskList
+                                tasks={recentTasks}
+                                onDelete={handleDelete}
+                                isLoading={false}
+                                showMeetingInfo
+                            />
+                            {hasMore && (
+                                <div className="flex justify-center mt-3">
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={handleLoadMore}
+                                        disabled={loadingMore}
+                                    >
+                                        {loadingMore ? (
+                                            <>
+                                                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                                                Loading...
+                                            </>
+                                        ) : (
+                                            'Load more'
+                                        )}
+                                    </Button>
+                                </div>
+                            )}
+                        </>
+                    )}
+                </TabsContent>
+            </Tabs>
         </div>
     );
 }

--- a/src/components/admin/tasks/ActiveTasks.tsx
+++ b/src/components/admin/tasks/ActiveTasks.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { TaskStatus } from '@prisma/client';
+import { Loader2 } from 'lucide-react';
+import { getActiveTasks } from '@/lib/db/tasks';
+import { deleteTaskStatus } from '@/lib/db/tasks';
+import TaskList from '@/components/meetings/admin/TaskList';
+
+const POLL_INTERVAL = 3000;
+
+export function ActiveTasks() {
+    const [tasks, setTasks] = useState<TaskStatus[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    const fetchTasks = useCallback(async () => {
+        try {
+            const activeTasks = await getActiveTasks();
+            setTasks(activeTasks);
+        } catch (error) {
+            console.error('Failed to fetch active tasks:', error);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchTasks();
+        const interval = setInterval(fetchTasks, POLL_INTERVAL);
+        return () => clearInterval(interval);
+    }, [fetchTasks]);
+
+    const handleDelete = async (taskId: string) => {
+        await deleteTaskStatus(taskId);
+        setTasks(prev => prev.filter(t => t.id !== taskId));
+    };
+
+    if (loading || tasks.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="border rounded-md p-4">
+            <h2 className="text-base font-semibold flex items-center gap-2 mb-3">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Active Tasks ({tasks.length})
+            </h2>
+            <TaskList
+                tasks={tasks}
+                onDelete={handleDelete}
+                isLoading={false}
+                showMeetingInfo
+            />
+        </div>
+    );
+}

--- a/src/components/admin/tasks/BatchRerunActions.tsx
+++ b/src/components/admin/tasks/BatchRerunActions.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import { useState, useRef, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import {
+    Collapsible,
+    CollapsibleContent,
+    CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { AlertTriangle, CheckCircle2, XCircle, Loader2, ChevronRight, ChevronDown } from 'lucide-react';
+import { formatDate } from '@/lib/formatters/time';
+import { batchRerunTask, type BatchRerunResult } from '@/lib/tasks/batchRerun';
+
+export interface BatchMeeting {
+    meetingId: string;
+    cityId: string;
+    cityName: string;
+    dateTime: string | null;
+    currentVersion: number | null;
+}
+
+interface BatchRerunActionsProps {
+    meetings: BatchMeeting[];
+}
+
+type TaskType = 'processAgenda' | 'summarize';
+type DialogState = 'confirm' | 'executing' | 'done';
+
+const TASK_LABELS: Record<TaskType, string> = {
+    processAgenda: 'Process Agenda',
+    summarize: 'Summarize',
+};
+
+
+export function BatchRerunActions({ meetings }: BatchRerunActionsProps) {
+    const t = useTranslations('admin.adminActions');
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [selectedTask, setSelectedTask] = useState<TaskType>('processAgenda');
+    const [dialogState, setDialogState] = useState<DialogState>('confirm');
+    const [results, setResults] = useState<BatchRerunResult[]>([]);
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const cancelledRef = useRef(false);
+
+    const openDialog = (taskType: TaskType) => {
+        setSelectedTask(taskType);
+        setDialogState('confirm');
+        setResults([]);
+        setCurrentIndex(0);
+        cancelledRef.current = false;
+        setDialogOpen(true);
+    };
+
+    const handleCancel = () => {
+        cancelledRef.current = true;
+    };
+
+    const handleClose = () => {
+        setDialogOpen(false);
+    };
+
+    const handleConfirm = useCallback(async () => {
+        setDialogState('executing');
+        const newResults: BatchRerunResult[] = [];
+
+        for (let i = 0; i < meetings.length; i++) {
+            if (cancelledRef.current) break;
+
+            setCurrentIndex(i);
+            const meeting = meetings[i];
+            const result = await batchRerunTask(meeting.cityId, meeting.meetingId, selectedTask);
+            newResults.push(result);
+            setResults([...newResults]);
+        }
+
+        setDialogState('done');
+    }, [meetings, selectedTask]);
+
+    const succeeded = results.filter(r => r.success).length;
+    const failed = results.filter(r => !r.success).length;
+    const remaining = meetings.length - results.length;
+    const progressPercent = meetings.length > 0 ? (results.length / meetings.length) * 100 : 0;
+
+    const cityCount = new Set(meetings.map(m => m.cityId)).size;
+
+    const [batchOpen, setBatchOpen] = useState(false);
+
+    return (
+        <>
+            <Collapsible open={batchOpen} onOpenChange={setBatchOpen} className="border rounded-md">
+                <CollapsibleTrigger className="flex items-center gap-2 w-full p-3 text-sm text-muted-foreground hover:bg-gray-50">
+                    {batchOpen
+                        ? <ChevronDown className="h-4 w-4" />
+                        : <ChevronRight className="h-4 w-4" />
+                    }
+                    Batch Actions
+                </CollapsibleTrigger>
+                <CollapsibleContent className="px-3 pb-3">
+                    <p className="text-sm text-muted-foreground mb-3">
+                        Re-run tasks for all filtered meetings. Useful when the processing algorithm has changed
+                        and past meetings need to be reprocessed. Tasks are dispatched one at a time.
+                    </p>
+                    <div className="flex items-center gap-3">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={meetings.length === 0}
+                            onClick={() => openDialog('processAgenda')}
+                        >
+                            Re-run Process Agenda
+                        </Button>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={meetings.length === 0}
+                            onClick={() => openDialog('summarize')}
+                        >
+                            Re-run Summarize
+                        </Button>
+                        {meetings.length === 0 && (
+                            <span className="text-sm text-muted-foreground">No meetings match current filters</span>
+                        )}
+                    </div>
+                </CollapsibleContent>
+            </Collapsible>
+
+            <Dialog open={dialogOpen} onOpenChange={(open) => {
+                // Prevent closing during execution by clicking outside
+                if (!open && dialogState === 'executing') return;
+                setDialogOpen(open);
+            }}>
+                <DialogContent className="max-w-2xl">
+                    {dialogState === 'confirm' && (
+                        <>
+                            <DialogHeader>
+                                <DialogTitle className="flex items-center gap-2">
+                                    <AlertTriangle className="h-5 w-5 text-destructive" />
+                                    Re-run {TASK_LABELS[selectedTask]} for {meetings.length} meetings?
+                                </DialogTitle>
+                                <DialogDescription asChild>
+                                    <div className="space-y-2">
+                                        <p>
+                                            This will force re-run <strong>{TASK_LABELS[selectedTask]}</strong> for{' '}
+                                            <strong>{meetings.length} meetings</strong> across{' '}
+                                            <strong>{cityCount} {cityCount === 1 ? 'city' : 'cities'}</strong>.
+                                            Tasks will be dispatched one at a time.
+                                        </p>
+                                        <p className="text-destructive">
+                                            {t(`forms.forceDescription.${selectedTask}`)}
+                                        </p>
+                                    </div>
+                                </DialogDescription>
+                            </DialogHeader>
+
+                            <ScrollArea className="max-h-80 border rounded-md">
+                                <table className="w-full text-sm">
+                                    <thead className="sticky top-0 bg-background border-b">
+                                        <tr>
+                                            <th className="text-left p-2 font-medium">Date</th>
+                                            <th className="text-left p-2 font-medium">Meeting</th>
+                                            <th className="text-left p-2 font-medium">City</th>
+                                            <th className="text-left p-2 font-medium">Version</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {meetings.map((meeting) => (
+                                            <tr key={`${meeting.cityId}-${meeting.meetingId}`} className="border-b last:border-0">
+                                                <td className="p-2 whitespace-nowrap">
+                                                    {meeting.dateTime ? formatDate(new Date(meeting.dateTime)) : '—'}
+                                                </td>
+                                                <td className="p-2">
+                                                    <a
+                                                        href={`/${meeting.cityId}/${meeting.meetingId}`}
+                                                        target="_blank"
+                                                        rel="noopener noreferrer"
+                                                        className="font-mono text-xs text-blue-600 hover:underline"
+                                                    >
+                                                        {meeting.meetingId}
+                                                    </a>
+                                                </td>
+                                                <td className="p-2">{meeting.cityName}</td>
+                                                <td className="p-2">
+                                                    {meeting.currentVersion !== null
+                                                        ? <Badge variant="outline">v{meeting.currentVersion}</Badge>
+                                                        : <Badge variant="outline" className="text-gray-400">unversioned</Badge>
+                                                    }
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </ScrollArea>
+
+                            <DialogFooter>
+                                <Button variant="outline" onClick={handleClose}>Cancel</Button>
+                                <Button variant="destructive" onClick={handleConfirm}>
+                                    Confirm Re-run
+                                </Button>
+                            </DialogFooter>
+                        </>
+                    )}
+
+                    {(dialogState === 'executing' || dialogState === 'done') && (
+                        <>
+                            <DialogHeader>
+                                <DialogTitle>
+                                    {dialogState === 'executing'
+                                        ? `Dispatching ${TASK_LABELS[selectedTask]}...`
+                                        : `${TASK_LABELS[selectedTask]} — All Tasks Dispatched`
+                                    }
+                                </DialogTitle>
+                                <DialogDescription>
+                                    {succeeded} dispatched, {failed} failed
+                                    {remaining > 0 && `, ${remaining} remaining`}
+                                    {cancelledRef.current && ' (cancelled)'}
+                                </DialogDescription>
+                            </DialogHeader>
+
+                            <Progress value={progressPercent} className="w-full" />
+
+                            {dialogState === 'executing' && currentIndex < meetings.length && (
+                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                    Processing: {meetings[currentIndex].cityId}/{meetings[currentIndex].meetingId}
+                                </div>
+                            )}
+
+                            <ScrollArea className="max-h-60 border rounded-md">
+                                <div className="p-2 space-y-1">
+                                    {results.map((result) => (
+                                        <div key={`${result.cityId}-${result.meetingId}`} className="flex items-center gap-2 text-sm">
+                                            {result.success
+                                                ? <CheckCircle2 className="h-4 w-4 text-green-600 shrink-0" />
+                                                : <XCircle className="h-4 w-4 text-red-600 shrink-0" />
+                                            }
+                                            <span className="font-mono text-xs">{result.cityId}/{result.meetingId}</span>
+                                            {result.error && (
+                                                <span className="text-red-600 text-xs truncate">— {result.error}</span>
+                                            )}
+                                        </div>
+                                    ))}
+                                </div>
+                            </ScrollArea>
+
+                            <DialogFooter>
+                                {dialogState === 'executing' ? (
+                                    <Button variant="destructive" onClick={handleCancel}>
+                                        Cancel
+                                    </Button>
+                                ) : (
+                                    <Button variant="outline" onClick={handleClose}>
+                                        Close
+                                    </Button>
+                                )}
+                            </DialogFooter>
+                        </>
+                    )}
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}

--- a/src/components/admin/tasks/TaskFilters.tsx
+++ b/src/components/admin/tasks/TaskFilters.tsx
@@ -16,6 +16,7 @@ interface TaskFiltersProps {
   taskTypes: MeetingTaskType[];
   versionMin: string | undefined;
   versionMax: string | undefined;
+  maxVersion: number;
   availableCities: { id: string; name: string; name_en: string }[];
 }
 
@@ -26,6 +27,7 @@ export function TaskFilters({
   taskTypes,
   versionMin,
   versionMax,
+  maxVersion,
   availableCities,
 }: TaskFiltersProps) {
   const { updateParam, isPending } = useUrlParams();
@@ -52,6 +54,16 @@ export function TaskFilters({
     o => o.value === taskTypesValue || (o.value === "default" && taskTypesValue === "transcribe,processAgenda,summarize")
   );
   const selectTaskTypesValue = matchingOption ? matchingOption.value : taskTypesValue;
+
+  // Build version options: "Any", 0 (unversioned), 1, 2, ... maxVersion
+  const versionOptions = [
+    { value: "any", label: "Any" },
+    { value: "0", label: "Unversioned" },
+    ...Array.from({ length: maxVersion }, (_, i) => ({
+      value: String(i + 1),
+      label: `v${i + 1}`,
+    })),
+  ];
 
   return (
     <>
@@ -123,46 +135,48 @@ export function TaskFilters({
         </Select>
       </div>
 
-      <div className="w-full md:w-28">
+      <div className="w-full md:w-36">
         <Label htmlFor="versionMin-filter" className="text-sm font-medium mb-2 block">
           Version Min
         </Label>
-        <Input
-          id="versionMin-filter"
-          type="number"
-          placeholder="Min"
-          defaultValue={versionMin ?? ""}
+        <Select
+          value={versionMin ?? "any"}
+          onValueChange={(v) => updateParam("versionMin", v === "any" ? null : v)}
           disabled={isPending}
-          onBlur={(e) => {
-            updateParam("versionMin", e.target.value.trim() || null);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              (e.target as HTMLInputElement).blur();
-            }
-          }}
-        />
+        >
+          <SelectTrigger id="versionMin-filter" disabled={isPending}>
+            <SelectValue placeholder="Any" />
+          </SelectTrigger>
+          <SelectContent>
+            {versionOptions.map(option => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
-      <div className="w-full md:w-28">
+      <div className="w-full md:w-36">
         <Label htmlFor="versionMax-filter" className="text-sm font-medium mb-2 block">
           Version Max
         </Label>
-        <Input
-          id="versionMax-filter"
-          type="number"
-          placeholder="Max"
-          defaultValue={versionMax ?? ""}
+        <Select
+          value={versionMax ?? "any"}
+          onValueChange={(v) => updateParam("versionMax", v === "any" ? null : v)}
           disabled={isPending}
-          onBlur={(e) => {
-            updateParam("versionMax", e.target.value.trim() || null);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              (e.target as HTMLInputElement).blur();
-            }
-          }}
-        />
+        >
+          <SelectTrigger id="versionMax-filter" disabled={isPending}>
+            <SelectValue placeholder="Any" />
+          </SelectTrigger>
+          <SelectContent>
+            {versionOptions.map(option => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       {isPending && (

--- a/src/components/meetings/admin/TaskList.tsx
+++ b/src/components/meetings/admin/TaskList.tsx
@@ -9,9 +9,10 @@ interface TaskListProps {
     tasks: TaskStatus[];
     onDelete: (taskId: string) => void;
     isLoading: boolean;
+    showMeetingInfo?: boolean;
 }
 
-export default function TaskList({ tasks, onDelete, isLoading }: TaskListProps) {
+export default function TaskList({ tasks, onDelete, isLoading, showMeetingInfo }: TaskListProps) {
     const t = useTranslations('admin.taskList');
     
     if (isLoading) {
@@ -40,7 +41,7 @@ export default function TaskList({ tasks, onDelete, isLoading }: TaskListProps) 
                     exit={{ opacity: 0, height: 0 }}
                     transition={{ duration: 0.1 }}
                 >
-                    <TaskStatusComponent task={task} onDelete={onDelete} />
+                    <TaskStatusComponent task={task} onDelete={onDelete} showMeetingInfo={showMeetingInfo} />
                 </motion.div>
             ))}
         </AnimatePresence>

--- a/src/components/meetings/admin/TaskStatus.tsx
+++ b/src/components/meetings/admin/TaskStatus.tsx
@@ -24,9 +24,10 @@ const staleTimeMs = 10 * 60 * 1000; // 10 minutes
 interface TaskStatusComponentProps {
     task: TaskStatus
     onDelete: (taskId: string) => void
+    showMeetingInfo?: boolean
 }
 
-export function TaskStatusComponent({ task, onDelete }: TaskStatusComponentProps) {
+export function TaskStatusComponent({ task, onDelete, showMeetingInfo }: TaskStatusComponentProps) {
     const t = useTranslations('admin.taskStatus.reprocessDialog');
     const tStatus = useTranslations('admin.taskStatus');
     const [isStale, setIsStale] = useState(false);
@@ -109,6 +110,17 @@ export function TaskStatusComponent({ task, onDelete }: TaskStatusComponentProps
                         <Badge variant="outline" className="text-xs font-normal">
                             {task.type}
                         </Badge>
+                        {showMeetingInfo && (
+                            <a
+                                href={`/${task.cityId}/${task.councilMeetingId}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="font-mono text-xs text-blue-600 hover:underline"
+                                onClick={(e) => e.stopPropagation()}
+                            >
+                                {task.cityId}/{task.councilMeetingId}
+                            </a>
+                        )}
                         <span className="text-xs font-medium">{tStatus(task.status)}</span>
                     </div>
                     <div className="flex items-center space-x-4">

--- a/src/lib/db/tasks.ts
+++ b/src/lib/db/tasks.ts
@@ -10,6 +10,16 @@ export type MeetingTaskStatus = {
     [K in MeetingTaskType]: boolean;
 };
 
+export async function getActiveTasks(): Promise<TaskStatus[]> {
+    await withUserAuthorizedToEdit({});
+    return prisma.taskStatus.findMany({
+        where: {
+            status: { notIn: ['succeeded', 'failed'] },
+        },
+        orderBy: { updatedAt: 'desc' },
+    });
+}
+
 export async function getTasksForMeeting(cityId: string, meetingId: string): Promise<TaskStatus[]> {
     await withUserAuthorizedToEdit({ councilMeetingId: meetingId, cityId: cityId })
     try {

--- a/src/lib/db/tasks.ts
+++ b/src/lib/db/tasks.ts
@@ -20,6 +20,22 @@ export async function getActiveTasks(): Promise<TaskStatus[]> {
     });
 }
 
+const RECENT_TASKS_PAGE_SIZE = 20;
+
+export async function getRecentTasks(offset: number = 0): Promise<{ tasks: TaskStatus[]; hasMore: boolean }> {
+    await withUserAuthorizedToEdit({});
+    const tasks = await prisma.taskStatus.findMany({
+        where: {
+            status: { in: ['succeeded', 'failed'] },
+        },
+        orderBy: { updatedAt: 'desc' },
+        skip: offset,
+        take: RECENT_TASKS_PAGE_SIZE + 1,
+    });
+    const hasMore = tasks.length > RECENT_TASKS_PAGE_SIZE;
+    return { tasks: tasks.slice(0, RECENT_TASKS_PAGE_SIZE), hasMore };
+}
+
 export async function getTasksForMeeting(cityId: string, meetingId: string): Promise<TaskStatus[]> {
     await withUserAuthorizedToEdit({ councilMeetingId: meetingId, cityId: cityId })
     try {

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -98,14 +98,16 @@ let getAgendaItemIndex = (subject: DbSubject): number | "BEFORE_AGENDA" | "OUT_O
     return subject.nonAgendaReason === "beforeAgenda" ? "BEFORE_AGENDA" : "OUT_OF_AGENDA";
 }
 
-export async function getSummarizeRequestBody(councilMeetingId: string, cityId: string, requestedSubjects: string[], additionalInstructions?: string): Promise<Omit<SummarizeRequest, 'callbackUrl'>> {
+export async function getSummarizeRequestBody(councilMeetingId: string, cityId: string, requestedSubjects: string[], additionalInstructions?: string, { force = false }: { force?: boolean } = {}): Promise<Omit<SummarizeRequest, 'callbackUrl'>> {
     const baseRequest = await getRequestOnTranscriptRequestBody(councilMeetingId, cityId);
     const existingSubjects = await getSubjectsForMeeting(cityId, councilMeetingId);
     return {
         ...baseRequest,
         requestedSubjects,
         existingSubjects: existingSubjects
-            .filter(s => s.agendaItemIndex || s.nonAgendaReason)
+            // When force re-running, only send agenda subjects — non-agenda subjects
+            // (BEFORE_AGENDA/OUT_OF_AGENDA) will be rediscovered fresh by the backend
+            .filter(s => force ? s.agendaItemIndex : (s.agendaItemIndex || s.nonAgendaReason))
             .map(s => ({
             name: s.name,
             description: s.description,

--- a/src/lib/tasks/batchRerun.ts
+++ b/src/lib/tasks/batchRerun.ts
@@ -34,7 +34,7 @@ export async function batchRerunTask(
 
             await requestProcessAgendaInternal(meeting.agendaUrl, meetingId, cityId, { force: true });
         } else {
-            const body = await getSummarizeRequestBody(meetingId, cityId, []);
+            const body = await getSummarizeRequestBody(meetingId, cityId, [], undefined, { force: true });
             await startTask('summarize', body, meetingId, cityId, { force: true });
         }
 

--- a/src/lib/tasks/batchRerun.ts
+++ b/src/lib/tasks/batchRerun.ts
@@ -1,0 +1,50 @@
+"use server";
+
+import { withUserAuthorizedToEdit } from "../auth";
+import { requestProcessAgendaInternal } from "./processAgendaInternal";
+import { getSummarizeRequestBody } from "../db/utils";
+import { startTask } from "./tasks";
+import prisma from "../db/prisma";
+
+export interface BatchRerunResult {
+    meetingId: string;
+    cityId: string;
+    success: boolean;
+    error?: string;
+}
+
+export async function batchRerunTask(
+    cityId: string,
+    meetingId: string,
+    taskType: 'processAgenda' | 'summarize'
+): Promise<BatchRerunResult> {
+    try {
+        await withUserAuthorizedToEdit({ cityId });
+
+        if (taskType === 'processAgenda') {
+            // Fetch agendaUrl from the meeting record
+            const meeting = await prisma.councilMeeting.findUnique({
+                where: { cityId_id: { cityId, id: meetingId } },
+                select: { agendaUrl: true }
+            });
+
+            if (!meeting?.agendaUrl) {
+                return { meetingId, cityId, success: false, error: 'No agenda URL' };
+            }
+
+            await requestProcessAgendaInternal(meeting.agendaUrl, meetingId, cityId, { force: true });
+        } else {
+            const body = await getSummarizeRequestBody(meetingId, cityId, []);
+            await startTask('summarize', body, meetingId, cityId, { force: true });
+        }
+
+        return { meetingId, cityId, success: true };
+    } catch (error) {
+        return {
+            meetingId,
+            cityId,
+            success: false,
+            error: error instanceof Error ? error.message : String(error)
+        };
+    }
+}

--- a/src/lib/tasks/processAgenda.ts
+++ b/src/lib/tasks/processAgenda.ts
@@ -37,6 +37,18 @@ export async function handleProcessAgendaResult(taskId: string, response: Proces
         throw new Error('Task not found');
     }
 
+    // Delete existing subjects and auto-generated highlights before saving new ones.
+    // This runs in the callback (not at dispatch time) so data is only deleted when
+    // new results are ready to replace it — a failed dispatch won't cause data loss.
+    // User-created highlights (createdById is set) are preserved — their subjectId
+    // will be set to null by the onDelete: SetNull cascade when subjects are deleted.
+    await prisma.highlight.deleteMany({
+        where: { meetingId: task.councilMeeting.id, cityId: task.councilMeeting.cityId, subjectId: { not: null }, createdById: null }
+    });
+    await prisma.subject.deleteMany({
+        where: { councilMeetingId: task.councilMeeting.id, cityId: task.councilMeeting.cityId }
+    });
+
     await saveSubjectsForMeeting(
         response.subjects,
         task.councilMeeting.cityId,

--- a/src/lib/tasks/processAgendaInternal.ts
+++ b/src/lib/tasks/processAgendaInternal.ts
@@ -45,25 +45,9 @@ export async function requestProcessAgendaInternal(agendaUrl: string, councilMee
         throw new Error("Council meeting not found");
     }
 
-    if (councilMeeting.subjects.length > 0) {
-        if (force) {
-            console.log(`Deleting existing subjects for meeting ${councilMeetingId}`);
-            // Delete auto-generated subject-linked highlights before subjects to avoid orphans.
-            // User-created highlights (createdById is set) are preserved — their subjectId
-            // will be set to null by the onDelete: SetNull cascade when subjects are deleted.
-            await prisma.highlight.deleteMany({
-                where: { meetingId: councilMeetingId, cityId, subjectId: { not: null }, createdById: null }
-            });
-            await prisma.subject.deleteMany({
-                where: {
-                    councilMeetingId,
-                    cityId
-                }
-            });
-        } else {
-            console.log(`Meeting already has subjects`);
-            throw new Error('Meeting already has subjects');
-        }
+    if (!force && councilMeeting.subjects.length > 0) {
+        console.log(`Meeting already has subjects`);
+        throw new Error('Meeting already has subjects');
     }
 
     // Get relevant people for the meeting (filtered by administrative body)

--- a/src/lib/tasks/summarize.ts
+++ b/src/lib/tasks/summarize.ts
@@ -17,7 +17,7 @@ export async function requestSummarize(cityId: string, councilMeetingId: string,
 } = {}) {
     await withUserAuthorizedToEdit({ cityId });
 
-    const body = await getSummarizeRequestBody(councilMeetingId, cityId, requestedSubjects, additionalInstructions);
+    const body = await getSummarizeRequestBody(councilMeetingId, cityId, requestedSubjects, additionalInstructions, { force });
 
     return startTask('summarize', body, councilMeetingId, cityId, { force });
 }

--- a/src/lib/tasks/tasks.ts
+++ b/src/lib/tasks/tasks.ts
@@ -393,13 +393,31 @@ export const getTaskVersionsForMeetings = async (filters: TaskVersionsFilter): P
     };
 
     if (filters.versionMin !== undefined || filters.versionMax !== undefined) {
-        taskStatusWhere.version = {};
-        if (filters.versionMin !== undefined) {
-            taskStatusWhere.version.gte = filters.versionMin;
+        // versionMin=0 or versionMax=0 means "include unversioned (null) tasks"
+        const includeUnversioned = filters.versionMin === 0 || filters.versionMax === 0;
+
+        if (includeUnversioned) {
+            // null OR within range
+            const rangeCondition: Prisma.IntNullableFilter = { gte: 0 };
+            if (filters.versionMax !== undefined) {
+                rangeCondition.lte = filters.versionMax;
+            }
+            taskStatusWhere.OR = [
+                { version: null },
+                { version: rangeCondition }
+            ];
+        } else {
+            taskStatusWhere.version = {};
+            if (filters.versionMin !== undefined) {
+                taskStatusWhere.version.gte = filters.versionMin;
+            }
+            if (filters.versionMax !== undefined) {
+                taskStatusWhere.version.lte = filters.versionMax;
+            }
         }
-        if (filters.versionMax !== undefined) {
-            taskStatusWhere.version.lte = filters.versionMax;
-        }
+
+        // Only return meetings that have at least one task matching the version range
+        meetingWhere.taskStatuses = { some: taskStatusWhere };
     }
 
     const meetings = await prisma.councilMeeting.findMany({


### PR DESCRIPTION
## Summary
- Rework version filter on admin tasks page: replace broken number inputs with Select dropdowns, fix query to exclude meetings with no matching tasks, treat version 0 as "unversioned"
- Add batch re-run capability for processAgenda and summarize tasks with confirmation dialog, sequential dispatch, and cancel support
- Batch actions are in a collapsible section (closed by default) with explanation text and force operation warnings from existing translations

## Screenshots
<img height="280" alt="Screenshot from 2026-06-03 07-42-33" src="https://github.com/user-attachments/assets/638a9faf-8138-4957-b2a3-15019ff3212a" />
<img height="304" alt="Screenshot from 2026-06-02 21-44-32" src="https://github.com/user-attachments/assets/e7c1ef7a-0d36-4df1-8d05-56347e043aa1" />


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reworks the admin tasks page version filter (number inputs → Select dropdowns with proper "Unversioned" handling), moves subject deletion from dispatch-time to callback-time in the processAgenda handler, and adds a collapsible batch re-run feature for `processAgenda` and `summarize` tasks with a confirmation dialog, sequential dispatch, and cancel support.

- **Version filter**: Inputs replaced with `Select` dropdowns driven by a computed `maxVersion`; the Prisma query now uses an OR clause for `null` versions and a `meetingWhere.taskStatuses.some` guard to exclude meetings with no matching tasks.
- **Deletion deferred to callback** (`processAgenda.ts`): Subjects and highlights are deleted at result-callback time rather than dispatch time, so a failed or un-answered dispatch no longer causes data loss.
- **Batch re-run** (`BatchRerunActions.tsx`, `batchRerun.ts`): Admin can force-requeue all currently-filtered meetings for `processAgenda` or `summarize`, with per-meeting success/failure tracking and a cancel-via-ref mechanism.

<h3>Confidence Score: 5/5</h3>

Safe to merge; changes are admin-internal, the core data-safety rework (deferred deletion) is logically sound, and no data path is left unguarded.

All three feature areas are well-reasoned. The deferred-deletion change in processAgenda.ts is cleaner than the original, the new batch server action wraps every call in a try/catch so individual failures never abort the loop, and the filter query correctly handles the null-version OR condition for the common cases. The only gaps found are an edge-case filter drop and a cosmetic title mismatch after cancel — neither affects production data.

src/lib/tasks/tasks.ts — the rangeCondition.gte hardcoding in the unversioned branch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/tasks/tasks.ts | Version filter reworked: adds OR clause for null (unversioned) tasks and a meetingWhere.taskStatuses.some guard. Minor logic gap: when versionMax=0 triggers the unversioned path but versionMin>0, the versionMin constraint is silently dropped from the range condition. |
| src/lib/tasks/processAgenda.ts | Deletion of existing subjects/highlights moved from dispatch-time to callback-time — a sound improvement that avoids data loss on failed dispatches. The dispatch guard in processAgendaInternal.ts still prevents double-processing for non-force tasks. |
| src/lib/tasks/batchRerun.ts | New server action for batch re-run; auth checks are in place, errors are caught per-meeting and returned as results rather than thrown, and force=true is correctly passed through for both task types. |
| src/components/admin/tasks/BatchRerunActions.tsx | New client component for batch re-run with collapsible UI, confirmation dialog, sequential dispatch loop, cancel-via-ref, and progress display. Dialog prevents closing during execution. |
| src/components/admin/tasks/ActiveTasks.tsx | New client component that polls active tasks every 3 s and lazy-loads recent tasks on tab switch; auth is handled by the server actions it calls. |
| src/lib/db/tasks.ts | Two new server actions added: getActiveTasks (non-terminal statuses) and getRecentTasks (paginated succeeded/failed). Both call withUserAuthorizedToEdit for auth. |
| src/lib/tasks/processAgendaInternal.ts | Simplified force-rerun guard: deletion removed from dispatch path (now handled in callback), leaving only the non-force block-on-existing-subjects check. |
| src/components/admin/tasks/TaskFilters.tsx | Number inputs replaced with Select dropdowns using generated version options from maxVersion prop; Unversioned maps to value 0. |
| src/app/[locale]/(other)/admin/tasks/page.tsx | Adds ActiveTasks and BatchRerunActions to the page; derives maxVersion and allMeetings from already-fetched data. |
| src/lib/db/utils.ts | getSummarizeRequestBody now accepts a force option; when force=true it strips non-agenda subjects from existingSubjects so the backend rediscovers them fresh. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Ftasks%2Ftasks.ts%3A399-404%0AWhen%20%60versionMax%20%3D%3D%3D%200%60%20triggers%20%60includeUnversioned%60%20but%20%60versionMin%60%20is%20a%20positive%20number%2C%20the%20%60rangeCondition%60%20starts%20at%20the%20hardcoded%20%60gte%3A%200%60%20instead%20of%20%60gte%3A%20versionMin%60%2C%20so%20%60versionMin%60%20is%20silently%20ignored.%20For%20example%2C%20selecting%20Min%3Dv2%2C%20Max%3DUnversioned%20produces%20%60version%20IS%20NULL%20OR%20version%20BETWEEN%200%20AND%200%60%20rather%20than%20the%20expected%20result%20with%20the%20min%20constraint%20applied.%20Since%20there%20are%20no%20tasks%20with%20%60version%20%3D%200%60%20in%20practice%20the%20version%20part%20of%20the%20OR%20always%20matches%20nothing%2C%20but%20%60versionMin%20%3E%200%60%20is%20still%20effectively%20dropped.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20%28includeUnversioned%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20null%20OR%20within%20range%0A%20%20%20%20%20%20%20%20%20%20%20%20const%20rangeCondition%3A%20Prisma.IntNullableFilter%20%3D%20%7B%20gte%3A%20filters.versionMin%20%3F%3F%200%20%7D%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20%28filters.versionMax%20!%3D%3D%20undefined%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20rangeCondition.lte%20%3D%20filters.versionMax%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fcomponents%2Fadmin%2Ftasks%2FBatchRerunActions.tsx%3A87-88%0AAfter%20the%20loop%20exits%20via%20%60cancelledRef.current%60%2C%20%60setDialogState%28'done'%29%60%20is%20called%20unconditionally%2C%20making%20the%20title%20read%20%22All%20Tasks%20Dispatched%22%20even%20for%20a%20cancelled%20run.%20The%20cancellation%20notice%20only%20appears%20in%20the%20smaller%20description%20line.%20Consider%20a%20separate%20%60'cancelled'%60%20state%20%28or%20a%20conditional%20title%29%20so%20the%20heading%20accurately%20reflects%20the%20outcome.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20setDialogState%28cancelledRef.current%20%3F%20'cancelled'%20%3A%20'done'%29%3B%0A%20%20%20%20%7D%2C%20%5Bmeetings%2C%20selectedTask%5D%29%3B%0A%60%60%60%0A%0A&repo=schemalabz%2Fopencouncil&pr=409&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/lib/tasks/tasks.ts:399-404
When `versionMax === 0` triggers `includeUnversioned` but `versionMin` is a positive number, the `rangeCondition` starts at the hardcoded `gte: 0` instead of `gte: versionMin`, so `versionMin` is silently ignored. For example, selecting Min=v2, Max=Unversioned produces `version IS NULL OR version BETWEEN 0 AND 0` rather than the expected result with the min constraint applied. Since there are no tasks with `version = 0` in practice the version part of the OR always matches nothing, but `versionMin > 0` is still effectively dropped.

```suggestion
        if (includeUnversioned) {
            // null OR within range
            const rangeCondition: Prisma.IntNullableFilter = { gte: filters.versionMin ?? 0 };
            if (filters.versionMax !== undefined) {
                rangeCondition.lte = filters.versionMax;
            }
```

### Issue 2 of 2
src/components/admin/tasks/BatchRerunActions.tsx:87-88
After the loop exits via `cancelledRef.current`, `setDialogState('done')` is called unconditionally, making the title read "All Tasks Dispatched" even for a cancelled run. The cancellation notice only appears in the smaller description line. Consider a separate `'cancelled'` state (or a conditional title) so the heading accurately reflects the outcome.

```suggestion
        setDialogState(cancelledRef.current ? 'cancelled' : 'done');
    }, [meetings, selectedTask]);
```

`````

</details>

<sub>Reviews (7): Last reviewed commit: ["feat(tasks): skip non-agenda subjects wh..."](https://github.com/schemalabz/opencouncil/commit/b8a4491dbc06eb0d1eb7b90bbbb8a8910ce62665) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35159457)</sub>

<!-- /greptile_comment -->