### PR TITLE
fix(nix): derive npm deps from lockfile via importNpmLock

### DIFF
--- a/.claude/commands/pre-pr.md
+++ b/.claude/commands/pre-pr.md
@@ -78,22 +78,16 @@ If no dev files were touched and no new packages added, mark this check as **N/A
 
 ## Check 4: Nix Build Readiness
 
-If `package-lock.json` was changed in this branch but `flake.nix`'s `npmDepsHash` line was not, the preview deployment **will fail**. Check this before wasting time on a full build:
+The Nix build reads npm dependency hashes directly from `package-lock.json` (via `importNpmLock`), so lockfile changes need no `flake.nix` update. The only failure mode is `package.json` dependencies changing without the lockfile being regenerated:
 
 ```bash
-git diff --name-only $(git merge-base HEAD $BASE)..HEAD | grep -q '^package-lock.json$' && \
-  ! git diff $(git merge-base HEAD $BASE)..HEAD -- flake.nix | grep -q 'npmDepsHash' && \
-  echo "FAIL: package-lock.json changed but npmDepsHash not updated" || \
+git diff --name-only $(git merge-base HEAD $BASE)..HEAD | grep -q '^package.json$' && \
+  ! git diff --name-only $(git merge-base HEAD $BASE)..HEAD | grep -q '^package-lock.json$' && \
+  echo "CHECK: package.json changed without package-lock.json — if dependencies changed, run 'npm install' and commit the lockfile" || \
   echo "PASS"
 ```
 
-If this fails, regenerate the hash and update `flake.nix`:
-
-```bash
-nix develop --command nix run nixpkgs#prefetch-npm-deps package-lock.json
-```
-
-If `package-lock.json` was not changed, mark as **N/A**.
+If `package.json` was not changed, mark as **N/A**.
 
 ## Check 5: Build & Lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           name: opencouncil
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-          pushFilter: opencouncil-npm-deps
+          # Don't cache npm deps: importNpmLock produces one .tgz fetchurl per
+          # package plus an opencouncil-*-sources lockfile derivation, all
+          # cheaply re-fetched from the npm registry.
+          pushFilter: "(\\.tgz$|opencouncil-.*-sources$)"
 
       - run: nix flake check --print-build-logs

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -54,21 +54,16 @@ jobs:
             echo "✅ No migrations detected - preview will use shared staging database" >> $GITHUB_STEP_SUMMARY
           fi
 
-      - name: Check npmDepsHash freshness
+      - name: Check lockfile freshness
         run: |
           set -euo pipefail
 
           LOCKFILE_CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '^package-lock.json$' || true)
-          HASH_CHANGED=$(git diff origin/${{ github.base_ref }}...HEAD -- flake.nix | grep 'npmDepsHash' || true)
           PKG_JSON_CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '^package.json$' || true)
 
-          # Case 1: lockfile changed but hash wasn't updated
-          if [ -n "$LOCKFILE_CHANGED" ] && [ -z "$HASH_CHANGED" ]; then
-            echo "::error::package-lock.json was modified but npmDepsHash in flake.nix was not updated. Run: nix run nixpkgs#prefetch-npm-deps package-lock.json"
-            exit 1
-          fi
-
-          # Case 2: dependencies changed in package.json but lockfile wasn't updated
+          # Dependencies changed in package.json but lockfile wasn't updated.
+          # (The Nix build reads dependency hashes straight from the lockfile
+          # via importNpmLock, so no flake.nix hash check is needed.)
           if [ -n "$PKG_JSON_CHANGED" ] && [ -z "$LOCKFILE_CHANGED" ]; then
             OLD_DEPS=$(git show origin/${{ github.base_ref }}:package.json | jq -S '{dep: .dependencies, dev: .devDependencies}')
             NEW_DEPS=$(jq -S '{dep: .dependencies, dev: .devDependencies}' package.json)
@@ -78,7 +73,7 @@ jobs:
             fi
           fi
 
-          echo "✅ npmDepsHash check passed" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Lockfile freshness check passed" >> $GITHUB_STEP_SUMMARY
 
   # Build and deploy preview
   deploy:
