### PR TITLE
docs: add PRODUCT.md and DESIGN.md design context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 .claude/launch.json
 .claude/worktrees/
 
+# Impeccable design-skill local state (sidecar, live-mode sessions)
+.impeccable/
+
 # dependencies
 /node_modules
 /.pnp

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,277 @@
+---
+name: OpenCouncil
+description: Open-source platform making Greek municipal council meetings transparent, searchable, and understandable.
+colors:
+  civic-flame: "#ff6600"
+  flame-deep: "#fc550a"
+  marble-blue: "#a4c0e1"
+  ink: "#0c0a09"
+  graphite: "#1c1917"
+  ink-soft: "#78716c"
+  stone-mist: "#f5f5f4"
+  cloud-border: "#e7e5e4"
+  paper: "#ffffff"
+  paper-warm: "#fafaf9"
+  signal-red: "#ef4444"
+typography:
+  headline:
+    fontFamily: "Relative Book Pro, Inter, sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: "-0.025em"
+  title:
+    fontFamily: "Relative Book Pro, Inter, sans-serif"
+    fontSize: "1.125rem"
+    fontWeight: 500
+    lineHeight: 1.4
+  body:
+    fontFamily: "Relative Book Pro, Inter, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.5
+  label:
+    fontFamily: "Relative Book Pro, Inter, sans-serif"
+    fontSize: "0.875rem"
+    fontWeight: 500
+    lineHeight: 1.4
+  transcript:
+    fontFamily: "Roboto, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.5
+  mono:
+    fontFamily: "Roboto Mono, monospace"
+    fontSize: "0.875rem"
+    fontWeight: 400
+rounded:
+  none: "0px"
+  card: "8px"
+  xl: "12px"
+  full: "9999px"
+spacing:
+  sm: "8px"
+  md: "16px"
+  lg: "24px"
+components:
+  button-primary:
+    backgroundColor: "{colors.civic-flame}"
+    textColor: "{colors.paper}"
+    typography: "{typography.label}"
+    rounded: "{rounded.none}"
+    padding: "8px 16px"
+    height: "40px"
+  button-secondary:
+    backgroundColor: "{colors.marble-blue}"
+    textColor: "{colors.graphite}"
+    typography: "{typography.label}"
+    rounded: "{rounded.none}"
+    padding: "8px 16px"
+    height: "40px"
+  button-outline:
+    backgroundColor: "{colors.paper}"
+    textColor: "{colors.ink}"
+    typography: "{typography.label}"
+    rounded: "{rounded.none}"
+    padding: "8px 16px"
+    height: "40px"
+  button-link:
+    backgroundColor: "transparent"
+    textColor: "{colors.civic-flame}"
+    typography: "{typography.label}"
+  badge:
+    backgroundColor: "{colors.graphite}"
+    textColor: "{colors.paper-warm}"
+    rounded: "{rounded.full}"
+    padding: "2px 10px"
+  input:
+    backgroundColor: "{colors.paper}"
+    textColor: "{colors.ink}"
+    typography: "{typography.label}"
+    rounded: "{rounded.none}"
+    padding: "8px 12px"
+    height: "40px"
+  card:
+    backgroundColor: "{colors.paper}"
+    rounded: "{rounded.card}"
+    padding: "24px"
+---
+
+# Design System: OpenCouncil
+
+## 1. Overview
+
+OpenCouncil is a transparency platform for Greek municipal council meetings. The interface exists to present a public record — verbatim transcripts, votes, and decisions — with minimal friction. The record is the content; the UI is a neutral container for it.
+
+The visual system is built on white surfaces, a warm-stone neutral ramp, sharp (square) corners by default, and plain typography. It uses a single saturated accent — Civic Flame orange (`--orange: 24 100% 50%`) — applied only to primary actions, links, inline emphasis, and live/highlight moments. One sanctioned gradient (Civic Flame → Marble Blue) is reserved for thin borders and brand moments; it is never used on text or as a surface fill.
+
+Design intent: high information density is acceptable; decoration is not. AI-generated content (summaries, subject extraction) is always visually labeled and rendered subordinate to the verbatim record.
+
+The system deliberately avoids three reference styles:
+- **Government-portal style** — dense menus, PDF-first layouts, institutional gray-blue, legalese-heavy walls of text.
+- **Generic SaaS style** — purple gradients, hero metrics, repeated identical card grids.
+- **Campaign style** — many competing colors, banners, and pervasive urgency cues.
+
+**Key characteristics:**
+- White surfaces (`--background`/`--card`) over a warm-stone neutral ramp; sharp corners by default (`--radius: 0rem`).
+- One saturated accent (Civic Flame), used sparingly at decisive moments only.
+- One sanctioned gradient (Civic Flame → Marble Blue) for thin borders and brand moments.
+- Three typographic roles with fixed jobs: UI chrome (Relative Book Pro), the record (Roboto), timestamps (Roboto Mono).
+- Flat-leaning surfaces; soft shadows signal interactivity, not decoration.
+- WCAG 2.1 AA: ≥4.5:1 body-text contrast, visible focus rings, reduced-motion alternatives.
+
+The component register in one line: **square, plain, exact controls, with the orange accent and brand gradient reserved for primary actions and hover states.**
+
+## 2. Colors: Civic Flame & Marble Blue
+
+A restrained warm-stone neutral field with one hot accent and one cool counterweight.
+
+### Primary
+- **Civic Flame** (#ff6600, `--orange: 24 100% 50%`): Democratic energy. Primary action buttons, link-style buttons, highlight moments. This is the citizen's voice made visible — and its rarity is what keeps it loud.
+- **Civic Flame Deep** (#fc550a, `--gradient-orange: 16 97% 52%`): The hotter end of the brand gradient. Inline emphasis (`em` renders in this color), the 15%-opacity highlight tint on targeted transcript utterances, and the gradient's hot endpoint. Never a standalone surface fill.
+
+### Secondary
+- **Marble Blue** (#a4c0e1, `--accent: 212 50% 76%`): Institutional calm, like veined marble in a public building. Secondary buttons, subtle hover tints (10% opacity washes on outline buttons), and the cool endpoint of the brand gradient (the card and gradient-button components hardcode the literal #a4c0e1). It cools the flame; it never competes with it. Note: `--gradient-blue: 213 49% 73%` (≈#98b7dc) is defined in `globals.css` but currently unused by any component — treat `--accent` as the canonical Marble Blue token.
+
+### Neutral
+- **Ink** (#0c0a09, `--foreground`): Body text and focus rings. Warm near-black, never pure black.
+- **Graphite** (#1c1917, `--primary`): Dark fills — default badges, the skip-link, primary-on-dark contexts.
+- **Soft Ink** (#78716c, `--muted-foreground`): Secondary text, placeholders, captions. Passes 4.5:1 on white; do not lighten it further.
+- **Stone Mist** (#f5f5f4, `--secondary` / `--muted`): Quiet panel and chip backgrounds; the second neutral layer behind sidebars and toolbars (sidebar uses #fafafa).
+- **Cloud Border** (#e7e5e4, `--border` / `--input`): Hairline borders and input strokes. The structural line of the whole system.
+- **Paper** (#ffffff, `--background` / `--card`): The default surface. The glass walls are white.
+- **Warm Paper** (#fafaf9, `--primary-foreground`): Text on dark fills.
+- **Signal Red** (#ef4444, `--destructive`): Destructive actions and errors only. Never decorative.
+
+The canonical source of truth is the HSL custom-property set in `src/app/globals.css` (shadcn/stone convention, consumed as `hsl(var(--token))` via `tailwind.config.ts`). The hex values above are their sRGB equivalents.
+
+### Named Rules
+**The Civic Flame Rule.** Orange appears only where the citizen acts or the record demands attention: primary buttons, links, live emphasis, highlights. It never tints backgrounds, borders-at-rest, icons-by-default, or any inactive state. If orange covers more than ~10% of a screen, the screen is wrong.
+
+**The One Gradient Rule.** Exactly one gradient exists: Civic Flame Deep → Marble Blue (→ back to flame). It is permitted on 1–1.5px borders (card hover, the gradient button outline) and brand moments — never on text, never as a surface fill, never as a third color scheme.
+
+## 3. Typography
+
+**UI Font:** Relative Book Pro (with Inter variable as loaded fallback)
+**Record Font:** Roboto (variable, 100–900)
+**Mono Font:** Roboto Mono (timestamps, code)
+
+**Character:** A plain-spoken civic voice. Relative Book Pro gives the interface a slightly characterful, humanist warmth at a single weight; Roboto renders the verbatim record with newspaper neutrality; Roboto Mono timestamps it with archival precision.
+
+### Hierarchy
+- **Headline** (600, 1.5rem / 24px, 1.2, -0.025em): Card titles and section headings (`text-2xl font-semibold tracking-tight`). Page-level `h2` defaults to 24px regular, centered.
+- **Title** (500, 1.125rem / 18px, 1.4): Sub-headings, header breadcrumb on desktop.
+- **Body** (400, 1rem / 16px, 1.5): Default prose. Cap prose at 65–75ch; data tables may run denser.
+- **Label** (500, 0.875rem / 14px): Buttons, inputs, navigation, form labels — the working size of the product UI. Badges drop to 12px semibold.
+- **Transcript** (Roboto 400, 1rem, 1.5): The public record itself (`.transcript-text`). Optimized for long-form reading with native content-visibility virtualization.
+- **Mono** (Roboto Mono 400, 0.875rem): Timestamps, IDs, code.
+
+### Named Rules
+**The Two Voices Rule.** The interface speaks Relative Book Pro; the record speaks Roboto. Never set transcript text in the UI font, and never set UI chrome in Roboto. The font switch IS the trust boundary between platform and record.
+
+**The Fixed Scale Rule.** Product surfaces use the fixed rem scale above — no fluid/clamp typography outside marketing pages. A heading that resizes with the viewport has no place in a transcript reader.
+
+## 4. Elevation
+
+Quiet ambient lift. Surfaces are flat-leaning, but shadows are soft and meaningful: interactive things sit slightly above the page to signal they can be touched. Cards rest at a whisper (`shadow-sm`); buttons carry a touch more presence (`shadow-md`); overlays (dialogs, popovers, dropdowns) earn the largest shadows because they are literally above the page. Depth is never used to decorate static content — structure at rest comes from Cloud Border hairlines and spacing.
+
+### Shadow Vocabulary
+Each role maps to the Tailwind class the codebase actually uses:
+
+- **Whisper** (`shadow-sm`, `box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05)`): Cards and resting containers.
+- **Lift** (`shadow-md`, `box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)`): Primary and secondary buttons; elements inviting touch.
+- **Float** (`shadow-lg`, `box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)`): Overlays only — dialogs, dropdowns, popovers, toasts.
+
+### Named Rules
+**The Touchable Lift Rule.** A shadow is a promise of interactivity. If an element casts more than a whisper and isn't clickable, remove the shadow.
+
+## 5. Layout & Breakpoints
+
+A single mobile-first breakpoint scale, defined in `tailwind.config.ts`. Screens are designed for the citizen on a phone first; wider viewports add room, never new structure.
+
+### Breakpoints
+- **xs** (480px): Large phones — the smallest width that earns layout changes beyond the base.
+- **sm** (640px): Landscape phones / small tablets.
+- **md** (768px): Tablets — the breakpoint where sidebars and breadcrumbs expand (e.g. header links scale 14→18px).
+- **lg** (1024px): Small laptops — the primary desktop target for the journalist workflow.
+- **xl** (1280px): Standard desktop.
+- **2xl** (1536px): Large desktop.
+
+### Container
+The centered `container` pads at **2rem** and caps its width at **1400px** from the `2xl` breakpoint up — content stops widening before the viewport does, so the record never sprawls into unreadable line lengths on large monitors. (Note: the container's `2xl` cap of 1400px is intentionally below the `2xl` *screen* value of 1536px.)
+
+### Named Rules
+**The Mobile-First Rule.** Design the base (phone) layout first; every breakpoint above only adds. The least-technical citizen on a phone is the primary reader, per PRODUCT.md — a screen that only works at `lg` has failed its first audience.
+
+**The Capped Measure Rule.** Wide viewports gain margin, not measure. Combined with the 65–75ch prose cap (§3), the 1400px container keeps the record legible from phone to 4K.
+
+## 6. Iconography
+
+**Canonical set: [Lucide](https://lucide.dev) (`lucide-react`).** Clean, geometric, single-weight line icons that match the system's quiet-precision register without competing with Civic Flame. `react-icons` also appears in the codebase for a few brand/legacy glyphs, but Lucide is the default — new screens should reach for it first.
+
+- **Style:** Line icons at the inherited stroke; default to the text color of their context (`currentColor`), not a standalone accent. Icons are chrome, not action — an icon turns Civic Flame only when it *is* the primary action (per The Civic Flame Rule, §2).
+- **Sizing:** Match the optical size of adjacent Label text (≈16px in 14px UI contexts); never larger than the text they accompany unless the icon is the sole content of a touch target.
+- **Touch targets:** Icon-only buttons still honor the 40px minimum (§7 Buttons / accessibility) — pad the hit area, don't grow the glyph.
+
+### Named Rules
+**The One Icon Set Rule.** Lucide is the system's voice for icons; don't mix in a second line-icon library. Consistency of stroke and corner is part of "quiet precision" — a stray icon set reads as clutter the same way a third accent color does.
+
+## 7. Components
+
+Square, plain, exact — with warmth reserved for action and hover.
+
+### Buttons
+- **Shape:** Sharp corners (0px — the radius token is `0rem`); only the oversized `xl` marketing button earns 12px.
+- **Primary:** Civic Flame fill (#ff6600), white label (14px / 500), 40px tall, 16px horizontal padding, Lift shadow.
+- **Hover / Focus:** Hover dims the fill to 90% opacity (150ms color transition); focus shows a 2px Ink ring offset 2px from the edge. Disabled drops to 50% opacity.
+- **Secondary:** Marble Blue fill, Graphite label, same geometry and shadow.
+- **Outline:** Paper background, 1px Cloud Border, hover washes Marble Blue at 10%.
+- **Ghost / Link:** Ghost is transparent until hover; Link is Civic Flame text with underline on hover.
+- **Gradient (brand moments only):** Paper fill wrapped in a 1px animated Civic Flame → Marble Blue border. Subject to The One Gradient Rule.
+
+### Badges
+- **Style:** Full-round pill, 12px semibold, 10px horizontal padding.
+- **Variants:** Default Graphite fill with Warm Paper text; secondary Stone Mist; destructive Signal Red; outline transparent with Ink text. AI-generated content always carries its dedicated AI badge — fidelity labeling is non-negotiable.
+
+### Cards / Containers (signature component)
+- **Corner Style:** 8px by default; some featured and marketing cards use 12px (`rounded-xl`).
+- **Background:** Paper, framed by a 1.5px gradient border that rests as quiet gray (gray-300 → gray-200 → gray-300).
+- **Hover:** The resting gray border ignites into the animated Civic Flame → Marble Blue gradient (300ms ignition; the card's inline animation loops at 5s, while the gradient button runs the same `gradientFlow` keyframes at 3s via `animate-gradientFlow`) — the system's signature warm moment.
+- **Shadow Strategy:** Whisper at rest (see Elevation).
+- **Internal Padding:** 24px (`p-6`) headers and content.
+
+### Inputs / Fields
+- **Style:** 40px tall, sharp corners, 1px Cloud Border stroke on Paper, 14px text, 12px horizontal padding.
+- **Focus:** 2px Ink ring offset 2px — the same focus vocabulary as buttons, everywhere.
+- **Placeholder:** Soft Ink. **Error / Disabled:** Signal Red border via form-message context; disabled at 50% opacity with `not-allowed` cursor.
+
+### Navigation
+- **Header:** Breadcrumb path with municipality logos, Label-size links (scaling 14→18px across breakpoints), `hover:text-primary` color transition, chevron separators. Auto-scrolling title for long Greek meeting names.
+- **Sidebar:** Second neutral layer (#fafafa) with its own muted token set; collapses on mobile via the sidebar trigger.
+- **Skip link:** First focusable element, Graphite fill — accessibility is part of the navigation design, not an afterthought.
+
+### The Transcript Surface (signature component)
+The record itself: Roboto at 16px/1.5, speaker segments with sticky headers, utterances with `scroll-margin-top: 25vh` so deep links land below the sticky chrome, and `content-visibility: auto` for native virtualization of hours-long meetings. Timestamps in Roboto Mono. The transcript page is the purest expression of the Glass Town Hall: maximum record, minimum building.
+
+### Named Rules
+**The Sharp Default Rule.** Corners are square unless a shape earns curvature: cards (8px, or 12px for featured cards), pills (full), the xl marketing button (12px). Nothing else rounds.
+
+## 8. Do's and Don'ts
+
+### Do:
+- **Do** spend the flame palette (#ff6600 / #fc550a) only on primary actions, links, inline emphasis, and highlights — rarity is the point.
+- **Do** keep the record verbatim and visually distinct: Roboto for transcript text, Roboto Mono for timestamps, and an explicit AI badge on every AI-generated summary or categorization.
+- **Do** use the same focus vocabulary everywhere: 2px Ink ring, 2px offset, on every interactive element.
+- **Do** hold body text at ≥4.5:1 contrast (Ink or Soft Ink on Paper — nothing lighter than #78716c).
+- **Do** ship every interactive component with default, hover, focus-visible, and disabled states, and provide `prefers-reduced-motion` alternatives for the gradient-flow and marquee animations.
+- **Do** design for the least-technical citizen: 40px+ touch targets, plain Greek before civic jargon, one obvious action per screen.
+
+### Don't:
+- **Don't** use bureaucratic portal patterns — no dense nested menus, PDF-first layouts, institutional gray-blue, or walls of unbroken administrative text.
+- **Don't** use marketing-site patterns — no decorative gradients, oversized hero metrics, or repeated identical card grids.
+- **Don't** use urgency or clutter patterns — no stacked banners, no persistent urgency cues, and no third accent color.
+- **Don't** put the brand gradient on text or surface fills; it lives on thin borders and brand moments only (The One Gradient Rule).
+- **Don't** use `border-left` stripes thicker than 1px as colored accents on cards, callouts, or alerts.
+- **Don't** round corners outside the sanctioned set (0 / 8px cards / 12px featured cards and xl buttons / full pills), and don't introduce new shadows outside Whisper/Lift/Float.
+- **Don't** color inactive states — orange and Marble Blue belong to action and selection, never to resting chrome.
+- **Don't** add decorative motion in the product register: motion conveys state (hover ignition, accordion, loading) in 150–300ms; no orchestrated page-load choreography.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,49 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+OpenCouncil serves three audiences, in priority order:
+
+1. **Citizens** — residents of Greek municipalities who want to know what their council decided and why. They arrive from a search result, a shared link, or a notification; they are not trained users and may visit once a month or once a year. Many are older, on mobile, and reading Greek.
+2. **Journalists & civic watchdogs** — power users who search across meetings, follow specific people, parties, and topics, and need to cite the record precisely (timestamps, word-for-word transcripts, links to official Diavgeia publications).
+3. **Municipal staff & council members** — administrators who manage meetings, review transcripts, correct speaker attribution, and release content to the public.
+
+The job to be done on any given screen: *find what was said, who said it, and what it means* — with the least possible friction between a citizen and the public record.
+
+## Product Purpose
+
+OpenCouncil digitizes, transcribes, and makes municipal council meetings searchable, helping citizens engage with their local government. It is built by Schema Labs, a non-profit building technology to strengthen democracy. The platform turns hours of council video into word-for-word transcripts with speaker recognition, AI summaries, subject categorization, full-text search, personalized notifications, and shareable highlights — all open-source, with open data via a public API.
+
+Success looks like: a citizen finds the exact moment their street was discussed in under a minute; a journalist quotes the record with confidence; a municipality trusts the platform enough to make it their official record of proceedings.
+
+## Brand Personality
+
+**Civic, trustworthy, approachable.**
+
+A serious public-interest tool that ordinary citizens can use without training — credible but warm. The voice is plain-spoken Greek (and English), never bureaucratic, never breathless. The interface should feel like a well-run public institution staffed by people who actually want you there: rigorous about the record, generous in how it explains it. AI-generated content (summaries, categorization) is always clearly labeled and subordinate to the verbatim record.
+
+## Anti-references
+
+Visual patterns OpenCouncil must avoid:
+
+- **Bureaucratic portal density** — dense nested menus, PDF-first layouts, institutional gray-blue palettes, and walls of unbroken administrative text. These patterns make public records hard to access; OpenCouncil exists to make them legible.
+- **Marketing-site gloss** — decorative gradients, oversized hero metrics, repeated identical card grids, and conversion-funnel landing patterns. OpenCouncil is civic infrastructure, not a growth product.
+- **Visual urgency and clutter** — stacked banners, multiple competing accent colors, and persistent urgency cues. OpenCouncil communicates through accuracy and clarity, not visual volume.
+
+## Design Principles
+
+1. **The record is the interface.** Transcripts, votes, and decisions are the content; the UI recedes so the public record can carry the weight. Density is acceptable; decoration is not.
+2. **Trust through fidelity.** Word-for-word comes first; AI assistance (summaries, subject extraction) is clearly labeled, never silently blended into the verbatim record. Timestamps, sources, and Diavgeia links are first-class.
+3. **Every citizen, not just the engaged ones.** Screens must work for a 70-year-old on a phone as well as a journalist on a desktop. Plain language over civic jargon; one obvious action per screen.
+4. **Earned familiarity.** Use standard, well-understood affordances (search, tabs, lists, players). Novelty spends trust this product cannot afford.
+5. **Warmth in moments, rigor everywhere.** The orange identity shows up at decisive moments (primary actions, highlights, the brand) — not spread across every surface.
+
+## Accessibility & Inclusion
+
+- **WCAG 2.1 AA** is the commitment: ≥4.5:1 body-text contrast, full keyboard navigation, visible focus states, reduced-motion alternatives for every animation.
+- Multilingual by architecture (next-intl); Greek is the primary locale, English second, with more languages planned for multicultural cities.
+- Audiences skew broad in age and technical ability — touch targets, font sizes, and reading level should assume the least-technical citizen, not the median SaaS user.


### PR DESCRIPTION
## Summary

Adds two root-level design context documents so contributors and AI agents building new screens stay on-brand:

- **PRODUCT.md** — the strategic layer: register (`product`), users (citizens → journalists → municipal staff), product purpose, brand personality ("civic, trustworthy, approachable"), explicit anti-references, five design principles, and the WCAG 2.1 AA accessibility commitment.
- **DESIGN.md** — the visual layer, based on the [Google Stitch DESIGN.md format](https://stitch.withgoogle.com/docs/design-md/format/): machine-readable design tokens in YAML frontmatter (11 colors, 6 typography roles, radii, spacing, 7 component specs) followed by a prose body (Overview, Colors, Typography, Elevation, Layout & Breakpoints, Iconography, Components, Do's and Don'ts — the Layout and Iconography sections are additions to the base six-section Stitch layout, per review).

Also adds `.impeccable/` to `.gitignore` — local tooling state (a derived sidecar and live-mode session journals) regenerated from DESIGN.md.

## What DESIGN.md captures

Both documents describe the system **as it exists in code today** (`globals.css`, `tailwind.config.ts`, `src/components/ui`), not an aspirational redesign. The notable codifications:

- **Named color roles**: Civic Flame (`#ff6600`, `--orange`) as the sole hot accent; Marble Blue (`#a4c0e1`, `--accent`) as its cool counterweight; the warm-stone shadcn neutral ramp.
- **The One Gradient Rule**: the orange→blue gradient is sanctioned only on thin borders (the card hover "ignition") and brand moments — never text, never fills.
- **The Two Voices Rule**: Relative Book Pro for UI chrome, Roboto for the verbatim record, Roboto Mono for timestamps — the font switch marks the trust boundary between platform and record.
- **The Sharp Default Rule**: `--radius: 0rem` means square corners by doctrine; only cards (8px, 12px for featured cards), pills (full), and the xl button (12px) earn curvature.
- Mobile-first breakpoints with the 1400px container cap, and Lucide as the canonical icon set.
- Signature components documented: the gradient-border card and the transcript surface.
- PRODUCT.md's anti-references (bureaucratic portal density, marketing-site gloss, visual urgency and clutter) carry through as enforced Don'ts.

## Notes for reviewers

- One discrepancy surfaced during extraction: the comment in `globals.css` calls Inter the primary UI font, but `tailwind.config.ts` places Relative Book Pro first in the `sans` stack, so that's what actually renders. DESIGN.md documents the rendered reality, with Inter as the loaded fallback.
- A second one surfaced during review: `--gradient-blue` is defined in `globals.css` but unused — the card and gradient-button components hardcode `#a4c0e1` (the `--accent` value) as the gradient endpoint. DESIGN.md notes this explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two root-level documentation files — `PRODUCT.md` (audiences, brand voice, design principles, accessibility commitment) and `DESIGN.md` (Stitch-format YAML tokens plus prose codifying the current UI system) — alongside a `.gitignore` entry for local Impeccable tooling state. No application code is changed.

- **DESIGN.md** documents the existing color tokens, typography roles, elevation vocabulary, breakpoints, and signature components (gradient-border card, transcript surface) as they exist in `globals.css` and `tailwind.config.ts` today, including the correct distinction between the card's inline 5s `gradientFlow` animation and the 3s `animate-gradientFlow` CSS utility class.
- **PRODUCT.md** captures the three-tier audience hierarchy, product purpose, brand personality, anti-references, and five design principles intended to guide contributors and AI tooling building new screens.

<h3>Confidence Score: 5/5</h3>

Documentation and .gitignore only; no runtime, auth, or data-path changes — safe to merge.

All three changed files are documentation or tooling-ignore additions. The DESIGN.md token values have been cross-checked against globals.css and tailwind.config.ts; the material discrepancies (em color attribution, gradient-blue HSL) were already flagged in earlier review threads and don't affect runtime behavior. The card's dual animation duration (5s inline vs 3s CSS class) is confirmed correct by card.tsx.

No files require special attention beyond the two open comment threads on DESIGN.md.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| DESIGN.md | New Stitch-format design reference document; accurately captures most tokens from globals.css/tailwind, with two previously-flagged discrepancies (em color attribution, gradient-blue HSL) that are separate open review threads |
| PRODUCT.md | New product context document; prose and brand intent only, no technical tokens to verify against code |
| .gitignore | Adds .impeccable/ to ignore local design-tool sidecar state; no issues |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: gitignore .impeccable local tooli..."](https://github.com/schemalabz/opencouncil/commit/e01c6d1490c05d5a66c0d4b53039592d7e0a177c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36685764)</sub>

<!-- /greptile_comment -->