### PR TITLE
feat(onboarding): collapse location search into an add-button after first location

### DIFF
--- a/messages/el.json
+++ b/messages/el.json
@@ -10,6 +10,7 @@
         "transcript": "Απομαγνητοφώνηση",
         "meetingNavigation": "Πλοήγηση συνεδρίασης",
         "searchAddressInMunicipality": "Αναζητήστε διεύθυνση στον δήμο {cityName}",
+        "addNewLocation": "Προσθέστε νέα τοποθεσία",
         "allTopics": "Όλα τα θέματα",
         "allMeetings": "Όλες",
         "adminBodyType_council": "Δημοτικά Συμβούλια",

--- a/messages/en.json
+++ b/messages/en.json
@@ -10,6 +10,7 @@
         "transcript": "Transcript",
         "meetingNavigation": "Meeting navigation",
         "searchAddressInMunicipality": "Search address in {cityName}",
+        "addNewLocation": "Add a new location",
         "allTopics": "All Topics",
         "allMeetings": "All",
         "adminBodyType_council": "Councils",

--- a/src/components/onboarding/selectors/LocationSelector.tsx
+++ b/src/components/onboarding/selectors/LocationSelector.tsx
@@ -184,7 +184,13 @@ export function LocationSelector({
             {showAddButton ? (
                 <Button
                     variant="outline"
-                    onClick={() => setIsSearchVisible(true)}
+                    onClick={() => {
+                        setIsSearchVisible(true);
+                        // Focus the input once React has rendered the search box,
+                        // so the user can type without an extra tap. Safe here
+                        // because revealing is a deliberate user action.
+                        setTimeout(() => inputRef.current?.focus(), 0);
+                    }}
                     className="w-full justify-center py-5 text-base md:text-sm touch-manipulation"
                 >
                     <Plus className="h-5 w-5 md:h-4 md:w-4 mr-2" />

--- a/src/components/onboarding/selectors/LocationSelector.tsx
+++ b/src/components/onboarding/selectors/LocationSelector.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { X, MapPin, AlertCircle, Loader2 } from 'lucide-react';
+import { X, MapPin, AlertCircle, Loader2, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Location } from '@/lib/types/onboarding';
@@ -19,6 +19,14 @@ interface LocationSelectorProps {
     city: CityWithGeometry;
     onLocationClick?: (location: Location) => void;
     hideSelectedList?: boolean;
+    /**
+     * When true, once at least one location has been added the search input is
+     * collapsed into an "add a new location" button, making the
+     * "you can add more than one" affordance explicit. Opt-in so the shared
+     * consultations usages (LocationNavigator, LayerControlsPanel) keep their
+     * always-visible search input. Defaults to false.
+     */
+    collapseAfterAdd?: boolean;
 }
 
 export function LocationSelector({
@@ -27,10 +35,16 @@ export function LocationSelector({
     onRemove,
     city,
     onLocationClick,
-    hideSelectedList = false
+    hideSelectedList = false,
+    collapseAfterAdd = false
 }: LocationSelectorProps) {
     const t = useTranslations('Common');
     const [inputValue, setInputValue] = useState('');
+    // When collapseAfterAdd is enabled, start collapsed if the user already has
+    // locations (e.g. re-entering the step via back navigation).
+    const [isSearchVisible, setIsSearchVisible] = useState(
+        () => !(collapseAfterAdd && selectedLocations.length > 0)
+    );
     const [suggestions, setSuggestions] = useState<PlaceSuggestion[]>([]);
     const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false);
     const [isSelectingLocation, setIsSelectingLocation] = useState(false);
@@ -145,6 +159,11 @@ export function LocationSelector({
                 setInputValue('');
                 setSuggestions([]);
                 setIsWaitingForDebounce(false);
+                // Collapse the search back into the "add new location" button
+                // after a successful add, so the affordance is explicit.
+                if (collapseAfterAdd) {
+                    setIsSearchVisible(false);
+                }
             } else {
                 setError('Δεν ήταν δυνατή η ανάκτηση των λεπτομερειών της τοποθεσίας.');
             }
@@ -156,8 +175,22 @@ export function LocationSelector({
         }
     };
 
+    // When collapseAfterAdd is on and there is at least one location, hide the
+    // search input behind a button until the user opts to add another.
+    const showAddButton = collapseAfterAdd && selectedLocations.length > 0 && !isSearchVisible;
+
     return (
         <div className="space-y-5">
+            {showAddButton ? (
+                <Button
+                    variant="outline"
+                    onClick={() => setIsSearchVisible(true)}
+                    className="w-full justify-center py-5 text-base md:text-sm touch-manipulation"
+                >
+                    <Plus className="h-5 w-5 md:h-4 md:w-4 mr-2" />
+                    {t('addNewLocation')}
+                </Button>
+            ) : (
             <div className="relative">
                 <div className="flex items-center gap-2">
                     <div className="relative flex-1">
@@ -229,6 +262,7 @@ export function LocationSelector({
                     </div>
                 )}
             </div>
+            )}
 
             {!hideSelectedList && (selectedLocations.length > 0 ? (
                 <div className="mt-4">

--- a/src/components/onboarding/steps/notification/NotificationLocationStep.tsx
+++ b/src/components/onboarding/steps/notification/NotificationLocationStep.tsx
@@ -49,6 +49,7 @@ export function NotificationLocationStep({ currentStep, totalSteps, onBack, onCo
           onSelect={handleLocationSelect}
           onRemove={handleLocationRemove}
           city={city}
+          collapseAfterAdd
         />
       </div>
     </OnboardingStepTemplate>


### PR DESCRIPTION
Closes #386

## What this does

In a UX test (PR #344), someone didn't realize they could add more than one address in the notification onboarding location step. The search box just sits there after you add a location — nothing signals "keep going, add another."

So now, once you've added at least one location, the search box collapses into a full-width "Add a new location" button. Click it and the search comes back in the same spot. Adding a second address becomes a deliberate, obvious action instead of a hidden one.

`LocationSelector` is shared with the consultations views (`LayerControlsPanel`, `LocationNavigator`), so the new behavior sits behind an opt-in `collapseAfterAdd` prop, and only `NotificationLocationStep` turns it on. Consultations are untouched.

Split out of #344.

## Changes

- `LocationSelector.tsx` — new `collapseAfterAdd` prop (default false). Local `isSearchVisible` state, initialized collapsed when you re-enter the step with locations already added. After a successful add it collapses back to the button. While collapsed it renders an outline "Add a new location" button with a Plus icon.
- `NotificationLocationStep.tsx` — passes `collapseAfterAdd`.
- `messages/el.json`, `messages/en.json` — new `Common.addNewLocation` key ("Προσθέστε νέα τοποθεσία" / "Add a new location").

## Testing

I couldn't exercise this through the real UI myself. The local dev environment has no `GOOGLE_API_KEY`, so the address autocomplete returns a service error and I can't actually add a location to trigger the collapse. What I did verify: the initial render in the browser (search box visible, no premature button) and the collapse logic by reading the code. `npx tsc --noEmit` is clean.

Someone with a working Places key should confirm the four states by hand: collapse after the first add, re-reveal on button click, auto-reveal after removing the last location, and starting collapsed when re-entering the step. 

## Notes

- `collapseAfterAdd` defaults to false, so the two consultations call sites behave exactly as before.
- Remove the last location and the search input comes back on its own — the collapse needs at least one location.
- The button label goes through next-intl; no hardcoded strings.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `collapseAfterAdd` opt-in prop to `LocationSelector` that, after the first location is added, replaces the always-visible search input with an explicit "Add a new location" button — addressing a UX discovery gap found in testing. The feature is safely gated behind a new prop (default `false`) so the two existing consultation call sites (`LayerControlsPanel`, `LocationNavigator`) are unaffected.

- `LocationSelector.tsx` introduces `isSearchVisible` local state (lazy-initialised to handle the back-navigation re-entry case) and derives `showAddButton` from it plus `selectedLocations.length`, covering all four advertised states.
- `NotificationLocationStep.tsx` passes `collapseAfterAdd` (boolean shorthand); `messages/*.json` add the `Common.addNewLocation` i18n key in both languages.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped, opt-in, and leaves all existing call sites untouched.

The collapse feature is self-contained: it only activates when collapseAfterAdd is explicitly passed, the four advertised UX states work correctly through derived state, and the two consultation usages are unaffected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/onboarding/selectors/LocationSelector.tsx | New `collapseAfterAdd` prop and `isSearchVisible` state added; collapse/reveal logic is correctly derived through `showAddButton`, and auto-reveal on last-location removal works without a useEffect. |
| src/components/onboarding/steps/notification/NotificationLocationStep.tsx | One-line change passing `collapseAfterAdd` to `LocationSelector`; no other logic touched. |
| messages/en.json | Added `Common.addNewLocation` key; matches the namespace and key used in LocationSelector. |
| messages/el.json | Added Greek translation for `Common.addNewLocation`; correct placement alongside the other Common keys. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2Fonboarding%2Fselectors%2FLocationSelector.tsx%3A178-180%0AWhen%20the%20user%20removes%20the%20last%20location%2C%20%60selectedLocations.length%60%20becomes%200%20so%20%60showAddButton%60%20goes%20false%20and%20the%20search%20box%20reappears%20%E2%80%94%20but%20%60isSearchVisible%60%20is%20still%20%60false%60%20from%20the%20last%20collapse.%20Because%20%60showAddButton%60%20is%20%60collapseAfterAdd%20%26%26%20selectedLocations.length%20%3E%200%20%26%26%20!isSearchVisible%60%2C%20the%20search%20is%20only%20shown%20when%20%60showAddButton%60%20is%20false%20AND%20the%20else-branch%20is%20rendered.%20That%20else-branch%20renders%20whenever%20%60showAddButton%60%20is%20false%2C%20which%20includes%20the%20case%20where%20%60isSearchVisible%60%20is%20false%20but%20there%20are%20no%20locations%20left.%20So%20the%20search%20input%20_will_%20reappear%20visually%20%E2%80%94%20but%20%60isSearchVisible%60%20is%20out%20of%20sync%20with%20reality.%20If%20locations%20are%20restored%20%28e.g.%20undo%2C%20context%20re-hydration%29%20or%20the%20prop%20values%20change%20in%20a%20future%20refactor%2C%20the%20stale%20%60false%60%20on%20%60isSearchVisible%60%20could%20cause%20the%20button%20to%20flash%20in%20unexpectedly.%20Syncing%20the%20state%20on%20removal%20keeps%20the%20invariant%20clean.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20When%20the%20last%20location%20is%20removed%2C%20reset%20isSearchVisible%20so%20the%20state%0A%20%20%20%20%2F%2F%20stays%20in%20sync%20with%20the%20rendered%20UI.%0A%20%20%20%20useEffect%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20if%20%28collapseAfterAdd%20%26%26%20selectedLocations.length%20%3D%3D%3D%200%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20setIsSearchVisible%28true%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%2C%20%5BcollapseAfterAdd%2C%20selectedLocations.length%5D%29%3B%0A%0A%20%20%20%20%2F%2F%20When%20collapseAfterAdd%20is%20on%20and%20there%20is%20at%20least%20one%20location%2C%20hide%20the%0A%20%20%20%20%2F%2F%20search%20input%20behind%20a%20button%20until%20the%20user%20opts%20to%20add%20another.%0A%20%20%20%20const%20showAddButton%20%3D%20collapseAfterAdd%20%26%26%20selectedLocations.length%20%3E%200%20%26%26%20!isSearchVisible%3B%0A%60%60%60%0A%0A&repo=schemalabz%2Fopencouncil&pr=425&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/components/onboarding/selectors/LocationSelector.tsx:178-180
When the user removes the last location, `selectedLocations.length` becomes 0 so `showAddButton` goes false and the search box reappears — but `isSearchVisible` is still `false` from the last collapse. Because `showAddButton` is `collapseAfterAdd && selectedLocations.length > 0 && !isSearchVisible`, the search is only shown when `showAddButton` is false AND the else-branch is rendered. That else-branch renders whenever `showAddButton` is false, which includes the case where `isSearchVisible` is false but there are no locations left. So the search input _will_ reappear visually — but `isSearchVisible` is out of sync with reality. If locations are restored (e.g. undo, context re-hydration) or the prop values change in a future refactor, the stale `false` on `isSearchVisible` could cause the button to flash in unexpectedly. Syncing the state on removal keeps the invariant clean.

```suggestion
    // When the last location is removed, reset isSearchVisible so the state
    // stays in sync with the rendered UI.
    useEffect(() => {
        if (collapseAfterAdd && selectedLocations.length === 0) {
            setIsSearchVisible(true);
        }
    }, [collapseAfterAdd, selectedLocations.length]);

    // When collapseAfterAdd is on and there is at least one location, hide the
    // search input behind a button until the user opts to add another.
    const showAddButton = collapseAfterAdd && selectedLocations.length > 0 && !isSearchVisible;
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(onboarding): focus the address searc..."](https://github.com/schemalabz/opencouncil/commit/0caa1cd278bb9f4eb23019b571cb3795b457c177) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36523689)</sub>

<!-- /greptile_comment -->