### PR TITLE
fix(tasks): treat empty agenda as a valid processAgenda success

### DIFF
--- a/src/lib/tasks/__tests__/processAgendaEmptySubjects.test.ts
+++ b/src/lib/tasks/__tests__/processAgendaEmptySubjects.test.ts
@@ -1,0 +1,90 @@
+/** @jest-environment node */
+
+/**
+ * Tests for handleProcessAgendaResult subject-handling on empty / malformed
+ * success payloads (issue #102).
+ *
+ * Some agendas (e.g. λογοδοσία / accountability sessions) genuinely have no
+ * extractable subjects. The backend reports success with `{ subjects: [] }`,
+ * which must be treated as a valid success — existing subjects are replaced
+ * (with nothing). A malformed success payload that omits `subjects` entirely
+ * must NOT throw (which would flip the succeeded task to failed) and must NOT
+ * delete existing subjects.
+ */
+
+const CITY_ID = 'city-1';
+const MEETING_ID = 'meeting-1';
+const TASK_ID = 'task-1';
+
+const mockHighlightDeleteMany = jest.fn().mockResolvedValue({ count: 0 });
+const mockSubjectDeleteMany = jest.fn().mockResolvedValue({ count: 0 });
+const mockTaskStatusFindUnique = jest.fn().mockResolvedValue({
+  id: TASK_ID,
+  councilMeeting: {
+    id: MEETING_ID,
+    cityId: CITY_ID,
+    city: { name_en: 'TestCity', name: 'TestCity' },
+    name: 'Test Meeting',
+    administrativeBody: null,
+  },
+});
+
+jest.mock('../../db/prisma', () => ({
+  __esModule: true,
+  default: {
+    taskStatus: {
+      findUnique: (...args: unknown[]) => mockTaskStatusFindUnique(...args),
+    },
+    highlight: {
+      deleteMany: (...args: unknown[]) => mockHighlightDeleteMany(...args),
+    },
+    subject: {
+      deleteMany: (...args: unknown[]) => mockSubjectDeleteMany(...args),
+    },
+  },
+}));
+
+const mockSaveSubjectsForMeeting = jest.fn().mockResolvedValue(new Map());
+jest.mock('../../db/utils', () => ({
+  saveSubjectsForMeeting: (...args: unknown[]) => mockSaveSubjectsForMeeting(...args),
+}));
+
+jest.mock('../../auth', () => ({
+  withUserAuthorizedToEdit: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../processAgendaInternal', () => ({
+  requestProcessAgendaInternal: jest.fn(),
+}));
+
+import { handleProcessAgendaResult } from '../processAgenda';
+import { ProcessAgendaResult } from '../../apiTypes';
+
+describe('handleProcessAgendaResult — empty / malformed subjects (issue #102)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('treats { subjects: [] } as a valid success: replaces subjects, does not throw', async () => {
+    await expect(
+      handleProcessAgendaResult(TASK_ID, { subjects: [] } as ProcessAgendaResult)
+    ).resolves.toBeUndefined();
+
+    // Empty agenda is authoritative → existing subjects are deleted/replaced
+    expect(mockSubjectDeleteMany).toHaveBeenCalledTimes(1);
+    expect(mockHighlightDeleteMany).toHaveBeenCalledTimes(1);
+    expect(mockSaveSubjectsForMeeting).toHaveBeenCalledWith([], CITY_ID, MEETING_ID);
+  });
+
+  it('does not throw and does not delete existing subjects when result omits the subjects array', async () => {
+    // Malformed/partial success payload (no `subjects` key). Must not throw
+    // (would flip the succeeded task to failed) and must preserve existing data.
+    await expect(
+      handleProcessAgendaResult(TASK_ID, {} as ProcessAgendaResult)
+    ).resolves.toBeUndefined();
+
+    expect(mockSubjectDeleteMany).not.toHaveBeenCalled();
+    expect(mockHighlightDeleteMany).not.toHaveBeenCalled();
+    expect(mockSaveSubjectsForMeeting).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/tasks/processAgenda.ts
+++ b/src/lib/tasks/processAgenda.ts
@@ -37,6 +37,26 @@ export async function handleProcessAgendaResult(taskId: string, response: Proces
         throw new Error('Task not found');
     }
 
+    // A success result with an empty `subjects` array is a valid outcome:
+    // some agendas (e.g. λογοδοσία / accountability sessions) genuinely have no
+    // extractable subjects. The backend reports success with `{ subjects: [] }`,
+    // so this must NOT be treated as a failure.
+    //
+    // We distinguish two cases:
+    //   - subjects is an array (including []): authoritative result → replace.
+    //   - subjects missing/not an array: malformed/partial success payload →
+    //     skip destructive replacement to avoid silently wiping existing agenda
+    //     data, and do not throw (which would flip the succeeded task to failed).
+    if (!Array.isArray(response?.subjects)) {
+        console.warn(
+            `processAgenda result for task ${taskId} has no subjects array (got ${typeof response?.subjects}); ` +
+            `skipping subject replacement to avoid data loss. Task remains succeeded.`
+        );
+        return;
+    }
+
+    const subjects = response.subjects;
+
     // Delete existing subjects and auto-generated highlights before saving new ones.
     // This runs in the callback (not at dispatch time) so data is only deleted when
     // new results are ready to replace it — a failed dispatch won't cause data loss.
@@ -50,7 +70,7 @@ export async function handleProcessAgendaResult(taskId: string, response: Proces
     });
 
     await saveSubjectsForMeeting(
-        response.subjects,
+        subjects,
         task.councilMeeting.cityId,
         task.councilMeeting.id
     );


### PR DESCRIPTION
Closes #102

## What & why

A `processAgenda` task for a meeting whose agenda has no extractable subjects (e.g. λογοδοσία / accountability sessions) actually completes on the backend, but was recorded as **failed** in the admin UI.

It's not a display rule, and not the backend emitting an error. Tracing it (DeepWiki on both repos plus a Codex review) led to a crash in the callback result handler:

- `handleTaskUpdate` (`src/lib/tasks/tasks.ts`) maps a backend `success` callback to DB `succeeded`, then runs `handleProcessAgendaResult`. If that handler throws, the catch block flips the status to `failed`.
- `handleProcessAgendaResult` passed `response.subjects` straight to `saveSubjectsForMeeting`, which calls `subjects.flatMap(...)`. When the success payload carried no usable `subjects` array, that threw a `TypeError`, which got caught, and the task ended up recorded as `failed` even though the backend succeeded.

The backend's normal empty path returns `{ subjects: [] }` (confirmed via DeepWiki), and `saveSubjectsForMeeting([])` already handles that safely. The failing case is a success payload where `subjects` is missing or not an array.

## Changes

- `src/lib/tasks/processAgenda.ts` — `handleProcessAgendaResult` now guards on the shape of `response.subjects`:
  - Array (including `[]`): authoritative result, so delete + replace subjects as before. Zero subjects is a legitimate success.
  - Missing or not an array: malformed/partial payload, so log a warning, skip the destructive delete+save (don't silently wipe existing agenda data), and don't throw (task stays `succeeded`).
- `src/lib/tasks/__tests__/processAgendaEmptySubjects.test.ts` — new unit tests: `{ subjects: [] }` replaces subjects and resolves; `{}` (no `subjects` key) resolves without throwing and doesn't delete existing subjects.

No schema change, no UI change, no i18n strings added. The `status: 'error'` failure path is untouched, so genuine failures still surface as `failed`.

## Testing

- `npx jest src/lib/tasks/__tests__/processAgendaEmptySubjects.test.ts` — 2 pass.
- Reverting the handler change makes the malformed-payload test fail, so the test actually exercises the bug.
- `npx tsc --noEmit` — no new errors. Two pre-existing errors in `src/app/api/cities/[cityId]/meetings/route.ts` are unrelated and present on the base branch.
- CodeRabbit (`coderabbit --agent`): 0 findings.

## Risks / notes

- The fix lives entirely in this repo. The backend already returns `{ subjects: [] }` for empty agendas, so no backend change is needed for the reported bug. If a production success payload ever shows up with a missing `subjects` key, that's a backend contract violation worth a separate `opencouncil-tasks` issue, flagged rather than fixed here.
- Treating a missing `subjects` field as "succeed but skip deletion" (rather than defaulting to `[]` and deleting) is deliberate: a truncated callback won't wipe existing agenda data. If we'd rather such payloads be a hard failure, that should be an explicit `error` path. The current choice favors no data loss.
- Confined to `handleProcessAgendaResult`; it doesn't rewrite `saveSubjectsForMeeting` or its helpers, so it stays merge-compatible with #308 and #366, which touch the same subject-save area.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where a `processAgenda` task for an empty agenda (no extractable subjects) was incorrectly recorded as `failed` in the admin UI, because a missing or non-array `subjects` field in the success payload caused a `TypeError` that was caught and mapped to `failed`.

- **`processAgenda.ts`**: Adds an `Array.isArray` guard before the destructive delete+save path. An empty array is treated as an authoritative result (deletes and re-saves); a missing or non-array `subjects` field logs a warning and returns early, preserving existing data without throwing.
- **`processAgendaEmptySubjects.test.ts`**: New unit tests verify the two cases — empty array replaces subjects, missing `subjects` key resolves cleanly without touching the DB.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the result handler and does not alter the failure path or any other task type.

The guard is correct: Array.isArray reliably distinguishes a valid (including empty) subjects array from a missing/malformed field. The early return on malformed payloads avoids both the prior crash and any accidental data deletion. The subjects local variable introduced after the guard is a clean improvement over using response.subjects directly. The test file covers both branching outcomes with proper mock isolation. No schema, UI, or auth changes are involved.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/tasks/processAgenda.ts | Adds Array.isArray guard before destructive delete+save; gracefully handles missing subjects without throwing or wiping data. Logic is correct and well-commented. |
| src/lib/tasks/__tests__/processAgendaEmptySubjects.test.ts | New unit tests covering empty array and missing-subjects cases; mocks are properly scoped and clearAllMocks ensures isolation between tests. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tasks): treat empty agenda as a vali..."](https://github.com/schemalabz/opencouncil/commit/a1f8c3c9cb6da0d1519e8a648bdfd0f7721fe823) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36653693)</sub>

<!-- /greptile_comment -->