### PR TITLE
fix(notifications): batch release emails so login emails aren't starved

### DIFF
--- a/src/lib/notifications/__tests__/deliver.test.ts
+++ b/src/lib/notifications/__tests__/deliver.test.ts
@@ -31,7 +31,7 @@ jest.mock('../outbound', () => ({
     sendAndPersistOutbound: jest.fn(),
 }));
 
-import { releaseNotifications, sendEmailDeliveriesBatched } from '../deliver';
+import { releaseNotifications } from '../deliver';
 
 function emailDelivery(id: string, to: string) {
     return {
@@ -150,22 +150,54 @@ describe('releaseNotifications — email batching (issue #380)', () => {
         expect(sendEmailBatchMock).not.toHaveBeenCalled();
         expect(result).toEqual({ success: true, emailsSent: 0, messagesSent: 0, failed: 0 });
     });
-});
 
-describe('sendEmailDeliveriesBatched', () => {
-    beforeEach(() => jest.clearAllMocks());
+    it('attributes per-recipient failures correctly when two deliveries share an email', async () => {
+        // Same `to` appears twice; Resend reports the address once in failedTos
+        // when only one of the two sends fails. Must mark exactly one as failed.
+        const deliveries = [
+            emailDelivery('d1', 'dup@x.com'),
+            emailDelivery('d2', 'dup@x.com'),
+            emailDelivery('d3', 'other@x.com'),
+        ];
+        getPendingDeliveriesMock.mockResolvedValue(deliveries);
+        sendEmailBatchMock.mockResolvedValue({
+            success: false,
+            failedTos: ['dup@x.com'],
+        });
 
-    it('is callable directly for unit testing the chunking', async () => {
-        const deliveries = Array.from({ length: 101 }, (_, i) =>
-            emailDelivery(`d${i}`, `u${i}@x.com`),
-        );
-        sendEmailBatchMock.mockResolvedValue({ success: true, failedTos: [] });
+        const result = await releaseNotifications(['n1']);
 
-        const result = await sendEmailDeliveriesBatched(deliveries);
+        expect(result.emailsSent).toBe(2);
+        expect(result.failed).toBe(1);
 
-        expect(sendEmailBatchMock).toHaveBeenCalledTimes(2);
-        expect(sendEmailBatchMock.mock.calls[0][0]).toHaveLength(100);
-        expect(sendEmailBatchMock.mock.calls[1][0]).toHaveLength(1);
-        expect(result).toEqual({ sent: 101, failed: 0 });
+        const statuses = updateDeliveryStatusMock.mock.calls
+            .filter((c) => ['d1', 'd2'].includes(c[0]))
+            .map((c) => c[1])
+            .sort();
+        expect(statuses).toEqual(['failed', 'sent']);
+    });
+
+    it('marks both shared-email deliveries failed when the whole batch fails', async () => {
+        // Whole-batch failure (non-2xx / network throw) returns every `to`,
+        // so a duplicate recipient appears twice and both rows must fail.
+        const deliveries = [
+            emailDelivery('d1', 'dup@x.com'),
+            emailDelivery('d2', 'dup@x.com'),
+        ];
+        getPendingDeliveriesMock.mockResolvedValue(deliveries);
+        sendEmailBatchMock.mockResolvedValue({
+            success: false,
+            failedTos: ['dup@x.com', 'dup@x.com'],
+        });
+
+        const result = await releaseNotifications(['n1']);
+
+        expect(result.emailsSent).toBe(0);
+        expect(result.failed).toBe(2);
+
+        const statuses = updateDeliveryStatusMock.mock.calls
+            .filter((c) => ['d1', 'd2'].includes(c[0]))
+            .map((c) => c[1]);
+        expect(statuses).toEqual(['failed', 'failed']);
     });
 });

--- a/src/lib/notifications/__tests__/deliver.test.ts
+++ b/src/lib/notifications/__tests__/deliver.test.ts
@@ -1,0 +1,171 @@
+/** @jest-environment node */
+
+// Mock env before importing the module under test.
+jest.mock('@/env.mjs', () => ({
+    env: {
+        RESEND_API_KEY: 'test-key',
+        BIRD_API_KEY: '',
+    },
+}));
+
+// Mock the Resend batch helper — we assert call shape and choose the return.
+const sendEmailBatchMock = jest.fn();
+jest.mock('@/lib/email/resend', () => ({
+    sendEmailBatch: (...args: any[]) => sendEmailBatchMock(...args),
+}));
+
+// DB layer mocks — capture status updates per delivery.
+const getPendingDeliveriesMock = jest.fn();
+const updateDeliveryStatusMock = jest.fn();
+jest.mock('@/lib/db/notifications', () => ({
+    getPendingDeliveries: (...args: any[]) => getPendingDeliveriesMock(...args),
+    updateDeliveryStatus: (...args: any[]) => updateDeliveryStatusMock(...args),
+}));
+
+// Bird/outbound are not exercised in email-only tests — stub them out.
+jest.mock('../bird', () => ({
+    createOrUpdateConversation: jest.fn(),
+    sendSMSMessage: jest.fn(),
+}));
+jest.mock('../outbound', () => ({
+    sendAndPersistOutbound: jest.fn(),
+}));
+
+import { releaseNotifications, sendEmailDeliveriesBatched } from '../deliver';
+
+function emailDelivery(id: string, to: string) {
+    return {
+        id,
+        medium: 'email',
+        email: to,
+        title: `Subject ${id}`,
+        body: `<p>Body ${id}</p>`,
+    };
+}
+
+describe('releaseNotifications — email batching (issue #380)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('sends all emails in a single batch when count <= 100, without 500ms per-email delay', async () => {
+        const deliveries = Array.from({ length: 50 }, (_, i) =>
+            emailDelivery(`d${i}`, `user${i}@example.com`),
+        );
+        getPendingDeliveriesMock.mockResolvedValue(deliveries);
+        sendEmailBatchMock.mockResolvedValue({ success: true, failedTos: [] });
+
+        const result = await releaseNotifications(['n1']);
+
+        expect(sendEmailBatchMock).toHaveBeenCalledTimes(1);
+        const [payloads, opts] = sendEmailBatchMock.mock.calls[0];
+        expect(payloads).toHaveLength(50);
+        expect(payloads[0]).toMatchObject({
+            to: 'user0@example.com',
+            subject: 'Subject d0',
+            html: '<p>Body d0</p>',
+        });
+        expect(opts.idempotencyKey).toEqual(expect.any(String));
+        expect(result).toEqual({ success: true, emailsSent: 50, messagesSent: 0, failed: 0 });
+        expect(updateDeliveryStatusMock).toHaveBeenCalledTimes(50);
+        for (const call of updateDeliveryStatusMock.mock.calls) {
+            expect(call[1]).toBe('sent');
+        }
+    });
+
+    it('chunks emails into batches of 100', async () => {
+        const deliveries = Array.from({ length: 250 }, (_, i) =>
+            emailDelivery(`d${i}`, `u${i}@x.com`),
+        );
+        getPendingDeliveriesMock.mockResolvedValue(deliveries);
+        sendEmailBatchMock.mockResolvedValue({ success: true, failedTos: [] });
+
+        const result = await releaseNotifications(['n1']);
+
+        expect(sendEmailBatchMock).toHaveBeenCalledTimes(3);
+        expect(sendEmailBatchMock.mock.calls[0][0]).toHaveLength(100);
+        expect(sendEmailBatchMock.mock.calls[1][0]).toHaveLength(100);
+        expect(sendEmailBatchMock.mock.calls[2][0]).toHaveLength(50);
+        expect(result.emailsSent).toBe(250);
+        expect(result.failed).toBe(0);
+    });
+
+    it('marks per-recipient failures from batch response', async () => {
+        const deliveries = [
+            emailDelivery('d1', 'ok@x.com'),
+            emailDelivery('d2', 'bad@x.com'),
+            emailDelivery('d3', 'ok2@x.com'),
+        ];
+        getPendingDeliveriesMock.mockResolvedValue(deliveries);
+        sendEmailBatchMock.mockResolvedValue({
+            success: false,
+            failedTos: ['bad@x.com'],
+        });
+
+        const result = await releaseNotifications(['n1']);
+
+        expect(result.emailsSent).toBe(2);
+        expect(result.failed).toBe(1);
+
+        const byId = new Map(updateDeliveryStatusMock.mock.calls.map((c) => [c[0], c[1]]));
+        expect(byId.get('d1')).toBe('sent');
+        expect(byId.get('d2')).toBe('failed');
+        expect(byId.get('d3')).toBe('sent');
+    });
+
+    it('marks deliveries missing email/title/body as failed before batch send', async () => {
+        const deliveries = [
+            emailDelivery('d1', 'ok@x.com'),
+            { id: 'd2', medium: 'email', email: null, title: 't', body: 'b' },
+        ];
+        getPendingDeliveriesMock.mockResolvedValue(deliveries);
+        sendEmailBatchMock.mockResolvedValue({ success: true, failedTos: [] });
+
+        const result = await releaseNotifications(['n1']);
+
+        expect(sendEmailBatchMock).toHaveBeenCalledTimes(1);
+        expect(sendEmailBatchMock.mock.calls[0][0]).toHaveLength(1);
+        expect(result.emailsSent).toBe(1);
+        expect(result.failed).toBe(1);
+    });
+
+    it('uses a deterministic idempotency key for the same delivery set', async () => {
+        const deliveries = [emailDelivery('a', 'a@x.com'), emailDelivery('b', 'b@x.com')];
+        getPendingDeliveriesMock.mockResolvedValue(deliveries);
+        sendEmailBatchMock.mockResolvedValue({ success: true, failedTos: [] });
+
+        await releaseNotifications(['n1']);
+        const firstKey = sendEmailBatchMock.mock.calls[0][1].idempotencyKey;
+
+        sendEmailBatchMock.mockClear();
+        await releaseNotifications(['n1']);
+        const secondKey = sendEmailBatchMock.mock.calls[0][1].idempotencyKey;
+
+        expect(firstKey).toBe(secondKey);
+    });
+
+    it('skips batch call entirely when there are no email deliveries', async () => {
+        getPendingDeliveriesMock.mockResolvedValue([]);
+        const result = await releaseNotifications(['n1']);
+        expect(sendEmailBatchMock).not.toHaveBeenCalled();
+        expect(result).toEqual({ success: true, emailsSent: 0, messagesSent: 0, failed: 0 });
+    });
+});
+
+describe('sendEmailDeliveriesBatched', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('is callable directly for unit testing the chunking', async () => {
+        const deliveries = Array.from({ length: 101 }, (_, i) =>
+            emailDelivery(`d${i}`, `u${i}@x.com`),
+        );
+        sendEmailBatchMock.mockResolvedValue({ success: true, failedTos: [] });
+
+        const result = await sendEmailDeliveriesBatched(deliveries);
+
+        expect(sendEmailBatchMock).toHaveBeenCalledTimes(2);
+        expect(sendEmailBatchMock.mock.calls[0][0]).toHaveLength(100);
+        expect(sendEmailBatchMock.mock.calls[1][0]).toHaveLength(1);
+        expect(result).toEqual({ sent: 101, failed: 0 });
+    });
+});

