### PR TITLE
feat(meetings): batch Poll Decisions action on /admin/meetings

### DIFF
--- a/src/app/[locale]/(admin)/admin/meetings/page.tsx
+++ b/src/app/[locale]/(admin)/admin/meetings/page.tsx
@@ -19,11 +19,13 @@ export default async function AdminMeetingsPage(props: PageProps) {
 
     let meetings: CouncilMeetingWithAdminBodyAndSubjects[] = [];
     let decisionCounts: MeetingDecisionCounts = {};
+    let cityHasDiavgeiaUid = false;
     if (selectedCityId) {
         [meetings, decisionCounts] = await Promise.all([
             getCouncilMeetingsForCity(selectedCityId, { includeUnreleased: true }),
             getDecisionCountsForCity(selectedCityId),
         ]);
+        cityHasDiavgeiaUid = !!cities.find(c => c.id === selectedCityId)?.diavgeiaUid;
     }
 
     const currentCityName = cities.find(c => c.id === selectedCityId)?.name || "Select City";
@@ -45,6 +47,7 @@ export default async function AdminMeetingsPage(props: PageProps) {
                 currentCityName={currentCityName}
                 selectedCityId={selectedCityId}
                 decisionCounts={decisionCounts}
+                cityHasDiavgeiaUid={cityHasDiavgeiaUid}
             />
         </div>
     );

--- a/src/components/admin/BatchProgressView.tsx
+++ b/src/components/admin/BatchProgressView.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import { DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Progress } from '@/components/ui/progress';
+import { CheckCircle2, XCircle, Loader2 } from 'lucide-react';
+import type { DispatchOutcome, DispatchPhase } from '@/hooks/useSequentialDispatch';
+
+interface BatchProgressViewProps<T> {
+    phase: DispatchPhase;
+    items: T[];
+    currentIndex: number;
+    results: DispatchOutcome<T>[];
+    cancelled: boolean;
+    getItemKey: (item: T) => string;
+    getItemLabel: (item: T) => string;
+    title: { executing: string; done: string };
+    /** Verb for the in-progress line, e.g. "Processing" or "Polling". */
+    currentVerb: string;
+    /** Optional content rendered in the done phase (e.g. a follow-up link). */
+    doneExtra?: ReactNode;
+    onCancel: () => void;
+    onClose: () => void;
+}
+
+export function BatchProgressView<T>({
+    phase,
+    items,
+    currentIndex,
+    results,
+    cancelled,
+    getItemKey,
+    getItemLabel,
+    title,
+    currentVerb,
+    doneExtra,
+    onCancel,
+    onClose,
+}: BatchProgressViewProps<T>) {
+    if (phase === 'idle') return null;
+
+    const succeeded = results.filter(r => r.success).length;
+    const failed = results.filter(r => !r.success).length;
+    const remaining = items.length - results.length;
+    const progressPercent = items.length > 0 ? (results.length / items.length) * 100 : 0;
+
+    return (
+        <>
+            <DialogHeader>
+                <DialogTitle>{phase === 'executing' ? title.executing : title.done}</DialogTitle>
+                <DialogDescription>
+                    {succeeded} dispatched, {failed} failed
+                    {remaining > 0 && `, ${remaining} remaining`}
+                    {cancelled && ' (cancelled)'}
+                </DialogDescription>
+            </DialogHeader>
+
+            <Progress value={progressPercent} className="w-full" />
+
+            {phase === 'executing' && currentIndex < items.length && (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    {currentVerb}: {getItemLabel(items[currentIndex])}
+                </div>
+            )}
+
+            <ScrollArea className="max-h-60 border rounded-md">
+                <div className="p-2 space-y-1">
+                    {results.map((result) => (
+                        <div key={getItemKey(result.item)} className="flex items-center gap-2 text-sm">
+                            {result.success
+                                ? <CheckCircle2 className="h-4 w-4 text-green-600 shrink-0" />
+                                : <XCircle className="h-4 w-4 text-red-600 shrink-0" />
+                            }
+                            <span className="text-xs truncate">{getItemLabel(result.item)}</span>
+                            {result.error && (
+                                <span className="text-red-600 text-xs truncate">— {result.error}</span>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            </ScrollArea>
+
+            {phase === 'done' && doneExtra}
+
+            <DialogFooter>
+                {phase === 'executing' ? (
+                    <Button variant="destructive" onClick={onCancel}>Cancel</Button>
+                ) : (
+                    <Button variant="outline" onClick={onClose}>Close</Button>
+                )}
+            </DialogFooter>
+        </>
+    );
+}

--- a/src/components/admin/BatchProgressView.tsx
+++ b/src/components/admin/BatchProgressView.tsx
@@ -19,6 +19,8 @@ interface BatchProgressViewProps<T> {
     title: { executing: string; done: string };
     /** Verb for the in-progress line, e.g. "Processing" or "Polling". */
     currentVerb: string;
+    /** Render result labels in a monospace font (e.g. for `cityId/meetingId` identifiers). */
+    monospaceLabels?: boolean;
     /** Optional content rendered in the done phase (e.g. a follow-up link). */
     doneExtra?: ReactNode;
     onCancel: () => void;
@@ -35,6 +37,7 @@ export function BatchProgressView<T>({
     getItemLabel,
     title,
     currentVerb,
+    monospaceLabels = false,
     doneExtra,
     onCancel,
     onClose,
@@ -74,7 +77,7 @@ export function BatchProgressView<T>({
                                 ? <CheckCircle2 className="h-4 w-4 text-green-600 shrink-0" />
                                 : <XCircle className="h-4 w-4 text-red-600 shrink-0" />
                             }
-                            <span className="text-xs truncate">{getItemLabel(result.item)}</span>
+                            <span className={`text-xs truncate${monospaceLabels ? ' font-mono' : ''}`}>{getItemLabel(result.item)}</span>
                             {result.error && (
                                 <span className="text-red-600 text-xs truncate">— {result.error}</span>
                             )}

--- a/src/components/admin/meetings/BulkPollDecisionsAction.tsx
+++ b/src/components/admin/meetings/BulkPollDecisionsAction.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { useState, useCallback, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Gavel, ExternalLink } from 'lucide-react';
+import { Link } from '@/i18n/routing';
+import { CouncilMeetingWithAdminBodyAndSubjects } from '@/lib/db/meetings';
+import { MeetingDecisionCounts } from '@/lib/db/decisions';
+import { partitionMeetingsForPolling, MeetingPollEligibility } from '@/lib/tasks/pollableMeetings';
+import { requestPollDecisions } from '@/lib/tasks/pollDecisions';
+import { useSequentialDispatch } from '@/hooks/useSequentialDispatch';
+import { BatchProgressView } from '@/components/admin/BatchProgressView';
+
+interface BulkPollDecisionsActionProps {
+    selectedMeetingIds: Set<string>;
+    meetings: CouncilMeetingWithAdminBodyAndSubjects[];
+    decisionCounts: MeetingDecisionCounts;
+    selectedCityId: string;
+    cityHasDiavgeiaUid: boolean;
+}
+
+export function BulkPollDecisionsAction({
+    selectedMeetingIds,
+    meetings,
+    decisionCounts,
+    selectedCityId,
+    cityHasDiavgeiaUid,
+}: BulkPollDecisionsActionProps) {
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [skipCache, setSkipCache] = useState(false);
+
+    const partition = useMemo(() => {
+        const selected = meetings
+            .filter(m => selectedMeetingIds.has(m.id))
+            .map(m => ({ id: m.id, name: m.name }));
+        return partitionMeetingsForPolling(selected, decisionCounts);
+    }, [meetings, selectedMeetingIds, decisionCounts]);
+
+    const dispatchPoll = useCallback(async (meeting: MeetingPollEligibility) => {
+        await requestPollDecisions(selectedCityId, meeting.meetingId, {
+            forceExtract: skipCache,
+        });
+    }, [selectedCityId, skipCache]);
+
+    const dispatch = useSequentialDispatch<MeetingPollEligibility>(dispatchPoll, { throttleMs: 400 });
+
+    const openDialog = () => {
+        setSkipCache(false);
+        dispatch.reset();
+        setDialogOpen(true);
+    };
+
+    if (selectedMeetingIds.size === 0) return null;
+
+    return (
+        <>
+            {cityHasDiavgeiaUid ? (
+                <Button variant="outline" size="sm" onClick={openDialog}>
+                    <Gavel className="w-4 h-4 mr-2" />
+                    <span className="hidden sm:inline">Poll Decisions</span>
+                </Button>
+            ) : (
+                <TooltipProvider>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span tabIndex={0}>
+                                <Button variant="outline" size="sm" disabled>
+                                    <Gavel className="w-4 h-4 mr-2" />
+                                    <span className="hidden sm:inline">Poll Decisions</span>
+                                </Button>
+                            </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            <p>This city has no Diavgeia UID configured.</p>
+                        </TooltipContent>
+                    </Tooltip>
+                </TooltipProvider>
+            )}
+
+            <Dialog open={dialogOpen} onOpenChange={(open) => {
+                if (!open && dispatch.phase === 'executing') return;
+                setDialogOpen(open);
+            }}>
+                <DialogContent className="max-w-2xl">
+                    {dispatch.phase === 'idle' ? (
+                        <>
+                            <DialogHeader>
+                                <DialogTitle className="flex items-center gap-2">
+                                    <Gavel className="h-5 w-5" />
+                                    Poll decisions for {partition.pollable.length} meeting{partition.pollable.length === 1 ? '' : 's'}?
+                                </DialogTitle>
+                                <DialogDescription asChild>
+                                    <div className="space-y-2">
+                                        <p>
+                                            Dispatches a decision poll for{' '}
+                                            <strong>{partition.pollable.length}</strong> meeting{partition.pollable.length === 1 ? '' : 's'}
+                                            {' '}one at a time against Diavgeia.
+                                            {partition.alreadyCompleteCount > 0 && (
+                                                <> <strong>{partition.alreadyCompleteCount}</strong> already have all decisions linked and will be re-polled.</>
+                                            )}
+                                            {partition.skipped.length > 0 && (
+                                                <> <strong>{partition.skipped.length}</strong> selected meeting{partition.skipped.length === 1 ? '' : 's'} will be skipped (Λογοδοσία or no eligible subjects).</>
+                                            )}
+                                        </p>
+                                    </div>
+                                </DialogDescription>
+                            </DialogHeader>
+
+                            <div className="flex items-center gap-2">
+                                <Checkbox
+                                    id="poll-skip-cache"
+                                    checked={skipCache}
+                                    onCheckedChange={(checked) => setSkipCache(checked === true)}
+                                />
+                                <Label htmlFor="poll-skip-cache" className="text-sm font-normal">
+                                    Skip extraction cache (re-process Diavgeia PDFs)
+                                </Label>
+                            </div>
+
+                            <ScrollArea className="max-h-80 border rounded-md">
+                                <table className="w-full text-sm">
+                                    <thead className="sticky top-0 bg-background border-b">
+                                        <tr>
+                                            <th className="text-left p-2 font-medium">Meeting</th>
+                                            <th className="text-left p-2 font-medium">Decisions</th>
+                                            <th className="text-left p-2 font-medium">Status</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {partition.pollable.map((m) => (
+                                            <tr key={m.meetingId} className="border-b last:border-0">
+                                                <td className="p-2">{m.name}</td>
+                                                <td className="p-2">
+                                                    <Badge variant={m.alreadyComplete ? 'default' : 'outline'}>
+                                                        {m.linked}/{m.eligible}
+                                                    </Badge>
+                                                </td>
+                                                <td className="p-2 text-muted-foreground">
+                                                    {m.alreadyComplete ? 'Re-poll (complete)' : 'Will poll'}
+                                                </td>
+                                            </tr>
+                                        ))}
+                                        {partition.skipped.map((m) => (
+                                            <tr key={m.meetingId} className="border-b last:border-0 text-muted-foreground/60">
+                                                <td className="p-2">{m.name}</td>
+                                                <td className="p-2">
+                                                    <Badge variant="outline" className="text-gray-400">
+                                                        {m.linked}/{m.eligible}
+                                                    </Badge>
+                                                </td>
+                                                <td className="p-2">
+                                                    Skip — {m.skipReason === 'logodosia' ? 'Λογοδοσία' : 'no eligible subjects'}
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </ScrollArea>
+
+                            <DialogFooter>
+                                <Button variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
+                                <Button
+                                    onClick={() => dispatch.run(partition.pollable)}
+                                    disabled={partition.pollable.length === 0}
+                                >
+                                    Poll {partition.pollable.length} meeting{partition.pollable.length === 1 ? '' : 's'}
+                                </Button>
+                            </DialogFooter>
+                        </>
+                    ) : (
+                        <BatchProgressView
+                            phase={dispatch.phase}
+                            items={partition.pollable}
+                            currentIndex={dispatch.currentIndex}
+                            results={dispatch.results}
+                            cancelled={dispatch.cancelled}
+                            getItemKey={(m) => m.meetingId}
+                            getItemLabel={(m) => m.name}
+                            title={{ executing: 'Dispatching polls...', done: 'All polls dispatched' }}
+                            currentVerb="Polling"
+                            doneExtra={
+                                <Link
+                                    href="/admin/tasks"
+                                    className="flex items-center gap-1 text-sm text-blue-600 hover:underline"
+                                >
+                                    Follow progress in Active Tasks
+                                    <ExternalLink className="h-3 w-3" />
+                                </Link>
+                            }
+                            onCancel={dispatch.cancel}
+                            onClose={() => setDialogOpen(false)}
+                        />
+                    )}
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}

--- a/src/components/admin/meetings/Meetings.tsx
+++ b/src/components/admin/meetings/Meetings.tsx
@@ -12,6 +12,7 @@ import { MeetingDecisionCounts } from "@/lib/db/decisions";
 import { BadgePicker, BadgePickerOption } from "@/components/ui/badge-picker";
 import { ExpandableMeetingRow } from "./ExpandableMeetingRow";
 import { BulkExportActions } from "./BulkExportActions";
+import { BulkPollDecisionsAction } from "./BulkPollDecisionsAction";
 import { StatsCard, StatsCardItem } from "@/components/ui/stats-card";
 
 interface MeetingsProps {
@@ -19,9 +20,10 @@ interface MeetingsProps {
     currentCityName: string;
     selectedCityId: string;
     decisionCounts: MeetingDecisionCounts;
+    cityHasDiavgeiaUid: boolean;
 }
 
-export default function Meetings({ meetings, currentCityName, selectedCityId, decisionCounts }: MeetingsProps) {
+export default function Meetings({ meetings, currentCityName, selectedCityId, decisionCounts, cityHasDiavgeiaUid }: MeetingsProps) {
     const tCommon = useTranslations('Common');
     const [searchQuery, setSearchQuery] = useState("");
     const [selectedAdminBodyId, setSelectedAdminBodyId] = useState<string | null>(null);
@@ -151,13 +153,20 @@ export default function Meetings({ meetings, currentCityName, selectedCityId, de
                     <CardTitle className='flex justify-between items-center'>
                         <span>Meetings</span>
                         <div className='flex items-center gap-4'>
-                            <BulkExportActions 
+                            <BulkExportActions
                                 selectedMeetingIds={selectedMeetingIds}
                                 meetings={filteredMeetings}
                                 selectedCityId={selectedCityId}
                                 onSelectAll={handleSelectAll}
                                 isAllSelected={selectedMeetingIds.size === filteredMeetings.length && filteredMeetings.length > 0}
                                 isPartiallySelected={selectedMeetingIds.size > 0 && selectedMeetingIds.size < filteredMeetings.length}
+                            />
+                            <BulkPollDecisionsAction
+                                selectedMeetingIds={selectedMeetingIds}
+                                meetings={filteredMeetings}
+                                decisionCounts={decisionCounts}
+                                selectedCityId={selectedCityId}
+                                cityHasDiavgeiaUid={cityHasDiavgeiaUid}
                             />
                             <span className='text-muted-foreground text-sm'>{currentCityName}</span>
                         </div>

--- a/src/components/admin/tasks/BatchRerunActions.tsx
+++ b/src/components/admin/tasks/BatchRerunActions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import {
@@ -18,10 +18,11 @@ import {
 } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
-import { Progress } from '@/components/ui/progress';
-import { AlertTriangle, CheckCircle2, XCircle, Loader2, ChevronRight, ChevronDown } from 'lucide-react';
+import { AlertTriangle, ChevronRight, ChevronDown } from 'lucide-react';
 import { formatDate } from '@/lib/formatters/time';
-import { batchRerunTask, type BatchRerunResult } from '@/lib/tasks/batchRerun';
+import { batchRerunTask } from '@/lib/tasks/batchRerun';
+import { useSequentialDispatch } from '@/hooks/useSequentialDispatch';
+import { BatchProgressView } from '@/components/admin/BatchProgressView';
 
 export interface BatchMeeting {
     meetingId: string;
@@ -36,65 +37,34 @@ interface BatchRerunActionsProps {
 }
 
 type TaskType = 'processAgenda' | 'summarize';
-type DialogState = 'confirm' | 'executing' | 'done';
 
 const TASK_LABELS: Record<TaskType, string> = {
     processAgenda: 'Process Agenda',
     summarize: 'Summarize',
 };
 
-
 export function BatchRerunActions({ meetings }: BatchRerunActionsProps) {
     const t = useTranslations('admin.adminActions');
     const [dialogOpen, setDialogOpen] = useState(false);
     const [selectedTask, setSelectedTask] = useState<TaskType>('processAgenda');
-    const [dialogState, setDialogState] = useState<DialogState>('confirm');
-    const [results, setResults] = useState<BatchRerunResult[]>([]);
-    const [currentIndex, setCurrentIndex] = useState(0);
-    const cancelledRef = useRef(false);
+    const [batchOpen, setBatchOpen] = useState(false);
+
+    const dispatchTask = useCallback(async (meeting: BatchMeeting) => {
+        const result = await batchRerunTask(meeting.cityId, meeting.meetingId, selectedTask);
+        if (!result.success) {
+            throw new Error(result.error ?? 'Dispatch failed');
+        }
+    }, [selectedTask]);
+
+    const dispatch = useSequentialDispatch<BatchMeeting>(dispatchTask);
 
     const openDialog = (taskType: TaskType) => {
         setSelectedTask(taskType);
-        setDialogState('confirm');
-        setResults([]);
-        setCurrentIndex(0);
-        cancelledRef.current = false;
+        dispatch.reset();
         setDialogOpen(true);
     };
 
-    const handleCancel = () => {
-        cancelledRef.current = true;
-    };
-
-    const handleClose = () => {
-        setDialogOpen(false);
-    };
-
-    const handleConfirm = useCallback(async () => {
-        setDialogState('executing');
-        const newResults: BatchRerunResult[] = [];
-
-        for (let i = 0; i < meetings.length; i++) {
-            if (cancelledRef.current) break;
-
-            setCurrentIndex(i);
-            const meeting = meetings[i];
-            const result = await batchRerunTask(meeting.cityId, meeting.meetingId, selectedTask);
-            newResults.push(result);
-            setResults([...newResults]);
-        }
-
-        setDialogState('done');
-    }, [meetings, selectedTask]);
-
-    const succeeded = results.filter(r => r.success).length;
-    const failed = results.filter(r => !r.success).length;
-    const remaining = meetings.length - results.length;
-    const progressPercent = meetings.length > 0 ? (results.length / meetings.length) * 100 : 0;
-
     const cityCount = new Set(meetings.map(m => m.cityId)).size;
-
-    const [batchOpen, setBatchOpen] = useState(false);
 
     return (
         <>
@@ -137,11 +107,11 @@ export function BatchRerunActions({ meetings }: BatchRerunActionsProps) {
 
             <Dialog open={dialogOpen} onOpenChange={(open) => {
                 // Prevent closing during execution by clicking outside
-                if (!open && dialogState === 'executing') return;
+                if (!open && dispatch.phase === 'executing') return;
                 setDialogOpen(open);
             }}>
                 <DialogContent className="max-w-2xl">
-                    {dialogState === 'confirm' && (
+                    {dispatch.phase === 'idle' ? (
                         <>
                             <DialogHeader>
                                 <DialogTitle className="flex items-center gap-2">
@@ -163,16 +133,14 @@ export function BatchRerunActions({ meetings }: BatchRerunActionsProps) {
                                 </DialogDescription>
                             </DialogHeader>
 
-                            {(selectedTask === 'processAgenda' || selectedTask === 'summarize') && (
-                                <div className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm">
-                                    <AlertTriangle className="h-4 w-4 text-amber-600 mt-0.5 shrink-0" />
-                                    <p className="text-amber-800">
-                                        {selectedTask === 'processAgenda' ? 'Before meeting' : 'After meeting'} notifications
-                                        will be created for meetings whose administrative body has notifications enabled.
-                                        Check each body&apos;s notification behavior setting if this is not intended.
-                                    </p>
-                                </div>
-                            )}
+                            <div className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm">
+                                <AlertTriangle className="h-4 w-4 text-amber-600 mt-0.5 shrink-0" />
+                                <p className="text-amber-800">
+                                    {selectedTask === 'processAgenda' ? 'Before meeting' : 'After meeting'} notifications
+                                    will be created for meetings whose administrative body has notifications enabled.
+                                    Check each body&apos;s notification behavior setting if this is not intended.
+                                </p>
+                            </div>
 
                             <ScrollArea className="max-h-80 border rounded-md">
                                 <table className="w-full text-sm">
@@ -214,68 +182,30 @@ export function BatchRerunActions({ meetings }: BatchRerunActionsProps) {
                             </ScrollArea>
 
                             <DialogFooter>
-                                <Button variant="outline" onClick={handleClose}>Cancel</Button>
-                                <Button variant="destructive" onClick={handleConfirm}>
+                                <Button variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
+                                <Button variant="destructive" onClick={() => dispatch.run(meetings)}>
                                     Confirm Re-run
                                 </Button>
                             </DialogFooter>
                         </>
-                    )}
-
-                    {(dialogState === 'executing' || dialogState === 'done') && (
-                        <>
-                            <DialogHeader>
-                                <DialogTitle>
-                                    {dialogState === 'executing'
-                                        ? `Dispatching ${TASK_LABELS[selectedTask]}...`
-                                        : `${TASK_LABELS[selectedTask]} — All Tasks Dispatched`
-                                    }
-                                </DialogTitle>
-                                <DialogDescription>
-                                    {succeeded} dispatched, {failed} failed
-                                    {remaining > 0 && `, ${remaining} remaining`}
-                                    {cancelledRef.current && ' (cancelled)'}
-                                </DialogDescription>
-                            </DialogHeader>
-
-                            <Progress value={progressPercent} className="w-full" />
-
-                            {dialogState === 'executing' && currentIndex < meetings.length && (
-                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                                    <Loader2 className="h-4 w-4 animate-spin" />
-                                    Processing: {meetings[currentIndex].cityId}/{meetings[currentIndex].meetingId}
-                                </div>
-                            )}
-
-                            <ScrollArea className="max-h-60 border rounded-md">
-                                <div className="p-2 space-y-1">
-                                    {results.map((result) => (
-                                        <div key={`${result.cityId}-${result.meetingId}`} className="flex items-center gap-2 text-sm">
-                                            {result.success
-                                                ? <CheckCircle2 className="h-4 w-4 text-green-600 shrink-0" />
-                                                : <XCircle className="h-4 w-4 text-red-600 shrink-0" />
-                                            }
-                                            <span className="font-mono text-xs">{result.cityId}/{result.meetingId}</span>
-                                            {result.error && (
-                                                <span className="text-red-600 text-xs truncate">— {result.error}</span>
-                                            )}
-                                        </div>
-                                    ))}
-                                </div>
-                            </ScrollArea>
-
-                            <DialogFooter>
-                                {dialogState === 'executing' ? (
-                                    <Button variant="destructive" onClick={handleCancel}>
-                                        Cancel
-                                    </Button>
-                                ) : (
-                                    <Button variant="outline" onClick={handleClose}>
-                                        Close
-                                    </Button>
-                                )}
-                            </DialogFooter>
-                        </>
+                    ) : (
+                        <BatchProgressView
+                            phase={dispatch.phase}
+                            items={meetings}
+                            currentIndex={dispatch.currentIndex}
+                            results={dispatch.results}
+                            cancelled={dispatch.cancelled}
+                            getItemKey={(m) => `${m.cityId}-${m.meetingId}`}
+                            getItemLabel={(m) => `${m.cityId}/${m.meetingId}`}
+                            title={{
+                                executing: `Dispatching ${TASK_LABELS[selectedTask]}...`,
+                                done: `${TASK_LABELS[selectedTask]} — All Tasks Dispatched`,
+                            }}
+                            currentVerb="Processing"
+                            monospaceLabels
+                            onCancel={dispatch.cancel}
+                            onClose={() => setDialogOpen(false)}
+                        />
                     )}
                 </DialogContent>
             </Dialog>

--- a/src/hooks/__tests__/useSequentialDispatch.test.tsx
+++ b/src/hooks/__tests__/useSequentialDispatch.test.tsx
@@ -1,0 +1,56 @@
+import { renderHook, act } from "@testing-library/react";
+import { useSequentialDispatch } from "../useSequentialDispatch";
+
+describe("useSequentialDispatch", () => {
+    it("accumulates a success/failure outcome per item and ends in 'done'", async () => {
+        const dispatch = jest.fn(async (n: number) => {
+            if (n === 2) throw new Error("boom");
+        });
+        const { result } = renderHook(() => useSequentialDispatch<number>(dispatch));
+
+        await act(async () => {
+            await result.current.run([1, 2, 3]);
+        });
+
+        expect(result.current.phase).toBe("done");
+        expect(result.current.results).toEqual([
+            { item: 1, success: true },
+            { item: 2, success: false, error: "boom" },
+            { item: 3, success: true },
+        ]);
+    });
+
+    it("stops dispatching once cancelled", async () => {
+        const seen: number[] = [];
+        const ref: { current: ReturnType<typeof useSequentialDispatch<number>> | null } = { current: null };
+        const dispatch = jest.fn(async (n: number) => {
+            seen.push(n);
+            if (n === 1) ref.current!.cancel();
+        });
+        const { result } = renderHook(() => useSequentialDispatch<number>(dispatch));
+        ref.current = result.current;
+
+        await act(async () => {
+            await result.current.run([1, 2, 3]);
+        });
+
+        expect(seen).toEqual([1]);
+        expect(result.current.cancelled).toBe(true);
+        expect(result.current.results).toEqual([{ item: 1, success: true }]);
+    });
+
+    it("reset returns to the idle phase with no results", async () => {
+        const dispatch = jest.fn(async () => {});
+        const { result } = renderHook(() => useSequentialDispatch<number>(dispatch));
+
+        await act(async () => {
+            await result.current.run([1]);
+        });
+        act(() => {
+            result.current.reset();
+        });
+
+        expect(result.current.phase).toBe("idle");
+        expect(result.current.results).toEqual([]);
+    });
+});

--- a/src/hooks/useSequentialDispatch.ts
+++ b/src/hooks/useSequentialDispatch.ts
@@ -1,0 +1,84 @@
+import { useCallback, useRef, useState } from "react";
+
+export type DispatchPhase = "idle" | "executing" | "done";
+
+export interface DispatchOutcome<T> {
+    item: T;
+    success: boolean;
+    error?: string;
+}
+
+export interface SequentialDispatch<T> {
+    phase: DispatchPhase;
+    currentIndex: number;
+    results: DispatchOutcome<T>[];
+    cancelled: boolean;
+    run: (items: T[]) => Promise<void>;
+    cancel: () => void;
+    reset: () => void;
+}
+
+/**
+ * Drives a list of items through an async `dispatch` one at a time, tracking
+ * progress for a batch-action dialog. `dispatch` throws to signal failure; the
+ * hook records the error and continues with the next item.
+ *
+ * @param dispatch  Per-item async action. Throw to mark the item failed.
+ * @param options.throttleMs  Delay between items (skipped after the last). Default 0.
+ */
+export function useSequentialDispatch<T>(
+    dispatch: (item: T) => Promise<void>,
+    options?: { throttleMs?: number },
+): SequentialDispatch<T> {
+    const [phase, setPhase] = useState<DispatchPhase>("idle");
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [results, setResults] = useState<DispatchOutcome<T>[]>([]);
+    const [cancelled, setCancelled] = useState(false);
+    const cancelledRef = useRef(false);
+
+    const throttleMs = options?.throttleMs ?? 0;
+
+    const run = useCallback(async (items: T[]) => {
+        cancelledRef.current = false;
+        setCancelled(false);
+        setResults([]);
+        setCurrentIndex(0);
+        setPhase("executing");
+
+        const acc: DispatchOutcome<T>[] = [];
+        for (let i = 0; i < items.length; i++) {
+            if (cancelledRef.current) break;
+            setCurrentIndex(i);
+            try {
+                await dispatch(items[i]);
+                acc.push({ item: items[i], success: true });
+            } catch (error) {
+                acc.push({
+                    item: items[i],
+                    success: false,
+                    error: error instanceof Error ? error.message : String(error),
+                });
+            }
+            setResults([...acc]);
+            if (i < items.length - 1 && throttleMs > 0) {
+                await new Promise(resolve => setTimeout(resolve, throttleMs));
+            }
+        }
+        setPhase("done");
+    }, [dispatch, throttleMs]);
+
+    const cancel = useCallback(() => {
+        cancelledRef.current = true;
+        setCancelled(true);
+    }, []);
+
+    const reset = useCallback(() => {
+        cancelledRef.current = false;
+        setCancelled(false);
+        setResults([]);
+        setCurrentIndex(0);
+        setPhase("idle");
+    }, []);
+
+    return { phase, currentIndex, results, cancelled, run, cancel, reset };
+}

--- a/src/lib/tasks/__tests__/pollableMeetings.test.ts
+++ b/src/lib/tasks/__tests__/pollableMeetings.test.ts
@@ -1,0 +1,53 @@
+import { partitionMeetingsForPolling } from "../pollableMeetings";
+
+describe("partitionMeetingsForPolling", () => {
+    it("marks a meeting with unlinked eligible subjects as pollable, not complete", () => {
+        const result = partitionMeetingsForPolling(
+            [{ id: "m1", name: "Συνεδρίαση 1" }],
+            { m1: { linked: 1, eligible: 3 } },
+        );
+        expect(result.pollable).toHaveLength(1);
+        expect(result.pollable[0].meetingId).toBe("m1");
+        expect(result.pollable[0].alreadyComplete).toBe(false);
+        expect(result.skipped).toHaveLength(0);
+        expect(result.alreadyCompleteCount).toBe(0);
+    });
+
+    it("flags fully-linked meetings as pollable but alreadyComplete", () => {
+        const result = partitionMeetingsForPolling(
+            [{ id: "m1", name: "Συνεδρίαση 1" }],
+            { m1: { linked: 3, eligible: 3 } },
+        );
+        expect(result.pollable).toHaveLength(1);
+        expect(result.pollable[0].alreadyComplete).toBe(true);
+        expect(result.alreadyCompleteCount).toBe(1);
+    });
+
+    it("skips meetings with no eligible subjects", () => {
+        const result = partitionMeetingsForPolling(
+            [{ id: "m1", name: "Συνεδρίαση 1" }],
+            { m1: { linked: 0, eligible: 0 } },
+        );
+        expect(result.pollable).toHaveLength(0);
+        expect(result.skipped).toHaveLength(1);
+        expect(result.skipped[0].skipReason).toBe("noEligibleSubjects");
+    });
+
+    it("skips Λογοδοσία meetings even when they have eligible subjects", () => {
+        const result = partitionMeetingsForPolling(
+            [{ id: "m1", name: "Λογοδοσία Δημάρχου" }],
+            { m1: { linked: 0, eligible: 2 } },
+        );
+        expect(result.pollable).toHaveLength(0);
+        expect(result.skipped[0].skipReason).toBe("logodosia");
+    });
+
+    it("treats a meeting missing from decisionCounts as having no eligible subjects", () => {
+        const result = partitionMeetingsForPolling(
+            [{ id: "m1", name: "Συνεδρίαση 1" }],
+            {},
+        );
+        expect(result.skipped).toHaveLength(1);
+        expect(result.skipped[0].skipReason).toBe("noEligibleSubjects");
+    });
+});

--- a/src/lib/tasks/pollableMeetings.ts
+++ b/src/lib/tasks/pollableMeetings.ts
@@ -1,0 +1,73 @@
+import { isLogodosiaMeeting } from "./pollDecisionsBackoff";
+import { MeetingDecisionCounts } from "../db/decisions";
+
+export type PollSkipReason = "logodosia" | "noEligibleSubjects";
+
+export interface MeetingPollEligibility {
+    meetingId: string;
+    name: string;
+    linked: number;
+    eligible: number;
+    pollable: boolean;
+    alreadyComplete: boolean;
+    skipReason: PollSkipReason | null;
+}
+
+export interface PollPartition {
+    pollable: MeetingPollEligibility[];
+    skipped: MeetingPollEligibility[];
+    alreadyCompleteCount: number;
+}
+
+/**
+ * Categorize selected meetings for batch decision polling.
+ *
+ * Per-meeting gates only — the city-level `diavgeiaUid` requirement is checked
+ * separately by the caller (the action is disabled when the city has none).
+ *
+ * - `skipped`: Λογοδοσία meetings, or meetings with no decision-eligible subjects.
+ * - `pollable`: everything else. `alreadyComplete` is true when every eligible
+ *   subject already has a linked decision (still pollable for a deliberate
+ *   re-poll, but surfaced so the admin knows).
+ */
+export function partitionMeetingsForPolling(
+    meetings: { id: string; name: string }[],
+    decisionCounts: MeetingDecisionCounts,
+): PollPartition {
+    const pollable: MeetingPollEligibility[] = [];
+    const skipped: MeetingPollEligibility[] = [];
+
+    for (const meeting of meetings) {
+        const counts = decisionCounts[meeting.id] ?? { linked: 0, eligible: 0 };
+        const base = {
+            meetingId: meeting.id,
+            name: meeting.name,
+            linked: counts.linked,
+            eligible: counts.eligible,
+        };
+
+        let skipReason: PollSkipReason | null = null;
+        if (isLogodosiaMeeting(meeting.name)) {
+            skipReason = "logodosia";
+        } else if (counts.eligible === 0) {
+            skipReason = "noEligibleSubjects";
+        }
+
+        if (skipReason) {
+            skipped.push({ ...base, pollable: false, alreadyComplete: false, skipReason });
+        } else {
+            pollable.push({
+                ...base,
+                pollable: true,
+                alreadyComplete: counts.linked >= counts.eligible,
+                skipReason: null,
+            });
+        }
+    }
+
+    return {
+        pollable,
+        skipped,
+        alreadyCompleteCount: pollable.filter(m => m.alreadyComplete).length,
+    };
+}


### PR DESCRIPTION
## Summary
- Adds a bulk **Poll Decisions** action to `/admin/meetings`: select meetings (guided by the existing `linked/eligible` decision badges) → confirm → live progress → done, dispatching the `pollDecisions` task per selected meeting.
- Extracts shared batch-dialog primitives — a `useSequentialDispatch` hook and a `BatchProgressView` component — and migrates the existing `/admin/tasks` batch-rerun onto them (net code reduction there, single source of truth).

## Details
- `partitionMeetingsForPolling` derives per-meeting eligibility from data already on the page: skips Λογοδοσία meetings and ones with no decision-eligible subjects, and flags already-complete meetings as re-pollable. City-level Diavgeia UID gates the action (button disabled with a tooltip when absent).
- Skip-cache (`forceExtract`) checkbox, ~400 ms inter-dispatch throttle, and a "Follow progress in Active Tasks" link to `/admin/tasks` on completion.
- Per-city scope (one city per action); no cross-city batch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a bulk **Poll Decisions** action to `/admin/meetings` and extracts the shared batch-progress infrastructure (`useSequentialDispatch` hook + `BatchProgressView` component) previously inlined in `BatchRerunActions`, reducing duplication and giving both features a single implementation path.

- Adds `BulkPollDecisionsAction` with per-meeting eligibility partitioning (`partitionMeetingsForPolling`), Diavgeia UID gating, a skip-cache checkbox, ~400 ms inter-dispatch throttle, and a post-completion link to `/admin/tasks`.
- Refactors `BatchRerunActions` onto the new primitives — behaviorally equivalent with less code; the removed always-true conditional around the notification warning is a clean-up.
- New unit tests cover all branches of `partitionMeetingsForPolling` and the three key `useSequentialDispatch` scenarios (success/failure accumulation, cancellation, reset).

<h3>Confidence Score: 5/5</h3>

Safe to merge — new feature is well-scoped, backed by tests, and the BatchRerunActions refactor is a straightforward extraction with no behavioral changes.

The core logic (partitioning, sequential dispatch, cancellation) is unit-tested and the implementation follows existing patterns. The only observation is a cosmetic one in the shared BatchProgressView: when a batch is cancelled mid-run, the dialog heading still reads the "done" text (e.g., "All polls dispatched") rather than a cancelled-specific string, because the title interface has no cancelled variant. This was also the pre-existing behavior in BatchRerunActions, so it is not a regression.

src/components/admin/BatchProgressView.tsx — the title interface could gain an optional cancelled key so consumers can show a more accurate heading after cancellation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/hooks/useSequentialDispatch.ts | New hook that drives a list of items through an async dispatch one at a time; clean implementation with ref-based cancellation, per-item error capture, and optional inter-dispatch throttle. Tests cover success, failure, cancellation, and reset paths. |
| src/components/admin/BatchProgressView.tsx | New shared progress component extracted from BatchRerunActions; well-structured but the title interface has no cancelled variant, so all consumers show the "done" heading text even after cancellation. |
| src/components/admin/meetings/BulkPollDecisionsAction.tsx | New bulk poll-decisions dialog; correctly gates on cityHasDiavgeiaUid, uses partition for per-meeting eligibility, resets skipCache on open, and hooks into useSequentialDispatch with 400 ms throttle. |
| src/lib/tasks/pollableMeetings.ts | New pure partitioning function with good test coverage; correctly skips Λογοδοσία and zero-eligible-subject meetings, flags already-complete meetings, and falls back safely for missing decision counts. |
| src/components/admin/tasks/BatchRerunActions.tsx | Migrated to useSequentialDispatch + BatchProgressView; net code reduction with equivalent behavior. The removed conditional around the notification warning was always true (TaskType is a union of exactly those two values), so the simplification is correct. |
| src/app/[locale]/(admin)/admin/meetings/page.tsx | Adds cityHasDiavgeiaUid derived from the already-loaded cities array and threads it down to Meetings. |
| src/components/admin/meetings/Meetings.tsx | Threads cityHasDiavgeiaUid prop and mounts BulkPollDecisionsAction alongside the existing BulkExportActions; consistent with the existing filtered-meetings pattern. |
| src/hooks/__tests__/useSequentialDispatch.test.tsx | Tests cover the three core scenarios: multi-item success/failure accumulation, cancellation stopping further dispatch, and reset returning to idle. |
| src/lib/tasks/__tests__/pollableMeetings.test.ts | Five tests covering pollable, complete, no-eligible-subjects, logodosia, and missing-from-decisionCounts cases — good coverage of all branches in partitionMeetingsForPolling. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(meetings): pass cityHasDiavgeiaUid ..."](https://github.com/schemalabz/opencouncil/commit/07e896665135ccab53df543ac1d6261a637fde21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37552407)</sub>

<!-- /greptile_comment -->