@@ -156,7 +151,9 @@ jobs:
         with:
           name: ${{ env.CACHIX_CACHE_NAME }}
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          pushFilter: "opencouncil-(prod|npm-deps)"
+          # Exclude the prod build itself and npm deps (per-package .tgz
+          # fetchurls + the opencouncil-*-sources lockfile derivation).
+          pushFilter: "(opencouncil-prod|\\.tgz$|opencouncil-.*-sources$)"
 
       - name: Build production package
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,7 +276,7 @@ Prefer describing changes from your working context when available. Fall back to
 - For schema changes: run `npm run prisma:generate` before building
 - Quick TypeScript check without full build: `npx tsc --noEmit`
 - **Tests**: `npm test` and `npm run test:integration` are fast — run them between changes to catch regressions early
-- **If `package-lock.json` changed**: update `npmDepsHash` in `flake.nix` — run `nix run nixpkgs#prefetch-npm-deps package-lock.json` and copy the hash. Preview deployments will fail without this.
+- **`package-lock.json` changes need no extra step**: the Nix build (`importNpmLock`) reads dependency hashes directly from the lockfile.
 
 ### TypeScript
 - Strict mode is enabled

--- a/docs/guides/preview-deployments.md
+++ b/docs/guides/preview-deployments.md
@@ -36,10 +36,7 @@ On the droplet, each PR maps to:
 
 The `opencouncil-prod` package in `flake.nix` uses `buildNpmPackage` with these key considerations:
 
-- **`npmDepsHash`**: Must be updated when `package-lock.json` changes. Regenerate with:
-  ```bash
-  nix run nixpkgs#prefetch-npm-deps package-lock.json
-  ```
+- **npm dependencies via `importNpmLock`**: Each package is fetched using the integrity hashes already in `package-lock.json`, so lockfile changes (including dependabot bumps) need no manual hash update.
 - **`--ignore-scripts` during install**: The `canvas` npm package requires native libraries (cairo, pango, libjpeg, giflib, librsvg, pixman). Scripts are skipped during the dependency fetch phase, then `npm rebuild canvas` runs in `preBuild` with all native deps available.
 - **`SKIP_ENV_VALIDATION=1`**: The app uses `@t3-oss/env-nextjs` which validates env vars at build time. Since secrets aren't available in the Nix sandbox, this flag (checked via `skipValidation` in `src/env.mjs`) skips validation during build.
 - **Prisma**: Engines are provided by `pkgs.prisma-engines`. `npx prisma generate` runs in `preBuild`.
@@ -251,11 +248,6 @@ set -a; source .env; set +a
 nix build --impure .#opencouncil-prod
 ```
 
-If `package-lock.json` changed, update `npmDepsHash` first:
-```bash
-nix run nixpkgs#prefetch-npm-deps package-lock.json
-```
-
 ### 2. Push to Cachix
 
 ```bash
@@ -391,7 +383,6 @@ To avoid this, prefer creating additive migrations instead of amending existing 
 **Build failures:**
 1. Check GitHub Actions logs
 2. Test locally: `nix build .#opencouncil-prod`
