### PR TITLE
fix(dev): enable quick login on preview deployments

### DIFF
--- a/src/app/[locale]/(other)/profile/page.tsx
+++ b/src/app/[locale]/(other)/profile/page.tsx
@@ -14,7 +14,7 @@ export default async function ProfilePage() {
     return (
         <div className="container max-w-2xl py-8 space-y-8 !px-3 sm:!px-8">
             <h1 className="text-3xl font-bold">{t("title")}</h1>
-            <DevelopmentSection />
+            <DevelopmentSection isPreview={process.env.IS_PREVIEW === 'true'} />
             {user.onboarded && (user.isSuperAdmin || user.administers.length > 0) && <AdminSection user={user} t={t} />}
             <UserInfoForm user={user} isOnboarded={!!user.onboarded} />
         </div>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -40,7 +40,7 @@ export default async function LocaleLayout({
             {children}
 
             <Toaster />
-            {QuickLogin && <QuickLogin />}
+            {QuickLogin && <QuickLogin isPreview={process.env.IS_PREVIEW === 'true'} />}
             {MobilePreviewReporter && <MobilePreviewReporter />}
         </NextIntlClientProvider>
     );

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -6,8 +6,11 @@ import { routing } from '@/i18n/routing';
 import { notFound } from "next/navigation";
 import { Toaster } from "@/components/ui/toaster";
 
-// Only import in development — excluded from production bundles entirely
-const QuickLogin = process.env.NODE_ENV === 'development'
+// Only import in development or on preview deployments — excluded from real
+// production bundles entirely. Both branches use literal `process.env.X === '...'`
+// comparisons so the bundler can dead-code-eliminate QuickLogin when neither flag
+// is set (i.e. real production).
+const QuickLogin = process.env.NODE_ENV === 'development' || process.env.IS_PREVIEW === 'true'
     ? require("@/components/dev/QuickLogin").default
     : null;
 const MobilePreviewReporter = process.env.NODE_ENV === 'development'

--- a/src/app/api/dev/quick-login/route.ts
+++ b/src/app/api/dev/quick-login/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db/prisma'
 import { PrismaAdapter } from "@auth/prisma-adapter"
-import { IS_DEV } from '@/lib/utils'
+import { IS_DEV, DEV_TOOLS_ALLOWED } from '@/lib/utils'
 
 export async function POST(request: NextRequest) {
-  // Only allow in development environment
-  if (!IS_DEV) {
+  // Only allow in development or on preview deployments — never on real production
+  if (!DEV_TOOLS_ALLOWED) {
     return NextResponse.json({ error: 'Not allowed in production' }, { status: 403 })
   }
 
@@ -41,8 +41,10 @@ export async function POST(request: NextRequest) {
       })
     }
 
-    // Set the session cookie with the same name Next-Auth uses
-    // In dev, use port-specific cookie name to allow multiple instances
+    // Set the session cookie with the same name Next-Auth uses.
+    // In local dev, use a port-specific non-secure cookie to allow multiple instances.
+    // Previews run over HTTPS in production mode, so they use the secure cookie name
+    // (this intentionally keys off IS_DEV, not DEV_TOOLS_ALLOWED).
     const port = process.env.APP_PORT || '3000'
     const cookieName = !IS_DEV
       ? '__Secure-authjs.session-token'

--- a/src/app/api/dev/seed-test-users/route.ts
+++ b/src/app/api/dev/seed-test-users/route.ts
@@ -1,15 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import prisma from '@/lib/db/prisma'
 import { TEST_USERS } from '@/lib/dev/test-users'
-import { IS_DEV } from '@/lib/utils'
+import { DEV_TOOLS_ALLOWED } from '@/lib/utils'
 import { env } from '@/env.mjs'
 import { createUser } from '@/lib/db/users'
 
 const DEV_TEST_CITY_ID = env.DEV_TEST_CITY_ID
 
 export async function POST(request: NextRequest) {
-  // Only allow in development environment
-  if (!IS_DEV) {
+  // Only allow in development or on preview deployments — never on real production
+  if (!DEV_TOOLS_ALLOWED) {
     return NextResponse.json({ error: 'Not allowed in production' }, { status: 403 })
   }
 
@@ -129,8 +129,8 @@ export async function POST(request: NextRequest) {
 
 // Add a GET endpoint to check if test users exist
 export async function GET(request: NextRequest) {
-  // Only allow in development environment
-  if (!IS_DEV) {
+  // Only allow in development or on preview deployments — never on real production
+  if (!DEV_TOOLS_ALLOWED) {
     return NextResponse.json({ error: 'Not allowed in production' }, { status: 403 })
   }
 

--- a/src/components/dev/QuickLogin.tsx
+++ b/src/components/dev/QuickLogin.tsx
@@ -18,7 +18,7 @@ import { Badge } from "@/components/ui/badge"
 import { LogOut, Settings, User, Crown, EyeOff } from 'lucide-react'
 import { getTestUsersForDisplay } from '@/lib/dev/test-users'
 import { useQuickLoginVisibility } from '@/hooks/useQuickLoginVisibility'
-import { IS_DEV } from '@/lib/utils'
+import { DEV_TOOLS_ALLOWED, IS_PREVIEW } from '@/lib/utils'
 import MobilePreviewButton from '@/components/dev/MobilePreviewButton'
 
 // Get predefined test users from shared definition
@@ -153,8 +153,8 @@ export default function QuickLogin() {
     setMessage('') // Clear any messages
   }
 
-  // Only show in development
-  if (!IS_DEV) {
+  // Only show in development or on preview deployments
+  if (!DEV_TOOLS_ALLOWED) {
     return null
   }
 
@@ -176,7 +176,9 @@ export default function QuickLogin() {
           <div className="w-px bg-red-400/40 my-1.5" />
           <DialogTrigger asChild>
             <button className="flex items-center gap-2 px-3 py-1.5 hover:bg-red-700/50 transition-colors rounded-r-md">
-              <span className="text-[10px] font-bold bg-red-800 px-1.5 py-0.5 rounded">DEV</span>
+              <span className="text-[10px] font-bold bg-red-800 px-1.5 py-0.5 rounded">
+                {IS_PREVIEW ? 'PREVIEW' : 'DEV'}
+              </span>
               <span className="text-xs">Quick Login</span>
             </button>
           </DialogTrigger>
@@ -194,7 +196,7 @@ export default function QuickLogin() {
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Settings className="h-5 w-5 text-red-600" />
-            Development Quick Login
+            {IS_PREVIEW ? 'Preview Quick Login' : 'Development Quick Login'}
           </DialogTitle>
           <DialogDescription>
             Quickly switch between different user accounts for testing authorization scenarios. 

--- a/src/components/dev/QuickLogin.tsx
+++ b/src/components/dev/QuickLogin.tsx
@@ -18,13 +18,17 @@ import { Badge } from "@/components/ui/badge"
 import { LogOut, Settings, User, Crown, EyeOff } from 'lucide-react'
 import { getTestUsersForDisplay } from '@/lib/dev/test-users'
 import { useQuickLoginVisibility } from '@/hooks/useQuickLoginVisibility'
-import { DEV_TOOLS_ALLOWED, IS_PREVIEW } from '@/lib/utils'
+import { IS_DEV } from '@/lib/utils'
 import MobilePreviewButton from '@/components/dev/MobilePreviewButton'
 
 // Get predefined test users from shared definition
 const PREDEFINED_USERS = getTestUsersForDisplay()
 
-export default function QuickLogin() {
+// `isPreview` is passed from the server (layout.tsx reads process.env.IS_PREVIEW
+// at runtime). It can't be read here directly: IS_PREVIEW is not a NEXT_PUBLIC_
+// var and is only set at runtime by the preview systemd unit, so it's undefined
+// in the client bundle.
+export default function QuickLogin({ isPreview = false }: { isPreview?: boolean }) {
   const [isOpen, setIsOpen] = useState(false)
   const [email, setEmail] = useState('')
   const [isLoading, setIsLoading] = useState(false)
@@ -154,7 +158,7 @@ export default function QuickLogin() {
   }
 
   // Only show in development or on preview deployments
-  if (!DEV_TOOLS_ALLOWED) {
+  if (!(IS_DEV || isPreview)) {
     return null
   }
 
@@ -177,7 +181,7 @@ export default function QuickLogin() {
           <DialogTrigger asChild>
             <button className="flex items-center gap-2 px-3 py-1.5 hover:bg-red-700/50 transition-colors rounded-r-md">
               <span className="text-[10px] font-bold bg-red-800 px-1.5 py-0.5 rounded">
-                {IS_PREVIEW ? 'PREVIEW' : 'DEV'}
+                {isPreview ? 'PREVIEW' : 'DEV'}
               </span>
               <span className="text-xs">Quick Login</span>
             </button>
@@ -196,7 +200,7 @@ export default function QuickLogin() {
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Settings className="h-5 w-5 text-red-600" />
-            {IS_PREVIEW ? 'Preview Quick Login' : 'Development Quick Login'}
+            {isPreview ? 'Preview Quick Login' : 'Development Quick Login'}
           </DialogTitle>
           <DialogDescription>
             Quickly switch between different user accounts for testing authorization scenarios. 

--- a/src/components/profile/DevelopmentSection.tsx
+++ b/src/components/profile/DevelopmentSection.tsx
@@ -6,13 +6,17 @@ import { Switch } from "@/components/ui/switch"
 import { Badge } from "@/components/ui/badge"
 import { Settings, Eye, EyeOff } from "lucide-react"
 import { useQuickLoginVisibility } from "@/hooks/useQuickLoginVisibility"
-import { DEV_TOOLS_ALLOWED, IS_PREVIEW } from "@/lib/utils"
+import { IS_DEV } from "@/lib/utils"
 
-export function DevelopmentSection() {
+// `isPreview` is passed from the server (profile/page.tsx reads
+// process.env.IS_PREVIEW at runtime). It can't be read here directly: IS_PREVIEW
+// is not a NEXT_PUBLIC_ var and is only set at runtime by the preview systemd
+// unit, so it's undefined in the client bundle.
+export function DevelopmentSection({ isPreview = false }: { isPreview?: boolean }) {
   const { isVisible, isLoaded, toggle } = useQuickLoginVisibility()
 
   // Only show in development or on preview deployments
-  if (!DEV_TOOLS_ALLOWED) {
+  if (!(IS_DEV || isPreview)) {
     return null
   }
 
@@ -28,7 +32,7 @@ export function DevelopmentSection() {
           <Settings className="h-5 w-5 text-red-600" />
           Development Tools
           <Badge variant="secondary" className="bg-red-100 text-red-800 text-xs">
-            {IS_PREVIEW ? 'PREVIEW ONLY' : 'DEV ONLY'}
+            {isPreview ? 'PREVIEW ONLY' : 'DEV ONLY'}
           </Badge>
         </CardTitle>
       </CardHeader>

--- a/src/components/profile/DevelopmentSection.tsx
+++ b/src/components/profile/DevelopmentSection.tsx
@@ -6,13 +6,13 @@ import { Switch } from "@/components/ui/switch"
 import { Badge } from "@/components/ui/badge"
 import { Settings, Eye, EyeOff } from "lucide-react"
 import { useQuickLoginVisibility } from "@/hooks/useQuickLoginVisibility"
-import { IS_DEV } from "@/lib/utils"
+import { DEV_TOOLS_ALLOWED, IS_PREVIEW } from "@/lib/utils"
 
 export function DevelopmentSection() {
   const { isVisible, isLoaded, toggle } = useQuickLoginVisibility()
 
-  // Only show in development
-  if (!IS_DEV) {
+  // Only show in development or on preview deployments
+  if (!DEV_TOOLS_ALLOWED) {
     return null
   }
 
@@ -28,7 +28,7 @@ export function DevelopmentSection() {
           <Settings className="h-5 w-5 text-red-600" />
           Development Tools
           <Badge variant="secondary" className="bg-red-100 text-red-800 text-xs">
-            DEV ONLY
+            {IS_PREVIEW ? 'PREVIEW ONLY' : 'DEV ONLY'}
           </Badge>
         </CardTitle>
       </CardHeader>

--- a/src/lib/__tests__/dev-tools-allowed.test.ts
+++ b/src/lib/__tests__/dev-tools-allowed.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for the dev-tooling gate (issue #250).
+ *
+ * IS_DEV / IS_PREVIEW / DEV_TOOLS_ALLOWED are evaluated at module load time from
+ * process.env, so each case sets env vars and re-imports the module in isolation.
+ */
+
+describe('DEV_TOOLS_ALLOWED gate', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    const originalIsPreview = process.env.IS_PREVIEW;
+
+    afterEach(() => {
+        // Restore original env
+        (process.env as Record<string, string | undefined>).NODE_ENV = originalNodeEnv;
+        process.env.IS_PREVIEW = originalIsPreview;
+        jest.resetModules();
+    });
+
+    const loadFlags = () => {
+        let flags!: typeof import('../utils');
+        jest.isolateModules(() => {
+            flags = require('../utils');
+        });
+        return flags;
+    };
+
+    it('is false on real production (no flags set)', () => {
+        (process.env as Record<string, string | undefined>).NODE_ENV = 'production';
+        delete process.env.IS_PREVIEW;
+        const { IS_DEV, IS_PREVIEW, DEV_TOOLS_ALLOWED } = loadFlags();
+        expect(IS_DEV).toBe(false);
+        expect(IS_PREVIEW).toBe(false);
+        expect(DEV_TOOLS_ALLOWED).toBe(false);
+    });
+
+    it('is true on preview deployments (production + IS_PREVIEW=true)', () => {
+        (process.env as Record<string, string | undefined>).NODE_ENV = 'production';
+        process.env.IS_PREVIEW = 'true';
+        const { IS_DEV, IS_PREVIEW, DEV_TOOLS_ALLOWED } = loadFlags();
+        expect(IS_DEV).toBe(false);
+        expect(IS_PREVIEW).toBe(true);
+        expect(DEV_TOOLS_ALLOWED).toBe(true);
+    });
+
+    it('is true in local development', () => {
+        (process.env as Record<string, string | undefined>).NODE_ENV = 'development';
+        delete process.env.IS_PREVIEW;
+        const { IS_DEV, DEV_TOOLS_ALLOWED } = loadFlags();
+        expect(IS_DEV).toBe(true);
+        expect(DEV_TOOLS_ALLOWED).toBe(true);
+    });
+
+    it('treats any non-"true" IS_PREVIEW value as disabled', () => {
+        (process.env as Record<string, string | undefined>).NODE_ENV = 'production';
+        process.env.IS_PREVIEW = '1';
+        const { IS_PREVIEW, DEV_TOOLS_ALLOWED } = loadFlags();
+        expect(IS_PREVIEW).toBe(false);
+        expect(DEV_TOOLS_ALLOWED).toBe(false);
+    });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -41,6 +41,12 @@ export {
 
 export const IS_DEV = process.env.NODE_ENV === 'development';
 
+// Preview deployments run with NODE_ENV=production but set IS_PREVIEW=true
+// (see flake.nix opencouncil-preview@ service). Dev tooling such as Quick Login
+// is allowed in local dev OR on previews, but never on real production.
+export const IS_PREVIEW = process.env.IS_PREVIEW === 'true';
+export const DEV_TOOLS_ALLOWED = IS_DEV || IS_PREVIEW;
+
 export const SUBJECT_POINT_COLOR = '#E57373'; // A nice red color that contrasts with the blue city polygons
 
 export const UNKNOWN_SPEAKER_LABEL = "Άγνωστος Ομιλητής";


### PR DESCRIPTION
Closes #250

## What & why

Reviewers can't log in as admin / city admin / other roles on PR preview deployments (`pr-N.preview.opencouncil.gr`). The Quick Login dev tool and its API routes are gated on `IS_DEV` (`NODE_ENV === 'development'`), but previews are production builds (`NODE_ENV=production`), so the tool never renders and the APIs return 403. That's exactly the role-based QA the issue asks for, and right now it's blocked.

## How this differs from #262

#262 was closed pending discussion, and the approach there detected previews by string-matching `*.preview.*` inside `NEXTAUTH_URL`. This PR reuses the existing `IS_PREVIEW=true` env var instead — the preview systemd service already sets it, and `src/lib/email/resend.ts` already reads it (it went in for the email-redirect feature). So no new env var, no brittle URL parsing, and no `flake.nix` / `env.mjs` / `.env.example` changes. The plumbing is already in the tree.

It also tries to answer your open question from the issue thread ("are there any downsides?") — see the security tradeoff section below.

## Changes

- `src/lib/utils.ts` — add `IS_PREVIEW` and `DEV_TOOLS_ALLOWED = IS_DEV || IS_PREVIEW` next to `IS_DEV`.
- `src/app/[locale]/layout.tsx` — load `QuickLogin` when `NODE_ENV === 'development'` OR `IS_PREVIEW === 'true'`. Both stay literal `process.env.X` comparisons so the bundler still dead-code-eliminates QuickLogin on real production.
- `src/components/dev/QuickLogin.tsx` — gate on `DEV_TOOLS_ALLOWED`; show a PREVIEW badge and "Preview Quick Login" title on previews.
- `src/components/profile/DevelopmentSection.tsx` — gate on `DEV_TOOLS_ALLOWED`; PREVIEW ONLY badge on previews.
- `src/app/api/dev/quick-login/route.ts` and `src/app/api/dev/seed-test-users/route.ts` — guard with `DEV_TOOLS_ALLOWED`. The HTTPS secure-cookie logic in `quick-login` stays keyed on `IS_DEV`, since previews are HTTPS and need the secure cookie name like production does.
- `src/lib/__tests__/dev-tools-allowed.test.ts` — unit tests for the gate.

`MobilePreviewReporter`, `seed-users`, `mobile-preview`, and `lan-info` stay `IS_DEV`-only, since they're LAN/HMR dev features that don't make sense on remote previews.

## Testing

- `npx jest src/lib/__tests__/dev-tools-allowed.test.ts` — 4/4 pass (false on production, true on preview, true in dev, false for a non-`"true"` value).
- `npx tsc --noEmit` — no new errors. Two pre-existing errors in `cities/[cityId]/meetings/route.ts` are unrelated and untouched.
- Manual QA scenarios in the QA doc, including one that confirms Quick Login is absent and stripped from the bundle on a production build.

## Security tradeoff (the "any downsides?" answer)

- On previews, Quick Login lets anyone with the URL log in as super-admin against the shared staging DB. I think that's acceptable: previews are non-production and already expose staging data and dev tooling (the email redirect, for one). Test-user emails are confined to the known `*@test.com` set, and the staging DB is PII-free. The task-server integration is also off by default unless a preview is explicitly wired to an opencouncil-tasks preview.
- Real production is protected by two independent layers: it sets neither `NODE_ENV=development` nor `IS_PREVIEW=true`, so QuickLogin is dead-code-eliminated from the bundle and the API routes return 403.
- The one residual risk: if someone manually set `IS_PREVIEW=true` on the production host, Quick Login would activate. That flag is only ever set by the preview systemd unit, and production uses a separate deployment path, so this leans on deployment hygiene rather than hard-coding a production domain into the code. I left out an optional hardening (reject when `NEXTAUTH_URL` is the production domain) to keep the change small, but happy to add it if you'd rather have the belt-and-suspenders version.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables the Quick Login dev tool on preview deployments (`pr-N.preview.opencouncil.gr`) by introducing `IS_PREVIEW` and `DEV_TOOLS_ALLOWED` constants and threading `isPreview` as a boolean prop from server components down to the two client components that gate the UI.

- `src/lib/utils.ts` gains `IS_PREVIEW` and `DEV_TOOLS_ALLOWED`; API routes swap their `IS_DEV` guards for `DEV_TOOLS_ALLOWED` (server-side, so `process.env.IS_PREVIEW` is readable at runtime).
- `QuickLogin.tsx` and `DevelopmentSection.tsx` receive `isPreview` as a serialized prop from their respective server-side parents (`layout.tsx`, `profile/page.tsx`) instead of reading the env var directly — correctly working around the `NEXT_PUBLIC_` requirement for client bundles.
- Unit tests cover production, preview, dev, and non-`"true"` values for the gate.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is well-scoped to dev tooling, real production is protected by two independent gates (neither NODE_ENV=development nor IS_PREVIEW=true is set there), and the client-bundle env-var limitation is correctly handled via server-to-client prop passing.

The implementation correctly threads isPreview as a serialized prop from server components to client components, avoiding the NEXT_PUBLIC_ requirement. API route guards are enforced server-side via DEV_TOOLS_ALLOWED. The secure-cookie logic intentionally stays keyed on IS_DEV (previews run over HTTPS). Tests cover all four gate combinations with proper module isolation. No logic errors or security regressions found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/utils.ts | Adds IS_PREVIEW and DEV_TOOLS_ALLOWED exports alongside IS_DEV; straightforward and correct. |
| src/app/[locale]/layout.tsx | Server component reads process.env.IS_PREVIEW at runtime and passes it as a prop to QuickLogin; dynamic require guard extended with the IS_PREVIEW branch. |
| src/components/dev/QuickLogin.tsx | Correctly uses IS_DEV (NODE_ENV-based, available client-side) combined with the isPreview prop; does not attempt to read IS_PREVIEW directly in the client bundle. |
| src/components/profile/DevelopmentSection.tsx | Same correct pattern as QuickLogin; isPreview prop from server, IS_DEV from bundle-inlined NODE_ENV. |
| src/app/api/dev/quick-login/route.ts | Guard updated to DEV_TOOLS_ALLOWED; secure cookie logic intentionally kept on IS_DEV (correct, previews are HTTPS). |
| src/app/api/dev/seed-test-users/route.ts | Both POST and GET handlers updated to DEV_TOOLS_ALLOWED; no other changes. |
| src/lib/__tests__/dev-tools-allowed.test.ts | Covers all four gate combinations; uses jest.isolateModules for correct module-reload behavior. |
| src/app/[locale]/(other)/profile/page.tsx | Server component correctly passes IS_PREVIEW env var as isPreview prop to DevelopmentSection. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(dev): pass IS\_PREVIEW from server so..."](https://github.com/schemalabz/opencouncil/commit/0690c48cafd66808f373fb5506c8d3171c97b0f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36655958)</sub>

<!-- /greptile_comment -->