--- a/src/lib/notifications/deliver.ts
+++ b/src/lib/notifications/deliver.ts
@@ -1,6 +1,7 @@
 "use server";
 
-import { sendEmail } from '@/lib/email/resend';
+import { createHash } from 'crypto';
+import { sendEmailBatch } from '@/lib/email/resend';
 import { getPendingDeliveries, updateDeliveryStatus } from '@/lib/db/notifications';
 import {
     createOrUpdateConversation,
@@ -9,8 +10,32 @@ import {
 import { sendAndPersistOutbound } from './outbound';
 import { env } from '@/env.mjs';
 
+const FROM_ADDRESS = 'OpenCouncil <notifications@opencouncil.gr>';
+const EMAIL_BATCH_SIZE = 100;
+const MESSAGE_DELAY_MS = 500;
+// Space successive batch calls so a multi-batch release stays under Resend's
+// per-key request rate limit. A 429 maps the whole chunk to failedTos, which
+// would drop ~100 notifications at once, so this is cheap insurance.
+const BATCH_DELAY_MS = 500;
+
+interface EmailPayload {
+    from: string;
+    to: string;
+    subject: string;
+    html: string;
+}
+
 /**
- * Release notifications by sending all pending deliveries
+ * Release notifications by sending all pending deliveries.
+ *
+ * Emails go through Resend's batch endpoint in chunks of 100, so a release of
+ * thousands of recipients consumes only a handful of API calls instead of
+ * thousands of sequential per-recipient sends with 500ms gaps. That sequential
+ * loop used to saturate the Resend rate limit for our shared API key, starving
+ * auth magic-link emails for minutes — see issue #380.
+ *
+ * Bird (WhatsApp/SMS) messages still go one-at-a-time with a 500ms gap; their
+ * API doesn't expose a batch endpoint and the rate concern there is separate.
  */
 export async function releaseNotifications(notificationIds: string[]): Promise<{
     success: boolean;
@@ -28,34 +53,32 @@ export async function releaseNotifications(notificationIds: string[]): Promise<{
 
         console.log(`Releasing ${pendingDeliveries.length} pending deliveries for ${notificationIds.length} notifications`);
 
-        // Process each delivery
-        for (const delivery of pendingDeliveries) {
+        // Partition by medium up front so emails can be batched and messages
+        // can keep their per-delivery loop.
+        const emailDeliveries = pendingDeliveries.filter((d: any) => d.medium === 'email');
+        const messageDeliveries = pendingDeliveries.filter((d: any) => d.medium === 'message');
+
+        // ---- Emails: batch send via Resend ----
+        const emailResult = await sendEmailDeliveriesBatched(emailDeliveries);
+        emailsSent += emailResult.sent;
+        failed += emailResult.failed;
+
+        // ---- Messages: sequential with rate-limit delay (unchanged) ----
+        for (const delivery of messageDeliveries) {
             try {
-                if (delivery.medium === 'email') {
-                    const result = await sendEmailDelivery(delivery);
-                    if (result) {
-                        emailsSent++;
-                    } else {
-                        failed++;
-                    }
-                } else if (delivery.medium === 'message') {
-                    const result = await sendMessageDelivery(delivery);
-                    if (result) {
-                        messagesSent++;
-                    } else {
-                        failed++;
-                    }
+                const result = await sendMessageDelivery(delivery);
+                if (result) {
+                    messagesSent++;
+                } else {
+                    failed++;
                 }
-
-                // Add a small delay to avoid rate limiting
-                // 500ms delay allows for ~2 requests per second, which is a safe limit for most services
-                await new Promise(resolve => setTimeout(resolve, 500));
-
             } catch (error) {
                 console.error(`Error sending delivery ${delivery.id}:`, error);
                 await updateDeliveryStatus(delivery.id, 'failed');
                 failed++;
             }
+            // Keep the 500ms spacing for Bird/SMS — only emails moved to batch.
+            await new Promise(resolve => setTimeout(resolve, MESSAGE_DELAY_MS));
         }
 
         console.log(`Release complete: ${emailsSent} emails, ${messagesSent} messages, ${failed} failed`);
@@ -78,37 +101,92 @@ export async function releaseNotifications(notificationIds: string[]): Promise<{
 }
 
 /**
- * Send email delivery via Resend
+ * Build the Resend payload for a single email delivery, or return null if the
+ * delivery is missing required fields (in which case the delivery is marked
+ * failed as a side effect, matching the pre-batch behaviour).
  */
-async function sendEmailDelivery(delivery: any): Promise<boolean> {
-    try {
-        if (!delivery.email || !delivery.title || !delivery.body) {
-            console.error('Missing email, title, or body for delivery', delivery.id);
-            await updateDeliveryStatus(delivery.id, 'failed');
-            return false;
-        }
-
-        const result = await sendEmail({
-            from: 'OpenCouncil <notifications@opencouncil.gr>',
-            to: delivery.email,
-            subject: delivery.title,
-            html: delivery.body
-        });
-
-        if (result.success) {
-            await updateDeliveryStatus(delivery.id, 'sent');
-            console.log(`Email sent successfully to ${delivery.email}`);
-            return true;
-        } else {
-            await updateDeliveryStatus(delivery.id, 'failed');
-            console.error(`Failed to send email to ${delivery.email}`);
-            return false;
-        }
-    } catch (error) {
-        console.error('Error sending email delivery:', error);
+async function buildEmailPayload(delivery: any): Promise<EmailPayload | null> {
+    if (!delivery.email || !delivery.title || !delivery.body) {
+        console.error('Missing email, title, or body for delivery', delivery.id);
         await updateDeliveryStatus(delivery.id, 'failed');
-        return false;
+        return null;
     }
+    return {
+        from: FROM_ADDRESS,
+        to: delivery.email,
+        subject: delivery.title,
+        html: delivery.body,
+    };
+}
+
+/**
+ * Chunk email deliveries into batches of 100 and send each batch via Resend's
+ * batch endpoint. Per-delivery status writes preserve the same granularity as
+ * the old sequential loop: any address Resend reports as failed (permissive
+ * mode `errors[]`) is marked `failed`, the rest are marked `sent`.
+ */
+export async function sendEmailDeliveriesBatched(deliveries: any[]): Promise<{
+    sent: number;
+    failed: number;
+}> {
+    let sent = 0;
+    let failed = 0;
+
+    // Pair each successfully-built payload with its delivery so we can map
+    // batch results back to delivery ids. Deliveries that fail validation
+    // here are already marked failed inside buildEmailPayload.
+    const prepared: Array<{ delivery: any; payload: EmailPayload }> = [];
+    for (const delivery of deliveries) {
+        const payload = await buildEmailPayload(delivery);
+        if (payload) {
+            prepared.push({ delivery, payload });
+        } else {
+            failed++;
+        }
+    }
+
+    for (let i = 0; i < prepared.length; i += EMAIL_BATCH_SIZE) {
+        // Pause between batches (not before the first, not after the last) to
+        // avoid bursting past Resend's request rate limit on large releases.
+        if (i > 0) {
+            await new Promise(resolve => setTimeout(resolve, BATCH_DELAY_MS));
+        }
+
+        const chunk = prepared.slice(i, i + EMAIL_BATCH_SIZE);
+        const payloads = chunk.map((p) => p.payload);
+        const idempotencyKey = makeBatchIdempotencyKey(chunk.map((p) => p.delivery.id));
+
+        const result = await sendEmailBatch(payloads, { idempotencyKey });
+        const failedTos = new Set(result.failedTos);
+
+        for (const { delivery, payload } of chunk) {
+            if (failedTos.has(payload.to)) {
+                await updateDeliveryStatus(delivery.id, 'failed');
+                console.error(`Failed to send email to ${payload.to}`);
+                failed++;
+            } else {
+                await updateDeliveryStatus(delivery.id, 'sent');
+                sent++;
+            }
+        }
+
+        if (!result.success) {
+            console.error(`Notification email batch had failures:`, result.error);
+        }
+    }
+
+    return { sent, failed };
+}
+
+/**
+ * Deterministic idempotency key from the set of delivery ids in the batch.
+ * A retried release with the same deliveries will dedupe inside Resend's 24h
+ * window — important because each delivery row is a single "send this once"
+ * commitment.
+ */
+function makeBatchIdempotencyKey(deliveryIds: string[]): string {
+    const data = JSON.stringify({ kind: 'notification-release', ids: [...deliveryIds].sort() });
+    return createHash('sha256').update(data).digest('hex');
 }
 
 /**
@@ -162,7 +240,7 @@ async function sendMessageDelivery(delivery: any): Promise<boolean> {
             console.log(`WhatsApp conversation seeded for ${delivery.phone}`);
             return true;
         }
-        
+
         console.log(
             waResult.success
                 ? `WhatsApp delivery failed post-send for ${delivery.phone}, falling back to SMS`
@@ -195,4 +273,3 @@ async function sendMessageDelivery(delivery: any): Promise<boolean> {
         return false;
     }
 }
-

--- a/src/lib/notifications/deliver.ts
+++ b/src/lib/notifications/deliver.ts
@@ -18,6 +18,10 @@ const MESSAGE_DELAY_MS = 500;
 // would drop ~100 notifications at once, so this is cheap insurance.
 const BATCH_DELAY_MS = 500;
 
+// Derive the delivery row shape from the DB function — keeps us honest if the
+// include shape ever changes, without redeclaring the type.
+type PendingDelivery = Awaited<ReturnType<typeof getPendingDeliveries>>[number];
+
 interface EmailPayload {
     from: string;
     to: string;
@@ -55,8 +59,8 @@ export async function releaseNotifications(notificationIds: string[]): Promise<{
 
         // Partition by medium up front so emails can be batched and messages
         // can keep their per-delivery loop.
-        const emailDeliveries = pendingDeliveries.filter((d: any) => d.medium === 'email');
-        const messageDeliveries = pendingDeliveries.filter((d: any) => d.medium === 'message');
+        const emailDeliveries = pendingDeliveries.filter((d) => d.medium === 'email');
+        const messageDeliveries = pendingDeliveries.filter((d) => d.medium === 'message');
 
         // ---- Emails: batch send via Resend ----
         const emailResult = await sendEmailDeliveriesBatched(emailDeliveries);
@@ -105,7 +109,7 @@ export async function releaseNotifications(notificationIds: string[]): Promise<{
  * delivery is missing required fields (in which case the delivery is marked
  * failed as a side effect, matching the pre-batch behaviour).
  */
-async function buildEmailPayload(delivery: any): Promise<EmailPayload | null> {
+async function buildEmailPayload(delivery: PendingDelivery): Promise<EmailPayload | null> {
     if (!delivery.email || !delivery.title || !delivery.body) {
         console.error('Missing email, title, or body for delivery', delivery.id);
         await updateDeliveryStatus(delivery.id, 'failed');
@@ -125,7 +129,7 @@ async function buildEmailPayload(delivery: any): Promise<EmailPayload | null> {
  * the old sequential loop: any address Resend reports as failed (permissive
  * mode `errors[]`) is marked `failed`, the rest are marked `sent`.
  */
-export async function sendEmailDeliveriesBatched(deliveries: any[]): Promise<{
+async function sendEmailDeliveriesBatched(deliveries: PendingDelivery[]): Promise<{
     sent: number;
     failed: number;
 }> {
@@ -135,7 +139,7 @@ export async function sendEmailDeliveriesBatched(deliveries: any[]): Promise<{
     // Pair each successfully-built payload with its delivery so we can map
     // batch results back to delivery ids. Deliveries that fail validation
     // here are already marked failed inside buildEmailPayload.
-    const prepared: Array<{ delivery: any; payload: EmailPayload }> = [];
+    const prepared: Array<{ delivery: PendingDelivery; payload: EmailPayload }> = [];
     for (const delivery of deliveries) {
         const payload = await buildEmailPayload(delivery);
         if (payload) {
@@ -157,10 +161,20 @@ export async function sendEmailDeliveriesBatched(deliveries: any[]): Promise<{
         const idempotencyKey = makeBatchIdempotencyKey(chunk.map((p) => p.delivery.id));
 
         const result = await sendEmailBatch(payloads, { idempotencyKey });
-        const failedTos = new Set(result.failedTos);
+
+        // Resend reports failures as a list of `to` addresses (count == #fails).
+        // If two deliveries target the same address and only one fails, the
+        // address appears once. Consume the list as a multiset so we mark the
+        // right number of rows failed instead of every match.
+        const failureBudget = new Map<string, number>();
+        for (const to of result.failedTos) {
+            failureBudget.set(to, (failureBudget.get(to) ?? 0) + 1);
+        }
 
         for (const { delivery, payload } of chunk) {
-            if (failedTos.has(payload.to)) {
+            const remaining = failureBudget.get(payload.to) ?? 0;
+            if (remaining > 0) {
+                failureBudget.set(payload.to, remaining - 1);
                 await updateDeliveryStatus(delivery.id, 'failed');
                 console.error(`Failed to send email to ${payload.to}`);
                 failed++;

--- a/src/lib/notifications/deliver.ts
+++ b/src/lib/notifications/deliver.ts
@@ -18,6 +18,10 @@ const MESSAGE_DELAY_MS = 500;
 // would drop ~100 notifications at once, so this is cheap insurance.
 const BATCH_DELAY_MS = 500;
 
+// Derive the delivery row shape from the DB function — keeps us honest if the
+// include shape ever changes, without redeclaring the type.
+type PendingDelivery = Awaited<ReturnType<typeof getPendingDeliveries>>[number];
+
 interface EmailPayload {
     from: string;
     to: string;
@@ -55,8 +59,8 @@ export async function releaseNotifications(notificationIds: string[]): Promise<{
 
         // Partition by medium up front so emails can be batched and messages
         // can keep their per-delivery loop.
-        const emailDeliveries = pendingDeliveries.filter((d: any) => d.medium === 'email');
-        const messageDeliveries = pendingDeliveries.filter((d: any) => d.medium === 'message');
+        const emailDeliveries = pendingDeliveries.filter((d) => d.medium === 'email');
+        const messageDeliveries = pendingDeliveries.filter((d) => d.medium === 'message');
 
         // ---- Emails: batch send via Resend ----
         const emailResult = await sendEmailDeliveriesBatched(emailDeliveries);
@@ -112,7 +116,7 @@ export async function releaseNotifications(notificationIds: string[]): Promise<{
  * delivery is missing required fields (in which case the delivery is marked
  * failed as a side effect, matching the pre-batch behaviour).
  */
-async function buildEmailPayload(delivery: any): Promise<EmailPayload | null> {
+async function buildEmailPayload(delivery: PendingDelivery): Promise<EmailPayload | null> {
     if (!delivery.email || !delivery.title || !delivery.body) {
         console.error('Missing email, title, or body for delivery', delivery.id);
         await updateDeliveryStatus(delivery.id, 'failed');
@@ -132,7 +136,7 @@ async function buildEmailPayload(delivery: any): Promise<EmailPayload | null> {
  * the old sequential loop: any address Resend reports as failed (permissive
  * mode `errors[]`) is marked `failed`, the rest are marked `sent`.
  */
-export async function sendEmailDeliveriesBatched(deliveries: any[]): Promise<{
+async function sendEmailDeliveriesBatched(deliveries: PendingDelivery[]): Promise<{
     sent: number;
     failed: number;
 }> {
@@ -142,7 +146,7 @@ export async function sendEmailDeliveriesBatched(deliveries: any[]): Promise<{
     // Pair each successfully-built payload with its delivery so we can map
     // batch results back to delivery ids. Deliveries that fail validation
     // here are already marked failed inside buildEmailPayload.
-    const prepared: Array<{ delivery: any; payload: EmailPayload }> = [];
+    const prepared: Array<{ delivery: PendingDelivery; payload: EmailPayload }> = [];
     for (const delivery of deliveries) {
         const payload = await buildEmailPayload(delivery);
         if (payload) {
@@ -164,10 +168,20 @@ export async function sendEmailDeliveriesBatched(deliveries: any[]): Promise<{
         const idempotencyKey = makeBatchIdempotencyKey(chunk.map((p) => p.delivery.id));
 
         const result = await sendEmailBatch(payloads, { idempotencyKey });
-        const failedTos = new Set(result.failedTos);
+
+        // Resend reports failures as a list of `to` addresses (count == #fails).
+        // If two deliveries target the same address and only one fails, the
+        // address appears once. Consume the list as a multiset so we mark the
+        // right number of rows failed instead of every match.
+        const failureBudget = new Map<string, number>();
+        for (const to of result.failedTos) {
+            failureBudget.set(to, (failureBudget.get(to) ?? 0) + 1);
+        }
 
         for (const { delivery, payload } of chunk) {
-            if (failedTos.has(payload.to)) {
+            const remaining = failureBudget.get(payload.to) ?? 0;
+            if (remaining > 0) {
+                failureBudget.set(payload.to, remaining - 1);
                 await updateDeliveryStatus(delivery.id, 'failed');
                 console.error(`Failed to send email to ${payload.to}`);
                 failed++;

--- a/src/lib/notifications/deliver.ts
+++ b/src/lib/notifications/deliver.ts
@@ -1,6 +1,7 @@
 "use server";
 
-import { sendEmail } from '@/lib/email/resend';
+import { createHash } from 'crypto';
+import { sendEmailBatch } from '@/lib/email/resend';
 import { getPendingDeliveries, updateDeliveryStatus } from '@/lib/db/notifications';
 import {
     createOrUpdateConversation,
@@ -9,8 +10,32 @@ import {
 import { sendAndPersistOutbound } from './outbound';
 import { env } from '@/env.mjs';
 
+const FROM_ADDRESS = 'OpenCouncil <notifications@opencouncil.gr>';
+const EMAIL_BATCH_SIZE = 100;
+const MESSAGE_DELAY_MS = 500;
+// Space successive batch calls so a multi-batch release stays under Resend's
+// per-key request rate limit. A 429 maps the whole chunk to failedTos, which
+// would drop ~100 notifications at once, so this is cheap insurance.
+const BATCH_DELAY_MS = 500;
+
+interface EmailPayload {
+    from: string;
+    to: string;
+    subject: string;
+    html: string;
+}
+
 /**
- * Release notifications by sending all pending deliveries
+ * Release notifications by sending all pending deliveries.
+ *
+ * Emails go through Resend's batch endpoint in chunks of 100, so a release of
+ * thousands of recipients consumes only a handful of API calls instead of
+ * thousands of sequential per-recipient sends with 500ms gaps. That sequential
+ * loop used to saturate the Resend rate limit for our shared API key, starving
+ * auth magic-link emails for minutes — see issue #380.
+ *
+ * Bird (WhatsApp/SMS) messages still go one-at-a-time with a 500ms gap; their
+ * API doesn't expose a batch endpoint and the rate concern there is separate.
  */
 export async function releaseNotifications(notificationIds: string[]): Promise<{
     success: boolean;
@@ -28,41 +53,39 @@ export async function releaseNotifications(notificationIds: string[]): Promise<{
 
         console.log(`Releasing ${pendingDeliveries.length} pending deliveries for ${notificationIds.length} notifications`);
 
-        // Process each delivery
-        for (const delivery of pendingDeliveries) {
+        // Partition by medium up front so emails can be batched and messages
+        // can keep their per-delivery loop.
+        const emailDeliveries = pendingDeliveries.filter((d: any) => d.medium === 'email');
+        const messageDeliveries = pendingDeliveries.filter((d: any) => d.medium === 'message');
+
+        // ---- Emails: batch send via Resend ----
+        const emailResult = await sendEmailDeliveriesBatched(emailDeliveries);
+        emailsSent += emailResult.sent;
+        failed += emailResult.failed;
+
+        // ---- Messages: sequential with rate-limit delay (unchanged) ----
+        for (const delivery of messageDeliveries) {
             try {
-                if (delivery.medium === 'email') {
-                    const result = await sendEmailDelivery(delivery);
-                    if (result) {
-                        emailsSent++;
-                    } else {
-                        failed++;
-                    }
-                } else if (delivery.medium === 'message') {
-                    // Defense in depth for the Notis rollout: a delivery created
-                    // before the user's notisEnabledAt flip must not send — Notis
-                    // owns their WhatsApp from that moment.
-                    if (delivery.notification?.user?.notisEnabledAt) {
-                        await updateDeliveryStatus(delivery.id, 'skipped');
-                        continue;
-                    }
-                    const result = await sendMessageDelivery(delivery);
-                    if (result) {
-                        messagesSent++;
-                    } else {
-                        failed++;
-                    }
+                // Defense in depth for the Notis rollout: a delivery created
+                // before the user's notisEnabledAt flip must not send — Notis
+                // owns their WhatsApp from that moment.
+                if (delivery.notification?.user?.notisEnabledAt) {
+                    await updateDeliveryStatus(delivery.id, 'skipped');
+                    continue;
                 }
-
-                // Add a small delay to avoid rate limiting
-                // 500ms delay allows for ~2 requests per second, which is a safe limit for most services
-                await new Promise(resolve => setTimeout(resolve, 500));
-
+                const result = await sendMessageDelivery(delivery);
+                if (result) {
+                    messagesSent++;
+                } else {
+                    failed++;
+                }
             } catch (error) {
                 console.error(`Error sending delivery ${delivery.id}:`, error);
                 await updateDeliveryStatus(delivery.id, 'failed');
                 failed++;
             }
+            // Keep the 500ms spacing for Bird/SMS — only emails moved to batch.
+            await new Promise(resolve => setTimeout(resolve, MESSAGE_DELAY_MS));
         }
 
         console.log(`Release complete: ${emailsSent} emails, ${messagesSent} messages, ${failed} failed`);
@@ -85,37 +108,92 @@ export async function releaseNotifications(notificationIds: string[]): Promise<{
 }
 
 /**
- * Send email delivery via Resend
+ * Build the Resend payload for a single email delivery, or return null if the
+ * delivery is missing required fields (in which case the delivery is marked
+ * failed as a side effect, matching the pre-batch behaviour).
  */
-async function sendEmailDelivery(delivery: any): Promise<boolean> {
-    try {
-        if (!delivery.email || !delivery.title || !delivery.body) {
-            console.error('Missing email, title, or body for delivery', delivery.id);
-            await updateDeliveryStatus(delivery.id, 'failed');
-            return false;
-        }
-
-        const result = await sendEmail({
-            from: 'OpenCouncil <notifications@opencouncil.gr>',
-            to: delivery.email,
-            subject: delivery.title,
-            html: delivery.body
-        });
-
-        if (result.success) {
-            await updateDeliveryStatus(delivery.id, 'sent');
-            console.log(`Email sent successfully to ${delivery.email}`);
-            return true;
-        } else {
-            await updateDeliveryStatus(delivery.id, 'failed');
-            console.error(`Failed to send email to ${delivery.email}`);
-            return false;
-        }
-    } catch (error) {
-        console.error('Error sending email delivery:', error);
+async function buildEmailPayload(delivery: any): Promise<EmailPayload | null> {
+    if (!delivery.email || !delivery.title || !delivery.body) {
+        console.error('Missing email, title, or body for delivery', delivery.id);
         await updateDeliveryStatus(delivery.id, 'failed');
-        return false;
+        return null;
     }
+    return {
+        from: FROM_ADDRESS,
+        to: delivery.email,
+        subject: delivery.title,
+        html: delivery.body,
+    };
+}
+
+/**
+ * Chunk email deliveries into batches of 100 and send each batch via Resend's
+ * batch endpoint. Per-delivery status writes preserve the same granularity as
+ * the old sequential loop: any address Resend reports as failed (permissive
+ * mode `errors[]`) is marked `failed`, the rest are marked `sent`.
+ */
+export async function sendEmailDeliveriesBatched(deliveries: any[]): Promise<{
+    sent: number;
+    failed: number;
+}> {
+    let sent = 0;
+    let failed = 0;
+
+    // Pair each successfully-built payload with its delivery so we can map
+    // batch results back to delivery ids. Deliveries that fail validation
+    // here are already marked failed inside buildEmailPayload.
+    const prepared: Array<{ delivery: any; payload: EmailPayload }> = [];
+    for (const delivery of deliveries) {
+        const payload = await buildEmailPayload(delivery);
+        if (payload) {
+            prepared.push({ delivery, payload });
+        } else {
+            failed++;
+        }
+    }
+
+    for (let i = 0; i < prepared.length; i += EMAIL_BATCH_SIZE) {
+        // Pause between batches (not before the first, not after the last) to
+        // avoid bursting past Resend's request rate limit on large releases.
+        if (i > 0) {
+            await new Promise(resolve => setTimeout(resolve, BATCH_DELAY_MS));
+        }
+
+        const chunk = prepared.slice(i, i + EMAIL_BATCH_SIZE);
+        const payloads = chunk.map((p) => p.payload);
+        const idempotencyKey = makeBatchIdempotencyKey(chunk.map((p) => p.delivery.id));
+
+        const result = await sendEmailBatch(payloads, { idempotencyKey });
+        const failedTos = new Set(result.failedTos);
+
+        for (const { delivery, payload } of chunk) {
+            if (failedTos.has(payload.to)) {
+                await updateDeliveryStatus(delivery.id, 'failed');
+                console.error(`Failed to send email to ${payload.to}`);
+                failed++;
+            } else {
+                await updateDeliveryStatus(delivery.id, 'sent');
+                sent++;
+            }
+        }
+
+        if (!result.success) {
+            console.error(`Notification email batch had failures:`, result.error);
+        }
+    }
+
+    return { sent, failed };
+}
+
+/**
+ * Deterministic idempotency key from the set of delivery ids in the batch.
+ * A retried release with the same deliveries will dedupe inside Resend's 24h
+ * window — important because each delivery row is a single "send this once"
+ * commitment.
+ */
+function makeBatchIdempotencyKey(deliveryIds: string[]): string {
+    const data = JSON.stringify({ kind: 'notification-release', ids: [...deliveryIds].sort() });
+    return createHash('sha256').update(data).digest('hex');
 }
 
 /**
@@ -169,7 +247,7 @@ async function sendMessageDelivery(delivery: any): Promise<boolean> {
             console.log(`WhatsApp conversation seeded for ${delivery.phone}`);
             return true;
         }
-        
+
         console.log(
             waResult.success
                 ? `WhatsApp delivery failed post-send for ${delivery.phone}, falling back to SMS`
@@ -202,4 +280,3 @@ async function sendMessageDelivery(delivery: any): Promise<boolean> {
         return false;
     }
 }
-


### PR DESCRIPTION
Closes #380

## Description

Magic-link login emails and bulk notification emails share one Resend API key. `releaseNotifications()` sent notifications one at a time with a 500ms gap between each, which saturated Resend's per-key rate limit for minutes during a release and left login emails waiting in line behind them.

This moves the email path to Resend's batch endpoint (`sendEmailBatch`, up to 100 per call), so a release of N emails takes a handful of API calls instead of N sequential sends. The auth path no longer gets starved.

Bird (SMS/WhatsApp) messages keep the 500ms-per-message spacing. Bird has no batch endpoint, and its rate-limit concern is a separate problem.

## Changes Made

- `src/lib/notifications/deliver.ts`:
  - Partition pending deliveries into email vs message up front.
  - Emails are chunked into batches of 100 and sent via `sendEmailBatch`, replacing the old per-recipient loop with its 500ms delay.
  - Split the old `sendEmailDelivery` into a pure `buildEmailPayload` (subject/html/to) plus the per-delivery status writes, so a batch response can be mapped back to individual delivery rows.
  - Failure attribution is by delivery slot rather than by email address. When two deliveries go to the same recipient and Resend lists that address once in `failedTos`, a small failure budget marks only one row failed instead of both.
  - Deterministic idempotency key per batch (from the sorted delivery ids) so replaying the same set doesn't double-send.
  - The `Release complete: X emails, Y messages, Z failed` log line stays.
- `src/lib/notifications/__tests__/deliver.test.ts`: new unit tests for the batching path.

## Testing

I don't have Resend credentials, so I couldn't run the full UI-to-inbox release flow locally. Instead I covered the change with unit tests against a mocked `sendEmailBatch`:

- single batch when count is 100 or fewer, with no per-email delay
- chunking into batches of 100
- per-recipient failures mapped back from the batch response
- deliveries missing email/title/body marked failed before the batch send
- deterministic idempotency key for the same delivery set
- batch call skipped entirely when there are no email deliveries
- the duplicate-recipient case: two deliveries on the same address, one failure marks only one row

All 7 pass. `npx tsc --noEmit` is clean and the existing notification tests still pass.

A reviewer with Resend access can confirm the end-to-end behaviour: trigger a release of 100 or more pending email deliveries, watch the Resend logs for about N/100 batch calls instead of a per-email loop, then request a magic-link sign-in a second or two into the release. It should arrive within seconds rather than waiting for the release to drain.

Splitting auth and notification traffic onto separate Resend keys (`RESEND_AUTH_API_KEY`) would give full isolation, but that's a possible follow-up and out of scope here.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR batches notification emails through Resend while retaining sequential pacing for Bird messages, reducing contention with authentication emails.
- Sends email deliveries in chunks of 100 with deterministic idempotency keys.
- Adds 500 ms pacing between successive Resend batch calls.
- Maps provider failures back to individual delivery rows using occurrence-counted recipient failures.
- Adds regression coverage for batching, invalid payloads, idempotency, and duplicate-recipient failure handling.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; both previously reported issues are addressed by inter-batch pacing and explicit duplicate-recipient whole-batch regression coverage.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/notifications/deliver.ts | Implements paced Resend batching, deterministic idempotency, validation, and per-delivery status attribution; the previously reported missing inter-batch delay is resolved. |
| src/lib/notifications/__tests__/deliver.test.ts | Adds focused batching tests, including the previously requested whole-batch duplicate-recipient failure case. |

<sub>Reviews (6): Last reviewed commit: ["fix(notifications): correct failure attr..."](https://github.com/schemalabz/opencouncil/commit/10167ea815020cd56b077da58a821034ce5fea21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35166866)</sub>

<!-- /greptile_comment -->