### PR TITLE
feat(meetings): redirect YouTube meeting links to OpenCouncil via URL prefix

### DIFF
--- a/src/app/yt/[...rest]/route.ts
+++ b/src/app/yt/[...rest]/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { env } from '@/env.mjs';
+import { findCouncilMeetingByYouTubeVideoId } from '@/lib/db/meetings';
+import {
+    isValidYouTubeUrl,
+    extractYouTubeVideoId,
+    extractYouTubeTimestamp,
+} from '@/lib/utils/youtube';
+
+/**
+ * URL-prefix redirect: prepend `opencouncil.gr/yt/` to any YouTube meeting link
+ * to land on the corresponding OpenCouncil meeting transcript at the same
+ * timestamp (12ft.io / github1s.com style).
+ *
+ * Example:
+ *   /yt/https://www.youtube.com/watch?v=abc123&t=90
+ *     -> /<cityId>/<meetingId>/transcript?t=90
+ *
+ * The embedded YouTube URL keeps its own query string (?v=…&t=…). A catch-all
+ * segment only captures the path, so we recover the full URL from request.url.
+ */
+export async function GET(request: NextRequest) {
+    try {
+        // Recover everything after the literal "/yt/" prefix, including the
+        // embedded YouTube URL's query string.
+        const marker = '/yt/';
+        const markerIndex = request.url.indexOf(marker);
+        if (markerIndex === -1) {
+            return NextResponse.redirect(new URL('/', env.NEXTAUTH_URL));
+        }
+
+        const rawTarget = request.url.slice(markerIndex + marker.length);
+        if (!rawTarget) {
+            return NextResponse.redirect(new URL('/', env.NEXTAUTH_URL));
+        }
+
+        // Tolerate links that were URL-encoded when prefixed.
+        let youtubeUrl = rawTarget;
+        if (!/^https?:\/\//i.test(youtubeUrl)) {
+            try {
+                youtubeUrl = decodeURIComponent(rawTarget);
+            } catch {
+                youtubeUrl = rawTarget;
+            }
+        }
+
+        if (!isValidYouTubeUrl(youtubeUrl)) {
+            return new NextResponse('Not a valid YouTube URL', { status: 404 });
+        }
+
+        const videoId = extractYouTubeVideoId(youtubeUrl);
+        if (!videoId) {
+            return new NextResponse('Could not extract YouTube video id', { status: 404 });
+        }
+
+        const meeting = await findCouncilMeetingByYouTubeVideoId(videoId);
+        if (!meeting) {
+            return new NextResponse('No OpenCouncil meeting found for this YouTube link', {
+                status: 404,
+            });
+        }
+
+        const timestamp = extractYouTubeTimestamp(youtubeUrl);
+        const target = `/${meeting.cityId}/${meeting.id}/transcript${timestamp != null ? `?t=${timestamp}` : ''}`;
+
+        return NextResponse.redirect(new URL(target, env.NEXTAUTH_URL));
+    } catch (error) {
+        console.error('Error redirecting YouTube link:', error);
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    }
+}

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -129,21 +129,27 @@ export async function getCouncilMeeting(cityId: string, id: string): Promise<Cou
 }
 
 /**
- * Finds a released council meeting whose stored youtubeUrl contains the given
- * YouTube video id. Matching by substring handles the various YouTube URL
- * formats (watch, live, shorts, youtu.be). When several meetings share the same
- * video (e.g. re-uploads), the most recent one is returned.
+ * Finds a released council meeting whose stored youtubeUrl references the given
+ * YouTube video id. Matching anchors the id to the positions where YouTube
+ * places it (`watch?v=<id>`, `youtu.be/<id>`, `live/<id>`, `shorts/<id>`) so it
+ * cannot match an id that merely appears inside a playlist or other parameter.
+ * When several meetings share the same video (e.g. re-uploads), the most recent
+ * one is returned.
  */
 export async function findCouncilMeetingByYouTubeVideoId(
     videoId: string
 ): Promise<{ cityId: string; id: string } | null> {
-    if (!videoId) return null;
+    // YouTube video IDs are always exactly 11 base64url characters.
+    if (!videoId || !/^[A-Za-z0-9_-]{11}$/.test(videoId)) return null;
 
     try {
         const meeting = await prisma.councilMeeting.findFirst({
             where: {
                 released: true,
-                youtubeUrl: { contains: videoId },
+                OR: [
+                    { youtubeUrl: { contains: `v=${videoId}` } },
+                    { youtubeUrl: { contains: `/${videoId}` } },
+                ],
             },
             orderBy: [{ dateTime: 'desc' }, { createdAt: 'desc' }],
             select: { cityId: true, id: true },

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -128,6 +128,33 @@ export async function getCouncilMeeting(cityId: string, id: string): Promise<Cou
     }
 }
 
+/**
+ * Finds a released council meeting whose stored youtubeUrl contains the given
+ * YouTube video id. Matching by substring handles the various YouTube URL
+ * formats (watch, live, shorts, youtu.be). When several meetings share the same
+ * video (e.g. re-uploads), the most recent one is returned.
+ */
+export async function findCouncilMeetingByYouTubeVideoId(
+    videoId: string
+): Promise<{ cityId: string; id: string } | null> {
+    if (!videoId) return null;
+
+    try {
+        const meeting = await prisma.councilMeeting.findFirst({
+            where: {
+                released: true,
+                youtubeUrl: { contains: videoId },
+            },
+            orderBy: [{ dateTime: 'desc' }, { createdAt: 'desc' }],
+            select: { cityId: true, id: true },
+        });
+        return meeting;
+    } catch (error) {
+        console.error('Error finding council meeting by YouTube video id:', error);
+        throw new Error('Failed to find council meeting by YouTube video id');
+    }
+}
+
 export async function getCouncilMeetingsForCity(cityId: string, { includeUnreleased, limit, page, pageSize = 12, from, to, administrativeBodyTypes, timeFilter }: { includeUnreleased?: boolean; limit?: number; page?: number; pageSize?: number; from?: Date; to?: Date; administrativeBodyTypes?: AdministrativeBodyType[]; timeFilter?: 'upcoming' | 'past' } = {}): Promise<CouncilMeetingWithAdminBodyAndSubjects[]> {
 
     try {

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -5,6 +5,7 @@ import prisma from "./prisma";
 import { withUserAuthorizedToEdit, isUserAuthorizedToEdit } from '../auth';
 import { buildDateFilter } from './reviews/dateFilters';
 import { formatDateAsMeetingId } from '../utils/meetingId';
+import { urlHasYouTubeVideoId } from '../utils/youtube';
 import { landingSubjectsTag } from './subject';
 import { CUSTOMER_CITY_WHERE, PUBLIC_CITY_WHERE } from '../cityStatus';
 // Import from the cache leaf (see the note in subject.ts) to keep the barrel's heavy chain out.
@@ -124,12 +125,11 @@ export async function getCouncilMeeting(cityId: string, id: string): Promise<Cou
 }
 
 /**
- * Finds a released council meeting whose stored youtubeUrl references the given
- * YouTube video id. Matching anchors the id to the positions where YouTube
- * places it (`watch?v=<id>`, `youtu.be/<id>`, `live/<id>`, `shorts/<id>`) so it
- * cannot match an id that merely appears inside a playlist or other parameter.
- * When several meetings share the same video (e.g. re-uploads), the most recent
- * one is returned.
+ * Finds a released council meeting whose stored youtubeUrl carries the given
+ * YouTube video id. The SQL predicates only narrow the candidate set; each
+ * candidate URL is then parsed, so an id sitting inside a playlist parameter or
+ * at the start of a longer path segment never counts as a match. When several
+ * meetings share the same video (e.g. re-uploads), the most recent one wins.
  */
 export async function findCouncilMeetingByYouTubeVideoId(
     videoId: string
@@ -138,7 +138,7 @@ export async function findCouncilMeetingByYouTubeVideoId(
     if (!videoId || !/^[A-Za-z0-9_-]{11}$/.test(videoId)) return null;
 
     try {
-        const meeting = await prisma.councilMeeting.findFirst({
+        const candidates = await prisma.councilMeeting.findMany({
             where: {
                 released: true,
                 OR: [
@@ -147,9 +147,11 @@ export async function findCouncilMeetingByYouTubeVideoId(
                 ],
             },
             orderBy: [{ dateTime: 'desc' }, { createdAt: 'desc' }],
-            select: { cityId: true, id: true },
+            select: { cityId: true, id: true, youtubeUrl: true },
         });
-        return meeting;
+
+        const meeting = candidates.find(candidate => urlHasYouTubeVideoId(candidate.youtubeUrl, videoId));
+        return meeting ? { cityId: meeting.cityId, id: meeting.id } : null;
     } catch (error) {
         console.error('Error finding council meeting by YouTube video id:', error);
         throw new Error('Failed to find council meeting by YouTube video id');

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -124,21 +124,27 @@ export async function getCouncilMeeting(cityId: string, id: string): Promise<Cou
 }
 
 /**
- * Finds a released council meeting whose stored youtubeUrl contains the given
- * YouTube video id. Matching by substring handles the various YouTube URL
- * formats (watch, live, shorts, youtu.be). When several meetings share the same
- * video (e.g. re-uploads), the most recent one is returned.
+ * Finds a released council meeting whose stored youtubeUrl references the given
+ * YouTube video id. Matching anchors the id to the positions where YouTube
+ * places it (`watch?v=<id>`, `youtu.be/<id>`, `live/<id>`, `shorts/<id>`) so it
+ * cannot match an id that merely appears inside a playlist or other parameter.
+ * When several meetings share the same video (e.g. re-uploads), the most recent
+ * one is returned.
  */
 export async function findCouncilMeetingByYouTubeVideoId(
     videoId: string
 ): Promise<{ cityId: string; id: string } | null> {
-    if (!videoId) return null;
+    // YouTube video IDs are always exactly 11 base64url characters.
+    if (!videoId || !/^[A-Za-z0-9_-]{11}$/.test(videoId)) return null;
 
     try {
         const meeting = await prisma.councilMeeting.findFirst({
             where: {
                 released: true,
-                youtubeUrl: { contains: videoId },
+                OR: [
+                    { youtubeUrl: { contains: `v=${videoId}` } },
+                    { youtubeUrl: { contains: `/${videoId}` } },
+                ],
             },
             orderBy: [{ dateTime: 'desc' }, { createdAt: 'desc' }],
             select: { cityId: true, id: true },

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -123,6 +123,33 @@ export async function getCouncilMeeting(cityId: string, id: string): Promise<Cou
     }
 }
 
+/**
+ * Finds a released council meeting whose stored youtubeUrl contains the given
+ * YouTube video id. Matching by substring handles the various YouTube URL
+ * formats (watch, live, shorts, youtu.be). When several meetings share the same
+ * video (e.g. re-uploads), the most recent one is returned.
+ */
+export async function findCouncilMeetingByYouTubeVideoId(
+    videoId: string
+): Promise<{ cityId: string; id: string } | null> {
+    if (!videoId) return null;
+
+    try {
+        const meeting = await prisma.councilMeeting.findFirst({
+            where: {
+                released: true,
+                youtubeUrl: { contains: videoId },
+            },
+            orderBy: [{ dateTime: 'desc' }, { createdAt: 'desc' }],
+            select: { cityId: true, id: true },
+        });
+        return meeting;
+    } catch (error) {
+        console.error('Error finding council meeting by YouTube video id:', error);
+        throw new Error('Failed to find council meeting by YouTube video id');
+    }
+}
+
 export async function getCouncilMeetingsForCity(cityId: string, { includeUnreleased, limit, page, pageSize = 12, from, to, administrativeBodyTypes, administrativeBodyIds, timeFilter }: { includeUnreleased?: boolean; limit?: number; page?: number; pageSize?: number; from?: Date; to?: Date; administrativeBodyTypes?: AdministrativeBodyType[]; administrativeBodyIds?: string[]; timeFilter?: 'upcoming' | 'past' } = {}): Promise<CouncilMeetingWithAdminBodyAndSubjects[]> {
 
     try {

--- a/src/lib/utils/__tests__/youtube.test.ts
+++ b/src/lib/utils/__tests__/youtube.test.ts
@@ -1,0 +1,78 @@
+import {
+  isValidYouTubeUrl,
+  extractYouTubeVideoId,
+  extractYouTubeTimestamp,
+} from '../youtube';
+
+describe('isValidYouTubeUrl', () => {
+  it.each([
+    'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    'https://youtube.com/watch?v=dQw4w9WgXcQ&t=90',
+    'https://m.youtube.com/watch?v=dQw4w9WgXcQ',
+    'https://www.youtube.com/live/dQw4w9WgXcQ',
+    'https://www.youtube.com/shorts/dQw4w9WgXcQ',
+    'https://youtu.be/dQw4w9WgXcQ',
+    'http://youtu.be/dQw4w9WgXcQ?t=120',
+  ])('accepts %s', (url) => {
+    expect(isValidYouTubeUrl(url)).toBe(true);
+  });
+
+  it.each([
+    'https://example.com/watch?v=dQw4w9WgXcQ',
+    'https://vimeo.com/12345',
+    'not a url',
+    '',
+  ])('rejects %s', (url) => {
+    expect(isValidYouTubeUrl(url)).toBe(false);
+  });
+});
+
+describe('extractYouTubeVideoId', () => {
+  it.each([
+    ['https://www.youtube.com/watch?v=dQw4w9WgXcQ', 'dQw4w9WgXcQ'],
+    ['https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=90', 'dQw4w9WgXcQ'],
+    ['https://youtu.be/dQw4w9WgXcQ?t=120', 'dQw4w9WgXcQ'],
+    ['https://www.youtube.com/live/dQw4w9WgXcQ', 'dQw4w9WgXcQ'],
+    ['https://www.youtube.com/shorts/dQw4w9WgXcQ', 'dQw4w9WgXcQ'],
+  ])('extracts id from %s', (url, expected) => {
+    expect(extractYouTubeVideoId(url)).toBe(expected);
+  });
+
+  it('returns null for a non-YouTube URL', () => {
+    expect(extractYouTubeVideoId('https://example.com/x')).toBeNull();
+  });
+});
+
+describe('extractYouTubeTimestamp', () => {
+  it('parses plain seconds', () => {
+    expect(extractYouTubeTimestamp('https://youtu.be/abc?t=90')).toBe(90);
+  });
+
+  it('parses seconds with trailing s', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=90s')).toBe(90);
+  });
+
+  it('parses 1h2m3s notation', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=1h2m3s')).toBe(3723);
+  });
+
+  it('parses 2m3s notation', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=2m3s')).toBe(123);
+  });
+
+  it('supports the start parameter', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&start=45')).toBe(45);
+  });
+
+  it('returns null when no timestamp is present', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc')).toBeNull();
+  });
+
+  it('returns null for an unparseable URL', () => {
+    expect(extractYouTubeTimestamp('not a url')).toBeNull();
+  });
+
+  it('returns null for an unparseable timestamp value', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=garbage')).toBeNull();
+  });
+});

--- a/src/lib/utils/__tests__/youtube.test.ts
+++ b/src/lib/utils/__tests__/youtube.test.ts
@@ -75,4 +75,16 @@ describe('extractYouTubeTimestamp', () => {
   it('returns null for an unparseable timestamp value', () => {
     expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=garbage')).toBeNull();
   });
+
+  it('accepts a timestamp at the 24h upper bound', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=86400')).toBe(86400);
+  });
+
+  it('returns null for an out-of-range timestamp', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=99999999999')).toBeNull();
+  });
+
+  it('returns null for a composite timestamp beyond the upper bound', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=25h')).toBeNull();
+  });
 });

--- a/src/lib/utils/__tests__/youtube.test.ts
+++ b/src/lib/utils/__tests__/youtube.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-import { parseChannelRef, isValidYouTubeUrl, extractYouTubeVideoId, extractYouTubeTimestamp } from '../youtube';
+import { parseChannelRef, isValidYouTubeUrl, extractYouTubeVideoId, extractYouTubeTimestamp, urlHasYouTubeVideoId } from '../youtube';
 
 describe('parseChannelRef', () => {
     it('extracts a canonical channel id from /channel/UC… URLs', () => {
@@ -155,5 +155,40 @@ describe('extractYouTubeTimestamp', () => {
 
   it('returns null for a composite timestamp beyond the upper bound', () => {
     expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=25h')).toBeNull();
+  });
+});
+
+describe('urlHasYouTubeVideoId', () => {
+  const ID = 'dQw4w9WgXcQ';
+
+  it('matches the id in the v= parameter', () => {
+    expect(urlHasYouTubeVideoId(`https://www.youtube.com/watch?v=${ID}`, ID)).toBe(true);
+  });
+
+  it('matches the id in a youtu.be, live and shorts path', () => {
+    expect(urlHasYouTubeVideoId(`https://youtu.be/${ID}`, ID)).toBe(true);
+    expect(urlHasYouTubeVideoId(`https://www.youtube.com/live/${ID}`, ID)).toBe(true);
+    expect(urlHasYouTubeVideoId(`https://www.youtube.com/shorts/${ID}`, ID)).toBe(true);
+  });
+
+  it('rejects an id that only appears inside another parameter', () => {
+    // A SQL `contains: 'v=<id>'` prefilter hits this row, but the actual video
+    // is a different one.
+    const url = `https://www.youtube.com/watch?v=OTHERvideo1&list=PLxxv=${ID}`;
+    expect(urlHasYouTubeVideoId(url, ID)).toBe(false);
+  });
+
+  it('rejects an id that is only the prefix of a longer path segment', () => {
+    expect(urlHasYouTubeVideoId(`https://youtu.be/${ID}extra`, ID)).toBe(false);
+  });
+
+  it('returns false for a null, undefined or empty url', () => {
+    expect(urlHasYouTubeVideoId(null, ID)).toBe(false);
+    expect(urlHasYouTubeVideoId(undefined, ID)).toBe(false);
+    expect(urlHasYouTubeVideoId('', ID)).toBe(false);
+  });
+
+  it('returns false for a non-YouTube url', () => {
+    expect(urlHasYouTubeVideoId(`https://vimeo.com/${ID}`, ID)).toBe(false);
   });
 });

--- a/src/lib/utils/__tests__/youtube.test.ts
+++ b/src/lib/utils/__tests__/youtube.test.ts
@@ -144,4 +144,16 @@ describe('extractYouTubeTimestamp', () => {
   it('returns null for an unparseable timestamp value', () => {
     expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=garbage')).toBeNull();
   });
+
+  it('accepts a timestamp at the 24h upper bound', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=86400')).toBe(86400);
+  });
+
+  it('returns null for an out-of-range timestamp', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=99999999999')).toBeNull();
+  });
+
+  it('returns null for a composite timestamp beyond the upper bound', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=25h')).toBeNull();
+  });
 });

--- a/src/lib/utils/__tests__/youtube.test.ts
+++ b/src/lib/utils/__tests__/youtube.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-import { parseChannelRef, isValidYouTubeUrl } from '../youtube';
+import { parseChannelRef, isValidYouTubeUrl, extractYouTubeVideoId, extractYouTubeTimestamp } from '../youtube';
 
 describe('parseChannelRef', () => {
     it('extracts a canonical channel id from /channel/UC… URLs', () => {
@@ -82,4 +82,66 @@ describe('isValidYouTubeUrl', () => {
         expect(isValidYouTubeUrl('https://www.youtube.com/@foo')).toBe(false);
         expect(isValidYouTubeUrl('https://example.com/watch?v=abc')).toBe(false);
     });
+});
+
+describe('isValidYouTubeUrl - URL shapes', () => {
+  it.each([
+    'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    'https://youtube.com/watch?v=dQw4w9WgXcQ&t=90',
+    'https://m.youtube.com/watch?v=dQw4w9WgXcQ',
+    'https://www.youtube.com/live/dQw4w9WgXcQ',
+    'https://www.youtube.com/shorts/dQw4w9WgXcQ',
+    'https://youtu.be/dQw4w9WgXcQ',
+    'http://youtu.be/dQw4w9WgXcQ?t=120',
+  ])('accepts %s', (url) => {
+    expect(isValidYouTubeUrl(url)).toBe(true);
+  });
+  it.each([
+    'https://example.com/watch?v=dQw4w9WgXcQ',
+    'https://vimeo.com/12345',
+    'not a url',
+    '',
+  ])('rejects %s', (url) => {
+    expect(isValidYouTubeUrl(url)).toBe(false);
+  });
+});
+describe('extractYouTubeVideoId', () => {
+  it.each([
+    ['https://www.youtube.com/watch?v=dQw4w9WgXcQ', 'dQw4w9WgXcQ'],
+    ['https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=90', 'dQw4w9WgXcQ'],
+    ['https://youtu.be/dQw4w9WgXcQ?t=120', 'dQw4w9WgXcQ'],
+    ['https://www.youtube.com/live/dQw4w9WgXcQ', 'dQw4w9WgXcQ'],
+    ['https://www.youtube.com/shorts/dQw4w9WgXcQ', 'dQw4w9WgXcQ'],
+  ])('extracts id from %s', (url, expected) => {
+    expect(extractYouTubeVideoId(url)).toBe(expected);
+  });
+  it('returns null for a non-YouTube URL', () => {
+    expect(extractYouTubeVideoId('https://example.com/x')).toBeNull();
+  });
+});
+describe('extractYouTubeTimestamp', () => {
+  it('parses plain seconds', () => {
+    expect(extractYouTubeTimestamp('https://youtu.be/abc?t=90')).toBe(90);
+  });
+  it('parses seconds with trailing s', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=90s')).toBe(90);
+  });
+  it('parses 1h2m3s notation', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=1h2m3s')).toBe(3723);
+  });
+  it('parses 2m3s notation', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=2m3s')).toBe(123);
+  });
+  it('supports the start parameter', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&start=45')).toBe(45);
+  });
+  it('returns null when no timestamp is present', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc')).toBeNull();
+  });
+  it('returns null for an unparseable URL', () => {
+    expect(extractYouTubeTimestamp('not a url')).toBeNull();
+  });
+  it('returns null for an unparseable timestamp value', () => {
+    expect(extractYouTubeTimestamp('https://www.youtube.com/watch?v=abc&t=garbage')).toBeNull();
+  });
 });

--- a/src/lib/utils/youtube.ts
+++ b/src/lib/utils/youtube.ts
@@ -11,3 +11,54 @@ export function isValidYouTubeUrl(url: string): boolean {
   return YOUTUBE_URL_REGEX.test(url)
 }
 
+/**
+ * Extracts the 11-character video id from a YouTube URL.
+ * Returns null if the URL is not a recognised YouTube URL or has no id.
+ */
+export function extractYouTubeVideoId(url: string): string | null {
+  const match = YOUTUBE_URL_REGEX.exec(url)
+  const videoId = match?.[1]
+  return videoId ? videoId : null
+}
+
+/**
+ * Parses a YouTube `t=` / `start=` timestamp value into total seconds.
+ * Accepts both plain seconds (`90`, `90s`) and the `1h2m3s` notation.
+ * Returns null when the value is missing or cannot be parsed.
+ */
+function parseTimestampValue(value: string | null): number | null {
+  if (!value) return null
+
+  // Plain integer seconds, e.g. "90" or "90s"
+  const plainMatch = /^(\d+)s?$/.exec(value)
+  if (plainMatch) {
+    return parseInt(plainMatch[1], 10)
+  }
+
+  // Composite notation, e.g. "1h2m3s", "2m3s", "45s"
+  const compositeMatch = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(value)
+  if (compositeMatch && (compositeMatch[1] || compositeMatch[2] || compositeMatch[3])) {
+    const hours = parseInt(compositeMatch[1] ?? '0', 10)
+    const minutes = parseInt(compositeMatch[2] ?? '0', 10)
+    const seconds = parseInt(compositeMatch[3] ?? '0', 10)
+    return hours * 3600 + minutes * 60 + seconds
+  }
+
+  return null
+}
+
+/**
+ * Extracts the timestamp (in seconds) from a YouTube URL's `t` or `start`
+ * query parameter. Returns null when no timestamp is present or parseable.
+ */
+export function extractYouTubeTimestamp(url: string): number | null {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+
+  const raw = parsed.searchParams.get('t') ?? parsed.searchParams.get('start')
+  return parseTimestampValue(raw)
+}

--- a/src/lib/utils/youtube.ts
+++ b/src/lib/utils/youtube.ts
@@ -26,13 +26,21 @@ export function extractYouTubeVideoId(url: string): string | null {
  * Accepts both plain seconds (`90`, `90s`) and the `1h2m3s` notation.
  * Returns null when the value is missing or cannot be parsed.
  */
+// Upper bound for a sane seek offset (24 hours). Anything larger is treated as
+// out of range so a crafted value can't push the player to a nonsensical point.
+const MAX_TIMESTAMP_SECONDS = 24 * 3600
+
+function clampTimestamp(seconds: number): number | null {
+  return seconds <= MAX_TIMESTAMP_SECONDS ? seconds : null
+}
+
 function parseTimestampValue(value: string | null): number | null {
   if (!value) return null
 
   // Plain integer seconds, e.g. "90" or "90s"
   const plainMatch = /^(\d+)s?$/.exec(value)
   if (plainMatch) {
-    return parseInt(plainMatch[1], 10)
+    return clampTimestamp(parseInt(plainMatch[1], 10))
   }
 
   // Composite notation, e.g. "1h2m3s", "2m3s", "45s"
@@ -41,7 +49,7 @@ function parseTimestampValue(value: string | null): number | null {
     const hours = parseInt(compositeMatch[1] ?? '0', 10)
     const minutes = parseInt(compositeMatch[2] ?? '0', 10)
     const seconds = parseInt(compositeMatch[3] ?? '0', 10)
-    return hours * 3600 + minutes * 60 + seconds
+    return clampTimestamp(hours * 3600 + minutes * 60 + seconds)
   }
 
   return null

--- a/src/lib/utils/youtube.ts
+++ b/src/lib/utils/youtube.ts
@@ -77,3 +77,54 @@ export function parseChannelRef(channelUrl: string): ChannelRef | null {
   return null
 }
 
+/**
+ * Extracts the 11-character video id from a YouTube URL.
+ * Returns null if the URL is not a recognised YouTube URL or has no id.
+ */
+export function extractYouTubeVideoId(url: string): string | null {
+  const match = YOUTUBE_URL_REGEX.exec(url)
+  const videoId = match?.[1]
+  return videoId ? videoId : null
+}
+
+/**
+ * Parses a YouTube `t=` / `start=` timestamp value into total seconds.
+ * Accepts both plain seconds (`90`, `90s`) and the `1h2m3s` notation.
+ * Returns null when the value is missing or cannot be parsed.
+ */
+function parseTimestampValue(value: string | null): number | null {
+  if (!value) return null
+
+  // Plain integer seconds, e.g. "90" or "90s"
+  const plainMatch = /^(\d+)s?$/.exec(value)
+  if (plainMatch) {
+    return parseInt(plainMatch[1], 10)
+  }
+
+  // Composite notation, e.g. "1h2m3s", "2m3s", "45s"
+  const compositeMatch = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/.exec(value)
+  if (compositeMatch && (compositeMatch[1] || compositeMatch[2] || compositeMatch[3])) {
+    const hours = parseInt(compositeMatch[1] ?? '0', 10)
+    const minutes = parseInt(compositeMatch[2] ?? '0', 10)
+    const seconds = parseInt(compositeMatch[3] ?? '0', 10)
+    return hours * 3600 + minutes * 60 + seconds
+  }
+
+  return null
+}
+
+/**
+ * Extracts the timestamp (in seconds) from a YouTube URL's `t` or `start`
+ * query parameter. Returns null when no timestamp is present or parseable.
+ */
+export function extractYouTubeTimestamp(url: string): number | null {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+
+  const raw = parsed.searchParams.get('t') ?? parsed.searchParams.get('start')
+  return parseTimestampValue(raw)
+}

--- a/src/lib/utils/youtube.ts
+++ b/src/lib/utils/youtube.ts
@@ -92,13 +92,21 @@ export function extractYouTubeVideoId(url: string): string | null {
  * Accepts both plain seconds (`90`, `90s`) and the `1h2m3s` notation.
  * Returns null when the value is missing or cannot be parsed.
  */
+// Upper bound for a sane seek offset (24 hours). Anything larger is treated as
+// out of range so a crafted value can't push the player to a nonsensical point.
+const MAX_TIMESTAMP_SECONDS = 24 * 3600
+
+function clampTimestamp(seconds: number): number | null {
+  return seconds <= MAX_TIMESTAMP_SECONDS ? seconds : null
+}
+
 function parseTimestampValue(value: string | null): number | null {
   if (!value) return null
 
   // Plain integer seconds, e.g. "90" or "90s"
   const plainMatch = /^(\d+)s?$/.exec(value)
   if (plainMatch) {
-    return parseInt(plainMatch[1], 10)
+    return clampTimestamp(parseInt(plainMatch[1], 10))
   }
 
   // Composite notation, e.g. "1h2m3s", "2m3s", "45s"
@@ -107,7 +115,7 @@ function parseTimestampValue(value: string | null): number | null {
     const hours = parseInt(compositeMatch[1] ?? '0', 10)
     const minutes = parseInt(compositeMatch[2] ?? '0', 10)
     const seconds = parseInt(compositeMatch[3] ?? '0', 10)
-    return hours * 3600 + minutes * 60 + seconds
+    return clampTimestamp(hours * 3600 + minutes * 60 + seconds)
   }
 
   return null

--- a/src/lib/utils/youtube.ts
+++ b/src/lib/utils/youtube.ts
@@ -88,6 +88,17 @@ export function extractYouTubeVideoId(url: string): string | null {
 }
 
 /**
+ * True when `url` is a YouTube URL whose video id is exactly `videoId`.
+ * Used to confirm a database candidate: a SQL substring match can also hit an
+ * id that sits inside a playlist parameter or at the start of a longer path
+ * segment, so the stored URL has to be parsed before it counts as the match.
+ */
+export function urlHasYouTubeVideoId(url: string | null | undefined, videoId: string): boolean {
+  if (!url) return false
+  return extractYouTubeVideoId(url) === videoId
+}
+
+/**
  * Parses a YouTube `t=` / `start=` timestamp value into total seconds.
  * Accepts both plain seconds (`90`, `90s`) and the `1h2m3s` notation.
  * Returns null when the value is missing or cannot be parsed.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -39,8 +39,8 @@ export default async function proxy(req: NextRequest) {
         return NextResponse.rewrite(url);
     }
 
-    // Handle i18n first (skip for /qr/* paths to allow direct route handler)
-    if (/^\/(?!api|_next|_vercel|qr\/|\..+).*/.test(pathname)) {
+    // Handle i18n first (skip for /qr/* and /yt/* paths to allow direct route handler)
+    if (/^\/(?!api|_next|_vercel|qr\/|yt\/|\..+).*/.test(pathname)) {
         const response = await i18nMiddleware(req);
         if (response) return response;
     }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -18,10 +18,10 @@ const i18nMiddleware = createIntlMiddleware(routing);
 // without touching per-city caches.
 const JUNK_PATH = /^\/(wp-admin|wp-login|wp-content|wp-includes|wordpress|xmlrpc|administrator|phpmyadmin|cgi-bin)(\/|$)/i;
 
-// Page paths that go through i18n routing (i.e. not api/_next/_vercel/qr or
+// Page paths that go through i18n routing (i.e. not api/_next/_vercel/qr/yt or
 // dotted asset paths). Both the realm-locale rewrite and the i18n handoff
 // gate on this.
-const APP_PATH = /^\/(?!api|_next|_vercel|qr\/|\..+).*/;
+const APP_PATH = /^\/(?!api|_next|_vercel|qr\/|yt\/|\..+).*/;
 
 
 export default async function proxy(req: NextRequest) {
@@ -204,7 +204,7 @@ async function proxyInner(req: NextRequest): Promise<Response | undefined> {
         return NextResponse.rewrite(localeUrl, { request: { headers: requestHeaders } });
     }
 
-    // Handle i18n first (skip for /qr/* paths to allow direct route handler)
+    // Handle i18n first (skip for /qr/* and /yt/* paths to allow direct route handler)
     if (APP_PATH.test(pathname)) {
         const response = await i18nMiddleware(req);
         if (response) {


### PR DESCRIPTION
Closes #342

## What & why

When someone shares a council meeting video, they share the YouTube link, usually with a timestamp. There was no way to turn that link into the OpenCouncil page for the same meeting at the same point.

This adds a 12ft.io / github1s.com-style prefix: put `opencouncil.gr/yt/` in front of any YouTube meeting link and you get a 307 redirect to the matching meeting transcript, with the timestamp preserved.

```
opencouncil.gr/yt/https://www.youtube.com/watch?v=abc123&t=90
  -> /<cityId>/<meetingId>/transcript?t=90
```

Meetings already store their raw `youtubeUrl`, so matching is a lookup by video id. The implementation follows the existing `/qr/[code]` route handler (DB lookup + redirect, i18n bypass in middleware) and the `/api/utterance/[utteranceId]` redirect (the transcript `?t=` deep-link format).

## Changes

- `src/lib/utils/youtube.ts`: `extractYouTubeVideoId(url)` pulls the video id via the existing `YOUTUBE_URL_REGEX` capture group. `extractYouTubeTimestamp(url)` parses the `t`/`start` param, supporting plain seconds (`90`, `90s`) and `1h2m3s` notation, and returns null otherwise.
- `src/lib/db/meetings.ts`: `findCouncilMeetingByYouTubeVideoId(videoId)` does a `findFirst` over released meetings whose `youtubeUrl` contains the id, most-recent-first, and returns `{ cityId, id } | null`.
- `src/app/yt/[...rest]/route.ts` (new): catch-all handler. It recovers the full embedded YouTube URL from `request.url` so the embedded `?v=…&t=…` query survives, tolerates percent-encoded links, validates with `isValidYouTubeUrl`, looks up the meeting, and 307s to `/<cityId>/<meetingId>/transcript[?t=<seconds>]`. Returns 404 when the link isn't a valid YouTube URL or no meeting matches, and redirects to `/` when the target is empty.
- `src/middleware.ts`: adds `yt\/` to the i18n bypass regex (next to `qr\/`) so the handler runs without locale-prefix injection.
- `src/lib/utils/__tests__/youtube.test.ts` (new): 25 unit tests for the validator and the two parsers.

## Testing

- `npx tsc --noEmit`: clean.
- `npm test -- src/lib/utils/__tests__/youtube.test.ts`: 25/25 pass.
- Full `npm run build` not run (scoped, additive change).
- Manual QA plan in `plans/qa/issue-342-qa.md`: valid link to correct meeting, timestamp notations, alternate URL formats, unknown link to 404, invalid URL to 404, URL-encoding edge cases, i18n bypass.

## Risks / Notes

- Released-only: the lookup filters `released: true`, so an unreleased meeting's video id won't leak its page.
- No proxying: the handler only redirects to internal pages. It never fetches or proxies YouTube content.
- Multiple matches: when several meetings share a video (re-uploads), the most recent one (`dateTime desc`) wins.
- Base URL: redirects are built against `NEXTAUTH_URL`, so PR previews work. No `NEXT_PUBLIC_*` baked-in URL.
- No DB index on `CouncilMeeting.youtubeUrl`. The `contains` lookup is a substring scan, fine at current volume (<10k meetings). A functional index can be added later if needed.
- Deferred (optional in the plan): no homepage/footer "paste a YouTube link" form and no separate `?url=` endpoint. The prefix route is the single entry point for v1.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This follow-up adds a prefix route that resolves shared YouTube links to released OpenCouncil meeting transcripts while preserving bounded timestamps.
- Adds the `/yt/` redirect handler and bypasses locale rewriting for that route.
- Resolves meetings by validated 11-character YouTube video IDs and verifies database candidates by parsing their stored URLs.
- Adds timestamp parsing, a 24-hour upper bound, and tests covering supported URL shapes and prior false-positive cases.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the current implementation fixes the previously reported short-ID, substring-match, and oversized-timestamp cases.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/yt/[...rest]/route.ts | Adds the public YouTube-prefix redirect flow with URL validation, released-meeting lookup, and timestamp preservation. |
| src/lib/db/meetings.ts | The revised lookup validates exact-length IDs and post-parses candidates, resolving the previously reported short-ID and substring false matches. |
| src/lib/utils/youtube.ts | Adds exact video-ID comparison and bounded timestamp parsing; the previously reported oversized timestamp is rejected. |
| src/lib/utils/__tests__/youtube.test.ts | Covers supported URL formats, exact candidate matching, false-positive exclusions, and timestamp bounds. |
| src/proxy.ts | Excludes `/yt/` from application locale and script routing so the direct route handler can resolve it. |

<sub>Reviews (5): Last reviewed commit: ["fix(meetings): verify the stored YouTube..."](https://github.com/schemalabz/opencouncil/commit/1c054375b559be00c1d760fd002dec175b9c0386) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35612134)</sub>

<!-- /greptile_comment -->