### PR TITLE
feat(navigation): surface subject context and add accessible back/home affordance

### DIFF
--- a/messages/el.json
+++ b/messages/el.json
@@ -16,7 +16,8 @@
         "adminBodyType_committee": "Επιτροπές",
         "adminBodyType_community": "Κοινότητες",
         "allPeople": "Όλα",
-        "allBodies": "Όλες"
+        "allBodies": "Όλες",
+        "backToHome": "Πίσω στην αρχική σελίδα"
     },
     "MeetingCard": {
         "noVideo": "Χωρίς μέσα",
@@ -778,6 +779,9 @@
     },
     "Subject": {
         "agendaItem": "Θέμα #{index}",
+        "backToMeeting": "Πίσω στη συνεδρίαση",
+        "backToMeetingNamed": "Πίσω στη συνεδρίαση: {meeting}",
+        "partOf": "Μέρος της συνεδρίασης",
         "parties": "Παρατάξεις",
         "minutes": "λεπτά",
         "speakers": "{count, plural, =1 {1 ομιλητής} other {# ομιλητές}}",

--- a/messages/el.json
+++ b/messages/el.json
@@ -779,7 +779,6 @@
     },
     "Subject": {
         "agendaItem": "Θέμα #{index}",
-        "backToMeeting": "Πίσω στη συνεδρίαση",
         "backToMeetingNamed": "Πίσω στη συνεδρίαση: {meeting}",
         "partOf": "Μέρος της συνεδρίασης",
         "parties": "Παρατάξεις",

--- a/messages/en.json
+++ b/messages/en.json
@@ -16,7 +16,8 @@
         "adminBodyType_committee": "Committees",
         "adminBodyType_community": "Communities",
         "allPeople": "All",
-        "allBodies": "All"
+        "allBodies": "All",
+        "backToHome": "Back to home"
     },
     "PilotPage": {
         "title": "OpenCouncil is running a pilot with some of the latest city council meetings of the Municipality of Athens.",
@@ -799,6 +800,9 @@
     },
     "Subject": {
         "agendaItem": "Subject #{index}",
+        "backToMeeting": "Back to meeting",
+        "backToMeetingNamed": "Back to meeting: {meeting}",
+        "partOf": "Part of the meeting",
         "parties": "Parties",
         "minutes": "minutes",
         "speakers": "{count, plural, =1 {1 speaker} other {# speakers}}",

--- a/messages/en.json
+++ b/messages/en.json
@@ -800,7 +800,6 @@
     },
     "Subject": {
         "agendaItem": "Subject #{index}",
-        "backToMeeting": "Back to meeting",
         "backToMeetingNamed": "Back to meeting: {meeting}",
         "partOf": "Part of the meeting",
         "parties": "Parties",

--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -178,7 +178,7 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                         {city.name}
                     </Link>
                     <span className="text-muted-foreground">
-                        {formatDate(new Date(meeting.dateTime))}
+                        {formatDate(new Date(meeting.dateTime), undefined, locale)}
                     </span>
                 </nav>
                 {isSuperAdmin && (

--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -4,7 +4,7 @@ import { useCouncilMeetingData } from "../CouncilMeetingDataContext";
 import { useVideo } from "../VideoProvider";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Play, FileText, MapPin, ScrollText, CheckSquare, Landmark, ExternalLink, Loader2 } from "lucide-react";
+import { Play, FileText, MapPin, ScrollText, CheckSquare, Landmark, ExternalLink, Loader2, ArrowLeft } from "lucide-react";
 import { PersonBadge } from "@/components/persons/PersonBadge";
 import { Link } from "@/i18n/routing";
 import { ColorPercentageRing } from "@/components/ui/color-percentage-ring";
@@ -29,7 +29,7 @@ import { getWithdrawnLabel } from "@/lib/utils/subjects";
 import { SubjectAdminControls } from "./SubjectAdminControls";
 
 export default function Subject({ subjectId }: { subjectId?: string }) {
-    const { subjects, getSpeakerTag, getPerson, getParty, meeting } = useCouncilMeetingData();
+    const { subjects, getSpeakerTag, getPerson, getParty, meeting, city } = useCouncilMeetingData();
     const { seekToAndPlay } = useVideo();
     const t = useTranslations("Subject");
     const locale = useLocale();
@@ -152,6 +152,35 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
         <div className="min-h-screen bg-background">
             {/* Main Content */}
             <div className="max-w-4xl mx-auto px-3 py-4 md:px-4 md:py-6 space-y-6">
+                {/* On-page context + back affordance.
+                    The breadcrumb in the header is the only other place that
+                    shows which meeting/council this subject belongs to and the
+                    only "back" path, which users miss (#405). This is a real
+                    navigational <Link> to the meeting page, so back never falls
+                    back to "/" the way browser history did in #51. */}
+                <nav
+                    aria-label={t("partOf")}
+                    className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm"
+                >
+                    <Link
+                        href={`/${meeting.cityId}/${meeting.id}`}
+                        aria-label={t("backToMeetingNamed", { meeting: meeting.name })}
+                        className="inline-flex items-center gap-1.5 font-medium text-foreground hover:text-primary transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    >
+                        <ArrowLeft className="h-4 w-4 shrink-0" aria-hidden="true" />
+                        <span>{meeting.name}</span>
+                    </Link>
+                    <span className="text-muted-foreground" aria-hidden="true">·</span>
+                    <Link
+                        href={`/${meeting.cityId}`}
+                        className="text-muted-foreground hover:text-primary transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    >
+                        {city.name}
+                    </Link>
+                    <span className="text-muted-foreground">
+                        {formatDate(new Date(meeting.dateTime))}
+                    </span>
+                </nav>
                 {isSuperAdmin && (
                     <div className="flex justify-end">
                         <SubjectAdminControls

--- a/src/components/search/SearchPage.tsx
+++ b/src/components/search/SearchPage.tsx
@@ -221,7 +221,6 @@ export default function SearchPage() {
             <div>
                 <Link
                     href="/"
-                    aria-label={t('backToHome')}
                     className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 >
                     <ArrowLeft className="h-4 w-4 shrink-0" aria-hidden="true" />

--- a/src/components/search/SearchPage.tsx
+++ b/src/components/search/SearchPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Search, Sparkles, AlertTriangle } from "lucide-react";
+import { Search, Sparkles, AlertTriangle, ArrowLeft } from "lucide-react";
+import { Link } from "@/i18n/routing";
 import { Input } from "../ui/input";
 import MetadataFilters from "./MetadataFilters";
 import { useEffect, useState, useCallback, useMemo } from "react";
@@ -213,6 +214,21 @@ export default function SearchPage() {
 
     return (
         <div className="flex flex-col gap-6 max-w-7xl mx-auto px-4 py-8">
+            {/* Home affordance — the search page otherwise has no obvious way
+                back; a user resorted to hand-editing the URL (#405). Real
+                navigational <Link>, keyboard-focusable with a visible focus
+                ring (#293). */}
+            <div>
+                <Link
+                    href="/"
+                    aria-label={t('backToHome')}
+                    className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                    <ArrowLeft className="h-4 w-4 shrink-0" aria-hidden="true" />
+                    <span>{t('backToHome')}</span>
+                </Link>
+            </div>
+
             {/* Temporary maintenance message */}
             {SEARCH_TEMPORARILY_DISABLED && (
                 <div className="mb-6 p-4 bg-amber-50 border border-amber-200 rounded-lg">


### PR DESCRIPTION
Closes #405

The header breadcrumb was doing too much. On a subject page it was the only thing telling you which meeting/council the subject belonged to, and the only way back, and people missed both. One user clicked the logo to get out because they never realized the breadcrumb was clickable. On the search page there was no home link at all, so a user ended up hand-editing the URL to escape.

This puts the subject's context (meeting + council) on the page body itself and adds a back/home link on the subject and search pages. The breadcrumb works exactly as before.

Back navigation is a real `<Link>` to the meeting page, not `history.back()`, so it can't fall back to `/` the way the old behavior did in #51, and it still works when the page is opened cold with no history. The links carry `aria-label`s and visible keyboard focus rings, which covers the WCAG points from #293.

## Changes
- `src/components/meetings/subject/subject.tsx` — read `city` alongside `meeting` from the existing `useCouncilMeetingData()` context (no refetch), then render a context `<nav>` at the top of the content column: a back link (arrow + meeting name) to `/<cityId>/<meetingId>`, the city name linking to `/<cityId>`, and the meeting date.
- `src/components/search/SearchPage.tsx` — add a keyboard-focusable back-to-home `<Link href="/">` at the top of the page.
- `messages/el.json`, `messages/en.json` — add `Subject.backToMeeting`, `Subject.backToMeetingNamed`, `Subject.partOf`, and `Common.backToHome` for both locales.

## Testing
- `npx tsc --noEmit` is clean.
- Ran the QA manually in a browser, both locales: the context row shows up on the page body, the back link lands on the meeting page and not `/`, the search home link works, keyboard focus and screen-reader labels behave, and the breadcrumb is untouched.

## Notes
- This is additive UI. The breadcrumb behavior doesn't change. The on-page context is deliberate redundancy for discoverability, kept light so it doesn't fight the breadcrumb.
- `meeting` and `city` are always there in the server-fetched `MeetingData`, and the component already `notFound()`s when the subject is missing, so there's no `/undefined/undefined` link to worry about.
- The other search-page strings are still hard-coded Greek (they were before); only the new home-link string goes through next-intl. Rewriting the rest is out of scope.
- Related closed issues: #51 (back must not redirect to `/`), #293 (WCAG audit).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces subject context (meeting name + city + date) directly on the subject page body and adds back/home links on the subject and search pages to address discoverability issues where users missed the header breadcrumb or had no obvious escape path.

- `subject.tsx`: reads `city` from the existing context (no extra fetch) and renders a `<nav>` with a back link to the meeting page, a city link, and the meeting date — `formatDate` correctly passes `locale` as the third argument.
- `SearchPage.tsx`: adds a `Link href=\"/\"` home affordance using the i18n-aware router; translation key correctly targets the `Common` namespace.
- `messages/en.json` + `messages/el.json`: adds `Common.backToHome` and `Subject.backToMeetingNamed` / `Subject.partOf` for both locales.

<h3>Confidence Score: 5/5</h3>

Purely additive UI — no existing behavior is modified, data comes from already-fetched context, and all navigation targets use real Link components with typed hrefs.

Both `meeting` and `city` are non-nullable in `MeetingDataCore`, the component already guards against a missing subject with `notFound()`, and the locale is correctly threaded through to `formatDate`. The translation keys are consistently named across both locale files and match exactly what the components consume.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/meetings/subject/subject.tsx | Adds an on-page context nav (back link + city link + meeting date) using already-available meeting/city data from context; locale is correctly passed to formatDate. |
| src/components/search/SearchPage.tsx | Adds a home affordance link at the top using the i18n-aware Link component; translation key correctly maps to the Common namespace. |
| messages/en.json | Adds backToHome to Common and backToMeetingNamed/partOf to Subject — keys match exactly what the components consume. |
| messages/el.json | Greek translations added for the same three keys, consistent with the English counterparts. |

</details>

<sub>Reviews (3): Last reviewed commit: ["chore(i18n): drop unused Subject.backToM..."](https://github.com/schemalabz/opencouncil/commit/8271ef4cda02c388fd039213a0a844216dc99f1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35662721)</sub>

<!-- /greptile_comment -->