### PR TITLE
feat(voiceprint): manual segment selection with audio + transcript preview

### DIFF
--- a/src/components/admin/people/voiceprint-actions.tsx
+++ b/src/components/admin/people/voiceprint-actions.tsx
@@ -344,7 +344,7 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
                                                 ) : (
                                                     <>
                                                         <p className='text-xs text-slate-500'>
-                                                            Pick the segment with the clearest audio. A 30-second window
+                                                            Pick the segment with the clearest audio. A {VOICEPRINT_DURATION}-second window
                                                             centered on the segment will be used.
                                                         </p>
                                                         <ul className='max-h-[45vh] space-y-2 overflow-y-auto pr-1'>

--- a/src/components/admin/people/voiceprint-actions.tsx
+++ b/src/components/admin/people/voiceprint-actions.tsx
@@ -20,6 +20,7 @@ import {
     getCandidateSegmentsForVoiceprint,
     type VoiceprintCandidateSegment,
 } from "@/lib/tasks/generateVoiceprint";
+import { VOICEPRINT_DURATION } from "@/lib/tasks/voiceprintWindow";
 import { deleteTaskStatus, getVoiceprintTasksForPerson } from "@/lib/db/tasks";
 import { useToast } from "@/hooks/use-toast";
 import { useRouter } from "next/navigation";
@@ -48,6 +49,19 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
     const [candidatesLoaded, setCandidatesLoaded] = useState(false);
     const [selectedSegmentId, setSelectedSegmentId] = useState<string | null>(null);
     const { toast } = useToast();
+
+    // Reset the manual picker whenever the dialog closes so reopening starts clean
+    // (no stale candidates expanded, no previously highlighted segment that could be
+    // generated from by accident).
+    const handleDialogOpenChange = useCallback((open: boolean) => {
+        setIsDialogOpen(open);
+        if (!open) {
+            setIsManualOpen(false);
+            setSelectedSegmentId(null);
+            setCandidates([]);
+            setCandidatesLoaded(false);
+        }
+    }, []);
 
     const fetchTaskStatuses = useCallback(async () => {
         try {
@@ -238,7 +252,7 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
     const canGenerateVoiceprint = !voicePrint && !latestPendingTask;
 
     return (
-        <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <Dialog open={isDialogOpen} onOpenChange={handleDialogOpenChange}>
             <DialogTrigger asChild>
                 <Button variant='outline' size='sm' className={voicePrint ? "border-blue-300 text-blue-700" : ""}>
                     <Volume2 className='mr-2 h-4 w-4' />
@@ -325,7 +339,7 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
                                                     </div>
                                                 ) : candidates.length === 0 ? (
                                                     <p className='text-sm text-slate-600'>
-                                                        No segments of at least 30 seconds are available for this person.
+                                                        No segments of at least {VOICEPRINT_DURATION} seconds are available for this person.
                                                     </p>
                                                 ) : (
                                                     <>
@@ -380,7 +394,7 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
                                                                                 preload='none'
                                                                                 src={`${candidate.mediaUrl}#t=${candidate.previewStartTimestamp},${candidate.previewEndTimestamp}`}
                                                                                 className='mt-1 h-8 w-full'
-                                                                                aria-label={`Προεπισκόπηση ήχου για ${candidate.meetingName}`}
+                                                                                aria-label={`Audio preview for ${candidate.meetingName}`}
                                                                             >
                                                                                 Your browser does not support audio playback.
                                                                             </audio>
@@ -388,7 +402,7 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
                                                                         {candidate.fullText && (
                                                                             <details className='mt-1'>
                                                                                 <summary className='cursor-pointer text-xs text-slate-500 hover:text-slate-700'>
-                                                                                    Όλο το κείμενο του τμήματος
+                                                                                    Full segment transcript
                                                                                 </summary>
                                                                                 <p className='mt-1 max-h-32 overflow-y-auto whitespace-pre-wrap rounded-md bg-slate-50 p-2 text-xs text-slate-600'>
                                                                                     {candidate.fullText}
@@ -439,7 +453,7 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
                             </Button>
                         )}
                     </div>
-                    <Button variant='outline' onClick={() => setIsDialogOpen(false)} disabled={isLoading}>
+                    <Button variant='outline' onClick={() => handleDialogOpenChange(false)} disabled={isLoading}>
                         Close
                     </Button>
                 </DialogFooter>

--- a/src/components/admin/people/voiceprint-actions.tsx
+++ b/src/components/admin/people/voiceprint-actions.tsx
@@ -47,6 +47,7 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
     const [candidates, setCandidates] = useState<VoiceprintCandidateSegment[]>([]);
     const [isLoadingCandidates, setIsLoadingCandidates] = useState(false);
     const [candidatesLoaded, setCandidatesLoaded] = useState(false);
+    const [candidatesError, setCandidatesError] = useState(false);
     const [selectedSegmentId, setSelectedSegmentId] = useState<string | null>(null);
     const { toast } = useToast();
 
@@ -60,6 +61,7 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
             setSelectedSegmentId(null);
             setCandidates([]);
             setCandidatesLoaded(false);
+            setCandidatesError(false);
         }
     }, []);
 
@@ -145,12 +147,16 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
 
     const loadCandidates = useCallback(async () => {
         setIsLoadingCandidates(true);
+        setCandidatesError(false);
         try {
             const segments = await getCandidateSegmentsForVoiceprint(personId);
             setCandidates(segments);
             setCandidatesLoaded(true);
         } catch (error) {
             console.error("Error loading candidate segments:", error);
+            // Flag the error so the panel shows a retry affordance instead of
+            // falling through to the misleading "No segments" empty state.
+            setCandidatesError(true);
             toast({
                 title: "Error",
                 description: error instanceof Error ? error.message : "Failed to load candidate segments.",
@@ -336,6 +342,20 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
                                                 {isLoadingCandidates ? (
                                                     <div className='flex justify-center py-4'>
                                                         <Loader2 className='h-5 w-5 animate-spin text-slate-400' />
+                                                    </div>
+                                                ) : candidatesError ? (
+                                                    <div className='space-y-2'>
+                                                        <p className='text-sm text-slate-600'>
+                                                            Could not load segments. Please try again.
+                                                        </p>
+                                                        <Button
+                                                            variant='outline'
+                                                            size='sm'
+                                                            onClick={loadCandidates}
+                                                            disabled={isLoadingCandidates}
+                                                        >
+                                                            Retry
+                                                        </Button>
                                                     </div>
                                                 ) : candidates.length === 0 ? (
                                                     <p className='text-sm text-slate-600'>

--- a/src/components/admin/people/voiceprint-actions.tsx
+++ b/src/components/admin/people/voiceprint-actions.tsx
@@ -11,7 +11,7 @@ import {
     DialogTrigger,
 } from "@/components/ui/dialog";
 import { VoicePrint, TaskStatus } from "@prisma/client";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { ChevronDown, ListMusic, Loader2, Play, Trash, Volume2 } from "lucide-react";
 import { deleteVoicePrint } from "@/lib/db/voiceprints";
 import {
@@ -49,6 +49,10 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
     const [candidatesLoaded, setCandidatesLoaded] = useState(false);
     const [candidatesError, setCandidatesError] = useState(false);
     const [selectedSegmentId, setSelectedSegmentId] = useState<string | null>(null);
+    // Identifies the latest candidate-load request. Bumped on every load and on
+    // dialog close, so a stale in-flight fetch can detect it has been superseded
+    // and skip its state updates instead of clobbering a fresh load.
+    const loadRequestIdRef = useRef(0);
     const { toast } = useToast();
 
     // Reset the manual picker whenever the dialog closes so reopening starts clean
@@ -57,11 +61,17 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
     const handleDialogOpenChange = useCallback((open: boolean) => {
         setIsDialogOpen(open);
         if (!open) {
+            // Invalidate any in-flight candidate load so its result is ignored.
+            loadRequestIdRef.current += 1;
             setIsManualOpen(false);
             setSelectedSegmentId(null);
             setCandidates([]);
             setCandidatesLoaded(false);
             setCandidatesError(false);
+            // Clear the spinner too: otherwise a fetch interrupted by close stays
+            // "loading", and on reopen handleToggleManual's guard blocks a fresh
+            // fetch, leaving the picker stuck on the spinner.
+            setIsLoadingCandidates(false);
         }
     }, []);
 
@@ -146,13 +156,17 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
     };
 
     const loadCandidates = useCallback(async () => {
+        const requestId = (loadRequestIdRef.current += 1);
+        const isCurrent = () => requestId === loadRequestIdRef.current;
         setIsLoadingCandidates(true);
         setCandidatesError(false);
         try {
             const segments = await getCandidateSegmentsForVoiceprint(personId);
+            if (!isCurrent()) return; // dialog closed/reopened — don't clobber fresh state
             setCandidates(segments);
             setCandidatesLoaded(true);
         } catch (error) {
+            if (!isCurrent()) return;
             console.error("Error loading candidate segments:", error);
             // Flag the error so the panel shows a retry affordance instead of
             // falling through to the misleading "No segments" empty state.
@@ -163,7 +177,9 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
                 variant: "destructive",
             });
         } finally {
-            setIsLoadingCandidates(false);
+            if (isCurrent()) {
+                setIsLoadingCandidates(false);
+            }
         }
     }, [personId, toast]);
 

--- a/src/components/admin/people/voiceprint-actions.tsx
+++ b/src/components/admin/people/voiceprint-actions.tsx
@@ -12,13 +12,20 @@ import {
 } from "@/components/ui/dialog";
 import { VoicePrint, TaskStatus } from "@prisma/client";
 import { useState, useEffect, useCallback } from "react";
-import { Loader2, Play, Trash, Volume2 } from "lucide-react";
+import { ChevronDown, ListMusic, Loader2, Play, Trash, Volume2 } from "lucide-react";
 import { deleteVoicePrint } from "@/lib/db/voiceprints";
-import { requestGenerateVoiceprint } from "@/lib/tasks/generateVoiceprint";
+import {
+    requestGenerateVoiceprint,
+    requestGenerateVoiceprintForSegment,
+    getCandidateSegmentsForVoiceprint,
+    type VoiceprintCandidateSegment,
+} from "@/lib/tasks/generateVoiceprint";
 import { deleteTaskStatus, getVoiceprintTasksForPerson } from "@/lib/db/tasks";
 import { useToast } from "@/hooks/use-toast";
 import { useRouter } from "next/navigation";
 import TaskList from "@/components/meetings/admin/TaskList";
+import { formatDuration, formatTimestamp } from "@/lib/formatters/time";
+import { cn } from "@/lib/utils";
 
 interface VoiceprintActionsProps {
     personId: string;
@@ -35,6 +42,11 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
     const [isLoadingTasks, setIsLoadingTasks] = useState(true);
     const [isLoading, setIsLoading] = useState(false);
     const [latestPendingTask, setLatestPendingTask] = useState<TaskStatus | null>(null);
+    const [isManualOpen, setIsManualOpen] = useState(false);
+    const [candidates, setCandidates] = useState<VoiceprintCandidateSegment[]>([]);
+    const [isLoadingCandidates, setIsLoadingCandidates] = useState(false);
+    const [candidatesLoaded, setCandidatesLoaded] = useState(false);
+    const [selectedSegmentId, setSelectedSegmentId] = useState<string | null>(null);
     const { toast } = useToast();
 
     const fetchTaskStatuses = useCallback(async () => {
@@ -104,6 +116,63 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
             });
         } catch (error) {
             console.error("Error generating voiceprint:", error);
+            toast({
+                title: "Error",
+                description:
+                    typeof error === "object" && error !== null && "message" in error
+                        ? String(error.message)
+                        : "Failed to generate voiceprint. Please try again.",
+                variant: "destructive",
+            });
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const loadCandidates = useCallback(async () => {
+        setIsLoadingCandidates(true);
+        try {
+            const segments = await getCandidateSegmentsForVoiceprint(personId);
+            setCandidates(segments);
+            setCandidatesLoaded(true);
+        } catch (error) {
+            console.error("Error loading candidate segments:", error);
+            toast({
+                title: "Error",
+                description: error instanceof Error ? error.message : "Failed to load candidate segments.",
+                variant: "destructive",
+            });
+        } finally {
+            setIsLoadingCandidates(false);
+        }
+    }, [personId, toast]);
+
+    const handleToggleManual = () => {
+        const next = !isManualOpen;
+        setIsManualOpen(next);
+        if (next && !candidatesLoaded && !isLoadingCandidates) {
+            loadCandidates();
+        }
+    };
+
+    const handleGenerateFromSegment = async () => {
+        if (!selectedSegmentId) return;
+        setIsLoading(true);
+        try {
+            const task = await requestGenerateVoiceprintForSegment(personId, selectedSegmentId);
+
+            setLatestPendingTask(task);
+            setTasks(prev => [task, ...prev]);
+            setIsManualOpen(false);
+            setSelectedSegmentId(null);
+
+            toast({
+                title: "Voiceprint generation requested",
+                description:
+                    "Voiceprint generation from the selected segment is now processing. You can track progress in this dialog.",
+            });
+        } catch (error) {
+            console.error("Error generating voiceprint from segment:", error);
             toast({
                 title: "Error",
                 description:
@@ -220,10 +289,108 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
 
                             <div className='flex flex-col space-y-2 mt-4'>
                                 {canGenerateVoiceprint && (
-                                    <Button onClick={handleGenerateVoiceprint} disabled={isLoading} className='w-full'>
-                                        <Volume2 className='mr-2 h-4 w-4' />
-                                        Generate Voiceprint
-                                    </Button>
+                                    <>
+                                        <Button
+                                            onClick={handleGenerateVoiceprint}
+                                            disabled={isLoading}
+                                            className='w-full'
+                                        >
+                                            <Volume2 className='mr-2 h-4 w-4' />
+                                            Generate Voiceprint (auto-select)
+                                        </Button>
+
+                                        <Button
+                                            variant='outline'
+                                            onClick={handleToggleManual}
+                                            disabled={isLoading}
+                                            className='w-full justify-between'
+                                        >
+                                            <span className='flex items-center'>
+                                                <ListMusic className='mr-2 h-4 w-4' />
+                                                Choose segment manually
+                                            </span>
+                                            <ChevronDown
+                                                className={cn(
+                                                    "h-4 w-4 transition-transform",
+                                                    isManualOpen && "rotate-180",
+                                                )}
+                                            />
+                                        </Button>
+
+                                        {isManualOpen && (
+                                            <div className='space-y-2 rounded-md border p-3'>
+                                                {isLoadingCandidates ? (
+                                                    <div className='flex justify-center py-4'>
+                                                        <Loader2 className='h-5 w-5 animate-spin text-slate-400' />
+                                                    </div>
+                                                ) : candidates.length === 0 ? (
+                                                    <p className='text-sm text-slate-600'>
+                                                        No segments of at least 30 seconds are available for this person.
+                                                    </p>
+                                                ) : (
+                                                    <>
+                                                        <p className='text-xs text-slate-500'>
+                                                            Pick the segment with the clearest audio. A 30-second window
+                                                            centered on the segment will be used.
+                                                        </p>
+                                                        <ul className='space-y-2'>
+                                                            {candidates.map(candidate => {
+                                                                const isSelected =
+                                                                    selectedSegmentId === candidate.segmentId;
+                                                                return (
+                                                                    <li key={candidate.segmentId}>
+                                                                        <button
+                                                                            type='button'
+                                                                            onClick={() =>
+                                                                                setSelectedSegmentId(candidate.segmentId)
+                                                                            }
+                                                                            className={cn(
+                                                                                "w-full rounded-md border p-2 text-left text-sm transition-colors",
+                                                                                isSelected
+                                                                                    ? "border-blue-400 bg-blue-50"
+                                                                                    : "hover:bg-slate-50",
+                                                                            )}
+                                                                        >
+                                                                            <div className='flex items-center justify-between gap-2'>
+                                                                                <span className='font-medium'>
+                                                                                    {candidate.meetingName}
+                                                                                </span>
+                                                                                <span className='whitespace-nowrap text-xs text-slate-500'>
+                                                                                    {formatDuration(candidate.duration)}
+                                                                                </span>
+                                                                            </div>
+                                                                            <div className='text-xs text-slate-500'>
+                                                                                {new Date(
+                                                                                    candidate.meetingDate,
+                                                                                ).toLocaleDateString()}{" "}
+                                                                                ·{" "}
+                                                                                {formatTimestamp(
+                                                                                    candidate.startTimestamp,
+                                                                                )}
+                                                                            </div>
+                                                                            {candidate.textPreview && (
+                                                                                <p className='mt-1 line-clamp-2 text-xs text-slate-600'>
+                                                                                    {candidate.textPreview}
+                                                                                </p>
+                                                                            )}
+                                                                        </button>
+                                                                    </li>
+                                                                );
+                                                            })}
+                                                        </ul>
+                                                        <Button
+                                                            onClick={handleGenerateFromSegment}
+                                                            disabled={isLoading || !selectedSegmentId}
+                                                            className='w-full'
+                                                        >
+                                                            <Volume2 className='mr-2 h-4 w-4' />
+                                                            Generate from selected segment
+                                                        </Button>
+                                                    </>
+                                                )}
+                                            </div>
+                                        )}
+                                    </>
                                 )}
 
                                 {voicePrint && (

--- a/src/components/admin/people/voiceprint-actions.tsx
+++ b/src/components/admin/people/voiceprint-actions.tsx
@@ -333,7 +333,7 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
                                                             Pick the segment with the clearest audio. A 30-second window
                                                             centered on the segment will be used.
                                                         </p>
-                                                        <ul className='space-y-2'>
+                                                        <ul className='max-h-[45vh] space-y-2 overflow-y-auto pr-1'>
                                                             {candidates.map(candidate => {
                                                                 const isSelected =
                                                                     selectedSegmentId === candidate.segmentId;
@@ -368,12 +368,33 @@ export function VoiceprintActions({ personId, personName, voicePrint }: Voicepri
                                                                                     candidate.startTimestamp,
                                                                                 )}
                                                                             </div>
-                                                                            {candidate.textPreview && (
-                                                                                <p className='mt-1 line-clamp-2 text-xs text-slate-600'>
-                                                                                    {candidate.textPreview}
+                                                                            {candidate.windowText && (
+                                                                                <p className='mt-1 text-xs text-slate-600'>
+                                                                                    {candidate.windowText}
                                                                                 </p>
                                                                             )}
                                                                         </button>
+                                                                        {candidate.mediaUrl && (
+                                                                            <audio
+                                                                                controls
+                                                                                preload='none'
+                                                                                src={`${candidate.mediaUrl}#t=${candidate.previewStartTimestamp},${candidate.previewEndTimestamp}`}
+                                                                                className='mt-1 h-8 w-full'
+                                                                                aria-label={`Προεπισκόπηση ήχου για ${candidate.meetingName}`}
+                                                                            >
+                                                                                Your browser does not support audio playback.
+                                                                            </audio>
+                                                                        )}
+                                                                        {candidate.fullText && (
+                                                                            <details className='mt-1'>
+                                                                                <summary className='cursor-pointer text-xs text-slate-500 hover:text-slate-700'>
+                                                                                    Όλο το κείμενο του τμήματος
+                                                                                </summary>
+                                                                                <p className='mt-1 max-h-32 overflow-y-auto whitespace-pre-wrap rounded-md bg-slate-50 p-2 text-xs text-slate-600'>
+                                                                                    {candidate.fullText}
+                                                                                </p>
+                                                                            </details>
+                                                                        )}
                                                                     </li>
                                                                 );
                                                             })}

--- a/src/lib/__tests__/generateVoiceprint.test.ts
+++ b/src/lib/__tests__/generateVoiceprint.test.ts
@@ -111,6 +111,13 @@ describe("getCandidateSegmentsForVoiceprint", () => {
         const result = await getCandidateSegmentsForVoiceprint(PERSON_ID);
 
         expect(mockWithUserAuthorizedToEdit).toHaveBeenCalledWith({ cityId: CITY_ID });
+        // The segment scan must be scoped to the person's city so a caller can't
+        // read transcript content from cities they aren't authorized for.
+        expect(mockPrisma.speakerSegment.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: expect.objectContaining({ cityId: CITY_ID }),
+            }),
+        );
         expect(result.map(c => c.segmentId)).toEqual(["seg-long", "seg-medium"]);
         expect(result[0].duration).toBe(90);
 

--- a/src/lib/__tests__/generateVoiceprint.test.ts
+++ b/src/lib/__tests__/generateVoiceprint.test.ts
@@ -7,6 +7,9 @@ const mockPrisma = {
         findUnique: jest.fn(),
         findMany: jest.fn(),
     },
+    utterance: {
+        findMany: jest.fn(),
+    },
 };
 
 jest.mock("../db/prisma", () => ({
@@ -56,15 +59,15 @@ beforeEach(() => {
 describe("getCandidateSegmentsForVoiceprint", () => {
     it("filters out short segments, sorts longest-first, and builds previews", async () => {
         mockPrisma.person.findUnique.mockResolvedValue({ cityId: CITY_ID });
+        // First pass: segment scan without transcripts.
         mockPrisma.speakerSegment.findMany.mockResolvedValue([
             {
                 id: "seg-short",
                 meetingId: MEETING_ID,
                 cityId: CITY_ID,
                 startTimestamp: 0,
-                endTimestamp: 10, // 10s -> filtered out
+                endTimestamp: 10, // 10s -> filtered out before the transcript fetch
                 meeting: { name: "Meeting A", name_en: "Meeting A", dateTime: new Date("2024-01-01T00:00:00Z") },
-                utterances: [{ text: "too short", startTimestamp: 0, endTimestamp: 10 }],
             },
             {
                 id: "seg-medium",
@@ -79,13 +82,6 @@ describe("getCandidateSegmentsForVoiceprint", () => {
                     audioUrl: null,
                     videoUrl: "https://media/meeting-b.mp4",
                 },
-                // window is [107.5, 137.5]; "intro" and "outro" fall outside it
-                utterances: [
-                    { text: "intro", startTimestamp: 100, endTimestamp: 105 },
-                    { text: "hello", startTimestamp: 110, endTimestamp: 120 },
-                    { text: "world", startTimestamp: 125, endTimestamp: 135 },
-                    { text: "outro", startTimestamp: 140, endTimestamp: 145 },
-                ],
             },
             {
                 id: "seg-long",
@@ -100,8 +96,16 @@ describe("getCandidateSegmentsForVoiceprint", () => {
                     audioUrl: "https://media/meeting-c.mp3",
                     videoUrl: "https://media/meeting-c.mp4",
                 },
-                utterances: [{ text: "longest segment", startTimestamp: 200, endTimestamp: 290 }],
             },
+        ]);
+        // Second pass: transcripts only for the surviving (longest) segments.
+        // seg-medium window is [107.5, 137.5]; "intro" and "outro" fall outside it.
+        mockPrisma.utterance.findMany.mockResolvedValue([
+            { speakerSegmentId: "seg-long", text: "longest segment", startTimestamp: 200, endTimestamp: 290 },
+            { speakerSegmentId: "seg-medium", text: "intro", startTimestamp: 100, endTimestamp: 105 },
+            { speakerSegmentId: "seg-medium", text: "hello", startTimestamp: 110, endTimestamp: 120 },
+            { speakerSegmentId: "seg-medium", text: "world", startTimestamp: 125, endTimestamp: 135 },
+            { speakerSegmentId: "seg-medium", text: "outro", startTimestamp: 140, endTimestamp: 145 },
         ]);
 
         const result = await getCandidateSegmentsForVoiceprint(PERSON_ID);

--- a/src/lib/__tests__/generateVoiceprint.test.ts
+++ b/src/lib/__tests__/generateVoiceprint.test.ts
@@ -42,6 +42,7 @@ import {
     getCandidateSegmentsForVoiceprint,
     requestGenerateVoiceprintForSegment,
 } from "../tasks/generateVoiceprint";
+import { computeVoiceprintWindow } from "../tasks/voiceprintWindow";
 
 const PERSON_ID = "person-1";
 const CITY_ID = "city-1";
@@ -63,7 +64,7 @@ describe("getCandidateSegmentsForVoiceprint", () => {
                 startTimestamp: 0,
                 endTimestamp: 10, // 10s -> filtered out
                 meeting: { name: "Meeting A", name_en: "Meeting A", dateTime: new Date("2024-01-01T00:00:00Z") },
-                utterances: [{ text: "too short" }],
+                utterances: [{ text: "too short", startTimestamp: 0, endTimestamp: 10 }],
             },
             {
                 id: "seg-medium",
@@ -71,8 +72,20 @@ describe("getCandidateSegmentsForVoiceprint", () => {
                 cityId: CITY_ID,
                 startTimestamp: 100,
                 endTimestamp: 145, // 45s
-                meeting: { name: "Meeting B", name_en: "Meeting B", dateTime: new Date("2024-02-01T00:00:00Z") },
-                utterances: [{ text: "hello" }, { text: "world" }],
+                meeting: {
+                    name: "Meeting B",
+                    name_en: "Meeting B",
+                    dateTime: new Date("2024-02-01T00:00:00Z"),
+                    audioUrl: null,
+                    videoUrl: "https://media/meeting-b.mp4",
+                },
+                // window is [107.5, 137.5]; "intro" and "outro" fall outside it
+                utterances: [
+                    { text: "intro", startTimestamp: 100, endTimestamp: 105 },
+                    { text: "hello", startTimestamp: 110, endTimestamp: 120 },
+                    { text: "world", startTimestamp: 125, endTimestamp: 135 },
+                    { text: "outro", startTimestamp: 140, endTimestamp: 145 },
+                ],
             },
             {
                 id: "seg-long",
@@ -80,8 +93,14 @@ describe("getCandidateSegmentsForVoiceprint", () => {
                 cityId: CITY_ID,
                 startTimestamp: 200,
                 endTimestamp: 290, // 90s
-                meeting: { name: "Meeting C", name_en: "Meeting C", dateTime: new Date("2024-03-01T00:00:00Z") },
-                utterances: [{ text: "longest segment" }],
+                meeting: {
+                    name: "Meeting C",
+                    name_en: "Meeting C",
+                    dateTime: new Date("2024-03-01T00:00:00Z"),
+                    audioUrl: "https://media/meeting-c.mp3",
+                    videoUrl: "https://media/meeting-c.mp4",
+                },
+                utterances: [{ text: "longest segment", startTimestamp: 200, endTimestamp: 290 }],
             },
         ]);
 
@@ -90,12 +109,48 @@ describe("getCandidateSegmentsForVoiceprint", () => {
         expect(mockWithUserAuthorizedToEdit).toHaveBeenCalledWith({ cityId: CITY_ID });
         expect(result.map(c => c.segmentId)).toEqual(["seg-long", "seg-medium"]);
         expect(result[0].duration).toBe(90);
-        expect(result[1].textPreview).toBe("hello world");
+
+        // windowText is only the utterances inside the centered 30s window;
+        // fullText is the whole segment
+        expect(result[1].windowText).toBe("hello world");
+        expect(result[1].fullText).toBe("intro hello world outro");
+
+        // mediaUrl prefers audioUrl, falls back to videoUrl
+        expect(result[0].mediaUrl).toBe("https://media/meeting-c.mp3");
+        expect(result[1].mediaUrl).toBe("https://media/meeting-b.mp4");
+
+        // preview window matches the 30s window the voiceprint job will consume
+        expect(result[0].previewStartTimestamp).toBe(230);
+        expect(result[0].previewEndTimestamp).toBe(260);
+        expect(result[1].previewStartTimestamp).toBe(107.5);
+        expect(result[1].previewEndTimestamp).toBe(137.5);
     });
 
     it("throws when the person does not exist", async () => {
         mockPrisma.person.findUnique.mockResolvedValue(null);
         await expect(getCandidateSegmentsForVoiceprint(PERSON_ID)).rejects.toThrow("Person not found");
+    });
+});
+
+describe("computeVoiceprintWindow", () => {
+    it("returns the whole segment when it is exactly the window length", () => {
+        expect(computeVoiceprintWindow(100, 130)).toEqual({ startTimestamp: 100, endTimestamp: 130 });
+    });
+
+    it("centers a 30s window on the midpoint of a longer segment", () => {
+        // 90s segment [200, 290] -> midpoint 245 -> [230, 260]
+        expect(computeVoiceprintWindow(200, 290)).toEqual({ startTimestamp: 230, endTimestamp: 260 });
+    });
+
+    it("handles fractional bounds", () => {
+        // 45s segment [100, 145] -> midpoint 122.5 -> [107.5, 137.5]
+        expect(computeVoiceprintWindow(100, 145)).toEqual({ startTimestamp: 107.5, endTimestamp: 137.5 });
+    });
+
+    it("rejects invalid inputs", () => {
+        expect(() => computeVoiceprintWindow(NaN, 100)).toThrow(/finite/);
+        expect(() => computeVoiceprintWindow(200, 100)).toThrow(/must not exceed/);
+        expect(() => computeVoiceprintWindow(0, 100, 0)).toThrow(/positive/);
     });
 });
 

--- a/src/lib/__tests__/generateVoiceprint.test.ts
+++ b/src/lib/__tests__/generateVoiceprint.test.ts
@@ -1,0 +1,163 @@
+// Mock Prisma client
+const mockPrisma = {
+    person: {
+        findUnique: jest.fn(),
+    },
+    speakerSegment: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+    },
+};
+
+jest.mock("../db/prisma", () => ({
+    __esModule: true,
+    default: mockPrisma,
+}));
+
+// Mock auth module
+const mockWithUserAuthorizedToEdit = jest.fn();
+jest.mock("../auth", () => ({
+    withUserAuthorizedToEdit: (...args: unknown[]) => mockWithUserAuthorizedToEdit(...args),
+    isUserAuthorizedToEdit: jest.fn(),
+}));
+
+// Mock task dispatch
+const mockStartTask = jest.fn();
+jest.mock("../tasks/tasks", () => ({
+    startTask: (...args: unknown[]) => mockStartTask(...args),
+}));
+
+// Mock meeting lookup
+const mockGetCouncilMeeting = jest.fn();
+jest.mock("../db/meetings", () => ({
+    getCouncilMeeting: (...args: unknown[]) => mockGetCouncilMeeting(...args),
+}));
+
+// Mock voiceprint db helper (imported by the module under test)
+jest.mock("@/lib/db/voiceprints", () => ({
+    createVoicePrint: jest.fn(),
+}));
+
+import {
+    getCandidateSegmentsForVoiceprint,
+    requestGenerateVoiceprintForSegment,
+} from "../tasks/generateVoiceprint";
+
+const PERSON_ID = "person-1";
+const CITY_ID = "city-1";
+const MEETING_ID = "meeting-1";
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockWithUserAuthorizedToEdit.mockResolvedValue(undefined);
+});
+
+describe("getCandidateSegmentsForVoiceprint", () => {
+    it("filters out short segments, sorts longest-first, and builds previews", async () => {
+        mockPrisma.person.findUnique.mockResolvedValue({ cityId: CITY_ID });
+        mockPrisma.speakerSegment.findMany.mockResolvedValue([
+            {
+                id: "seg-short",
+                meetingId: MEETING_ID,
+                cityId: CITY_ID,
+                startTimestamp: 0,
+                endTimestamp: 10, // 10s -> filtered out
+                meeting: { name: "Meeting A", name_en: "Meeting A", dateTime: new Date("2024-01-01T00:00:00Z") },
+                utterances: [{ text: "too short" }],
+            },
+            {
+                id: "seg-medium",
+                meetingId: MEETING_ID,
+                cityId: CITY_ID,
+                startTimestamp: 100,
+                endTimestamp: 145, // 45s
+                meeting: { name: "Meeting B", name_en: "Meeting B", dateTime: new Date("2024-02-01T00:00:00Z") },
+                utterances: [{ text: "hello" }, { text: "world" }],
+            },
+            {
+                id: "seg-long",
+                meetingId: MEETING_ID,
+                cityId: CITY_ID,
+                startTimestamp: 200,
+                endTimestamp: 290, // 90s
+                meeting: { name: "Meeting C", name_en: "Meeting C", dateTime: new Date("2024-03-01T00:00:00Z") },
+                utterances: [{ text: "longest segment" }],
+            },
+        ]);
+
+        const result = await getCandidateSegmentsForVoiceprint(PERSON_ID);
+
+        expect(mockWithUserAuthorizedToEdit).toHaveBeenCalledWith({ cityId: CITY_ID });
+        expect(result.map(c => c.segmentId)).toEqual(["seg-long", "seg-medium"]);
+        expect(result[0].duration).toBe(90);
+        expect(result[1].textPreview).toBe("hello world");
+    });
+
+    it("throws when the person does not exist", async () => {
+        mockPrisma.person.findUnique.mockResolvedValue(null);
+        await expect(getCandidateSegmentsForVoiceprint(PERSON_ID)).rejects.toThrow("Person not found");
+    });
+});
+
+describe("requestGenerateVoiceprintForSegment", () => {
+    it("rejects a segment that does not belong to the person", async () => {
+        mockPrisma.speakerSegment.findUnique.mockResolvedValue({
+            id: "seg-1",
+            cityId: CITY_ID,
+            meetingId: MEETING_ID,
+            startTimestamp: 0,
+            endTimestamp: 60,
+            speakerTag: { personId: "someone-else" },
+        });
+
+        await expect(requestGenerateVoiceprintForSegment(PERSON_ID, "seg-1")).rejects.toThrow(
+            "The selected segment does not belong to this person",
+        );
+        expect(mockStartTask).not.toHaveBeenCalled();
+    });
+
+    it("rejects a segment that is too short", async () => {
+        mockPrisma.speakerSegment.findUnique.mockResolvedValue({
+            id: "seg-1",
+            cityId: CITY_ID,
+            meetingId: MEETING_ID,
+            startTimestamp: 0,
+            endTimestamp: 10, // 10s < 30s
+            speakerTag: { personId: PERSON_ID },
+        });
+
+        await expect(requestGenerateVoiceprintForSegment(PERSON_ID, "seg-1")).rejects.toThrow(/too short/);
+        expect(mockStartTask).not.toHaveBeenCalled();
+    });
+
+    it("dispatches a task with a 30s window centered on the segment midpoint", async () => {
+        mockPrisma.speakerSegment.findUnique.mockResolvedValue({
+            id: "seg-1",
+            cityId: CITY_ID,
+            meetingId: MEETING_ID,
+            startTimestamp: 100,
+            endTimestamp: 200, // 100s, midpoint 150
+            speakerTag: { personId: PERSON_ID },
+        });
+        mockGetCouncilMeeting.mockResolvedValue({ audioUrl: "http://audio", videoUrl: null });
+        mockStartTask.mockResolvedValue({ id: "task-1" });
+
+        const task = await requestGenerateVoiceprintForSegment(PERSON_ID, "seg-1");
+
+        expect(task).toEqual({ id: "task-1" });
+        expect(mockWithUserAuthorizedToEdit).toHaveBeenCalledWith({ cityId: CITY_ID });
+        expect(mockStartTask).toHaveBeenCalledWith(
+            "generateVoiceprint",
+            expect.objectContaining({
+                mediaUrl: "http://audio",
+                personId: PERSON_ID,
+                segmentId: "seg-1",
+                startTimestamp: 135, // 150 - 15
+                endTimestamp: 165, // 135 + 30
+                cityId: CITY_ID,
+            }),
+            MEETING_ID,
+            CITY_ID,
+        );
+    });
+});

--- a/src/lib/__tests__/generateVoiceprint.test.ts
+++ b/src/lib/__tests__/generateVoiceprint.test.ts
@@ -1,0 +1,163 @@
+// Mock Prisma client
+const mockPrisma = {
+    person: {
+        findUnique: jest.fn(),
+    },
+    speakerSegment: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+    },
+};
+
+jest.mock("../db/prisma", () => ({
+    __esModule: true,
+    default: mockPrisma,
+}));
+
+// Mock auth module
+const mockWithUserAuthorizedToEdit = jest.fn();
+jest.mock("../auth", () => ({
+    withUserAuthorizedToEdit: (...args: unknown[]) => mockWithUserAuthorizedToEdit(...args),
+    isUserAuthorizedToEdit: jest.fn(),
+}));
+
+// Mock task dispatch
+const mockStartTask = jest.fn();
+jest.mock("../tasks/tasks", () => ({
+    startTask: (...args: unknown[]) => mockStartTask(...args),
+}));
+
+// Mock meeting lookup
+const mockGetCouncilMeeting = jest.fn();
+jest.mock("../db/meetings", () => ({
+    getCouncilMeeting: (...args: unknown[]) => mockGetCouncilMeeting(...args),
+}));
+
+// Mock voiceprint db helper (imported by the module under test)
+jest.mock("@/lib/db/voiceprintsCreate", () => ({
+    createVoicePrintDirect: jest.fn(),
+}));
+
+import {
+    getCandidateSegmentsForVoiceprint,
+    requestGenerateVoiceprintForSegment,
+} from "../tasks/generateVoiceprint";
+
+const PERSON_ID = "person-1";
+const CITY_ID = "city-1";
+const MEETING_ID = "meeting-1";
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockWithUserAuthorizedToEdit.mockResolvedValue(undefined);
+});
+
+describe("getCandidateSegmentsForVoiceprint", () => {
+    it("filters out short segments, sorts longest-first, and builds previews", async () => {
+        mockPrisma.person.findUnique.mockResolvedValue({ cityId: CITY_ID });
+        mockPrisma.speakerSegment.findMany.mockResolvedValue([
+            {
+                id: "seg-short",
+                meetingId: MEETING_ID,
+                cityId: CITY_ID,
+                startTimestamp: 0,
+                endTimestamp: 10, // 10s -> filtered out
+                meeting: { name: "Meeting A", name_en: "Meeting A", dateTime: new Date("2024-01-01T00:00:00Z") },
+                utterances: [{ text: "too short" }],
+            },
+            {
+                id: "seg-medium",
+                meetingId: MEETING_ID,
+                cityId: CITY_ID,
+                startTimestamp: 100,
+                endTimestamp: 145, // 45s
+                meeting: { name: "Meeting B", name_en: "Meeting B", dateTime: new Date("2024-02-01T00:00:00Z") },
+                utterances: [{ text: "hello" }, { text: "world" }],
+            },
+            {
+                id: "seg-long",
+                meetingId: MEETING_ID,
+                cityId: CITY_ID,
+                startTimestamp: 200,
+                endTimestamp: 290, // 90s
+                meeting: { name: "Meeting C", name_en: "Meeting C", dateTime: new Date("2024-03-01T00:00:00Z") },
+                utterances: [{ text: "longest segment" }],
+            },
+        ]);
+
+        const result = await getCandidateSegmentsForVoiceprint(PERSON_ID);
+
+        expect(mockWithUserAuthorizedToEdit).toHaveBeenCalledWith({ cityId: CITY_ID });
+        expect(result.map(c => c.segmentId)).toEqual(["seg-long", "seg-medium"]);
+        expect(result[0].duration).toBe(90);
+        expect(result[1].textPreview).toBe("hello world");
+    });
+
+    it("throws when the person does not exist", async () => {
+        mockPrisma.person.findUnique.mockResolvedValue(null);
+        await expect(getCandidateSegmentsForVoiceprint(PERSON_ID)).rejects.toThrow("Person not found");
+    });
+});
+
+describe("requestGenerateVoiceprintForSegment", () => {
+    it("rejects a segment that does not belong to the person", async () => {
+        mockPrisma.speakerSegment.findUnique.mockResolvedValue({
+            id: "seg-1",
+            cityId: CITY_ID,
+            meetingId: MEETING_ID,
+            startTimestamp: 0,
+            endTimestamp: 60,
+            speakerTag: { personId: "someone-else" },
+        });
+
+        await expect(requestGenerateVoiceprintForSegment(PERSON_ID, "seg-1")).rejects.toThrow(
+            "The selected segment does not belong to this person",
+        );
+        expect(mockStartTask).not.toHaveBeenCalled();
+    });
+
+    it("rejects a segment that is too short", async () => {
+        mockPrisma.speakerSegment.findUnique.mockResolvedValue({
+            id: "seg-1",
+            cityId: CITY_ID,
+            meetingId: MEETING_ID,
+            startTimestamp: 0,
+            endTimestamp: 10, // 10s < 30s
+            speakerTag: { personId: PERSON_ID },
+        });
+
+        await expect(requestGenerateVoiceprintForSegment(PERSON_ID, "seg-1")).rejects.toThrow(/too short/);
+        expect(mockStartTask).not.toHaveBeenCalled();
+    });
+
+    it("dispatches a task with a 30s window centered on the segment midpoint", async () => {
+        mockPrisma.speakerSegment.findUnique.mockResolvedValue({
+            id: "seg-1",
+            cityId: CITY_ID,
+            meetingId: MEETING_ID,
+            startTimestamp: 100,
+            endTimestamp: 200, // 100s, midpoint 150
+            speakerTag: { personId: PERSON_ID },
+        });
+        mockGetCouncilMeeting.mockResolvedValue({ audioUrl: "http://audio", videoUrl: null });
+        mockStartTask.mockResolvedValue({ id: "task-1" });
+
+        const task = await requestGenerateVoiceprintForSegment(PERSON_ID, "seg-1");
+
+        expect(task).toEqual({ id: "task-1" });
+        expect(mockWithUserAuthorizedToEdit).toHaveBeenCalledWith({ cityId: CITY_ID });
+        expect(mockStartTask).toHaveBeenCalledWith(
+            "generateVoiceprint",
+            expect.objectContaining({
+                mediaUrl: "http://audio",
+                personId: PERSON_ID,
+                segmentId: "seg-1",
+                startTimestamp: 135, // 150 - 15
+                endTimestamp: 165, // 135 + 30
+                cityId: CITY_ID,
+            }),
+            MEETING_ID,
+            CITY_ID,
+        );
+    });
+});

--- a/src/lib/tasks/generateVoiceprint.ts
+++ b/src/lib/tasks/generateVoiceprint.ts
@@ -7,8 +7,7 @@ import { startTask } from "./tasks";
 import { GenerateVoiceprintRequest, GenerateVoiceprintResult } from "../apiTypes";
 import { SpeakerSegment } from "@prisma/client";
 import { createVoicePrint } from "@/lib/db/voiceprints";
-
-const VOICEPRINT_DURATION = 30;
+import { VOICEPRINT_DURATION, computeVoiceprintWindow } from "@/lib/tasks/voiceprintWindow";
 
 /**
  * Find all people in a city who are eligible for voiceprint generation
@@ -134,13 +133,11 @@ async function dispatchVoiceprintTaskForSegment(personId: string, segment: Speak
         throw new Error("Meeting media URL not found");
     }
 
-    // Calculate a segment centered on the midpoint
-    const segmentMidpoint = segment.startTimestamp + segmentDuration / 2;
-
-    // Take VOICEPRINT_DURATION seconds centered on the midpoint, ensuring we stay within segment bounds
-    const halfDuration = VOICEPRINT_DURATION / 2;
-    const startTimestamp = Math.max(segment.startTimestamp, segmentMidpoint - halfDuration);
-    const endTimestamp = Math.min(segment.endTimestamp, startTimestamp + VOICEPRINT_DURATION);
+    // Take a VOICEPRINT_DURATION window centered on the segment, clamped to its bounds
+    const { startTimestamp, endTimestamp } = computeVoiceprintWindow(
+        segment.startTimestamp,
+        segment.endTimestamp,
+    );
 
     // Create the request
     const request: Omit<GenerateVoiceprintRequest, "callbackUrl"> = {
@@ -263,11 +260,14 @@ export interface VoiceprintCandidateSegment {
     startTimestamp: number;
     endTimestamp: number;
     duration: number; // seconds
-    textPreview: string; // first chunk of the transcript for this segment
+    mediaUrl: string | null; // meeting audio/video URL for audio preview, if available
+    previewStartTimestamp: number; // start of the 30s window the voiceprint will use (seconds)
+    previewEndTimestamp: number; // end of the 30s window the voiceprint will use (seconds)
+    windowText: string; // transcript of the centered 30s window — what the admin actually hears
+    fullText: string; // full transcript of the segment — shown on demand for fuller context
 }
 
 const MAX_VOICEPRINT_CANDIDATES = 5;
-const TEXT_PREVIEW_MAX_LENGTH = 240;
 
 /**
  * Return the top candidate speaker segments for manual voiceprint selection.
@@ -301,11 +301,11 @@ export async function getCandidateSegmentsForVoiceprint(personId: string): Promi
             startTimestamp: true,
             endTimestamp: true,
             meeting: {
-                select: { name: true, name_en: true, dateTime: true },
+                select: { name: true, name_en: true, dateTime: true, audioUrl: true, videoUrl: true },
             },
             utterances: {
                 orderBy: { startTimestamp: "asc" },
-                select: { text: true },
+                select: { text: true, startTimestamp: true, endTimestamp: true },
             },
         },
     });
@@ -313,11 +313,25 @@ export async function getCandidateSegmentsForVoiceprint(personId: string): Promi
     return segments
         .map(segment => {
             const duration = segment.endTimestamp - segment.startTimestamp;
+
+            // Same media URL the dispatch uses, so the admin previews exactly what
+            // the voiceprint job will consume.
+            const mediaUrl = segment.meeting.audioUrl || segment.meeting.videoUrl || null;
+            const previewWindow = computeVoiceprintWindow(segment.startTimestamp, segment.endTimestamp);
+
+            // windowText is the transcript of the centered 30s window the voiceprint
+            // uses — i.e. what the admin hears in the audio preview, so they can read
+            // along. fullText is the whole segment, shown on demand.
+            const windowText = segment.utterances
+                .filter(
+                    u =>
+                        u.startTimestamp < previewWindow.endTimestamp &&
+                        u.endTimestamp > previewWindow.startTimestamp,
+                )
+                .map(u => u.text)
+                .join(" ")
+                .trim();
             const fullText = segment.utterances.map(u => u.text).join(" ").trim();
-            const textPreview =
-                fullText.length > TEXT_PREVIEW_MAX_LENGTH
-                    ? `${fullText.slice(0, TEXT_PREVIEW_MAX_LENGTH).trimEnd()}…`
-                    : fullText;
 
             return {
                 segmentId: segment.id,
@@ -329,7 +343,11 @@ export async function getCandidateSegmentsForVoiceprint(personId: string): Promi
                 startTimestamp: segment.startTimestamp,
                 endTimestamp: segment.endTimestamp,
                 duration,
-                textPreview,
+                mediaUrl,
+                previewStartTimestamp: previewWindow.startTimestamp,
+                previewEndTimestamp: previewWindow.endTimestamp,
+                windowText,
+                fullText,
             };
         })
         .filter(candidate => candidate.duration >= VOICEPRINT_DURATION)

--- a/src/lib/tasks/generateVoiceprint.ts
+++ b/src/lib/tasks/generateVoiceprint.ts
@@ -189,8 +189,10 @@ export async function requestGenerateVoiceprintForSegment(personId: string, segm
         throw new Error("Speaker segment not found");
     }
 
-    // Ensure the chosen segment actually belongs to this person
-    if (segment.speakerTag.personId !== personId) {
+    // Ensure the chosen segment actually belongs to this person. The speakerTag
+    // FK is required by the schema, but guard against a missing relation anyway so
+    // an unexpected null raises the ownership error rather than a bare TypeError.
+    if (!segment.speakerTag || segment.speakerTag.personId !== personId) {
         throw new Error("The selected segment does not belong to this person");
     }
 

--- a/src/lib/tasks/generateVoiceprint.ts
+++ b/src/lib/tasks/generateVoiceprint.ts
@@ -104,16 +104,14 @@ export async function requestGenerateVoiceprintsForCity(cityId: string) {
 }
 
 /**
- * Request to generate a voiceprint for a person
+ * Build and dispatch a generateVoiceprint task for an explicit speaker segment.
+ *
+ * Shared by both the automatic (longest-segment) flow and the manual
+ * segment-selection flow. Validates the segment is long enough, resolves the
+ * meeting media URL, authorizes the caller for the segment's city, and computes
+ * a VOICEPRINT_DURATION window centered on the segment midpoint.
  */
-export async function requestGenerateVoiceprint(personId: string) {
-    // Find the longest speaker segment for this person
-    const segment = await findLongestSpeakerSegmentForPerson(personId);
-
-    if (!segment) {
-        throw new Error("No speaker segments found for this person");
-    }
-
+async function dispatchVoiceprintTaskForSegment(personId: string, segment: SpeakerSegment) {
     // Check if the segment is long enough for a voiceprint
     const segmentDuration = segment.endTimestamp - segment.startTimestamp;
     if (segmentDuration < VOICEPRINT_DURATION) {
@@ -158,6 +156,56 @@ export async function requestGenerateVoiceprint(personId: string) {
 }
 
 /**
+ * Request to generate a voiceprint for a person, automatically selecting the
+ * longest available speaker segment.
+ */
+export async function requestGenerateVoiceprint(personId: string) {
+    // Find the longest speaker segment for this person
+    const segment = await findLongestSpeakerSegmentForPerson(personId);
+
+    if (!segment) {
+        throw new Error("No speaker segments found for this person");
+    }
+
+    return dispatchVoiceprintTaskForSegment(personId, segment);
+}
+
+/**
+ * Request to generate a voiceprint for a person from a specific, manually
+ * chosen speaker segment.
+ *
+ * This is the manual counterpart to {@link requestGenerateVoiceprint}: instead
+ * of auto-picking the longest segment, the admin picks one of the candidate
+ * segments returned by {@link getCandidateSegmentsForVoiceprint}.
+ */
+export async function requestGenerateVoiceprintForSegment(personId: string, segmentId: string) {
+    const segment = await prisma.speakerSegment.findUnique({
+        where: { id: segmentId },
+        include: {
+            speakerTag: {
+                select: { personId: true },
+            },
+        },
+    });
+
+    if (!segment) {
+        throw new Error("Speaker segment not found");
+    }
+
+    // Ensure the chosen segment actually belongs to this person
+    if (segment.speakerTag.personId !== personId) {
+        throw new Error("The selected segment does not belong to this person");
+    }
+
+    // dispatchVoiceprintTaskForSegment expects a plain SpeakerSegment; drop the
+    // included relation before passing it through.
+    const { speakerTag, ...plainSegment } = segment;
+    void speakerTag;
+
+    return dispatchVoiceprintTaskForSegment(personId, plainSegment);
+}
+
+/**
  * Find the longest speaker segment for a given person
  */
 export async function findLongestSpeakerSegmentForPerson(personId: string): Promise<SpeakerSegment | null> {
@@ -199,6 +247,94 @@ export async function findLongestSpeakerSegmentForPerson(personId: string): Prom
         console.error("Error finding longest speaker segment:", error);
         return null;
     }
+}
+
+/**
+ * A speaker segment that is eligible to be used as the source for a voiceprint,
+ * enriched with the metadata an admin needs to choose between candidates.
+ */
+export interface VoiceprintCandidateSegment {
+    segmentId: string;
+    meetingId: string;
+    cityId: string;
+    meetingName: string;
+    meetingNameEn: string;
+    meetingDate: string; // ISO string
+    startTimestamp: number;
+    endTimestamp: number;
+    duration: number; // seconds
+    textPreview: string; // first chunk of the transcript for this segment
+}
+
+const MAX_VOICEPRINT_CANDIDATES = 5;
+const TEXT_PREVIEW_MAX_LENGTH = 240;
+
+/**
+ * Return the top candidate speaker segments for manual voiceprint selection.
+ *
+ * Candidates are segments belonging to the person that are at least
+ * VOICEPRINT_DURATION long, sorted longest-first and capped at
+ * MAX_VOICEPRINT_CANDIDATES. Each candidate carries enough metadata
+ * (meeting, duration, transcript preview) for an admin to make an informed
+ * choice in the UI.
+ */
+export async function getCandidateSegmentsForVoiceprint(personId: string): Promise<VoiceprintCandidateSegment[]> {
+    const person = await prisma.person.findUnique({
+        where: { id: personId },
+        select: { cityId: true },
+    });
+
+    if (!person) {
+        throw new Error("Person not found");
+    }
+
+    await withUserAuthorizedToEdit({ cityId: person.cityId });
+
+    const segments = await prisma.speakerSegment.findMany({
+        where: {
+            speakerTag: { personId },
+        },
+        select: {
+            id: true,
+            meetingId: true,
+            cityId: true,
+            startTimestamp: true,
+            endTimestamp: true,
+            meeting: {
+                select: { name: true, name_en: true, dateTime: true },
+            },
+            utterances: {
+                orderBy: { startTimestamp: "asc" },
+                select: { text: true },
+            },
+        },
+    });
+
+    return segments
+        .map(segment => {
+            const duration = segment.endTimestamp - segment.startTimestamp;
+            const fullText = segment.utterances.map(u => u.text).join(" ").trim();
+            const textPreview =
+                fullText.length > TEXT_PREVIEW_MAX_LENGTH
+                    ? `${fullText.slice(0, TEXT_PREVIEW_MAX_LENGTH).trimEnd()}…`
+                    : fullText;
+
+            return {
+                segmentId: segment.id,
+                meetingId: segment.meetingId,
+                cityId: segment.cityId,
+                meetingName: segment.meeting.name,
+                meetingNameEn: segment.meeting.name_en,
+                meetingDate: segment.meeting.dateTime.toISOString(),
+                startTimestamp: segment.startTimestamp,
+                endTimestamp: segment.endTimestamp,
+                duration,
+                textPreview,
+            };
+        })
+        .filter(candidate => candidate.duration >= VOICEPRINT_DURATION)
+        .sort((a, b) => b.duration - a.duration)
+        .slice(0, MAX_VOICEPRINT_CANDIDATES);
 }
 
 /**

--- a/src/lib/tasks/generateVoiceprint.ts
+++ b/src/lib/tasks/generateVoiceprint.ts
@@ -292,6 +292,11 @@ export async function getCandidateSegmentsForVoiceprint(personId: string): Promi
 
     await withUserAuthorizedToEdit({ cityId: person.cityId });
 
+    // First pass: scan the person's segments WITHOUT transcripts — just timestamps
+    // and meeting metadata — and keep only the longest eligible ones. Prisma can't
+    // order/filter by the computed (endTimestamp - startTimestamp) duration, but
+    // these rows are cheap, and this bounds the expensive transcript fetch below to
+    // MAX_VOICEPRINT_CANDIDATES segments even for prolific speakers.
     const segments = await prisma.speakerSegment.findMany({
         where: {
             speakerTag: { personId },
@@ -305,56 +310,75 @@ export async function getCandidateSegmentsForVoiceprint(personId: string): Promi
             meeting: {
                 select: { name: true, name_en: true, dateTime: true, audioUrl: true, videoUrl: true },
             },
-            utterances: {
-                orderBy: { startTimestamp: "asc" },
-                select: { text: true, startTimestamp: true, endTimestamp: true },
-            },
         },
     });
 
-    return segments
-        .map(segment => {
-            const duration = segment.endTimestamp - segment.startTimestamp;
-
-            // Same media URL the dispatch uses, so the admin previews exactly what
-            // the voiceprint job will consume.
-            const mediaUrl = segment.meeting.audioUrl || segment.meeting.videoUrl || null;
-            const previewWindow = computeVoiceprintWindow(segment.startTimestamp, segment.endTimestamp);
-
-            // windowText is the transcript of the centered 30s window the voiceprint
-            // uses — i.e. what the admin hears in the audio preview, so they can read
-            // along. fullText is the whole segment, shown on demand.
-            const windowText = segment.utterances
-                .filter(
-                    u =>
-                        u.startTimestamp < previewWindow.endTimestamp &&
-                        u.endTimestamp > previewWindow.startTimestamp,
-                )
-                .map(u => u.text)
-                .join(" ")
-                .trim();
-            const fullText = segment.utterances.map(u => u.text).join(" ").trim();
-
-            return {
-                segmentId: segment.id,
-                meetingId: segment.meetingId,
-                cityId: segment.cityId,
-                meetingName: segment.meeting.name,
-                meetingNameEn: segment.meeting.name_en,
-                meetingDate: segment.meeting.dateTime.toISOString(),
-                startTimestamp: segment.startTimestamp,
-                endTimestamp: segment.endTimestamp,
-                duration,
-                mediaUrl,
-                previewStartTimestamp: previewWindow.startTimestamp,
-                previewEndTimestamp: previewWindow.endTimestamp,
-                windowText,
-                fullText,
-            };
-        })
-        .filter(candidate => candidate.duration >= VOICEPRINT_DURATION)
+    const topSegments = segments
+        .map(segment => ({ ...segment, duration: segment.endTimestamp - segment.startTimestamp }))
+        .filter(segment => segment.duration >= VOICEPRINT_DURATION)
         .sort((a, b) => b.duration - a.duration)
         .slice(0, MAX_VOICEPRINT_CANDIDATES);
+
+    if (topSegments.length === 0) {
+        return [];
+    }
+
+    // Second pass: fetch transcripts only for the chosen segments.
+    const utterances = await prisma.utterance.findMany({
+        where: { speakerSegmentId: { in: topSegments.map(s => s.id) } },
+        orderBy: { startTimestamp: "asc" },
+        select: { speakerSegmentId: true, text: true, startTimestamp: true, endTimestamp: true },
+    });
+
+    const utterancesBySegment = new Map<string, typeof utterances>();
+    for (const utterance of utterances) {
+        const list = utterancesBySegment.get(utterance.speakerSegmentId);
+        if (list) {
+            list.push(utterance);
+        } else {
+            utterancesBySegment.set(utterance.speakerSegmentId, [utterance]);
+        }
+    }
+
+    return topSegments.map(segment => {
+        // Same media URL the dispatch uses, so the admin previews exactly what
+        // the voiceprint job will consume.
+        const mediaUrl = segment.meeting.audioUrl || segment.meeting.videoUrl || null;
+        const previewWindow = computeVoiceprintWindow(segment.startTimestamp, segment.endTimestamp);
+
+        const segmentUtterances = utterancesBySegment.get(segment.id) ?? [];
+
+        // windowText is the transcript of the centered 30s window the voiceprint
+        // uses — i.e. what the admin hears in the audio preview, so they can read
+        // along. fullText is the whole segment, shown on demand.
+        const windowText = segmentUtterances
+            .filter(
+                u =>
+                    u.startTimestamp < previewWindow.endTimestamp &&
+                    u.endTimestamp > previewWindow.startTimestamp,
+            )
+            .map(u => u.text)
+            .join(" ")
+            .trim();
+        const fullText = segmentUtterances.map(u => u.text).join(" ").trim();
+
+        return {
+            segmentId: segment.id,
+            meetingId: segment.meetingId,
+            cityId: segment.cityId,
+            meetingName: segment.meeting.name,
+            meetingNameEn: segment.meeting.name_en,
+            meetingDate: segment.meeting.dateTime.toISOString(),
+            startTimestamp: segment.startTimestamp,
+            endTimestamp: segment.endTimestamp,
+            duration: segment.duration,
+            mediaUrl,
+            previewStartTimestamp: previewWindow.startTimestamp,
+            previewEndTimestamp: previewWindow.endTimestamp,
+            windowText,
+            fullText,
+        };
+    });
 }
 
 /**

--- a/src/lib/tasks/generateVoiceprint.ts
+++ b/src/lib/tasks/generateVoiceprint.ts
@@ -300,6 +300,10 @@ export async function getCandidateSegmentsForVoiceprint(personId: string): Promi
     const segments = await prisma.speakerSegment.findMany({
         where: {
             speakerTag: { personId },
+            // Scope to the person's city: the auth check above only asserts access
+            // to person.cityId, so without this a caller could read transcript text
+            // (meeting name, timestamps, full text) from segments in other cities.
+            cityId: person.cityId,
         },
         select: {
             id: true,

--- a/src/lib/tasks/generateVoiceprint.ts
+++ b/src/lib/tasks/generateVoiceprint.ts
@@ -7,8 +7,7 @@ import { startTask } from "./tasks";
 import { GenerateVoiceprintRequest, GenerateVoiceprintResult } from "../apiTypes";
 import { SpeakerSegment } from "@prisma/client";
 import { createVoicePrintDirect } from "@/lib/db/voiceprintsCreate";
-
-const VOICEPRINT_DURATION = 30;
+import { VOICEPRINT_DURATION, computeVoiceprintWindow } from "@/lib/tasks/voiceprintWindow";
 
 /**
  * Find all people in a city who are eligible for voiceprint generation
@@ -134,13 +133,11 @@ async function dispatchVoiceprintTaskForSegment(personId: string, segment: Speak
         throw new Error("Meeting media URL not found");
     }
 
-    // Calculate a segment centered on the midpoint
-    const segmentMidpoint = segment.startTimestamp + segmentDuration / 2;
-
-    // Take VOICEPRINT_DURATION seconds centered on the midpoint, ensuring we stay within segment bounds
-    const halfDuration = VOICEPRINT_DURATION / 2;
-    const startTimestamp = Math.max(segment.startTimestamp, segmentMidpoint - halfDuration);
-    const endTimestamp = Math.min(segment.endTimestamp, startTimestamp + VOICEPRINT_DURATION);
+    // Take a VOICEPRINT_DURATION window centered on the segment, clamped to its bounds
+    const { startTimestamp, endTimestamp } = computeVoiceprintWindow(
+        segment.startTimestamp,
+        segment.endTimestamp,
+    );
 
     // Create the request
     const request: Omit<GenerateVoiceprintRequest, "callbackUrl"> = {
@@ -263,11 +260,14 @@ export interface VoiceprintCandidateSegment {
     startTimestamp: number;
     endTimestamp: number;
     duration: number; // seconds
-    textPreview: string; // first chunk of the transcript for this segment
+    mediaUrl: string | null; // meeting audio/video URL for audio preview, if available
+    previewStartTimestamp: number; // start of the 30s window the voiceprint will use (seconds)
+    previewEndTimestamp: number; // end of the 30s window the voiceprint will use (seconds)
+    windowText: string; // transcript of the centered 30s window — what the admin actually hears
+    fullText: string; // full transcript of the segment — shown on demand for fuller context
 }
 
 const MAX_VOICEPRINT_CANDIDATES = 5;
-const TEXT_PREVIEW_MAX_LENGTH = 240;
 
 /**
  * Return the top candidate speaker segments for manual voiceprint selection.
@@ -301,11 +301,11 @@ export async function getCandidateSegmentsForVoiceprint(personId: string): Promi
             startTimestamp: true,
             endTimestamp: true,
             meeting: {
-                select: { name: true, name_en: true, dateTime: true },
+                select: { name: true, name_en: true, dateTime: true, audioUrl: true, videoUrl: true },
             },
             utterances: {
                 orderBy: { startTimestamp: "asc" },
-                select: { text: true },
+                select: { text: true, startTimestamp: true, endTimestamp: true },
             },
         },
     });
@@ -313,11 +313,25 @@ export async function getCandidateSegmentsForVoiceprint(personId: string): Promi
     return segments
         .map(segment => {
             const duration = segment.endTimestamp - segment.startTimestamp;
+
+            // Same media URL the dispatch uses, so the admin previews exactly what
+            // the voiceprint job will consume.
+            const mediaUrl = segment.meeting.audioUrl || segment.meeting.videoUrl || null;
+            const previewWindow = computeVoiceprintWindow(segment.startTimestamp, segment.endTimestamp);
+
+            // windowText is the transcript of the centered 30s window the voiceprint
+            // uses — i.e. what the admin hears in the audio preview, so they can read
+            // along. fullText is the whole segment, shown on demand.
+            const windowText = segment.utterances
+                .filter(
+                    u =>
+                        u.startTimestamp < previewWindow.endTimestamp &&
+                        u.endTimestamp > previewWindow.startTimestamp,
+                )
+                .map(u => u.text)
+                .join(" ")
+                .trim();
             const fullText = segment.utterances.map(u => u.text).join(" ").trim();
-            const textPreview =
-                fullText.length > TEXT_PREVIEW_MAX_LENGTH
-                    ? `${fullText.slice(0, TEXT_PREVIEW_MAX_LENGTH).trimEnd()}…`
-                    : fullText;
 
             return {
                 segmentId: segment.id,
@@ -329,7 +343,11 @@ export async function getCandidateSegmentsForVoiceprint(personId: string): Promi
                 startTimestamp: segment.startTimestamp,
                 endTimestamp: segment.endTimestamp,
                 duration,
-                textPreview,
+                mediaUrl,
+                previewStartTimestamp: previewWindow.startTimestamp,
+                previewEndTimestamp: previewWindow.endTimestamp,
+                windowText,
+                fullText,
             };
         })
         .filter(candidate => candidate.duration >= VOICEPRINT_DURATION)

--- a/src/lib/tasks/voiceprintWindow.ts
+++ b/src/lib/tasks/voiceprintWindow.ts
@@ -1,0 +1,40 @@
+// Pure helpers for voiceprint segment windows. Kept out of the "use server"
+// module (generateVoiceprint.ts) so non-async exports are allowed and the logic
+// can be unit-tested and reused on the client.
+
+/** Target length, in seconds, of the audio window used to build a voiceprint. */
+export const VOICEPRINT_DURATION = 30;
+
+/**
+ * Compute the time window actually used to build a voiceprint from a segment.
+ *
+ * The window is `windowDuration` seconds centered on the segment midpoint,
+ * clamped to the segment bounds. This is the single source of truth shared by
+ * task dispatch (what the voiceprint job consumes) and the admin candidate
+ * picker (what the admin previews), so "what you hear" equals "what is used".
+ *
+ * Timestamps are in seconds, matching SpeakerSegment timestamps and HTML media
+ * fragment (`#t=`) semantics.
+ */
+export function computeVoiceprintWindow(
+    startTimestamp: number,
+    endTimestamp: number,
+    windowDuration: number = VOICEPRINT_DURATION,
+): { startTimestamp: number; endTimestamp: number } {
+    if (!Number.isFinite(startTimestamp) || !Number.isFinite(endTimestamp)) {
+        throw new Error("computeVoiceprintWindow: timestamps must be finite numbers");
+    }
+    if (startTimestamp > endTimestamp) {
+        throw new Error("computeVoiceprintWindow: startTimestamp must not exceed endTimestamp");
+    }
+    if (!(windowDuration > 0)) {
+        throw new Error("computeVoiceprintWindow: windowDuration must be positive");
+    }
+
+    const segmentDuration = endTimestamp - startTimestamp;
+    const segmentMidpoint = startTimestamp + segmentDuration / 2;
+    const halfDuration = windowDuration / 2;
+    const windowStart = Math.max(startTimestamp, segmentMidpoint - halfDuration);
+    const windowEnd = Math.min(endTimestamp, windowStart + windowDuration);
+    return { startTimestamp: windowStart, endTimestamp: windowEnd };
+}


### PR DESCRIPTION
## What

Admins can now manually pick which speaker segment a person's voiceprint is built from, instead of always relying on the automatic longest-segment heuristic. This is the "simpler alternative" path described in #88: the automatic selection sometimes lands on a noisy or unclear segment, and there was no way to override it.

## How it works

In the admin People page, the voiceprint dialog for a person without a voiceprint now offers "Choose segment manually" next to the existing auto-select. Expanding it lists the person's longest eligible (>=30s) segments, and for each one the admin can:

- Listen to the exact 30-second window that will be used, via an inline audio player seeked to that window (`#t=start,end`) on the meeting media.
- Read the transcript of that same 30s window inline, to follow along, plus the full segment transcript behind a collapsible.

"What you hear" equals "what the voiceprint job consumes": a single `computeVoiceprintWindow` helper computes the centered 30s window, shared by both task dispatch and the candidate list.
## How it looks:
<img width="495" height="708" alt="Screenshot 2026-06-11 at 4 35 38 PM" src="https://github.com/user-attachments/assets/2dc4af8e-c490-40fe-ba58-e24352abdfe4" />


## Notes

- Auto-select stays the default; manual selection is opt-in.
- Server actions validate the chosen segment belongs to the person, enforce the 30s minimum, and authorize the caller for the segment's city, the same path as the automatic flow.
- No backend (opencouncil-tasks) change: the generate task already accepts an explicit segment plus window.
- Scope: this is the focused "manual single-segment selection" from #88, not the larger in-transcript voiceprint mode the issue also sketches.

## Tests

`generateVoiceprint.test.ts` covers `computeVoiceprintWindow` (centered/edge/invalid), candidate filtering and sorting, the enriched payload (mediaUrl, preview window, windowText vs fullText), and segment validation. Verified end to end against a real meeting: the audio loads with a 206 range request to the correct window and the transcript aligns.

Closes #88



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds manual voiceprint segment selection with synchronized audio and transcript previews while retaining automatic selection.
- Adds a reusable helper for computing the centered voiceprint window.
- Adds candidate loading, selection, retry, and request-lifecycle handling to the admin dialog.
- Validates manually selected segments and dispatches the existing voiceprint task with an explicit segment and window.
- Adds coverage for candidate construction, window calculation, and manual dispatch validation.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because the manual dispatch path can still create a voiceprint for a person outside the administrator's authorized city.

The ownership check accepts a matching person ID while dispatch authorization checks only the segment's city, and the result is subsequently persisted against the caller-provided person ID; the previously reported cross-city authorization failure therefore remains.

**Files Needing Attention:** src/lib/tasks/generateVoiceprint.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/admin/people/voiceprint-actions.tsx | Adds the manual candidate picker and correctly addresses the previously reported dialog-reset, loading-state, duration-label, and language inconsistencies. |
| src/lib/tasks/generateVoiceprint.ts | Adds candidate retrieval and explicit-segment dispatch, but the previously reported cross-city authorization boundary remains unenforced. |
| src/lib/tasks/voiceprintWindow.ts | Centralizes finite, validated computation of the voiceprint preview and dispatch window. |
| src/lib/__tests__/generateVoiceprint.test.ts | Covers window computation, candidate enrichment, ownership rejection, minimum duration, and task payload construction, but not the outstanding cross-city authorization case. |

<sub>Reviews (10): Last reviewed commit: ["fix(voiceprint): reset loading state and..."](https://github.com/schemalabz/opencouncil/commit/45431b659463cd2b92baed43fbb1d3a5366c6c1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36957394)</sub>

<!-- /greptile_comment -->