### PR TITLE
feat(webhooks): id-based replay protection for Bird webhooks

### DIFF
--- a/src/app/api/webhooks/bird/__tests__/extract.test.ts
+++ b/src/app/api/webhooks/bird/__tests__/extract.test.ts
@@ -1,5 +1,6 @@
 /** @jest-environment node */
 import {
+    buildDedupeId,
     extractBody,
     extractChannel,
     extractDirection,
@@ -9,6 +10,7 @@ import {
     extractPhone,
     unwrapEvent,
     type BirdMessageLike,
+    type ExtractedMessageFields,
 } from '../extract';
 
 // ---------------------------------------------------------------------------
@@ -469,5 +471,58 @@ describe('extractMessageFields', () => {
         expect(() => extractMessageFields(null, channelIds)).not.toThrow();
         expect(() => extractMessageFields({}, channelIds)).not.toThrow();
         expect(() => extractMessageFields('not an object', channelIds)).not.toThrow();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// buildDedupeId
+// ---------------------------------------------------------------------------
+
+describe('buildDedupeId', () => {
+    const fields = (overrides: Partial<ExtractedMessageFields> = {}): ExtractedMessageFields => ({
+        direction: 'inbound',
+        body: 'hi',
+        channel: 'whatsapp',
+        status: 'delivered',
+        birdMessageId: 'msg-1',
+        ...overrides,
+    });
+
+    it('composes payload.id, message id and status joined by "|"', () => {
+        expect(buildDedupeId({ payload: { id: 'evt-1' } }, fields())).toBe('evt-1|msg-1|delivered');
+    });
+
+    it('prefers payload.id over data.id', () => {
+        expect(buildDedupeId({ payload: { id: 'p' }, data: { id: 'd' } }, fields())).toBe(
+            'p|msg-1|delivered',
+        );
+    });
+
+    it('falls back to data.id when payload.id is absent', () => {
+        expect(buildDedupeId({ data: { id: 'd-2' } }, fields())).toBe('d-2|msg-1|delivered');
+    });
+
+    it('falls back to "-" for the event id when neither payload.id nor data.id is present', () => {
+        expect(buildDedupeId({}, fields())).toBe('-|msg-1|delivered');
+        expect(buildDedupeId(null, fields())).toBe('-|msg-1|delivered');
+    });
+
+    it('falls back to "-" for a missing birdMessageId', () => {
+        expect(buildDedupeId({ payload: { id: 'evt-1' } }, fields({ birdMessageId: undefined }))).toBe(
+            'evt-1|-|delivered',
+        );
+    });
+
+    it('keeps distinct keys across status progressions of the same message', () => {
+        const sent = buildDedupeId({ payload: { id: 'evt-1' } }, fields({ status: 'sent' }));
+        const delivered = buildDedupeId({ payload: { id: 'evt-1' } }, fields({ status: 'delivered' }));
+        expect(sent).not.toBe(delivered);
+    });
+
+    it('does not let a value containing the legacy ":" forge a collision', () => {
+        // With ":" the keys "a:b" + "c" and "a" + "b:c" used to collide; "|" keeps them distinct.
+        const a = buildDedupeId({ payload: { id: 'a:b' } }, fields({ birdMessageId: 'c' }));
+        const b = buildDedupeId({ payload: { id: 'a' } }, fields({ birdMessageId: 'b:c' }));
+        expect(a).not.toBe(b);
     });
 });

--- a/src/app/api/webhooks/bird/__tests__/extract.test.ts
+++ b/src/app/api/webhooks/bird/__tests__/extract.test.ts
@@ -1,5 +1,6 @@
 /** @jest-environment node */
 import {
+    buildDedupeId,
     extractBody,
     extractChannel,
     extractDirection,
@@ -9,6 +10,7 @@ import {
     extractPhone,
     unwrapEvent,
     type BirdMessageLike,
+    type ExtractedMessageFields,
 } from '../extract';
 
 // ---------------------------------------------------------------------------
@@ -460,5 +462,58 @@ describe('extractMessageFields', () => {
         expect(() => extractMessageFields(null, channelIds)).not.toThrow();
         expect(() => extractMessageFields({}, channelIds)).not.toThrow();
         expect(() => extractMessageFields('not an object', channelIds)).not.toThrow();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// buildDedupeId
+// ---------------------------------------------------------------------------
+
+describe('buildDedupeId', () => {
+    const fields = (overrides: Partial<ExtractedMessageFields> = {}): ExtractedMessageFields => ({
+        direction: 'inbound',
+        body: 'hi',
+        channel: 'whatsapp',
+        status: 'delivered',
+        birdMessageId: 'msg-1',
+        ...overrides,
+    });
+
+    it('composes payload.id, message id and status joined by "|"', () => {
+        expect(buildDedupeId({ payload: { id: 'evt-1' } }, fields())).toBe('evt-1|msg-1|delivered');
+    });
+
+    it('prefers payload.id over data.id', () => {
+        expect(buildDedupeId({ payload: { id: 'p' }, data: { id: 'd' } }, fields())).toBe(
+            'p|msg-1|delivered',
+        );
+    });
+
+    it('falls back to data.id when payload.id is absent', () => {
+        expect(buildDedupeId({ data: { id: 'd-2' } }, fields())).toBe('d-2|msg-1|delivered');
+    });
+
+    it('falls back to "-" for the event id when neither payload.id nor data.id is present', () => {
+        expect(buildDedupeId({}, fields())).toBe('-|msg-1|delivered');
+        expect(buildDedupeId(null, fields())).toBe('-|msg-1|delivered');
+    });
+
+    it('falls back to "-" for a missing birdMessageId', () => {
+        expect(buildDedupeId({ payload: { id: 'evt-1' } }, fields({ birdMessageId: undefined }))).toBe(
+            'evt-1|-|delivered',
+        );
+    });
+
+    it('keeps distinct keys across status progressions of the same message', () => {
+        const sent = buildDedupeId({ payload: { id: 'evt-1' } }, fields({ status: 'sent' }));
+        const delivered = buildDedupeId({ payload: { id: 'evt-1' } }, fields({ status: 'delivered' }));
+        expect(sent).not.toBe(delivered);
+    });
+
+    it('does not let a value containing the legacy ":" forge a collision', () => {
+        // With ":" the keys "a:b" + "c" and "a" + "b:c" used to collide; "|" keeps them distinct.
+        const a = buildDedupeId({ payload: { id: 'a:b' } }, fields({ birdMessageId: 'c' }));
+        const b = buildDedupeId({ payload: { id: 'a' } }, fields({ birdMessageId: 'b:c' }));
+        expect(a).not.toBe(b);
     });
 });

--- a/src/app/api/webhooks/bird/extract.ts
+++ b/src/app/api/webhooks/bird/extract.ts
@@ -112,6 +112,25 @@ export function unwrapEvent(event: unknown): UnwrappedEvent {
     };
 }
 
+/**
+ * Build the replay-dedupe id for an event. Bird emits multiple lifecycle
+ * status webhooks for the same message id (sent → delivered → failed), so the
+ * message id alone is too coarse — it would drop legitimate progressions. The
+ * key composes every stable identifier we have: the top-level event/payload id
+ * (when present), the message id, and the normalized status. A duplicate then
+ * requires the exact same event — i.e. a true replay/retry — while status
+ * progressions remain distinct keys.
+ *
+ * Fields are joined with `|`, a character Bird ids never contain, so a literal
+ * separator inside one field can't forge a collision with a different split
+ * (e.g. payloadId `a|b` + msgId `c` no longer equals payloadId `a` + msgId `b|c`).
+ */
+export function buildDedupeId(event: unknown, fields: ExtractedMessageFields): string {
+    const evt = (event ?? {}) as BirdWebhookEvent;
+    const payloadId = evt.payload?.id ?? evt.data?.id ?? '-';
+    return `${payloadId}|${fields.birdMessageId ?? '-'}|${fields.status}`;
+}
+
 export function extractDirection(message: BirdMessageLike | undefined): MessageDirection {
     const explicit = String(message?.direction ?? message?.kind ?? '').toLowerCase();
     if (explicit.includes('out')) return 'outbound';

--- a/src/app/api/webhooks/bird/route.ts
+++ b/src/app/api/webhooks/bird/route.ts
@@ -16,7 +16,7 @@ import { sendUnsupportedReply } from '@/lib/notifications/autoReply';
 import { normalizePhone } from '@/lib/notifications/phone';
 import { markWebhookSeen, clearWebhookSeen } from '@/lib/notifications/webhookDedupe';
 import type { VerifyRequestResult, VerifySignatureResult } from '@/lib/notifications/types';
-import { extractMessageFields, type ExtractedMessageFields } from './extract';
+import { extractMessageFields, buildDedupeId, type ExtractedMessageFields } from './extract';
 import type { MessageStatus, Prisma } from '@prisma/client';
 
 // Replay protection model (issue #391):
@@ -298,23 +298,6 @@ async function sendUnsupportedReplyIfApplicable(
         phone: normalizePhone(fields.phone),
         notificationDeliveryId,
     });
-}
-
-/**
- * Build the replay-dedupe id for an event. Bird emits multiple lifecycle
- * status webhooks for the same message id (sent → delivered → failed), so the
- * message id alone is too coarse — it would drop legitimate progressions. The
- * key composes every stable identifier we have: the top-level event/payload id
- * (when present), the message id, and the normalized status. A duplicate then
- * requires the exact same event — i.e. a true replay/retry — while status
- * progressions remain distinct keys.
- */
-function buildDedupeId(event: unknown, fields: ExtractedMessageFields): string {
-    const payloadId =
-        (event as { payload?: { id?: string }; data?: { id?: string } } | null)?.payload?.id ??
-        (event as { data?: { id?: string } } | null)?.data?.id ??
-        '-';
-    return `${payloadId}:${fields.birdMessageId ?? '-'}:${fields.status}`;
 }
 
 export async function POST(request: Request) {

--- a/src/app/api/webhooks/bird/route.ts
+++ b/src/app/api/webhooks/bird/route.ts
@@ -14,18 +14,27 @@ import {
 } from '@/lib/notifications/unsubscribe';
 import { sendUnsupportedReply } from '@/lib/notifications/autoReply';
 import { normalizePhone } from '@/lib/notifications/phone';
+import { markWebhookSeen, clearWebhookSeen } from '@/lib/notifications/webhookDedupe';
 import type { VerifyRequestResult, VerifySignatureResult } from '@/lib/notifications/types';
 import { extractMessageFields, type ExtractedMessageFields } from './extract';
 import type { MessageStatus, Prisma } from '@prisma/client';
 
+// Replay protection model (issue #391):
+//   1. Verify the HMAC signature — proves the request came from Bird untampered.
+//   2. Atomic id-based dedupe — record the event's stable id in Valkey
+//      (`SET NX EX`); an exact replay/retry of the same event is dropped with
+//      200 OK so Bird stops retrying. This is the PRIMARY replay defense.
+//   3. Process (extract → persist → unsubscribe) only first-seen events.
+// Time is no longer part of the security model. Bird's retry queue re-delivers
+// webhooks with the original event timestamp (observed 3–4h stale), so a tight
+// timestamp window dropped legitimate retries; the window below is now only a
+// residual sanity ceiling against absurdly skewed clocks/signatures. It MUST
+// stay well above Bird's retry staleness so legitimate retries pass signature
+// verification and reach the id-dedupe layer (which returns 200 OK for true
+// replays). Replay rejection is the dedupe layer's job, not this window's.
 const SIGNATURE_HEADER = 'messagebird-signature';
 const TIMESTAMP_HEADER = 'messagebird-request-timestamp';
-// Wide sanity ceiling, not the primary replay defense. Bird's retry queue
-// re-delivers webhooks with the original event timestamp (observed: 3–4h
-// stale), which the previous 300s window was silently rejecting and losing
-// real user messages. Proper replay protection should come from id-based
-// dedupe — see follow-up ticket.
-const REPLAY_WINDOW_SECONDS = 24 * 60 * 60;
+const REPLAY_WINDOW_SECONDS = 24 * 60 * 60; // 24h sanity ceiling; id dedupe is primary
 
 function verifyBirdSignature(opts: {
     rawBody: string;
@@ -291,6 +300,23 @@ async function sendUnsupportedReplyIfApplicable(
     });
 }
 
+/**
+ * Build the replay-dedupe id for an event. Bird emits multiple lifecycle
+ * status webhooks for the same message id (sent → delivered → failed), so the
+ * message id alone is too coarse — it would drop legitimate progressions. The
+ * key composes every stable identifier we have: the top-level event/payload id
+ * (when present), the message id, and the normalized status. A duplicate then
+ * requires the exact same event — i.e. a true replay/retry — while status
+ * progressions remain distinct keys.
+ */
+function buildDedupeId(event: unknown, fields: ExtractedMessageFields): string {
+    const payloadId =
+        (event as { payload?: { id?: string }; data?: { id?: string } } | null)?.payload?.id ??
+        (event as { data?: { id?: string } } | null)?.data?.id ??
+        '-';
+    return `${payloadId}:${fields.birdMessageId ?? '-'}:${fields.status}`;
+}
+
 export async function POST(request: Request) {
     const verified = await verifyRequest(request);
     if (!verified.ok) return verified.response;
@@ -304,13 +330,21 @@ export async function POST(request: Request) {
         return NextResponse.json({ ok: true });
     }
 
-    if (fields.direction === 'outbound' && await updateOutboundMessage(fields)) {
+    // Id-based replay protection (primary defense — see header). Atomic
+    // check-and-set: a duplicate is dropped here so Bird stops retrying.
+    const dedupeId = buildDedupeId(verified.event, fields);
+    const seen = await markWebhookSeen(dedupeId);
+    if (seen === 'duplicate') {
+        console.log(`Bird webhook: webhook id ${dedupeId} already processed — skipping`);
         return NextResponse.json({ ok: true });
     }
 
-    const notificationDeliveryId = await getNotificationDeliveryForMessage(fields);
-
     try {
+        if (fields.direction === 'outbound' && await updateOutboundMessage(fields)) {
+            return NextResponse.json({ ok: true });
+        }
+
+        const notificationDeliveryId = await getNotificationDeliveryForMessage(fields);
         await persistMessageRow(fields, notificationDeliveryId);
         const handledAsUnsubscribe = await handleUnsubscribeIfApplicable(fields, notificationDeliveryId);
         if (!handledAsUnsubscribe) {
@@ -320,7 +354,10 @@ export async function POST(request: Request) {
         const code = (error as Prisma.PrismaClientKnownRequestError | undefined)?.code;
         if (code !== 'P2002') {
             console.error('Bird webhook: persist error', error);
-            // Returning 500 makes Bird retry — appropriate for transient DB issues.
+            // Transient failure → return 500 so Bird retries. Roll back the
+            // dedupe marker first; otherwise the retry would be dropped as a
+            // duplicate and the event lost permanently.
+            await clearWebhookSeen(dedupeId);
             return NextResponse.json({ error: 'persist failed' }, { status: 500 });
         }
     }

--- a/src/app/api/webhooks/bird/route.ts
+++ b/src/app/api/webhooks/bird/route.ts
@@ -17,7 +17,7 @@ import { isNotisServedPhone } from '@/lib/notifications/notis-gate';
 import { normalizePhone } from '@/lib/notifications/phone';
 import { markWebhookSeen, clearWebhookSeen } from '@/lib/notifications/webhookDedupe';
 import type { VerifyRequestResult, VerifySignatureResult } from '@/lib/notifications/types';
-import { extractMessageFields, type ExtractedMessageFields } from './extract';
+import { extractMessageFields, buildDedupeId, type ExtractedMessageFields } from './extract';
 import type { MessageStatus, Prisma } from '@prisma/client';
 
 // Replay protection model (issue #391):
@@ -299,23 +299,6 @@ async function sendUnsupportedReplyIfApplicable(
         phone: normalizePhone(fields.phone),
         notificationDeliveryId,
     });
-}
-
-/**
- * Build the replay-dedupe id for an event. Bird emits multiple lifecycle
- * status webhooks for the same message id (sent → delivered → failed), so the
- * message id alone is too coarse — it would drop legitimate progressions. The
- * key composes every stable identifier we have: the top-level event/payload id
- * (when present), the message id, and the normalized status. A duplicate then
- * requires the exact same event — i.e. a true replay/retry — while status
- * progressions remain distinct keys.
- */
-function buildDedupeId(event: unknown, fields: ExtractedMessageFields): string {
-    const payloadId =
-        (event as { payload?: { id?: string }; data?: { id?: string } } | null)?.payload?.id ??
-        (event as { data?: { id?: string } } | null)?.data?.id ??
-        '-';
-    return `${payloadId}:${fields.birdMessageId ?? '-'}:${fields.status}`;
 }
 
 export async function POST(request: Request) {

--- a/src/app/api/webhooks/bird/route.ts
+++ b/src/app/api/webhooks/bird/route.ts
@@ -15,18 +15,27 @@ import {
 import { sendUnsupportedReply } from '@/lib/notifications/autoReply';
 import { isNotisServedPhone } from '@/lib/notifications/notis-gate';
 import { normalizePhone } from '@/lib/notifications/phone';
+import { markWebhookSeen, clearWebhookSeen } from '@/lib/notifications/webhookDedupe';
 import type { VerifyRequestResult, VerifySignatureResult } from '@/lib/notifications/types';
 import { extractMessageFields, type ExtractedMessageFields } from './extract';
 import type { MessageStatus, Prisma } from '@prisma/client';
 
+// Replay protection model (issue #391):
+//   1. Verify the HMAC signature — proves the request came from Bird untampered.
+//   2. Atomic id-based dedupe — record the event's stable id in Valkey
+//      (`SET NX EX`); an exact replay/retry of the same event is dropped with
+//      200 OK so Bird stops retrying. This is the PRIMARY replay defense.
+//   3. Process (extract → persist → unsubscribe) only first-seen events.
+// Time is no longer part of the security model. Bird's retry queue re-delivers
+// webhooks with the original event timestamp (observed 3–4h stale), so a tight
+// timestamp window dropped legitimate retries; the window below is now only a
+// residual sanity ceiling against absurdly skewed clocks/signatures. It MUST
+// stay well above Bird's retry staleness so legitimate retries pass signature
+// verification and reach the id-dedupe layer (which returns 200 OK for true
+// replays). Replay rejection is the dedupe layer's job, not this window's.
 const SIGNATURE_HEADER = 'messagebird-signature';
 const TIMESTAMP_HEADER = 'messagebird-request-timestamp';
-// Wide sanity ceiling, not the primary replay defense. Bird's retry queue
-// re-delivers webhooks with the original event timestamp (observed: 3–4h
-// stale), which the previous 300s window was silently rejecting and losing
-// real user messages. Proper replay protection should come from id-based
-// dedupe — see follow-up ticket.
-const REPLAY_WINDOW_SECONDS = 24 * 60 * 60;
+const REPLAY_WINDOW_SECONDS = 24 * 60 * 60; // 24h sanity ceiling; id dedupe is primary
 
 function verifyBirdSignature(opts: {
     rawBody: string;
@@ -292,6 +301,23 @@ async function sendUnsupportedReplyIfApplicable(
     });
 }
 
+/**
+ * Build the replay-dedupe id for an event. Bird emits multiple lifecycle
+ * status webhooks for the same message id (sent → delivered → failed), so the
+ * message id alone is too coarse — it would drop legitimate progressions. The
+ * key composes every stable identifier we have: the top-level event/payload id
+ * (when present), the message id, and the normalized status. A duplicate then
+ * requires the exact same event — i.e. a true replay/retry — while status
+ * progressions remain distinct keys.
+ */
+function buildDedupeId(event: unknown, fields: ExtractedMessageFields): string {
+    const payloadId =
+        (event as { payload?: { id?: string }; data?: { id?: string } } | null)?.payload?.id ??
+        (event as { data?: { id?: string } } | null)?.data?.id ??
+        '-';
+    return `${payloadId}:${fields.birdMessageId ?? '-'}:${fields.status}`;
+}
+
 export async function POST(request: Request) {
     const verified = await verifyRequest(request);
     if (!verified.ok) return verified.response;
@@ -305,35 +331,43 @@ export async function POST(request: Request) {
         return NextResponse.json({ ok: true });
     }
 
-    if (fields.direction === 'outbound' && await updateOutboundMessage(fields)) {
+    // Id-based replay protection (primary defense — see header). Atomic
+    // check-and-set: a duplicate is dropped here so Bird stops retrying.
+    const dedupeId = buildDedupeId(verified.event, fields);
+    const seen = await markWebhookSeen(dedupeId);
+    if (seen === 'duplicate') {
+        console.log(`Bird webhook: webhook id ${dedupeId} already processed — skipping`);
         return NextResponse.json({ ok: true });
     }
-
-    // Notis-served users belong to the notis webhook subscription: no reply,
-    // no unsubscribe handling, no Message row (notis's database is the record
-    // of those conversations). Legacy outbound reconciliation stays above —
-    // a Message row that exists here is this app's send regardless of flag.
-    //
-    // KNOWN GAP, deliberately deferred to the rollout PRs: a ΣΤΟΠ from a
-    // notis-served reader is therefore recorded in notis alone, and this
-    // app's NotificationPreference.notifyByPhone keeps its old value. That is
-    // the intended end state (PRD §2.1 — notis holds the only copy), and it
-    // is safe while the flag is set, because the matching engine skips these
-    // users. It stops being safe if someone clears notisEnabledAt: the old
-    // path then sees notifyByPhone: true and resumes messaging a reader who
-    // asked to be left alone, and the release panel shows no sign they ever
-    // sent ΣΤΟΠ. PRD §9 promises narrowing never unsubscribes anyone; this is
-    // the mirror case, and it is answered where the profile checkbox becomes
-    // a notis API client (PR 5) rather than by adding a second copy of the
-    // opt-out here.
-    if (await isNotisServedPhone(fields.phone)) {
-        console.log(`Bird webhook: ${fields.direction} event for a notis-served phone — skipping`);
-        return NextResponse.json({ ok: true });
-    }
-
-    const notificationDeliveryId = await getNotificationDeliveryForMessage(fields);
 
     try {
+        if (fields.direction === 'outbound' && await updateOutboundMessage(fields)) {
+            return NextResponse.json({ ok: true });
+        }
+
+        // Notis-served users belong to the notis webhook subscription: no reply,
+        // no unsubscribe handling, no Message row (notis's database is the record
+        // of those conversations). Legacy outbound reconciliation stays above —
+        // a Message row that exists here is this app's send regardless of flag.
+        //
+        // KNOWN GAP, deliberately deferred to the rollout PRs: a ΣΤΟΠ from a
+        // notis-served reader is therefore recorded in notis alone, and this
+        // app's NotificationPreference.notifyByPhone keeps its old value. That is
+        // the intended end state (PRD §2.1 — notis holds the only copy), and it
+        // is safe while the flag is set, because the matching engine skips these
+        // users. It stops being safe if someone clears notisEnabledAt: the old
+        // path then sees notifyByPhone: true and resumes messaging a reader who
+        // asked to be left alone, and the release panel shows no sign they ever
+        // sent ΣΤΟΠ. PRD §9 promises narrowing never unsubscribes anyone; this is
+        // the mirror case, and it is answered where the profile checkbox becomes
+        // a notis API client (PR 5) rather than by adding a second copy of the
+        // opt-out here.
+        if (await isNotisServedPhone(fields.phone)) {
+            console.log(`Bird webhook: ${fields.direction} event for a notis-served phone — skipping`);
+            return NextResponse.json({ ok: true });
+        }
+
+        const notificationDeliveryId = await getNotificationDeliveryForMessage(fields);
         await persistMessageRow(fields, notificationDeliveryId);
         const handledAsUnsubscribe = await handleUnsubscribeIfApplicable(fields, notificationDeliveryId);
         if (!handledAsUnsubscribe) {
@@ -343,7 +377,10 @@ export async function POST(request: Request) {
         const code = (error as Prisma.PrismaClientKnownRequestError | undefined)?.code;
         if (code !== 'P2002') {
             console.error('Bird webhook: persist error', error);
-            // Returning 500 makes Bird retry — appropriate for transient DB issues.
+            // Transient failure → return 500 so Bird retries. Roll back the
+            // dedupe marker first; otherwise the retry would be dropped as a
+            // duplicate and the event lost permanently.
+            await clearWebhookSeen(dedupeId);
             return NextResponse.json({ error: 'persist failed' }, { status: 500 });
         }
     }

--- a/src/lib/notifications/__tests__/webhookDedupe.test.ts
+++ b/src/lib/notifications/__tests__/webhookDedupe.test.ts
@@ -1,0 +1,93 @@
+/** @jest-environment node */
+
+// In-memory stand-in for a Valkey/redis client driven by the tests.
+const store = new Set<string>();
+const setMock = jest.fn(
+    async (key: string, _value: string, _opts: { NX?: boolean; EX?: number }) => {
+        if (store.has(key)) return null; // NX: key exists → no write
+        store.add(key);
+        return 'OK';
+    },
+);
+const delMock = jest.fn(async (key: string) => {
+    const had = store.delete(key);
+    return had ? 1 : 0;
+});
+
+let connectShouldThrow = false;
+const connectMock = jest.fn(async () => {
+    if (connectShouldThrow) throw new Error('connect failed');
+});
+
+jest.mock('redis', () => ({
+    createClient: jest.fn(() => ({
+        isReady: true,
+        connect: connectMock,
+        disconnect: jest.fn(async () => {}),
+        on: jest.fn(),
+        set: setMock,
+        del: delMock,
+    })),
+}));
+
+// env is read at call time inside markWebhookSeen via the module; mock it so we
+// can toggle CACHE_URL between tests.
+jest.mock('@/env.mjs', () => ({
+    env: { get CACHE_URL() { return process.env.__TEST_CACHE_URL; } },
+}));
+
+describe('markWebhookSeen', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        store.clear();
+        setMock.mockClear();
+        delMock.mockClear();
+        connectMock.mockClear();
+        connectShouldThrow = false;
+        process.env.__TEST_CACHE_URL = 'valkeys://localhost:6379';
+    });
+
+    it('returns "new" the first time an id is seen and "duplicate" on replay', async () => {
+        const { markWebhookSeen } = await import('../webhookDedupe');
+        expect(await markWebhookSeen('evt-1:msg-1:sent')).toBe('new');
+        expect(await markWebhookSeen('evt-1:msg-1:sent')).toBe('duplicate');
+    });
+
+    it('treats different statuses for the same message as distinct events', async () => {
+        const { markWebhookSeen } = await import('../webhookDedupe');
+        expect(await markWebhookSeen('evt-1:msg-1:sent')).toBe('new');
+        expect(await markWebhookSeen('evt-1:msg-1:delivered')).toBe('new');
+    });
+
+    it('uses SET NX EX with the 7-day TTL', async () => {
+        const { markWebhookSeen } = await import('../webhookDedupe');
+        await markWebhookSeen('evt-2:msg-2:sent');
+        expect(setMock).toHaveBeenCalledWith(
+            'bird:webhook:seen:evt-2:msg-2:sent',
+            '1',
+            { NX: true, EX: 7 * 24 * 60 * 60 },
+        );
+    });
+
+    it('fails open with "unknown" when CACHE_URL is unset', async () => {
+        delete process.env.__TEST_CACHE_URL;
+        const { markWebhookSeen } = await import('../webhookDedupe');
+        expect(await markWebhookSeen('evt-3:msg-3:sent')).toBe('unknown');
+        expect(setMock).not.toHaveBeenCalled();
+    });
+
+    it('fails open with "unknown" when the client throws', async () => {
+        connectShouldThrow = true;
+        const { markWebhookSeen } = await import('../webhookDedupe');
+        expect(await markWebhookSeen('evt-4:msg-4:sent')).toBe('unknown');
+    });
+
+    it('clearWebhookSeen removes the marker so a retry is seen as new again', async () => {
+        const { markWebhookSeen, clearWebhookSeen } = await import('../webhookDedupe');
+        expect(await markWebhookSeen('evt-5:msg-5:sent')).toBe('new');
+        await clearWebhookSeen('evt-5:msg-5:sent');
+        expect(delMock).toHaveBeenCalledWith('bird:webhook:seen:evt-5:msg-5:sent');
+        // After rollback, the same event id is treated as first-seen again.
+        expect(await markWebhookSeen('evt-5:msg-5:sent')).toBe('new');
+    });
+});

--- a/src/lib/notifications/webhookDedupe.ts
+++ b/src/lib/notifications/webhookDedupe.ts
@@ -1,0 +1,115 @@
+import { createClient } from 'redis';
+import { env } from '@/env.mjs';
+
+/**
+ * Id-based replay protection for incoming webhooks (Bird).
+ *
+ * Atomic check-and-set against Valkey: `SET <key> 1 NX EX <ttl>`. A non-null
+ * reply means the key did not exist (first time we've seen this event); a null
+ * reply means it already existed (a replay/retry of the exact same event).
+ *
+ * Backend choice: Valkey is already wired via `CACHE_URL` (DO Valkey,
+ * `valkeys://`) and proven in `src/app/api/admin/cache/stats/route.ts`. `SET NX`
+ * is a single atomic op, so there is no read-then-write race. The 7-day TTL
+ * comfortably covers Bird's retry horizon without unbounded key growth.
+ *
+ * Degradation: when `CACHE_URL` is unset (single-instance dev) or Valkey is
+ * unreachable, the dedupe call FAILS OPEN — it returns `'unknown'` so the
+ * webhook is still processed. Correctness is then guarded by the existing DB
+ * layer (the `birdMessageId` unique constraint + forward-only status
+ * progression), so failing open only loses replay *rejection*, not integrity.
+ */
+
+const KEY_PREFIX = 'bird:webhook:seen:';
+const TTL_SECONDS = 7 * 24 * 60 * 60; // 604800 — covers Bird's retry horizon
+
+export type DedupeResult = 'new' | 'duplicate' | 'unknown';
+
+// Module-level singleton — reused across requests, mirrors the pattern in
+// src/app/api/admin/cache/stats/route.ts.
+let client: ReturnType<typeof createClient> | null = null;
+let connectingPromise: Promise<ReturnType<typeof createClient> | null> | null = null;
+
+async function getClient(): Promise<ReturnType<typeof createClient> | null> {
+    if (client?.isReady) return client;
+    if (connectingPromise) return connectingPromise;
+
+    const cacheUrl = env.CACHE_URL;
+    if (!cacheUrl) return null;
+
+    connectingPromise = (async () => {
+        if (client) {
+            client.disconnect().catch(() => {});
+        }
+        // The `redis` npm package uses rediss:// for TLS; DO Valkey uses valkeys://
+        const normalizedUrl = cacheUrl.replace(/^valkeys:\/\//, 'rediss://');
+        const next = createClient({ url: normalizedUrl, pingInterval: 60_000 });
+        next.on('error', (error) => {
+            console.error('[webhook-dedupe] Valkey client error:', error.message);
+        });
+        await next.connect();
+        client = next;
+        return client;
+    })();
+
+    try {
+        return await connectingPromise;
+    } finally {
+        connectingPromise = null;
+    }
+}
+
+/**
+ * Atomically record that we've seen this webhook event id.
+ *
+ * @returns
+ *   - `'new'`       — first time we've seen this id; caller should process it.
+ *   - `'duplicate'` — already processed; caller should drop it (200 OK).
+ *   - `'unknown'`   — dedupe unavailable (no CACHE_URL / Valkey down); fail open
+ *                     and process, relying on the DB idempotency layer.
+ */
+export async function markWebhookSeen(id: string): Promise<DedupeResult> {
+    try {
+        const redisClient = await getClient();
+        if (!redisClient) return 'unknown';
+
+        const reply = await redisClient.set(`${KEY_PREFIX}${id}`, '1', {
+            NX: true,
+            EX: TTL_SECONDS,
+        });
+        // redis@4 returns 'OK' when set, null when NX prevented the write.
+        return reply === null ? 'duplicate' : 'new';
+    } catch (error) {
+        // Reset a broken client so the next request reconnects.
+        if (client && !client.isReady) {
+            client.disconnect().catch(() => {});
+            client = null;
+        }
+        console.warn(
+            '[webhook-dedupe] dedupe check failed, failing open:',
+            error instanceof Error ? error.message : error,
+        );
+        return 'unknown';
+    }
+}
+
+/**
+ * Remove a previously-recorded seen marker. Called when processing of a
+ * first-seen event fails transiently (e.g. a DB error that returns 500 and
+ * makes Bird retry) — without this, the dedupe entry would cause the retry to
+ * be dropped as a duplicate and the event would be lost permanently.
+ *
+ * Best-effort: failures are swallowed (the entry will expire via its TTL).
+ */
+export async function clearWebhookSeen(id: string): Promise<void> {
+    try {
+        const redisClient = await getClient();
+        if (!redisClient) return;
+        await redisClient.del(`${KEY_PREFIX}${id}`);
+    } catch (error) {
+        console.warn(
+            '[webhook-dedupe] failed to clear seen marker (will expire via TTL):',
+            error instanceof Error ? error.message : error,
+        );
+    }
+}


### PR DESCRIPTION
Closes #391

## What & why

PR #389 widened the Bird webhook timestamp freshness window from 300s to 24h. The reason was real: Bird's retry queue re-delivers webhooks carrying the *original* event timestamp, sometimes 3-4h stale, and the tight window was silently dropping legitimate user messages. The trade-off was that replay protection then leaned entirely on a 24h time window, so a captured signed payload could be replayed for most of a day.

This PR moves replay protection off the clock and onto the event id. After signature verification we record each event's id in Valkey with an atomic `SET NX EX` and drop exact replays. Time is no longer part of the security model.

## Changes

- **New `src/lib/notifications/webhookDedupe.ts`**
  - `markWebhookSeen(id)` does an atomic `SET bird:webhook:seen:<id> 1 NX EX 604800` (7-day TTL). A non-null reply means `'new'`, null means `'duplicate'`. When `CACHE_URL` is unset or Valkey is unreachable it returns `'unknown'` and fails open.
  - `clearWebhookSeen(id)` rolls back a marker (best-effort) so a transient processing failure doesn't poison the retry.
  - Reuses the Valkey client pattern already proven in `admin/cache/stats` (module singleton, `pingInterval`, `valkeys://` to `rediss://`).
- **`src/app/api/webhooks/bird/route.ts`**
  - Right after signature verification and field extraction, compute a dedupe id and call `markWebhookSeen`.
  - `'duplicate'` returns `200 { ok: true }` plus one info log, and Bird stops retrying.
  - `'new'` / `'unknown'` take the existing extract, persist, unsubscribe path, unchanged.
  - On a transient (non-P2002) persist error that returns 500, call `clearWebhookSeen` so the retry isn't dropped as a duplicate.
  - Rewrote the header comment to describe the new model.
- **Unit tests** for the dedupe module: new vs duplicate, status-progression keys staying distinct, the `NX/EX` args, fail-open on no `CACHE_URL` and on client error, and rollback via `clearWebhookSeen`.

### On the dedupe key and the replay window

The dedupe key is `payload.id : birdMessageId : status`, not the message id alone. Bird emits several lifecycle events for one message (`sent`, `delivered`, `failed`) under the same message id, so a message-only key would suppress legitimate progressions. Composing the stable identifiers means only an exact replay collides.

`REPLAY_WINDOW_SECONDS` stays at 24h rather than being tightened to 1h. A 1h window would reject Bird's 3-4h-stale retries at signature verification, before the dedupe layer ever runs, which is exactly the bug #389 fixed. So the window's *role* changes (sanity ceiling, not replay defense) while its value stays generous. Id dedupe is now the only replay defense.

## Testing

- `npx jest src/lib/notifications/__tests__/webhookDedupe.test.ts src/app/api/webhooks/bird/__tests__/extract.test.ts`: 54 passing.
- `npx tsc --noEmit` clean for the changed files. (There's a pre-existing unrelated `diavgeiaSignerIds`/TS2322 error on the branch base, not touched here.)


## Risks / notes

- **Threat model**: signature verification proves the payload came from Bird untampered; id dedupe stops the same signed payload being processed twice. A real attacker would still need a valid signature (they don't have the secret), so this mainly hardens against Bird's own retries and accidental re-delivery.
- **Fail-open**: if Valkey is down, dedupe degrades to the existing DB guards: the `birdMessageId` unique constraint (P2002 swallow) for inbound and `isForwardProgression` for outbound. We lose replay *rejection*, not correctness, which matches today's behaviour. Worth metering Valkey errors so a fail-open storm is visible.
- **Backend choice**: Valkey over a Postgres `WebhookSeenId` table because Valkey is already wired via `CACHE_URL`, `SET NX` is a single atomic op, and the TTL handles cleanup. No migration.
- Did not refactor `admin/cache/stats` to share the new client, to keep the change surgical.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Valkey-backed, ID-based replay protection for signed Bird webhooks while retaining retry behavior after transient processing failures.
- Builds dedupe identifiers from the event ID, Bird message ID, and normalized status.
- Uses atomic `SET NX EX` markers with fail-open behavior when Valkey is unavailable.
- Clears first-seen markers after transient failures so Bird retries can be processed.
- Addresses the previous delimiter-collision feedback and adds the requested fallback and precedence tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/api/webhooks/bird/extract.ts | Extracts the composite dedupe-ID builder and replaces the ambiguous colon delimiter as previously requested. |
| src/app/api/webhooks/bird/__tests__/extract.test.ts | Adds coverage for ID precedence, missing-ID fallbacks, status separation, and the previously reported delimiter collision. |
| src/app/api/webhooks/bird/route.ts | Integrates first-seen checks, duplicate acknowledgment, and marker rollback into the signed webhook processing flow. |
| src/lib/notifications/webhookDedupe.ts | Implements atomic Valkey replay markers, fail-open handling, singleton connection reuse, and best-effort rollback. |
| src/lib/notifications/__tests__/webhookDedupe.test.ts | Covers atomic marker behavior, expiration options, unavailable-cache degradation, status-specific keys, and rollback. |

<sub>Reviews (4): Last reviewed commit: ["fix(webhooks): use | as dedupe-key separ..."](https://github.com/schemalabz/opencouncil/commit/b8a9cd4a0d743757fd35ce54ecf3b29c652e5ac6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35615094)</sub>

<!-- /greptile_comment -->