### PR TITLE
fix(stories): order story subjects by importance before summarization

### DIFF
--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -9,6 +9,7 @@ import {
   klitiki,
   subjectToMapFeature,
   sortSubjectsByImportance,
+  sortSubjectsBySpeakerContributionCount,
   joinTranscriptSegments,
   isRoleActive,
   filterActiveRoles,
@@ -359,6 +360,80 @@ describe('sortSubjectsByImportance', () => {
 
     const sorted = sortSubjectsByImportance(subjects as any);
     expect(sorted.map(s => s.name)).toEqual(['Alpha', 'Middle', 'Zebra']);
+  });
+});
+
+describe('sortSubjectsBySpeakerContributionCount', () => {
+  it('should sort by contributions count (descending)', () => {
+    const subjects = [
+      { name: 'Subject 1', _count: { contributions: 2 } },
+      { name: 'Subject 2', _count: { contributions: 5 } },
+    ];
+
+    const sorted = sortSubjectsBySpeakerContributionCount(subjects as any);
+    expect(sorted.map(s => s.name)).toEqual(['Subject 2', 'Subject 1']);
+  });
+
+  it('should break contribution-count ties by topicImportance (high > normal > doNotNotify)', () => {
+    const subjects = [
+      { name: 'Low', topicImportance: 'doNotNotify' },
+      { name: 'High', topicImportance: 'high' },
+      { name: 'Normal', topicImportance: 'normal' },
+    ];
+
+    const sorted = sortSubjectsBySpeakerContributionCount(subjects as any);
+    expect(sorted.map(s => s.name)).toEqual(['High', 'Normal', 'Low']);
+  });
+
+  it('should treat missing topicImportance as lowest priority', () => {
+    const subjects = [
+      { name: 'Unset' },
+      { name: 'High', topicImportance: 'high' },
+    ];
+
+    const sorted = sortSubjectsBySpeakerContributionCount(subjects as any);
+    expect(sorted.map(s => s.name)).toEqual(['High', 'Unset']);
+  });
+
+  it('should fall back to agendaItemIndex when contributions and topicImportance tie', () => {
+    const subjects = [
+      { name: 'Item 3', agendaItemIndex: 3, topicImportance: 'normal' },
+      { name: 'Item 1', agendaItemIndex: 1, topicImportance: 'normal' },
+      { name: 'Item 2', agendaItemIndex: 2, topicImportance: 'normal' },
+    ];
+
+    const sorted = sortSubjectsBySpeakerContributionCount(subjects as any);
+    expect(sorted.map(s => s.name)).toEqual(['Item 1', 'Item 2', 'Item 3']);
+  });
+
+  it('should prefer topicImportance over agendaItemIndex', () => {
+    const subjects = [
+      { name: 'First in agenda, low', agendaItemIndex: 1, topicImportance: 'doNotNotify' },
+      { name: 'Last in agenda, high', agendaItemIndex: 9, topicImportance: 'high' },
+    ];
+
+    const sorted = sortSubjectsBySpeakerContributionCount(subjects as any);
+    expect(sorted.map(s => s.name)).toEqual(['Last in agenda, high', 'First in agenda, low']);
+  });
+
+  it('should fall back to alphabetical name as the final tie-breaker', () => {
+    const subjects = [
+      { name: 'Zebra', topicImportance: 'normal', agendaItemIndex: 1 },
+      { name: 'Alpha', topicImportance: 'normal', agendaItemIndex: 1 },
+    ];
+
+    const sorted = sortSubjectsBySpeakerContributionCount(subjects as any);
+    expect(sorted.map(s => s.name)).toEqual(['Alpha', 'Zebra']);
+  });
+
+  it('should keep contribution count as the dominant signal over topicImportance', () => {
+    const subjects = [
+      { name: 'Many contributions, low importance', _count: { contributions: 10 }, topicImportance: 'doNotNotify' },
+      { name: 'No contributions, high importance', _count: { contributions: 0 }, topicImportance: 'high' },
+    ];
+
+    const sorted = sortSubjectsBySpeakerContributionCount(subjects as any);
+    expect(sorted[0].name).toBe('Many contributions, low importance');
   });
 });
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -141,6 +141,10 @@ interface SortableSubject {
   speakerSegments?: unknown[];
   agendaItemIndex?: number | null;
   nonAgendaReason?: string | null;
+  // Notification importance assigned during agenda processing ('high' | 'normal' |
+  // 'doNotNotify'). Available before summarization, so it is a meaningful tie-breaker
+  // when contribution counts are still zero.
+  topicImportance?: string | null;
   // Server queries surface contribution count via the aggregated _count.contributions;
   // client-loaded data (CouncilMeetingDataContext) carries the full contributions array.
   // Sorters accept either shape.
@@ -201,12 +205,34 @@ export function sortSubjectsByImportance<T extends SortableSubject>(
   });
 }
 
