### PR TITLE
feat(admin): notification visibility improvements

### DIFF
--- a/src/app/api/admin/notifications/route.ts
+++ b/src/app/api/admin/notifications/route.ts
@@ -49,10 +49,13 @@ export async function GET(request: NextRequest) {
 
     if (startDateStr) {
         startDate = new Date(startDateStr);
-    }
-    if (endDateStr) {
+        // When filtering by start date, default endDate to 90 days in the future
+        // to include pending beforeMeeting notifications for upcoming meetings
+        endDate = endDateStr ? new Date(endDateStr) : new Date(Date.now() + 90 * 24 * 60 * 60 * 1000);
+    } else if (endDateStr) {
         endDate = new Date(endDateStr);
     }
+    // No dates = no date filter (all time)
 
     const result = await getNotificationsGroupedByMeeting({
         cityId,

--- a/src/components/admin/tasks/BatchRerunActions.tsx
+++ b/src/components/admin/tasks/BatchRerunActions.tsx
@@ -163,6 +163,17 @@ export function BatchRerunActions({ meetings }: BatchRerunActionsProps) {
                                 </DialogDescription>
                             </DialogHeader>
 
+                            {(selectedTask === 'processAgenda' || selectedTask === 'summarize') && (
+                                <div className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm">
+                                    <AlertTriangle className="h-4 w-4 text-amber-600 mt-0.5 shrink-0" />
+                                    <p className="text-amber-800">
+                                        {selectedTask === 'processAgenda' ? 'Before meeting' : 'After meeting'} notifications
+                                        will be created for meetings whose administrative body has notifications enabled.
+                                        Check each body&apos;s notification behavior setting if this is not intended.
+                                    </p>
+                                </div>
+                            )}
+
                             <ScrollArea className="max-h-80 border rounded-md">
                                 <table className="w-full text-sm">
                                     <thead className="sticky top-0 bg-background border-b">

--- a/src/components/meetings/admin/Admin.tsx
+++ b/src/components/meetings/admin/Admin.tsx
@@ -18,7 +18,7 @@ import { useCouncilMeetingData } from '../CouncilMeetingDataContext';
 import { requestProcessAgenda } from '@/lib/tasks/processAgenda';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import AddMeetingForm from '@/components/meetings/AddMeetingForm';
-import { Pencil, Bell, Eye } from 'lucide-react';
+import { Pencil, Bell, BellOff, Eye } from 'lucide-react';
 import { DecisionsPanel } from './DecisionsPanel';
 import { MinutesPreviewDialog } from './MinutesPreviewDialog';
 import { LinkOrDrop } from '@/components/ui/link-or-drop';
@@ -62,6 +62,9 @@ export default function AdminActions({
         setMediaUrl(meeting.youtubeUrl || '');
     }, [meeting.youtubeUrl]);
 
+    const notificationBehavior = meeting.administrativeBody?.notificationBehavior;
+
+    const notificationsEnabled = notificationBehavior && notificationBehavior !== 'NOTIFICATIONS_DISABLED';
     const fetchTaskStatuses = React.useCallback(async () => {
         try {
             const tasks = await getTasksForMeeting(meeting.cityId, meeting.id);
@@ -367,6 +370,7 @@ export default function AdminActions({
                                 </div>
                                 <Button onClick={() => handleProcessAgenda(forceAgenda)} disabled={isProcessingAgenda}>
                                     {isProcessingAgenda ? t('buttons.starting') : t('buttons.process')}
+                                    {notificationsEnabled ? <Bell className="ml-1.5 h-3 w-3" /> : <BellOff className="ml-1.5 h-3 w-3 text-amber-500" />}
                                 </Button>
                             </div>
                             {forceAgenda && (
@@ -411,6 +415,7 @@ export default function AdminActions({
                                 </div>
                                 <Button onClick={() => handleSummarize(forceSummarize)} disabled={isSummarizing}>
                                     {isSummarizing ? t('buttons.starting') : t('buttons.summarize')}
+                                    {notificationsEnabled ? <Bell className="ml-1.5 h-3 w-3" /> : <BellOff className="ml-1.5 h-3 w-3 text-amber-500" />}
                                 </Button>
                             </div>
                             {forceSummarize && (

--- a/src/components/meetings/admin/CreateNotificationModal.tsx
+++ b/src/components/meetings/admin/CreateNotificationModal.tsx
@@ -51,6 +51,47 @@ export function CreateNotificationModal({
     });
     const [impactPreview, setImpactPreview] = useState<{ totalUsers: number; subjectImpact: Record<string, number> } | null>(null);
     const [isLoadingImpact, setIsLoadingImpact] = useState(false);
+    const [existingNotifications, setExistingNotifications] = useState<{
+        total: number;
+        sent: number;
+        pending: number;
+        failed: number;
+    } | null>(null);
+
+    useEffect(() => {
+        if (!open) {
+            setExistingNotifications(null);
+            return;
+        }
+
+        const fetchExisting = async () => {
+            try {
+                const response = await fetch(
+                    `/api/admin/notifications?meetingId=${meeting.id}&cityIdForMeeting=${city.id}&type=${notificationType}`
+                );
+                if (response.ok) {
+                    const data = await response.json();
+                    const notifications = data.notifications || [];
+                    const stats = { total: notifications.length, sent: 0, pending: 0, failed: 0 };
+                    for (const n of notifications) {
+                        const deliveryStatuses = n.deliveries.map((d: { status: string }) => d.status);
+                        if (deliveryStatuses.includes('pending')) {
+                            stats.pending++;
+                        } else if (deliveryStatuses.includes('failed')) {
+                            stats.failed++;
+                        } else if (deliveryStatuses.length > 0) {
+                            stats.sent++;
+                        }
+                    }
+                    setExistingNotifications(stats);
+                }
+            } catch (error) {
+                console.error('Error fetching existing notifications:', error);
+            }
+        };
+
+        fetchExisting();
+    }, [open, meeting.id, city.id, notificationType]);
 
     // Reset importance values from current subject data each time the modal opens,
     // so values are fresh if subjects changed since the component mounted
@@ -210,6 +251,21 @@ export function CreateNotificationModal({
                         Importance levels are pre-filled from the last processing run. Adjust as needed before creating notifications. Users will be matched based on their topic interests and location preferences.
                     </DialogDescription>
                 </DialogHeader>
+
+                {existingNotifications && existingNotifications.total > 0 && (
+                    <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg">
+                        <p className="text-sm font-medium text-amber-900">
+                            {existingNotifications.total} {notificationType === 'beforeMeeting' ? 'before meeting' : 'after meeting'} notification{existingNotifications.total !== 1 ? 's' : ''} already exist
+                        </p>
+                        <p className="text-xs text-amber-700 mt-1">
+                            {[
+                                existingNotifications.sent > 0 && `${existingNotifications.sent} sent`,
+                                existingNotifications.pending > 0 && `${existingNotifications.pending} pending`,
+                                existingNotifications.failed > 0 && `${existingNotifications.failed} failed`,
+                            ].filter(Boolean).join(', ')}
+                        </p>
+                    </div>
+                )}
 
                 <div className="flex justify-end">
                     <Button

--- a/src/components/meetings/admin/CreateNotificationModal.tsx
+++ b/src/components/meetings/admin/CreateNotificationModal.tsx
@@ -10,21 +10,7 @@ import { Loader2, Users, Ban, Star, AlertCircle, Download } from 'lucide-react';
 import { useCouncilMeetingData } from '../CouncilMeetingDataContext';
 import { TripleToggle } from '@/components/ui/triple-toggle';
 import { stripMarkdown } from '@/lib/formatters/markdown';
-
-interface Subject {
-    id: string;
-    name: string;
-    description: string;
-    topic: {
-        id: string;
-        name: string;
-        colorHex: string;
-    } | null;
-    location: {
-        id: string;
-        text: string;
-    } | null;
-}
+import { SubjectWithRelations } from '@/lib/db/subject';
 
 interface SubjectImportance {
     topicImportance: 'doNotNotify' | 'normal' | 'high';
@@ -34,7 +20,7 @@ interface SubjectImportance {
 interface CreateNotificationModalProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
-    subjects: Subject[];
+    subjects: SubjectWithRelations[];
     notificationType: 'beforeMeeting' | 'afterMeeting';
     onCreateNotifications: (
         type: 'beforeMeeting' | 'afterMeeting',
@@ -54,18 +40,32 @@ export function CreateNotificationModal({
     const [sendImmediately, setSendImmediately] = useState(false);
     const [isCreating, setIsCreating] = useState(false);
     const [subjectImportances, setSubjectImportances] = useState<Record<string, SubjectImportance>>(() => {
-        // Initialize all subjects with default values
         const initial: Record<string, SubjectImportance> = {};
         subjects.forEach(subject => {
             initial[subject.id] = {
-                topicImportance: 'doNotNotify',
-                proximityImportance: 'none'
+                topicImportance: (subject.topicImportance as SubjectImportance['topicImportance']) || 'doNotNotify',
+                proximityImportance: (subject.proximityImportance as SubjectImportance['proximityImportance']) || 'none'
             };
         });
         return initial;
     });
     const [impactPreview, setImpactPreview] = useState<{ totalUsers: number; subjectImpact: Record<string, number> } | null>(null);
     const [isLoadingImpact, setIsLoadingImpact] = useState(false);
+
+    // Reset importance values from current subject data each time the modal opens,
+    // so values are fresh if subjects changed since the component mounted
+    useEffect(() => {
+        if (open) {
+            const fresh: Record<string, SubjectImportance> = {};
+            subjects.forEach(subject => {
+                fresh[subject.id] = {
+                    topicImportance: (subject.topicImportance as SubjectImportance['topicImportance']) || 'doNotNotify',
+                    proximityImportance: (subject.proximityImportance as SubjectImportance['proximityImportance']) || 'none'
+                };
+            });
+            setSubjectImportances(fresh);
+        }
+    }, [open, subjects]);
 
     const updateSubjectImportance = (
         subjectId: string,
@@ -207,7 +207,7 @@ export function CreateNotificationModal({
                         Create {notificationType === 'beforeMeeting' ? 'Before Meeting' : 'After Meeting'} Notifications
                     </DialogTitle>
                     <DialogDescription>
-                        Configure which subjects to include and their importance levels. Users will be notified based on their topic interests and location preferences.
+                        Importance levels are pre-filled from the last processing run. Adjust as needed before creating notifications. Users will be matched based on their topic interests and location preferences.
                     </DialogDescription>
                 </DialogHeader>
 

--- a/src/components/meetings/admin/TaskStatus.tsx
+++ b/src/components/meetings/admin/TaskStatus.tsx
@@ -110,6 +110,9 @@ export function TaskStatusComponent({ task, onDelete, showMeetingInfo }: TaskSta
                         <Badge variant="outline" className="text-xs font-normal">
                             {task.type}
                         </Badge>
+                        {task.status === 'succeeded' && task.version !== null && (
+                            <span className="text-xs text-muted-foreground font-mono">v{task.version}</span>
+                        )}
                         {showMeetingInfo && (
                             <a
                                 href={`/${task.cityId}/${task.councilMeetingId}`}

--- a/src/lib/db/notifications.ts
+++ b/src/lib/db/notifications.ts
@@ -1101,20 +1101,15 @@ export async function getNotificationsGroupedByMeeting(filters: {
         pageSize = 20
     } = filters;
 
-    // Default to last 30 days for start date, and 90 days in the future for end date
-    // This ensures we show pending notifications for upcoming meetings (beforeMeeting notifications)
-    const effectiveEndDate = endDate || new Date(Date.now() + 90 * 24 * 60 * 60 * 1000);
-    const effectiveStartDate = startDate || new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-
     // Build the where clause for notifications
-    const notificationWhere: Prisma.NotificationWhereInput = {
-        meeting: {
-            dateTime: {
-                gte: effectiveStartDate,
-                lte: effectiveEndDate
-            }
-        }
-    };
+    const notificationWhere: Prisma.NotificationWhereInput = {};
+
+    if (startDate || endDate) {
+        const dateFilter: { gte?: Date; lte?: Date } = {};
+        if (startDate) dateFilter.gte = startDate;
+        if (endDate) dateFilter.lte = endDate;
+        notificationWhere.meeting = { dateTime: dateFilter };
+    }
 
     if (cityId) {
         notificationWhere.cityId = cityId;


### PR DESCRIPTION
Improves notification visibility across the admin interface so operators always know what will happen with notifications when processing meetings.

Context: we processed a meeting with notifications disabled, re-enabled them later, and had no clean way to create notifications — reprocessing the task has side effects (subject ID changes, ES orphans), and the notification dialog was impractical (defaulted everything to "Do Not Notify"). These changes make the dialog usable for manually creating notifications after the fact, and prevent the root cause by making notification behavior visible when triggering tasks.

- Modal pre-fills stored importance values from summarize/processAgenda
- Modal shows existing notification status (sent/pending/failed)
- Bell/BellOff icon on Summarize and Process Agenda buttons
- Warning in batch rerun dialog about notifications firing
- Task version shown on succeeded tasks
- Fixed "All time" filter in notifications admin — was applying a 30-day floor from the DB layer

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves notification visibility in the admin interface by surfacing notification state at every decision point — buttons, dialogs, and the notification creation modal — and fixes the "All time" filter that was silently applying a 30-day floor.

- **`CreateNotificationModal`** now pre-fills subject importances from stored DB values on each open, fetches and displays existing notifications (sent/pending/failed) via `getNotificationsForMeeting`, and replaces the local `Subject` interface with the shared `SubjectWithRelations` type; previous stale-state issues from the review thread are addressed with an open-gated `useEffect`.
- **`notifications.ts` / `route.ts`**: The hardcoded 30-day `effectiveStartDate` floor is removed; date filtering is now entirely conditional — no params means no date filter, and `endDate` defaults to +90 days only when `startDate` is also provided.
- **`Admin.tsx` / `BatchRerunActions.tsx` / `TaskStatus.tsx`**: Bell/BellOff icons are added to the Summarize and Process Agenda buttons, a notification-will-fire warning is inserted into the batch rerun dialog, and succeeded tasks now display their version number.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive UI improvements and a targeted DB query fix with no data mutation risk.

The changes touch only read paths and UI rendering. The date filter fix correctly removes the 30-day floor without altering any writes, and the modal improvements are purely informational. No auth changes, schema migrations, or write-path modifications are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/api/admin/notifications/route.ts | Fixed "All time" filter: now passes no date args when neither date param is provided, and defaults endDate to +90 days only when startDate is set |
| src/lib/db/notifications.ts | Removed hardcoded 30-day start-date floor; date filter is now conditional — applied only when at least one bound is provided |
| src/components/meetings/admin/CreateNotificationModal.tsx | Pre-fills importance from stored DB values; adds open-gated useEffect to refresh on re-open; fetches and displays existing notification status; previous thread issues addressed |
| src/components/meetings/admin/Admin.tsx | Adds Bell/BellOff icons to Summarize and Process Agenda buttons to surface notification status; safely handles missing administrativeBody with falsy guard |
| src/components/admin/tasks/BatchRerunActions.tsx | Adds informational amber warning when processAgenda or summarize is selected in the batch rerun dialog, noting that notifications will fire |
| src/components/meetings/admin/TaskStatus.tsx | Conditionally renders task version as a monospace badge next to succeeded tasks |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2Fmeetings%2Fadmin%2FCreateNotificationModal.tsx%3A260-266%0AThe%20amber%20warning%20box%20always%20renders%20a%20%60%3Cp%3E%60%20element%20for%20the%20breakdown%20line%2C%20even%20when%20%60sent%20%2B%20pending%20%2B%20failed%60%20sums%20to%20zero%20%28e.g.%2C%20all%20notifications%20have%20zero%20deliveries%29.%20In%20that%20scenario%20%60filter%28Boolean%29.join%28'%2C%20'%29%60%20resolves%20to%20%60''%60%2C%20producing%20an%20empty%20paragraph%20tag%20and%20a%20visible%20blank%20line%20below%20the%20%22N%20notifications%20already%20exist%22%20heading.%20A%20guard%20that%20only%20renders%20this%20line%20when%20the%20joined%20string%20is%20non-empty%20avoids%20the%20cosmetic%20gap.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7B%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20const%20breakdown%20%3D%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20existingNotifications.sent%20%3E%200%20%26%26%20%60%24%7BexistingNotifications.sent%7D%20sent%60%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20existingNotifications.pending%20%3E%200%20%26%26%20%60%24%7BexistingNotifications.pending%7D%20pending%60%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20existingNotifications.failed%20%3E%200%20%26%26%20%60%24%7BexistingNotifications.failed%7D%20failed%60%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5D.filter%28Boolean%29.join%28'%2C%20'%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20return%20breakdown%20%3F%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%3Cp%20className%3D%22text-xs%20text-amber-700%20mt-1%22%3E%7Bbreakdown%7D%3C%2Fp%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%29%20%3A%20null%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%29%28%29%7D%0A%60%60%60%0A%0A&repo=schemalabz%2Fopencouncil&pr=424&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/components/meetings/admin/CreateNotificationModal.tsx:260-266
The amber warning box always renders a `<p>` element for the breakdown line, even when `sent + pending + failed` sums to zero (e.g., all notifications have zero deliveries). In that scenario `filter(Boolean).join(', ')` resolves to `''`, producing an empty paragraph tag and a visible blank line below the "N notifications already exist" heading. A guard that only renders this line when the joined string is non-empty avoids the cosmetic gap.

```suggestion
                        {(() => {
                            const breakdown = [
                                existingNotifications.sent > 0 && `${existingNotifications.sent} sent`,
                                existingNotifications.pending > 0 && `${existingNotifications.pending} pending`,
                                existingNotifications.failed > 0 && `${existingNotifications.failed} failed`,
                            ].filter(Boolean).join(', ');
                            return breakdown ? (
                                <p className="text-xs text-amber-700 mt-1">{breakdown}</p>
                            ) : null;
                        })()}
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(admin): &#39;All time&#39; filter in notific..."](https://github.com/schemalabz/opencouncil/commit/f8f3b13b45ea167e116106fc8db7e894d1a95a59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36201752)</sub>

<!-- /greptile_comment -->