### PR TITLE
fix: add commit sha to build identity for preview deployments

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -168,6 +168,7 @@ jobs:
           NEXT_PUBLIC_CONTACT_PHONE: ${{ secrets.NEXT_PUBLIC_CONTACT_PHONE }}
           NEXT_PUBLIC_CONTACT_EMAIL: ${{ secrets.NEXT_PUBLIC_CONTACT_EMAIL }}
           NEXT_PUBLIC_CONTACT_ADDRESS: ${{ secrets.NEXT_PUBLIC_CONTACT_ADDRESS }}
+          NEXT_PUBLIC_BUILD_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           echo "Building OpenCouncil production package..."
           nix build --impure .#opencouncil-prod --print-build-logs

--- a/flake.nix
+++ b/flake.nix
@@ -1094,6 +1094,7 @@ EOF
               ${let v = builtins.getEnv "NEXT_PUBLIC_CONTACT_PHONE"; in if v != "" then "export NEXT_PUBLIC_CONTACT_PHONE=\"${v}\"" else "# NEXT_PUBLIC_CONTACT_PHONE not set"}
               ${let v = builtins.getEnv "NEXT_PUBLIC_CONTACT_EMAIL"; in if v != "" then "export NEXT_PUBLIC_CONTACT_EMAIL=\"${v}\"" else "# NEXT_PUBLIC_CONTACT_EMAIL not set"}
               ${let v = builtins.getEnv "NEXT_PUBLIC_CONTACT_ADDRESS"; in if v != "" then "export NEXT_PUBLIC_CONTACT_ADDRESS=\"${v}\"" else "# NEXT_PUBLIC_CONTACT_ADDRESS not set"}
+              ${let v = builtins.getEnv "NEXT_PUBLIC_BUILD_COMMIT_SHA"; in if v != "" then "export NEXT_PUBLIC_BUILD_COMMIT_SHA=\"${v}\"" else "# NEXT_PUBLIC_BUILD_COMMIT_SHA not set"}
 
               # Run patch-package
               npm run postinstall

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -86,6 +86,7 @@ export const env = createEnv({
     NEXT_PUBLIC_CONTACT_PHONE: z.string().optional(),
     NEXT_PUBLIC_CONTACT_EMAIL: z.string().email().optional(),
     NEXT_PUBLIC_CONTACT_ADDRESS: z.string().optional(),
+    NEXT_PUBLIC_BUILD_COMMIT_SHA: z.string().optional(),
   },
 
   /**
@@ -141,6 +142,7 @@ export const env = createEnv({
     NEXT_PUBLIC_CONTACT_PHONE: process.env.NEXT_PUBLIC_CONTACT_PHONE,
     NEXT_PUBLIC_CONTACT_EMAIL: process.env.NEXT_PUBLIC_CONTACT_EMAIL,
     NEXT_PUBLIC_CONTACT_ADDRESS: process.env.NEXT_PUBLIC_CONTACT_ADDRESS,
+    NEXT_PUBLIC_BUILD_COMMIT_SHA: process.env.NEXT_PUBLIC_BUILD_COMMIT_SHA,
   },
 
   /**

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -58,6 +58,24 @@ async function sendDiscordMessage(payload: DiscordWebhookPayload): Promise<void>
 }
 
 /**
+ * Identifies which deployment produced an alert: the preview PR (parsed from
+ * NEXTAUTH_URL), the build commit, and the instance URL.
+ */
+function buildIdentityFooter(): DiscordEmbed['footer'] {
+    const instance = env.NEXTAUTH_URL;
+    const pr = instance.match(/pr-(\d+)\./)?.[1];
+    const commit = env.NEXT_PUBLIC_BUILD_COMMIT_SHA;
+
+    const parts = [
+        pr ? `pr-${pr}` : undefined,
+        commit ? `commit ${commit.slice(0, 7)}` : undefined,
+        instance,
+    ].filter((part): part is string => Boolean(part));
+
+    return parts.length > 0 ? { text: parts.join(' · ') } : undefined;
+}
+
+/**
  * Thin wrapper around sendDiscordMessage that adds the embed boilerplate.
  */
 async function sendAdminAlert(embed: {
@@ -70,6 +88,7 @@ async function sendAdminAlert(embed: {
     await sendDiscordMessage({
         embeds: [{
             ...embed,
+            footer: embed.footer ?? buildIdentityFooter(),
             timestamp: new Date().toISOString(),
         }],
     });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR threads a build commit SHA through the preview deployment pipeline — from the GitHub Actions workflow into the Nix build and Next.js env — then surfaces it alongside the PR number and instance URL as a footer on every Discord admin alert that doesn't already carry an explicit footer.

- **Workflow → build pipeline**: `NEXT_PUBLIC_BUILD_COMMIT_SHA` is set via `github.event.pull_request.head.sha` in `preview-deploy.yml`, picked up by the same conditional `getEnv` pattern used by all other `NEXT_PUBLIC_*` vars in `flake.nix`, and registered as an optional string in `src/env.mjs`.
- **Discord identity footer**: `buildIdentityFooter()` in `src/lib/discord.ts` composes `pr-<n>`, `commit <7-char-sha>`, and the instance URL into a single footer string; the `??` operator in `sendAdminAlert` ensures callers that already set an explicit footer (e.g. the PII-privacy notices) are left unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive, all optional, and degrade gracefully when the SHA or PR context is absent.

The four files each make a small, self-contained addition. The env var is optional everywhere it appears, the Nix build already has the conditional getEnv guard, and buildIdentityFooter() handles missing SHA/PR gracefully. Existing footers on privacy-sensitive alerts are preserved by the nullish coalescing operator.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/preview-deploy.yml | Adds NEXT_PUBLIC_BUILD_COMMIT_SHA env var using github.event.pull_request.head.sha; correct for PR-triggered preview workflows. |
| flake.nix | Propagates NEXT_PUBLIC_BUILD_COMMIT_SHA into the Nix build using the same conditional getEnv pattern as all other NEXT_PUBLIC_* vars. |
| src/env.mjs | Registers NEXT_PUBLIC_BUILD_COMMIT_SHA as an optional string in both the client schema and runtimeEnv; follows existing conventions. |
| src/lib/discord.ts | Adds buildIdentityFooter() that composes PR number, short commit SHA, and instance URL into a Discord embed footer, applied via nullish coalescing so explicit footers are preserved. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add commit sha to build identity fo..."](https://github.com/schemalabz/opencouncil/commit/421dcf651a0e2e5a6a523ec3e86fb513c7a503ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35367763)</sub>

<!-- /greptile_comment -->