### PR TITLE
fix(notifications): announce upcoming meeting when agenda has no items

### DIFF
--- a/src/lib/db/notifications.ts
+++ b/src/lib/db/notifications.ts
@@ -795,16 +795,34 @@ export async function createNotificationsForMeeting(
             }
         }
 
-        // Use shared matching logic to determine which users should be notified
-        const userSubjectMatches = await matchUsersToSubjects(
-            subjectsForMatching,
-            usersWithPreferences,
-            effectiveOverrides
-        );
+        // Determine which users should be notified.
+        //
+        // Special case — meeting announcement with no agenda items:
+        // Some sessions (notably Λογοδοσία/accountability meetings) are processed with
+        // zero subjects. Subject-based matching would notify nobody, silently dropping the
+        // upcoming-meeting announcement. For `beforeMeeting` we instead notify every user
+        // with a preference for this city, creating a subject-less announcement
+        // notification. This mirrors the existing `topicImportance: 'high'` behavior, which
+        // already notifies all city subscribers. `afterMeeting` keeps the old behavior:
+        // a post-meeting summary with no subjects has nothing to report.
+        const isMeetingAnnouncement = subjectsForMatching.length === 0 && type === 'beforeMeeting';
 
-        // Filter out users with no matching subjects
-        const usersToNotify = Array.from(userSubjectMatches.entries())
-            .filter(([_, subjects]) => subjects.size > 0);
+        let usersToNotify: Array<[string, Set<{ subjectId: string; reason: 'proximity' | 'topic' | 'generalInterest' }>]>;
+        if (isMeetingAnnouncement) {
+            console.log('Meeting has no subjects — creating beforeMeeting announcement for all city subscribers');
+            usersToNotify = usersWithPreferences.map(user => [user.userId, new Set()]);
+        } else {
+            // Use shared matching logic to determine which users should be notified
+            const userSubjectMatches = await matchUsersToSubjects(
+                subjectsForMatching,
+                usersWithPreferences,
+                effectiveOverrides
+            );
+
+            // Filter out users with no matching subjects
+            usersToNotify = Array.from(userSubjectMatches.entries())
+                .filter(([_, subjects]) => subjects.size > 0);
+        }
 
         if (usersToNotify.length === 0) {
             console.log('No users matched any subjects');

--- a/src/lib/db/notifications.ts
+++ b/src/lib/db/notifications.ts
@@ -758,16 +758,34 @@ export async function createNotificationsForMeeting(
             }
         }
 
-        // Use shared matching logic to determine which users should be notified
-        const userSubjectMatches = await matchUsersToSubjects(
-            subjectsForMatching,
-            usersWithPreferences,
-            effectiveOverrides
-        );
+        // Determine which users should be notified.
+        //
+        // Special case — meeting announcement with no agenda items:
+        // Some sessions (notably Λογοδοσία/accountability meetings) are processed with
+        // zero subjects. Subject-based matching would notify nobody, silently dropping the
+        // upcoming-meeting announcement. For `beforeMeeting` we instead notify every user
+        // with a preference for this city, creating a subject-less announcement
+        // notification. This mirrors the existing `topicImportance: 'high'` behavior, which
+        // already notifies all city subscribers. `afterMeeting` keeps the old behavior:
+        // a post-meeting summary with no subjects has nothing to report.
+        const isMeetingAnnouncement = subjectsForMatching.length === 0 && type === 'beforeMeeting';
 
