### PR TITLE
fix(cache): never shared-cache authenticated HTML (PII/admin leak)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -41,11 +41,16 @@ const nextConfig = {
                 ],
             },
             {
-                // Cap edge cache on HTML so a broken deploy can't be served by Cloudflare for a year.
+                // HTML pages vary by auth (per-user profile data, admin-only UI, the admin
+                // dashboard itself), so they must NEVER be stored by a shared cache like
+                // Cloudflare — doing so leaks one user's rendered page to another and can
+                // serve cached admin HTML to anonymous visitors, bypassing the auth gate.
+                // `private, no-store` keeps every HTML response per-request and also caps a
+                // broken deploy, since the edge can't cache HTML at all.
                 // Excludes _next/* (immutable hashed assets), api/*, files with extensions, and the embed rule above.
                 source: '/((?!_next/|api/|[^/]*\\.[^/]*|[^/]+/embed/).*)',
                 headers: [
-                    { key: 'Cache-Control', value: 'public, max-age=0, s-maxage=30, stale-while-revalidate=60' },
+                    { key: 'Cache-Control', value: 'private, no-store' },
                 ],
             },
         ];


### PR DESCRIPTION
## P0 security fix

### Root cause
The catch-all `headers()` rule in `next.config.mjs` marked nearly all HTML pages `Cache-Control: public, max-age=0, s-maxage=30, stale-while-revalidate=60`. The `public` + `s-maxage` directives let shared caches (Cloudflare) store **per-user authenticated HTML** and serve it to other users for ~30–90s.

### Production symptoms
- **PII leak:** users (e.g. Μυρτώ) saw another user's name/phone on `/profile`. The client-rendered session greeting was correct, but the server-rendered form body came from the shared cache — the signature of an edge-cache leak.
- **Auth bypass:** `/admin` was *sometimes* publicly accessible. When an admin's render was cached, anonymous visitors got the cached dashboard from the edge without the origin auth gate ever running.

### Fix
Switch the catch-all to `Cache-Control: private, no-store`. No HTML response can be stored by a shared cache; safe-by-default for any future authenticated page; still caps a broken deploy (the edge can't cache HTML at all). The embed rule stays `public` — unauthenticated iframe content.

### Tradeoff
Public pages (meeting/city/landing) lose Cloudflare edge HTML caching. They still serve from the origin's app-level Valkey route cache. Watch origin load after deploy.

### Required operational steps (outside this PR)
1. **Purge the Cloudflare cache** to stop the active leak immediately.
2. Consider a Cloudflare rule to bypass cache when the auth session cookie is present (defense-in-depth).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Corrects a critical cache misconfiguration but increases origin load on all non-embed HTML; operational cache purge and monitoring are still required outside the diff.
> 
> **Overview**
> **Security fix:** the catch-all HTML `headers()` rule in `next.config.mjs` no longer allows shared edge caching of document responses.
> 
> Previously, `Cache-Control: public, max-age=0, s-maxage=30, stale-while-revalidate=60` let Cloudflare store HTML for ~30–90s, which could serve **another user's authenticated markup** (e.g. profile PII) or **cached admin HTML** to visitors without hitting origin auth. The rule now sends **`private, no-store`**, so shared caches must not store those HTML pages. Comments document the auth/PII rationale.
> 
> **Unchanged:** `/:locale/embed/:path*` stays **`public`** with its existing `s-maxage` for iframe embeds. **`_next/*`, `api/*`, static files with extensions** remain excluded by the same negative-lookahead `source` pattern.
> 
> **Tradeoff:** public marketing/city pages lose Cloudflare HTML edge cache; origin/Valkey app caching still applies per the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 841697b8836ce7f2e5c5e3913fa68b6d2396d73d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an active shared-cache leak by replacing the catch-all HTML `Cache-Control` header from `public, …, s-maxage=30` to `private, no-store`, preventing Cloudflare and any other shared cache from storing per-user HTML responses.

- The regex exclusion for embed paths (`[^/]+/embed/`) correctly prevents the new `private, no-store` rule from clobbering the intentionally public embed cache rule.
- Public unauthenticated pages (landing, meeting, city) lose Cloudflare edge HTML caching as a deliberate tradeoff; the PR notes these still benefit from origin-level Valkey route caching.
- The operational step to purge the existing Cloudflare cache is correctly called out as a required action outside this PR to stop the active leak immediately.

<h3>Confidence Score: 5/5</h3>

Safe to merge immediately — the one-line header change is minimal, targeted, and correct.

The change is a single header value swap with no logic paths, no new dependencies, and no interface changes. The embed route exclusion in the regex was already in place and correctly prevents the private, no-store rule from affecting public iframe content. The tradeoff (losing Cloudflare edge caching for public pages) is documented and tolerable given origin-level Valkey caching.

No files require special attention — the change touches only the catch-all HTTP header rule in next.config.mjs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| next.config.mjs | Switches catch-all HTML Cache-Control from `public, max-age=0, s-maxage=30, stale-while-revalidate=60` to `private, no-store`, correctly preventing shared caches from storing authenticated HTML. Embed route exclusion in the regex is correctly maintained. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cache): never shared-cache authentic..."](https://github.com/schemalabz/opencouncil/commit/841697b8836ce7f2e5c5e3913fa68b6d2396d73d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35373013)</sub>

<!-- /greptile_comment -->