-3. If `package-lock.json` changed, update `npmDepsHash` (see [Nix Build Details](#nix-build-details))
 
 **Disk space:**
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -56,19 +56,12 @@
         export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
       '';
 
-      # Shared npm config (used by opencouncil-prod and CI checks)
-      # Update this hash when package-lock.json changes:
-      #   nix run nixpkgs#prefetch-npm-deps package-lock.json
-      npmDepsHash = "sha256-ZvqENLhwRTCbjyMcjpq8RwZ8smwMNyP0CEL4pOEZPZo=";
-
-      # Single npm-deps derivation shared by all buildNpmPackage consumers.
-      # Without this, each consumer (prod build + 3 checks) would create its
-      # own identical copy with a different store path.
-      mkNpmDeps = pkgs: pkgs.fetchNpmDeps {
-        src = ./.;
-        name = "opencouncil-npm-deps";
-        hash = npmDepsHash;
-      };
+      # Shared npm deps (used by opencouncil-prod and CI checks).
+      # importNpmLock fetches each package using the integrity hashes already
+      # in package-lock.json, so there is no aggregate npmDepsHash to keep in
+      # sync when the lockfile changes (e.g. dependabot bumps). Consumers must
+      # pair this with importNpmLock.npmConfigHook.
+      mkNpmDeps = pkgs: pkgs.importNpmLock { npmRoot = ./.; };
 
       mkNpmBuildInputs = pkgs: with pkgs; [
         cairo pango libjpeg giflib pixman libpng glib librsvg
@@ -1050,6 +1043,7 @@ EOF
             # derivation hash when values change.
 
             npmDeps = mkNpmDeps pkgs;
+            npmConfigHook = pkgs.importNpmLock.npmConfigHook;
 
             # Configure npm - ignore scripts during dependency installation
             makeCacheWritable = true;
@@ -1291,14 +1285,15 @@ EOF
             version = "0.1.0";
             src = ./.;
             npmDeps = mkNpmDeps pkgs;
+            npmConfigHook = pkgs.importNpmLock.npmConfigHook;
             makeCacheWritable = true;
             npmFlags = [ "--legacy-peer-deps" ];
             npmInstallFlags = [ "--ignore-scripts" ];
             nativeBuildInputs = npmNativeBuildInputs;
             buildInputs = npmBuildInputs;
             dontNpmBuild = true;
-            # Setup runs in preBuild (not postPatch) because postPatch also
-            # runs inside the npm-deps FOD where npm/node aren't available.
+            # Setup runs in preBuild so it executes after npmConfigHook has
+            # installed node_modules.
             preBuild = ''
               export HOME=$TMPDIR
               ${mkPrismaEnv pkgs}


### PR DESCRIPTION
Replace fetchNpmDeps + manually maintained npmDepsHash with pkgs.importNpmLock, which fetches each package using the integrity hashes already present in package-lock.json. Lockfile changes (including dependabot bumps) no longer require a flake.nix update, fixing the hash-mismatch CI failures on every dependabot npm PR.

Also drop the now-obsolete npmDepsHash freshness gate in preview-deploy (keeping the package.json-vs-lockfile consistency check), update the cachix push filters for the new derivation shapes, and update docs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the manually-maintained `npmDepsHash` + `fetchNpmDeps` pattern with `pkgs.importNpmLock`, which derives per-package hashes directly from `package-lock.json`. This eliminates the hash-mismatch CI failures that occurred on every dependabot lockfile bump.

- **`flake.nix`**: `mkNpmDeps` now calls `importNpmLock { npmRoot = ./.; }` and both `buildNpmPackage` consumers (`opencouncil-prod` and `mkCheck`) correctly wire in `npmConfigHook = pkgs.importNpmLock.npmConfigHook`.
- **Workflows**: The obsolete `npmDepsHash` freshness gate is removed from `preview-deploy.yml`; the `package.json`-vs-lockfile consistency check is retained. Cachix `pushFilter` in both workflow files is updated to exclude the new per-package `.tgz` store paths and the `opencouncil-*-sources` derivation.
- **Docs/tooling**: `CLAUDE.md`, `docs/guides/preview-deployments.md`, and the pre-PR command are updated to remove stale `prefetch-npm-deps` instructions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a clean mechanical substitution of one Nix fetcher for another, with all consumers correctly updated.

Both buildNpmPackage consumers in flake.nix set both npmDeps and npmConfigHook, satisfying importNpmLock's contract. The Cachix pushFilter correctly excludes per-package .tgz paths and the lockfile sources derivation. The workflow freshness gate retains the meaningful package.json-vs-lockfile check. All docs and tooling are updated consistently.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| flake.nix | Replaces fetchNpmDeps+npmDepsHash with importNpmLock; both buildNpmPackage consumers (opencouncil-prod and mkCheck) correctly add npmConfigHook |
| .github/workflows/ci.yml | Updates Cachix pushFilter from single opencouncil-npm-deps to exclude per-package .tgz and sources derivation; semantics are correct (filter is an exclusion list) |
| .github/workflows/preview-deploy.yml | Drops the now-obsolete npmDepsHash freshness gate; retains the package.json vs lockfile consistency check (with jq comparison to allow non-dep changes) |
| CLAUDE.md | Removes stale npmDepsHash update instructions and replaces with accurate note that lockfile changes need no extra step |
| docs/guides/preview-deployments.md | Removes outdated prefetch-npm-deps instructions and troubleshooting step; docs accurately reflect the new importNpmLock workflow |
| .claude/commands/pre-pr.md | Updates Check 4 from a lockfile-vs-hash gate to a package.json-vs-lockfile consistency reminder; changes FAIL to CHECK (non-blocking) which is appropriate for a local pre-PR hint |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(nix): derive npm deps from lockfile ..."](https://github.com/schemalabz/opencouncil/commit/d1002a7abfaf2277b197cea81efd92de06e69cac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36955928)</sub>

<!-- /greptile_comment -->