+// Ordering rank for topicImportance: lower sorts first. Unset/unknown values are
+// treated as 'doNotNotify' (lowest), matching the notification matcher's default.
+const TOPIC_IMPORTANCE_RANK: Record<string, number> = { high: 0, normal: 1, doNotNotify: 2 };
+
+function topicImportanceRank(value?: string | null): number {
+  return value != null && value in TOPIC_IMPORTANCE_RANK
+    ? TOPIC_IMPORTANCE_RANK[value]
+    : TOPIC_IMPORTANCE_RANK.doNotNotify;
+}
+
 export function sortSubjectsBySpeakerContributionCount<T extends SortableSubject>(subjects: T[]): T[] {
   return [...subjects].sort((a, b) => {
     // Accept either server (_count.contributions) or client (contributions[]) shape.
     const aCount = a._count?.contributions ?? a.contributions?.length ?? 0;
     const bCount = b._count?.contributions ?? b.contributions?.length ?? 0;
     if (bCount !== aCount) return bCount - aCount;
+
+    // Tie-breakers when contribution counts are equal — notably before summarization,
+    // when every subject has zero contributions. Fall back to meaningful agenda signals
+    // (notification importance, then agenda order) instead of alphabetical name.
+    const aRank = topicImportanceRank(a.topicImportance);
+    const bRank = topicImportanceRank(b.topicImportance);
+    if (aRank !== bRank) return aRank - bRank;
+
+    const aIndex = a.agendaItemIndex ?? Infinity;
+    const bIndex = b.agendaItemIndex ?? Infinity;
+    if (aIndex !== bIndex) return aIndex - bIndex;
+
     return a.name.localeCompare(b.name);
   });
 }


### PR DESCRIPTION
Closes #423

Shareable stories pick their top subjects with `sortSubjectsBySpeakerContributionCount()`, which ranks by how many speaker contributions each subject has. The catch: that count only exists once a meeting has been summarized. Before that, every subject sits at zero, the sort ties, and the only tie-breaker left is the alphabetical name. So the story ends up showing whatever comes first in the alphabet rather than what actually matters. Zografou are hitting this right now, since they share stories before summarization is done.

### The fix

Two extra tie-breakers ahead of the alphabetical fallback, both available before summarization:

1. `topicImportance` (high > normal > doNotNotify), the same signal the notification matcher already uses to decide which subjects are worth notifying about.
2. `agendaItemIndex`, the same fallback `sortSubjectsByImportance()` already relies on.

They only come into play when contribution counts tie, so anything already summarized sorts exactly as it did before.

### Notes

- The subjects in the context already carry `topicImportance` (it lives on the Prisma `Subject`), so nothing changed in data fetching.
- Two other callers, the meeting page agenda list and the before/out-of-agenda buckets, get the same importance-aware ordering on ties. That's an improvement in the same direction, not a regression.

### Testing

- 6 new unit tests covering the tie-breaker chain in `utils.test.ts`; full suite passes.
- `tsc --noEmit` clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes alphabetical-drift in shareable story subject ordering by inserting two pre-summarization tie-breakers (`topicImportance` rank, then `agendaItemIndex`) into `sortSubjectsBySpeakerContributionCount`, which previously fell straight through to alphabetical when all contribution counts were zero.

- `SortableSubject` gains an optional `topicImportance` field; `TOPIC_IMPORTANCE_RANK` maps the three enum values to integers so comparisons stay cheap and explicit.
- The tie-breaker chain mirrors what `sortSubjectsByImportance` already does for agenda order, making the two sort paths consistent; existing behaviour for summarized meetings is unchanged because the contribution-count branch still fires first.

<h3>Confidence Score: 5/5</h3>

The change is purely additive and scoped to a single sort function; it activates only when contribution counts tie, leaving all already-summarized data unaffected.

Both changed files are self-contained utility logic with no database writes or side effects. The new tie-breaker path is exercised by 7 focused unit tests that cover every branch, including edge cases like missing topicImportance and equal agendaItemIndex. The TOPIC_IMPORTANCE_RANK constant is explicit and the helper is well-guarded against unknown values.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/utils.ts | Adds topicImportance to SortableSubject and inserts two tie-breakers (topicImportance rank, then agendaItemIndex) into sortSubjectsBySpeakerContributionCount before the alphabetical fallback; backward-compatible when contribution counts differ. |
| src/lib/__tests__/utils.test.ts | Adds 7 unit tests for sortSubjectsBySpeakerContributionCount covering the full tie-breaker chain: contribution count dominance, topicImportance ordering, missing importance, agendaItemIndex fallback, importance-over-index priority, and alphabetical final fallback. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(stories): order story subjects by im..."](https://github.com/schemalabz/opencouncil/commit/62a136766f10432b8b565366e0c87cc6b00dc8e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36529523)</sub>

<!-- /greptile_comment -->