-        // Filter out users with no matching subjects
-        const usersToNotify = Array.from(userSubjectMatches.entries())
-            .filter(([_, subjects]) => subjects.size > 0);
+        let usersToNotify: Array<[string, Set<{ subjectId: string; reason: 'proximity' | 'topic' | 'generalInterest' }>]>;
+        if (isMeetingAnnouncement) {
+            console.log('Meeting has no subjects — creating beforeMeeting announcement for all city subscribers');
+            usersToNotify = usersWithPreferences.map(user => [user.userId, new Set()]);
+        } else {
+            // Use shared matching logic to determine which users should be notified
+            const userSubjectMatches = await matchUsersToSubjects(
+                subjectsForMatching,
+                usersWithPreferences,
+                effectiveOverrides
+            );
+
+            // Filter out users with no matching subjects
+            usersToNotify = Array.from(userSubjectMatches.entries())
+                .filter(([_, subjects]) => subjects.size > 0);
+        }
 
         if (usersToNotify.length === 0) {
             console.log('No users matched any subjects');

--- a/src/lib/email/templates/NotificationEmail.tsx
+++ b/src/lib/email/templates/NotificationEmail.tsx
@@ -37,7 +37,7 @@ export const NotificationEmail = ({
 
     // Announcement-only notification: the meeting has no agenda items yet (e.g. Λογοδοσία).
     // We still inform subscribers about the upcoming session, without a subject list.
-    const isAnnouncementOnly = subjects.length === 0;
+    const isAnnouncementOnly = subjects.length === 0 && type === 'beforeMeeting';
 
     const meetingDateFormatted = meetingDate.toLocaleDateString('el-GR', {
         day: 'numeric',

--- a/src/lib/email/templates/NotificationEmail.tsx
+++ b/src/lib/email/templates/NotificationEmail.tsx
@@ -35,6 +35,10 @@ export const NotificationEmail = ({
         ? 'Ειδοποίηση επερχόμενης συνεδρίασης'
         : 'Ειδοποίηση πρόσφατης συνεδρίασης';
 
+    // Announcement-only notification: the meeting has no agenda items yet (e.g. Λογοδοσία).
+    // We still inform subscribers about the upcoming session, without a subject list.
+    const isAnnouncementOnly = subjects.length === 0;
+
     const meetingDateFormatted = meetingDate.toLocaleDateString('el-GR', {
         day: 'numeric',
         month: 'long',
@@ -75,17 +79,31 @@ export const NotificationEmail = ({
                     {cityName}
                 </Text>
 
-                <Heading
-                    style={{
-                        color: '#1f2937',
-                        fontSize: '18px',
-                        fontWeight: '600',
-                        margin: '32px 0 16px 0',
-                        textAlign: 'left',
-                    }}
-                >
-                    Θέματα που σας αφορούν:
-                </Heading>
+                {isAnnouncementOnly ? (
+                    <Text
+                        style={{
+                            color: '#4b5563',
+                            fontSize: '15px',
+                            margin: '24px 0',
+                            lineHeight: '22px',
+                        }}
+                    >
+                        Η ημερήσια διάταξη δεν περιλαμβάνει συγκεκριμένα θέματα. Δείτε
+                        περισσότερες πληροφορίες για τη συνεδρίαση παρακάτω.
+                    </Text>
+                ) : (
+                    <Heading
+                        style={{
+                            color: '#1f2937',
+                            fontSize: '18px',
+                            fontWeight: '600',
+                            margin: '32px 0 16px 0',
+                            textAlign: 'left',
+                        }}
+                    >
+                        Θέματα που σας αφορούν:
+                    </Heading>
+                )}
 
                 {subjects.map((subject) => (
                     <Container

--- a/src/lib/email/templates/__tests__/NotificationEmail.test.tsx
+++ b/src/lib/email/templates/__tests__/NotificationEmail.test.tsx
@@ -1,0 +1,43 @@
+/** @jest-environment node */
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NotificationEmail } from '../NotificationEmail';
+
+// Render the template synchronously with react-dom/server to avoid @react-email/render's
+// dynamic import (which requires --experimental-vm-modules under Jest). We only assert on
+// the visible text branches, which are identical in both renderers.
+const render = (element: React.ReactElement) => Promise.resolve(renderToStaticMarkup(element));
+
+const baseProps = {
+    type: 'beforeMeeting' as const,
+    meetingDate: new Date('2026-04-20T10:00:00Z'),
+    administrativeBodyName: 'Δημοτικό Συμβούλιο',
+    cityName: 'Χανιά',
+    notificationUrl: 'https://opencouncil.gr/el/notifications/notif-1',
+    unsubscribeUrl: 'https://opencouncil.gr/el/unsubscribe?token=x',
+};
+
+describe('NotificationEmail', () => {
+    it('renders an announcement (no subject-list heading) when there are no subjects', async () => {
+        const html = await render(NotificationEmail({ ...baseProps, subjects: [] }));
+
+        // Issue #308: announcement email must not show the "topics for you" heading.
+        expect(html).not.toContain('Θέματα που σας αφορούν');
+        expect(html).toContain('Η ημερήσια διάταξη δεν περιλαμβάνει συγκεκριμένα θέματα');
+        expect(html).toContain('Χανιά');
+        expect(html).toContain('Δημοτικό Συμβούλιο');
+    });
+
+    it('renders the subject list when subjects are present', async () => {
+        const html = await render(
+            NotificationEmail({
+                ...baseProps,
+                subjects: [{ id: 's1', name: 'Θέμα Α', description: 'Περιγραφή', topic: null }],
+            })
+        );
+
+        expect(html).toContain('Θέματα που σας αφορούν');
+        expect(html).toContain('Θέμα Α');
+        expect(html).not.toContain('Η ημερήσια διάταξη δεν περιλαμβάνει συγκεκριμένα θέματα');
+    });
+});

--- a/src/lib/notifications/__tests__/content.test.ts
+++ b/src/lib/notifications/__tests__/content.test.ts
@@ -1,0 +1,49 @@
+/** @jest-environment node */
+jest.mock('@/env.mjs', () => ({
+    env: {
+        NEXTAUTH_URL: 'https://opencouncil.gr',
+        NEXTAUTH_SECRET: 'test-secret-do-not-use-in-prod',
+    },
+}));
+
+import { generateSmsContent } from '../content';
+
+type NotificationData = Parameters<typeof generateSmsContent>[0];
+
+const baseNotification = (subjects: NotificationData['subjects']): NotificationData => ({
+    id: 'notif-1',
+    userId: 'user-1',
+    cityId: 'city-1',
+    type: 'beforeMeeting',
+    subjects,
+    meeting: {
+        dateTime: new Date('2026-04-20T10:00:00Z'),
+        administrativeBody: { name: 'Δημοτικό Συμβούλιο' },
+    },
+    city: { name_municipality: 'Χανιά' },
+});
+
+describe('generateSmsContent', () => {
+    it('produces a meeting announcement (no subject count) when there are no subjects', async () => {
+        const sms = await generateSmsContent(baseNotification([]));
+
+        // Issue #308: announcement-only SMS must not claim "0 νέα θέματα".
+        expect(sms).not.toContain('νέα θέματα');
+        expect(sms).toContain('Χανιά');
+        expect(sms).toContain('Δημοτικό Συμβούλιο');
+        expect(sms).toContain('https://opencouncil.gr/el/notifications/notif-1');
+    });
+
+    it('still lists subjects and the count for a meeting with subjects', async () => {
+        const sms = await generateSmsContent(
+            baseNotification([
+                { id: 's1', name: 'Θέμα Α', description: 'desc', topic: null },
+                { id: 's2', name: 'Θέμα Β', description: 'desc', topic: null },
+            ])
+        );
+
+        expect(sms).toContain('2 νέα θέματα');
+        expect(sms).toContain('Θέμα Α');
+        expect(sms).toContain('Θέμα Β');
+    });
+});

--- a/src/lib/notifications/content.ts
+++ b/src/lib/notifications/content.ts
@@ -78,7 +78,7 @@ export async function generateSmsContent(notification: NotificationData): Promis
 
     // Announcement-only notification: the meeting has no agenda items (e.g. Λογοδοσία).
     // Announce the upcoming session without referencing a subject count.
-    if (subjectCount === 0) {
+    if (subjectCount === 0 && notification.type === 'beforeMeeting') {
         return `${notification.city.name_municipality} - ${adminBody} στις ${meetingDateFormatted}. Δείτε περισσότερα: ${notificationUrl}`;
     }
 

--- a/src/lib/notifications/content.ts
+++ b/src/lib/notifications/content.ts
@@ -76,6 +76,12 @@ export async function generateSmsContent(notification: NotificationData): Promis
     const adminBody = notification.meeting.administrativeBody?.name || 'συνεδρίαση';
     const notificationUrl = `${env.NEXTAUTH_URL || 'https://opencouncil.gr'}/el/notifications/${notification.id}`;
 
+    // Announcement-only notification: the meeting has no agenda items (e.g. Λογοδοσία).
+    // Announce the upcoming session without referencing a subject count.
+    if (subjectCount === 0) {
+        return `${notification.city.name_municipality} - ${adminBody} στις ${meetingDateFormatted}. Δείτε περισσότερα: ${notificationUrl}`;
+    }
+
     const subjectNames =
         subjectCount > 3
             ? `${notification.subjects.slice(0, 3).map(s => s.name).join(', ')} και άλλα`

--- a/tests/integration/notifications.creation.test.ts
+++ b/tests/integration/notifications.creation.test.ts
@@ -148,4 +148,88 @@ describe('createNotificationsForMeeting - end-to-end', () => {
         expect(byEmail('sms@example.com').deliveries.map(d => d.medium).sort()).toEqual(['message'])
         expect(notifs.find(n => n.user.email === 'none@example.com')).toBeUndefined()
     })
+
+    // Regression test for issue #308: a meeting processed with NO agenda items
+    // (typical of Λογοδοσία/accountability sessions) must still send an upcoming-meeting
+    // announcement to every city subscriber, instead of silently notifying nobody.
+    test('creates beforeMeeting announcements for a zero-subject meeting (issue #308)', async () => {
+        const city = await createCity({ id: 'c5', name_municipality: 'Χανιά', name_municipality_en: 'Chania' })
+        const body = await createAdministrativeBody(city.id)
+        const meeting = await createMeeting(city.id, { id: 'm3', administrativeBodyId: body.id })
+        // No subjects created — this is the λογοδοσία / empty-agenda case.
+
+        const uEmail = await createUser('a-email@example.com')
+        await createNotificationPreference({ userId: uEmail.id, cityId: city.id })
+        await prisma.notificationPreference.update({
+            where: { userId_cityId: { userId: uEmail.id, cityId: city.id } },
+            data: { notifyByEmail: true, notifyByPhone: false },
+        })
+
+        const uPhone = await createUser('a-phone@example.com', { phone: '+306900000010' })
+        await createNotificationPreference({ userId: uPhone.id, cityId: city.id })
+        await prisma.notificationPreference.update({
+            where: { userId_cityId: { userId: uPhone.id, cityId: city.id } },
+            data: { notifyByEmail: false, notifyByPhone: true },
+        })
+
+        const uNone = await createUser('a-none@example.com', { phone: '+306900000011' })
+        await createNotificationPreference({ userId: uNone.id, cityId: city.id })
+        await prisma.notificationPreference.update({
+            where: { userId_cityId: { userId: uNone.id, cityId: city.id } },
+            data: { notifyByEmail: false, notifyByPhone: false },
+        })
+
+        const result = await createNotificationsForMeeting(city.id, meeting.id, 'beforeMeeting')
+
+        // Two users opted into a channel; the third (no channel) is skipped.
+        expect(result.notificationsCreated).toBe(2)
+        // Announcement notifications carry no subjects.
+        expect(result.subjectsTotal).toBe(0)
+
+        const notifs = await prisma.notification.findMany({
+            where: { cityId: city.id, meetingId: meeting.id, type: 'beforeMeeting' },
+            include: { subjects: true, deliveries: true, user: true },
+        })
+        expect(notifs).toHaveLength(2)
+        for (const n of notifs) {
+            expect(n.subjects).toHaveLength(0)
+        }
+
+        const byEmail = (e: string) => notifs.find(n => n.user.email === e)!
+        // Channel preferences are still respected.
+        expect(byEmail('a-email@example.com').deliveries.map(d => d.medium).sort()).toEqual(['email'])
+        expect(byEmail('a-phone@example.com').deliveries.map(d => d.medium).sort()).toEqual(['message'])
+        expect(notifs.find(n => n.user.email === 'a-none@example.com')).toBeUndefined()
+        // Note: the user-facing announcement copy (no "0 νέα θέματα" / subject-list heading)
+        // is asserted in the unit tests for content/template rendering, since integration
+        // tests mock @/lib/notifications/content.
+
+        // Idempotency: a re-run (e.g. force re-processing the agenda) creates no duplicates.
+        const rerun = await createNotificationsForMeeting(city.id, meeting.id, 'beforeMeeting')
+        expect(rerun.notificationsCreated).toBe(0)
+        const afterRerun = await prisma.notification.count({
+            where: { cityId: city.id, meetingId: meeting.id, type: 'beforeMeeting' },
+        })
+        expect(afterRerun).toBe(2)
+    })
+
+    // afterMeeting with zero subjects must stay a no-op: a post-meeting summary with
+    // nothing to report should not generate announcement notifications.
+    test('does not create afterMeeting notifications for a zero-subject meeting (issue #308)', async () => {
+        const city = await createCity({ id: 'c6', name_municipality: 'Y', name_municipality_en: 'Y' })
+        const body = await createAdministrativeBody(city.id)
+        const meeting = await createMeeting(city.id, { id: 'm4', administrativeBodyId: body.id })
+
+        const u = await createUser('after@example.com')
+        await createNotificationPreference({ userId: u.id, cityId: city.id })
+
+        const result = await createNotificationsForMeeting(city.id, meeting.id, 'afterMeeting')
+        expect(result.notificationsCreated).toBe(0)
+        expect(result.subjectsTotal).toBe(0)
+
+        const count = await prisma.notification.count({
+            where: { cityId: city.id, meetingId: meeting.id },
+        })
+        expect(count).toBe(0)
+    })
 })


### PR DESCRIPTION
## What

Fixes inconsistent notification behavior when a meeting's agenda is processed with no items, which is typical for Λογοδοσία (accountability) sessions.

Two such meetings behaved differently. Athens (20/04) sent no notifications; Chania (22/04) sent them. Same situation, different outcome.

The cause: when an agenda has zero subjects, `createNotificationsForMeeting` builds an empty matching list, `matchUsersToSubjects` returns nothing, and the function returns early with `notificationsCreated: 0`. So the upcoming-meeting announcement gets silently dropped.

## Change

- For `beforeMeeting` notifications with zero subjects, notify every user subscribed to the city with a subject-less announcement. This follows the existing `topicImportance: 'high'` path, which already notifies all city subscribers. The `(userId, cityId, meetingId, type)` unique constraint keeps re-runs idempotent.
- `afterMeeting` is left alone, since a post-meeting summary with no subjects has nothing to report.
- The email template gets an announcement-only branch that drops the "Θέματα που σας αφορούν" heading.
- SMS drops the "N νέα θέματα" phrasing and announces the session instead.

One note on where this lives: the agenda PDF parser in opencouncil-tasks reports an empty agenda as an ordinary success (`{ subjects: [] }`) with no distinguishing signal, so the no-items behavior is handled here in the frontend rather than upstream.

## Tests

- `content.test.ts` — SMS announcement copy
- `NotificationEmail.test.tsx` — announcement-only render
- `integration/notifications.creation.test.ts` — no-items meeting produces notifications end to end

Closes #308



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds subject-less upcoming-meeting announcements for city subscribers when an agenda contains no items, while preserving the no-op behavior for post-meeting notifications.
- Creates idempotent `beforeMeeting` notifications without subject matches for eligible city subscribers.
- Adds type-specific announcement copy for email and SMS.
- Adds unit and integration coverage for rendering, delivery preferences, post-meeting behavior, and reruns.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; both previously reported type-agnostic announcement branches are now restricted to `beforeMeeting`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/db/notifications.ts | Adds the zero-subject `beforeMeeting` fan-out while retaining city subscription, channel preference, notification policy, and idempotency behavior. |
| src/lib/email/templates/NotificationEmail.tsx | Renders announcement-only text specifically for zero-subject `beforeMeeting` emails; the previous type-agnostic branch has been corrected. |
| src/lib/notifications/content.ts | Generates subject-count-free SMS copy specifically for zero-subject `beforeMeeting` notifications; the previous type-agnostic branch has been corrected. |
| tests/integration/notifications.creation.test.ts | Covers empty-agenda fan-out, channel opt-ins, subject-less records, rerun idempotency, and the `afterMeeting` no-op contract. |
| src/lib/email/templates/__tests__/NotificationEmail.test.tsx | Verifies announcement-only email rendering and unchanged subject-list rendering. |
| src/lib/notifications/__tests__/content.test.ts | Verifies zero-subject announcement SMS copy and unchanged subject-bearing SMS content. |

<sub>Reviews (4): Last reviewed commit: ["fix(notifications): restrict no-items an..."](https://github.com/schemalabz/opencouncil/commit/0dd13f1995c557f8b78bd9699c19f55bed625acc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36929848)</sub>

<!-- /greptile_comment -->