### PR TITLE
Fix/task callback resilience

### DIFF
--- a/prisma/migrations/20260527120000_task_status_processing_error/migration.sql
+++ b/prisma/migrations/20260527120000_task_status_processing_error/migration.sql
@@ -1,0 +1,6 @@
+-- Add a separate column to capture errors thrown by the post-callback
+-- processor (e.g. summarize/transcribe/etc.), so the raw task server payload
+-- in `responseBody` is preserved verbatim and the task can be replayed
+-- without re-running the (paid) backend job. See issue #360.
+
+ALTER TABLE "TaskStatus" ADD COLUMN "processingError" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -230,6 +230,7 @@ model TaskStatus {
   type      String
   requestBody String
   responseBody String?
+  processingError String?
 
   version Int?
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -265,6 +265,7 @@ model TaskStatus {
   type      String
   requestBody String
   responseBody String?
+  processingError String?
 
   version Int?
 

--- a/src/components/meetings/admin/TaskStatus.tsx
+++ b/src/components/meetings/admin/TaskStatus.tsx
@@ -170,10 +170,10 @@ export function TaskStatusComponent({ task, onDelete, showMeetingInfo }: TaskSta
                                     </div>
                                 </div>
                             )}
-                            {task.status === 'failed' && task.responseBody && (
+                            {task.status === 'failed' && (task.processingError || task.responseBody) && (
                                 <div className="flex items-center justify-between">
                                     <code className="font-mono truncate block max-w-[300px]">
-                                        {task.responseBody || tStatus('unknownError')}
+                                        {task.processingError || task.responseBody || tStatus('unknownError')}
                                     </code>
                                     <div className="flex space-x-1">
                                         <Button

--- a/src/components/meetings/admin/TaskStatus.tsx
+++ b/src/components/meetings/admin/TaskStatus.tsx
@@ -356,6 +356,9 @@ export function TaskStatusComponent({ task, onDelete, showMeetingInfo }: TaskSta
                 views={[
                     { label: 'Request', data: parseJson(task.requestBody) },
                     { label: 'Response', data: parseJson(task.responseBody) },
+                    ...(task.processingError
+                        ? [{ label: 'Processing Error', data: task.processingError }]
+                        : []),
                 ]}
                 metadata={[
                     { label: 'Task ID', value: task.id },

--- a/src/components/meetings/admin/TaskStatus.tsx
+++ b/src/components/meetings/admin/TaskStatus.tsx
@@ -167,10 +167,10 @@ export function TaskStatusComponent({ task, onDelete, showMeetingInfo }: TaskSta
                                     </div>
                                 </div>
                             )}
-                            {task.status === 'failed' && task.responseBody && (
+                            {task.status === 'failed' && (task.processingError || task.responseBody) && (
                                 <div className="flex items-center justify-between">
                                     <code className="font-mono truncate block max-w-[300px]">
-                                        {task.responseBody || tStatus('unknownError')}
+                                        {task.processingError || task.responseBody || tStatus('unknownError')}
                                     </code>
                                     <div className="flex space-x-1">
                                         <Button

--- a/src/components/meetings/admin/TaskStatus.tsx
+++ b/src/components/meetings/admin/TaskStatus.tsx
@@ -331,6 +331,9 @@ export function TaskStatusComponent({ task, onDelete, showMeetingInfo }: TaskSta
                 views={[
                     { label: 'Request', data: parseJson(task.requestBody) },
                     { label: 'Response', data: parseJson(task.responseBody) },
+                    ...(task.processingError
+                        ? [{ label: 'Processing Error', data: task.processingError }]
+                        : []),
                 ]}
                 metadata={[
                     { label: 'Task ID', value: task.id },

--- a/src/lib/tasks/__tests__/handleTaskUpdateProcessingError.test.ts
+++ b/src/lib/tasks/__tests__/handleTaskUpdateProcessingError.test.ts
@@ -95,4 +95,39 @@ describe('handleTaskUpdate — persist raw payload before processing', () => {
       },
     });
   });
+
+  it('stores processor stack without duplicating the error message', async () => {
+    const result = { foo: 'bar' };
+    const processorErr = new Error('boom');
+    processorErr.stack = 'Error: boom\n    at processor';
+    const processResult = jest.fn().mockRejectedValue(processorErr);
+
+    const update: TaskUpdate<typeof result> = { status: 'success', stage: '', progressPercent: 100, result, version: 9 };
+    await handleTaskUpdate(TASK_ID, update, processResult);
+
+    expect(mockUpdate).toHaveBeenNthCalledWith(2, {
+      where: { id: TASK_ID },
+      data: expect.objectContaining({
+        processingError: 'Error: boom\n    at processor',
+      }),
+    });
+  });
+
+  it('clears stale processingError when backend reports an error', async () => {
+    const processResult = jest.fn();
+    const update: TaskUpdate<never> = { status: 'error', stage: '', progressPercent: 100, error: 'backend failed', version: 11 };
+
+    await handleTaskUpdate(TASK_ID, update, processResult);
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: TASK_ID },
+      data: {
+        status: 'failed',
+        responseBody: 'backend failed',
+        processingError: null,
+        version: 11,
+      },
+    });
+    expect(processResult).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/tasks/__tests__/handleTaskUpdateProcessingError.test.ts
+++ b/src/lib/tasks/__tests__/handleTaskUpdateProcessingError.test.ts
@@ -1,0 +1,95 @@
+/** @jest-environment node */
+
+const mockFindUnique = jest.fn();
+const mockUpdate = jest.fn();
+const mockUpdateMany = jest.fn().mockResolvedValue({ count: 1 });
+
+jest.mock('../../db/prisma', () => ({
+  __esModule: true,
+  default: {
+    taskStatus: {
+      findFirst: jest.fn(),
+      findUnique: (...args: unknown[]) => mockFindUnique(...args),
+      create: jest.fn(),
+      update: (...args: unknown[]) => mockUpdate(...args),
+      updateMany: (...args: unknown[]) => mockUpdateMany(...args),
+    },
+  },
+}));
+jest.mock('@/env.mjs', () => ({ env: { NEXTAUTH_URL: 'http://test', TASK_API_URL: 'http://test', TASK_API_KEY: 'key' } }));
+jest.mock('next/cache', () => ({ revalidateTag: jest.fn() }));
+jest.mock('../../auth', () => ({ withUserAuthorizedToEdit: jest.fn() }));
+jest.mock('../../discord', () => ({ sendTaskAdminAlert: jest.fn() }));
+jest.mock('../registry', () => ({ taskHandlers: {}, taskTerminalHooks: {} }));
+
+import { handleTaskUpdate } from '../tasks';
+
+const TASK_ID = 'task-1';
+
+const baseTask = {
+  id: TASK_ID,
+  type: 'summarize',
+  status: 'pending',
+  cityId: 'city-1',
+  councilMeetingId: 'meeting-1',
+  createdAt: new Date(),
+  councilMeeting: { name_en: 'M', city: { name_en: 'C' } },
+};
+
+describe('handleTaskUpdate — persist raw payload before processing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindUnique.mockResolvedValue(baseTask);
+    mockUpdate.mockResolvedValue({ ...baseTask, status: 'succeeded' });
+  });
+
+  it('writes responseBody first, then leaves it untouched when processor throws and stores processingError', async () => {
+    const result = { foo: 'bar', n: 42 };
+    const processorErr = new Error('boom');
+    const processResult = jest.fn().mockRejectedValue(processorErr);
+
+    await handleTaskUpdate(TASK_ID, { status: 'success', result, version: 7 } as any, processResult);
+
+    // First update: success branch persists raw payload BEFORE processing.
+    expect(mockUpdate).toHaveBeenNthCalledWith(1, {
+      where: { id: TASK_ID },
+      data: {
+        status: 'succeeded',
+        responseBody: JSON.stringify(result),
+        processingError: null,
+        version: 7,
+      },
+    });
+
+    // Second update: processor failed → status flips to failed, processingError set,
+    // and responseBody is NOT overwritten (so the raw payload survives for replay).
+    expect(mockUpdate).toHaveBeenNthCalledWith(2, {
+      where: { id: TASK_ID },
+      data: expect.objectContaining({
+        status: 'failed',
+        processingError: expect.stringContaining('boom'),
+        version: 7,
+      }),
+    });
+    const secondCallData = (mockUpdate.mock.calls[1][0] as any).data;
+    expect(secondCallData).not.toHaveProperty('responseBody');
+
+    expect(processResult).toHaveBeenCalledWith(TASK_ID, result, undefined);
+  });
+
+  it('clears processingError on a clean success', async () => {
+    const processResult = jest.fn().mockResolvedValue(undefined);
+    await handleTaskUpdate(TASK_ID, { status: 'success', result: { ok: 1 }, version: 3 } as any, processResult);
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: TASK_ID },
+      data: {
+        status: 'succeeded',
+        responseBody: JSON.stringify({ ok: 1 }),
+        processingError: null,
+        version: 3,
+      },
+    });
+  });
+});

--- a/src/lib/tasks/__tests__/handleTaskUpdateProcessingError.test.ts
+++ b/src/lib/tasks/__tests__/handleTaskUpdateProcessingError.test.ts
@@ -23,6 +23,7 @@ jest.mock('../../discord', () => ({ sendTaskAdminAlert: jest.fn() }));
 jest.mock('../registry', () => ({ taskHandlers: {}, taskTerminalHooks: {} }));
 
 import { handleTaskUpdate } from '../tasks';
+import type { TaskUpdate } from '../../apiTypes';
 
 const TASK_ID = 'task-1';
 
@@ -48,7 +49,8 @@ describe('handleTaskUpdate — persist raw payload before processing', () => {
     const processorErr = new Error('boom');
     const processResult = jest.fn().mockRejectedValue(processorErr);
 
-    await handleTaskUpdate(TASK_ID, { status: 'success', result, version: 7 } as any, processResult);
+    const update: TaskUpdate<typeof result> = { status: 'success', stage: '', progressPercent: 100, result, version: 7 };
+    await handleTaskUpdate(TASK_ID, update, processResult);
 
     // First update: success branch persists raw payload BEFORE processing.
     expect(mockUpdate).toHaveBeenNthCalledWith(1, {
@@ -71,15 +73,16 @@ describe('handleTaskUpdate — persist raw payload before processing', () => {
         version: 7,
       }),
     });
-    const secondCallData = (mockUpdate.mock.calls[1][0] as any).data;
-    expect(secondCallData).not.toHaveProperty('responseBody');
+    const secondCallArg = mockUpdate.mock.calls[1][0] as { data: Record<string, unknown> };
+    expect(secondCallArg.data).not.toHaveProperty('responseBody');
 
     expect(processResult).toHaveBeenCalledWith(TASK_ID, result, undefined);
   });
 
   it('clears processingError on a clean success', async () => {
     const processResult = jest.fn().mockResolvedValue(undefined);
-    await handleTaskUpdate(TASK_ID, { status: 'success', result: { ok: 1 }, version: 3 } as any, processResult);
+    const update: TaskUpdate<{ ok: number }> = { status: 'success', stage: '', progressPercent: 100, result: { ok: 1 }, version: 3 };
+    await handleTaskUpdate(TASK_ID, update, processResult);
 
     expect(mockUpdate).toHaveBeenCalledTimes(1);
     expect(mockUpdate).toHaveBeenCalledWith({

--- a/src/lib/tasks/__tests__/handleTaskUpdateProcessingError.test.ts
+++ b/src/lib/tasks/__tests__/handleTaskUpdateProcessingError.test.ts
@@ -52,11 +52,12 @@ describe('handleTaskUpdate — persist raw payload before processing', () => {
     const update: TaskUpdate<typeof result> = { status: 'success', stage: '', progressPercent: 100, result, version: 7 };
     await handleTaskUpdate(TASK_ID, update, processResult);
 
-    // First update: success branch persists raw payload BEFORE processing.
+    // First update: success branch persists raw payload BEFORE processing, and
+    // deliberately leaves the status non-terminal so a sibling task's terminal
+    // hook can't read this one as succeeded mid-processing.
     expect(mockUpdate).toHaveBeenNthCalledWith(1, {
       where: { id: TASK_ID },
       data: {
-        status: 'succeeded',
         responseBody: JSON.stringify(result),
         processingError: null,
         version: 7,
@@ -84,15 +85,46 @@ describe('handleTaskUpdate — persist raw payload before processing', () => {
     const update: TaskUpdate<{ ok: number }> = { status: 'success', stage: '', progressPercent: 100, result: { ok: 1 }, version: 3 };
     await handleTaskUpdate(TASK_ID, update, processResult);
 
-    expect(mockUpdate).toHaveBeenCalledTimes(1);
-    expect(mockUpdate).toHaveBeenCalledWith({
+    expect(mockUpdate).toHaveBeenCalledTimes(2);
+    expect(mockUpdate).toHaveBeenNthCalledWith(1, {
       where: { id: TASK_ID },
       data: {
-        status: 'succeeded',
         responseBody: JSON.stringify({ ok: 1 }),
         processingError: null,
         version: 3,
       },
+    });
+    expect(mockUpdate).toHaveBeenNthCalledWith(2, {
+      where: { id: TASK_ID },
+      data: { status: 'succeeded', version: 3 },
+    });
+  });
+
+  it('marks the task succeeded only after the processor returns', async () => {
+    const order: string[] = [];
+    mockUpdate.mockImplementation((args: { data: Record<string, unknown> }) => {
+      if (args.data.status === 'succeeded') order.push('terminal-write');
+      return Promise.resolve({ ...baseTask, status: 'succeeded' });
+    });
+    const processResult = jest.fn().mockImplementation(async () => { order.push('processor'); });
+
+    const update: TaskUpdate<{ ok: number }> = { status: 'success', stage: '', progressPercent: 100, result: { ok: 1 }, version: 5 };
+    await handleTaskUpdate(TASK_ID, update, processResult);
+
+    expect(order).toEqual(['processor', 'terminal-write']);
+  });
+
+  it('marks a result-less success terminal straight away', async () => {
+    const processResult = jest.fn();
+    const update: TaskUpdate<undefined> = { status: 'success', stage: '', progressPercent: 100, result: undefined, version: 4 };
+
+    await handleTaskUpdate(TASK_ID, update, processResult);
+
+    expect(processResult).not.toHaveBeenCalled();
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: TASK_ID },
+      data: expect.objectContaining({ status: 'succeeded', version: 4 }),
     });
   });
 

--- a/src/lib/tasks/__tests__/handleTaskUpdateProcessingError.test.ts
+++ b/src/lib/tasks/__tests__/handleTaskUpdateProcessingError.test.ts
@@ -113,6 +113,25 @@ describe('handleTaskUpdate — persist raw payload before processing', () => {
     });
   });
 
+  it('still marks the task failed when the processor rejects with a non-Error', async () => {
+    // A processor that rejects with a string (or a plain object, or undefined)
+    // has no .stack/.message. Reading those off it throws inside the catch, so
+    // the failed-status write below never runs and the task stays 'succeeded'.
+    const processResult = jest.fn().mockRejectedValue('plain string failure');
+
+    const update: TaskUpdate<{ foo: string }> = { status: 'success', stage: '', progressPercent: 100, result: { foo: 'bar' }, version: 13 };
+    await handleTaskUpdate(TASK_ID, update, processResult);
+
+    expect(mockUpdate).toHaveBeenNthCalledWith(2, {
+      where: { id: TASK_ID },
+      data: expect.objectContaining({
+        status: 'failed',
+        processingError: 'plain string failure',
+        version: 13,
+      }),
+    });
+  });
+
   it('clears stale processingError when backend reports an error', async () => {
     const processResult = jest.fn();
     const update: TaskUpdate<never> = { status: 'error', stage: '', progressPercent: 100, error: 'backend failed', version: 11 };

--- a/src/lib/tasks/tasks.ts
+++ b/src/lib/tasks/tasks.ts
@@ -244,7 +244,7 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
                     where: { id: taskId },
                     data: {
                         status: 'failed',
-                        processingError: `${err.message}\n${err.stack ?? ''}`.trim(),
+                        processingError: (err.stack ?? err.message).trim(),
                         version: update.version,
                     }
                 });
@@ -282,7 +282,7 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
     } else if (update.status === 'error') {
         await prisma.taskStatus.update({
             where: { id: taskId },
-            data: { status: 'failed', responseBody: update.error, version: update.version }
+            data: { status: 'failed', responseBody: update.error, processingError: null, version: update.version }
         });
 
         // Send Discord admin alert for task failure

--- a/src/lib/tasks/tasks.ts
+++ b/src/lib/tasks/tasks.ts
@@ -195,9 +195,17 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
     const sendGenericAlerts = getDiscordAlertMode(task.type) !== 'none';
 
     if (update.status === 'success') {
+        // Persist the raw task server payload BEFORE running our processor.
+        // If processing throws, responseBody stays intact and the task can be
+        // replayed without re-running the (paid) backend job.
         const updatedTask = await prisma.taskStatus.update({
             where: { id: taskId },
-            data: { status: 'succeeded', responseBody: JSON.stringify(update.result), version: update.version }
+            data: {
+                status: 'succeeded',
+                responseBody: JSON.stringify(update.result),
+                processingError: null,
+                version: update.version,
+            }
         });
 
         if (update.result) {
@@ -227,11 +235,18 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
                 }
             } catch (error) {
                 console.error(`Error processing result for task ${taskId}:`, error);
-                const originalResponse = JSON.stringify(update.result);
-                const errorDetail = `Processing error: ${(error as Error).message}\n\n--- Original task server response ---\n${originalResponse}`;
+                const err = error as Error;
+                // Keep responseBody untouched — it already holds the raw task
+                // server payload from the pre-processing write above, so the
+                // task can be replayed via processTaskResponse once the bug
+                // in the processor is fixed.
                 await prisma.taskStatus.update({
                     where: { id: taskId },
-                    data: { status: 'failed', responseBody: errorDetail, version: update.version }
+                    data: {
+                        status: 'failed',
+                        processingError: `${err.message}\n${err.stack ?? ''}`.trim(),
+                        version: update.version,
+                    }
                 });
 
                 // Send Discord admin alert for processing failure

--- a/src/lib/tasks/tasks.ts
+++ b/src/lib/tasks/tasks.ts
@@ -238,7 +238,14 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
                 }
             } catch (error) {
                 console.error(`Error processing result for task ${taskId}:`, error);
-                const err = error as Error;
+                // A processor can reject with a non-Error (a string, a plain
+                // object, undefined). Reading .stack/.message off one of those
+                // throws, which would skip the failed-status write and the alert
+                // below and leave the task marked succeeded.
+                const failureMessage = error instanceof Error ? error.message : String(error);
+                const failureDetail = error instanceof Error
+                    ? (error.stack ?? error.message).trim()
+                    : failureMessage;
                 // Keep responseBody untouched — it already holds the raw task
                 // server payload from the pre-processing write above, so the
                 // task can be replayed via processTaskResponse once the bug
@@ -247,7 +254,7 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
                     where: { id: taskId },
                     data: {
                         status: 'failed',
-                        processingError: (err.stack ?? err.message).trim(),
+                        processingError: failureDetail,
                         version: update.version,
                     }
                 });
@@ -262,7 +269,7 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
                         taskId: task.id,
                         cityId: task.cityId,
                         meetingId: task.councilMeetingId,
-                        error: (error as Error).message,
+                        error: failureMessage,
                     });
                 }
             }

--- a/src/lib/tasks/tasks.ts
+++ b/src/lib/tasks/tasks.ts
@@ -247,7 +247,7 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
                     where: { id: taskId },
                     data: {
                         status: 'failed',
-                        processingError: `${err.message}\n${err.stack ?? ''}`.trim(),
+                        processingError: (err.stack ?? err.message).trim(),
                         version: update.version,
                     }
                 });
@@ -285,7 +285,7 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
     } else if (update.status === 'error') {
         await prisma.taskStatus.update({
             where: { id: taskId },
-            data: { status: 'failed', responseBody: update.error, version: update.version }
+            data: { status: 'failed', responseBody: update.error, processingError: null, version: update.version }
         });
 
         // Send Discord admin alert for task failure

--- a/src/lib/tasks/tasks.ts
+++ b/src/lib/tasks/tasks.ts
@@ -201,10 +201,17 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
         // Persist the raw task server payload BEFORE running our processor.
         // If processing throws, responseBody stays intact and the task can be
         // replayed without re-running the (paid) backend job.
+        //
+        // The status stays non-terminal while the processor runs. Tasks in the
+        // same batch finish concurrently, and a sibling's terminal hook reads
+        // every task's status: flipping to 'succeeded' up here would let that
+        // hook report a clean batch while this processor is still running (and
+        // possibly about to fail). Only a task with nothing to process is
+        // terminal at this point.
         const updatedTask = await prisma.taskStatus.update({
             where: { id: taskId },
             data: {
-                status: 'succeeded',
+                ...(update.result ? {} : { status: 'succeeded' as const }),
                 responseBody: JSON.stringify(update.result),
                 processingError: null,
                 version: update.version,
@@ -214,6 +221,12 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
         if (update.result) {
             try {
                 await processResult(taskId, update.result, options);
+
+                // Processing is done, so the task is terminal now.
+                await prisma.taskStatus.update({
+                    where: { id: taskId },
+                    data: { status: 'succeeded', version: update.version },
+                });
 
                 // Send Discord admin alert for successful completion AFTER processing succeeds
                 if (sendGenericAlerts) {

--- a/src/lib/tasks/tasks.ts
+++ b/src/lib/tasks/tasks.ts
@@ -198,9 +198,17 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
     const sendGenericAlerts = getDiscordAlertMode(task.type) !== 'none';
 
     if (update.status === 'success') {
+        // Persist the raw task server payload BEFORE running our processor.
+        // If processing throws, responseBody stays intact and the task can be
+        // replayed without re-running the (paid) backend job.
         const updatedTask = await prisma.taskStatus.update({
             where: { id: taskId },
-            data: { status: 'succeeded', responseBody: JSON.stringify(update.result), version: update.version }
+            data: {
+                status: 'succeeded',
+                responseBody: JSON.stringify(update.result),
+                processingError: null,
+                version: update.version,
+            }
         });
 
         if (update.result) {
@@ -230,11 +238,18 @@ export const handleTaskUpdate = async <T>(taskId: string, update: TaskUpdate<T>,
                 }
             } catch (error) {
                 console.error(`Error processing result for task ${taskId}:`, error);
-                const originalResponse = JSON.stringify(update.result);
-                const errorDetail = `Processing error: ${(error as Error).message}\n\n--- Original task server response ---\n${originalResponse}`;
+                const err = error as Error;
+                // Keep responseBody untouched — it already holds the raw task
+                // server payload from the pre-processing write above, so the
+                // task can be replayed via processTaskResponse once the bug
+                // in the processor is fixed.
                 await prisma.taskStatus.update({
                     where: { id: taskId },
-                    data: { status: 'failed', responseBody: errorDetail, version: update.version }
+                    data: {
+                        status: 'failed',
+                        processingError: `${err.message}\n${err.stack ?? ''}`.trim(),
+                        version: update.version,
+                    }
                 });
 
                 // Send Discord admin alert for processing failure


### PR DESCRIPTION
Closes #360

## Description
This pull request changes how task failures are recorded and shown in the admin dashboard.

Currently, if the post-callback results processor throws an error, the application overwrites the task's `responseBody` with the error details. This prevents developers from replaying the task using the original payload after fixing the processor.

To fix this:
- I added a `processingError` column to the `TaskStatus` database model to store processor errors separately.
- I updated `src/lib/tasks/tasks.ts` to write the raw task server payload to `responseBody` before running the processor. If the processor fails, the task status becomes `failed` and the stack trace is saved in `processingError` without overwriting the original response.
- I updated the task status component in `src/components/meetings/admin/TaskStatus.tsx` to show the human-readable `processingError` stack trace in the expanded task card view.
- I added unit tests to verify the error handling and state persistence logic in `src/lib/tasks/__tests__/handleTaskUpdateProcessingError.test.ts`.

## Testing
I ran the following local tests:
- **Database & Migrations**: Removed an empty leftover migration directory (`20260518203511_enable_unaccent_extension`) to allow migrations to run. Applied the new migration (`20260527120000_task_status_processing_error`) to add the `processingError` column.
- **Fail Path End-to-End**: Inserted a mock pending `transcribe` task and sent a malformed payload via `curl` to the callback route. Verified that the task status updated to `failed`, the raw payload stayed intact in `responseBody` (byte-for-byte matching), and `processingError` stored the error stack trace.
- **Admin UI Display**: Logged in as a superadmin and opened the admin dashboard. Expanded the failed task status card and confirmed that it shows the human-readable stack trace instead of raw JSON.
- **Replay & Recovery**: Re-posted the malformed payload to test idempotency, then POSTed a corrected payload. Confirmed that the task transitioned to `succeeded` and the `processingError` was cleared.
- **Unit Tests**: Ran `npm test` to verify all 793 unit tests pass.

No regressions or unexpected issues were encountered.







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves raw task callback payloads separately from post-processing failures and delays terminal success until result processing completes.
- Adds nullable `processingError` persistence through the Prisma schema and migration.
- Records and clears processing failures across success, replay, and backend-error transitions.
- Exposes complete processing errors in the administrative task details dialog.
- Adds unit coverage for payload preservation, failure normalization, stale-error clearing, and terminal-state ordering.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/tasks/tasks.ts | Separates processor errors from callback payloads, safely handles non-Error rejections, clears stale errors, and marks success only after processing completes. |
| src/components/meetings/admin/TaskStatus.tsx | Prioritizes processing errors for failed tasks and adds the complete value to the expanded metadata dialog. |
| src/lib/tasks/__tests__/handleTaskUpdateProcessingError.test.ts | Covers payload preservation, delayed terminal success, clean retries, backend failures, and non-Error processor rejections. |
| prisma/schema.prisma | Adds the nullable `processingError` field to `TaskStatus`. |
| prisma/migrations/20260527120000_task_status_processing_error/migration.sql | Adds the corresponding nullable text column without rewriting existing task records. |

<sub>Reviews (6): Last reviewed commit: ["fix(tasks): mark a task succeeded only a..."](https://github.com/schemalabz/opencouncil/commit/2cac62ccbe65e6d7600b4e91c629779bf241bba9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35316110)</sub>

<!-- /greptile_comment -->