### PR TITLE
fix(subject): gate Admin details section behind edit authorization

### DIFF
--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -27,6 +27,7 @@ import { useSubjectHeader } from "@/contexts/SubjectHeaderContext";
 import { useSession } from "next-auth/react";
 import { getWithdrawnLabel } from "@/lib/utils/subjects";
 import { SubjectAdminControls } from "./SubjectAdminControls";
+import { useTranscriptOptions } from "../options/OptionsContext";
 
 export default function Subject({ subjectId }: { subjectId?: string }) {
     const { subjects, getSpeakerTag, getPerson, getParty, meeting } = useCouncilMeetingData();
@@ -36,6 +37,7 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
     const { setSubjectHeader } = useSubjectHeader();
     const { data: session } = useSession();
     const isSuperAdmin = session?.user?.isSuperAdmin ?? false;
+    const { options } = useTranscriptOptions();
     const [isFetchingDecision, setIsFetchingDecision] = useState(false);
     const [localDecision, setLocalDecision] = useState<{
         ada: string | null;
@@ -507,8 +509,8 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                     </CollapsibleCard>
                 )}
 
-                {/* Admin Section */}
-                {(topicImportance || proximityImportance) && (
+                {/* Admin Section - internal signals, only for users authorized to edit */}
+                {options.editsAllowed && (topicImportance || proximityImportance) && (
                     <CollapsibleCard
                         icon={<ScrollText className="w-4 h-4" />}
                         title={t("adminDetails")}


### PR DESCRIPTION
Closes the UX issue where the "Admin details" section leaked internal data to everyone.
Closes #406 
## What

On the subject page, the "Admin details" (διαχειριστικά στοιχεία) section showed up for everyone whenever its data existed. It renders `topicImportance` / `proximityImportance`, which are internal signals we use for notification matching, not something a citizen reading the page needs. During a UX test a user stopped on it and asked "Τι είναι τα διαχειριστικά στοιχεία;".

This hides the section from logged-out and non-admin users, so it only shows to people who can actually act on it.

## How

`subject.tsx` is a client component, so it can't call the server-only `isUserAuthorizedToEdit` directly. It already lives inside `CouncilMeetingWrapper`, which gets the server-computed `editable` boolean (from `isUserAuthorizedToEdit`) and hands it down through `TranscriptOptionsProvider` as `options.editsAllowed`.

So the gate is just `options.editsAllowed` from `useTranscriptOptions()`. That covers both superadmins and city admins, which is what we want here, and it's the same pattern other components already use (`SpeakerSegment.tsx`, `Transcript.tsx`). Gating on `isSuperAdmin` instead would have been too tight: it would hide the section from city-level admins who are allowed to edit.

## Testing

- `npx tsc --noEmit` passes with no new errors.
- Confirmed the subject page renders inside the meeting layout's `CouncilMeetingWrapper`, so `useTranscriptOptions()` is in scope and won't throw.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Gates the "Admin details" section (`topicImportance` / `proximityImportance`) behind `options.editsAllowed`, so it is only shown to users who are authorised to edit the meeting (superadmins and city admins). This follows the existing `editsAllowed` pattern already used in `SpeakerSegment.tsx` and `Transcript.tsx`.

- `useTranscriptOptions()` is imported and its `options.editsAllowed` value is prepended to the existing `topicImportance || proximityImportance` condition, preventing the section from being rendered for anonymous or non-admin visitors.
- `DebugUtterances` — which sits inside the same block and carries the inline comment \"Superadmin only\" — retains its own API-level authorization check (`/api/subject/debug-utterances` returns 403), so city admins who reach the section will still not see debug data they are not permitted to access.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal two-line addition that hides an internal data section from non-editor users, with no risk of breaking existing functionality.

The edit is narrow and self-contained: a single new import and one extra boolean prepended to an existing render condition. The `editsAllowed` value is server-computed and propagated via an established context, `DebugUtterances` retains its own API-level auth check, and the default for `editsAllowed` is `false`, so a missing provider would either throw (caught by the existing error boundary in `useTranscriptOptions`) or default to hiding the section.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/meetings/subject/subject.tsx | Adds `options.editsAllowed` guard from `useTranscriptOptions()` to the Admin Section, hiding `topicImportance`/`proximityImportance` from non-editor users. Two-line change (import + conditional) that follows the same pattern already used by `SpeakerSegment.tsx` and `Transcript.tsx`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(subject): gate Admin details section..."](https://github.com/schemalabz/opencouncil/commit/f8a502c1362e7ca2a06988b5eb423428f90cf464) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35380998)</sub>

<!-- /greptile_comment -->