### PR TITLE
fix(search): person filter matches subjects introduced OR spoken in

### DIFF
--- a/src/lib/search/__tests__/query.test.ts
+++ b/src/lib/search/__tests__/query.test.ts
@@ -1,0 +1,105 @@
+import type { estypes } from '@elastic/elasticsearch';
+import type { SearchRequest } from '../types';
+
+// Avoid pulling the full env validation (createEnv) at import time; buildFilters
+// itself does not read env, only the module-level import does.
+jest.mock('@/env.mjs', () => ({ env: { ELASTICSEARCH_INDEX: 'test-index' } }));
+
+import { buildFilters } from '../query';
+
+type BoolQuery = estypes.QueryDslBoolQuery;
+
+function findPersonFilter(
+    filters: estypes.QueryDslQueryContainer[]
+): estypes.QueryDslQueryContainer | undefined {
+    // The person filter is the bool/should clause referencing introduced_by_person_id.
+    // Use a structural lookup (not a JSON substring match) so the tests can't pass
+    // vacuously if key ordering or the serialised shape changes.
+    return filters.find(
+        (f) =>
+            Array.isArray(f.bool?.should) &&
+            (f.bool!.should as estypes.QueryDslQueryContainer[]).some(
+                (c) => c.terms?.['introduced_by_person_id'] !== undefined
+            )
+    );
+}
+
+describe('buildFilters person filter', () => {
+    it('OR-combines introduced-by and spoke-in clauses (issue #373)', () => {
+        const request: SearchRequest = { query: 'roads', personIds: ['p1'] };
+
+        const filters = buildFilters(request);
+        const personFilter = findPersonFilter(filters);
+
+        expect(personFilter).toBeDefined();
+
+        const bool = personFilter!.bool as BoolQuery;
+        const should = (bool.should ?? []) as estypes.QueryDslQueryContainer[];
+
+        // Single bool.should with both clauses, OR-combined.
+        expect(bool.minimum_should_match).toBe(1);
+        expect(should).toHaveLength(2);
+
+        // Clause 1: introduced by the person.
+        const introducedBy = should.find((c) => c.terms?.['introduced_by_person_id']);
+        expect(introducedBy?.terms?.['introduced_by_person_id']).toEqual(['p1']);
+
+        // Clause 2: spoke in the subject (nested speaker segments).
+        const spokeIn = should.find((c) => c.nested);
+        expect(spokeIn?.nested?.path).toBe('speaker_segments');
+        expect(
+            (spokeIn?.nested?.query as estypes.QueryDslQueryContainer).terms?.[
+                'speaker_segments.speaker_person_id'
+            ]
+        ).toEqual(['p1']);
+    });
+
+    it('does not split the person filter into two separate AND-combined top-level clauses', () => {
+        const request: SearchRequest = { query: 'roads', personIds: ['p1'] };
+
+        const filters = buildFilters(request);
+
+        // Regression guard: the two person clauses must NOT appear as separate
+        // top-level filter entries (that would AND them — the original bug).
+        const topLevelIntroduced = filters.filter(
+            (f) => f.terms?.['introduced_by_person_id']
+        );
+        const topLevelNested = filters.filter(
+            (f) =>
+                f.nested?.path === 'speaker_segments' &&
+                JSON.stringify(f).includes('speaker_person_id')
+        );
+        expect(topLevelIntroduced).toHaveLength(0);
+        expect(topLevelNested).toHaveLength(0);
+    });
+
+    it('keeps person and party filters as independent top-level (AND) clauses', () => {
+        const request: SearchRequest = {
+            query: 'roads',
+            personIds: ['p1'],
+            partyIds: ['party1'],
+        };
+
+        const filters = buildFilters(request);
+
+        expect(findPersonFilter(filters)).toBeDefined();
+        const partyFilter = filters.find((f) => f.terms?.['introduced_by_party_id']);
+        expect(partyFilter?.terms?.['introduced_by_party_id']).toEqual(['party1']);
+    });
+
+    it('omits the person filter entirely when no personIds are given', () => {
+        const request: SearchRequest = { query: 'roads' };
+
+        const filters = buildFilters(request);
+
+        expect(findPersonFilter(filters)).toBeUndefined();
+    });
+
+    it('omits the person filter when personIds is an empty array', () => {
+        const request: SearchRequest = { query: 'roads', personIds: [] };
+
+        const filters = buildFilters(request);
+
+        expect(findPersonFilter(filters)).toBeUndefined();
+    });
+});

--- a/src/lib/search/query.ts
+++ b/src/lib/search/query.ts
@@ -22,30 +22,35 @@ export function buildFilters(request: SearchRequest): estypes.QueryDslQueryConta
         });
     }
 
-    // Add person filter if specified
+    // Add person filter if specified.
+    // A subject is relevant to a person if they EITHER introduced it OR spoke in it.
+    // These two clauses must be OR-combined inside a single `bool.should`; pushing
+    // them as separate entries in the top-level `filter` array would AND them, which
+    // almost never matches (the person rarely both introduces and speaks in the same
+    // subject) and breaks search on every person profile page.
     if (request.personIds && request.personIds.length > 0) {
-        // Add filter for introduced by person
         filters.push({
-            terms: {
-                'introduced_by_person_id': request.personIds
-            }
-        });
-
-        // Add filter for speaker segments
-        filters.push({
-            nested: {
-                path: 'speaker_segments',
-                query: {
-                    bool: {
-                        must: [
-                            {
+            bool: {
+                should: [
+                    // Introduced by the person
+                    {
+                        terms: {
+                            'introduced_by_person_id': request.personIds
+                        }
+                    },
+                    // Spoke in the subject (nested speaker segments)
+                    {
+                        nested: {
+                            path: 'speaker_segments',
+                            query: {
                                 terms: {
                                     'speaker_segments.speaker_person_id': request.personIds
                                 }
                             }
-                        ]
+                        }
                     }
-                }
+                ],
+                minimum_should_match: 1
             }
         });
     }


### PR DESCRIPTION
## What & why

On a council member's profile page the search box returned zero results for any phrase the person actually said, even when global search surfaced that same person as the top hit. Party-only filtering worked; only the person filter was broken, and since the person filter is always applied on a profile page, search there was effectively dead.

Root cause: in `src/lib/search/query.ts`, `buildFilters` pushed two clauses into the bool `filter` array for a person — a `terms` on `introduced_by_person_id` and a `nested` query on `speaker_segments.speaker_person_id`. Clauses in a bool `filter` are AND-combined, so a subject matched only if the person both introduced it and spoke in it. That is almost never true, so results came back empty.

## Changes

- `src/lib/search/query.ts`: wrap the two person clauses in a single `bool.should` with `minimum_should_match: 1`, so a subject matches if the person either introduced it or spoke in it. Also flattened the nested clause's redundant `bool.must` wrapper to a direct `terms` query (same semantics).
- `src/lib/search/__tests__/query.test.ts` (new): unit tests for `buildFilters` covering the OR shape and `minimum_should_match: 1`, a regression guard that the two clauses are not separate top-level (AND) filters, the person+party combination, and the no-`personIds` case.

## Testing

- `npx jest src/lib/search/__tests__/query.test.ts` — 4 passing.
- `npx tsc --noEmit` — no new errors in `query.ts`.
- Live Elasticsearch not exercised here (no ES instance in this environment). Staging smoke checklist is in the QA notes.

## Risks / notes

- Pure query-shape change against the same indexed fields. No index/mapping change, and no change to global (no-person) search or to the party/city/topic/date/location filters.
- The "show a matching quote/snippet on the profile card" stretch goal from the issue is left out on purpose: it needs `inner_hits` plus result-mapping and UI work. Keeping this PR to the correctness fix; the snippet is a follow-up.

Closes #373

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where person-scoped search returned no results on council member profile pages. The root cause was two Elasticsearch filter clauses for a person (introduced-by and spoke-in) being pushed as separate entries into a `bool.filter` array, making them AND-combined rather than OR-combined.

- **`query.ts`**: Wraps both person clauses in a single `bool.should` with `minimum_should_match: 1`, and removes a redundant `bool.must` wrapper from the nested spoke-in clause. A comment explains why OR is semantically required here.
- **`query.test.ts`** (new): Five tests lock in the OR shape, `minimum_should_match: 1`, regression guard against the original AND bug, person+party combination, and both the `undefined` and empty-array `personIds` edge cases. `findPersonFilter` uses structural property lookup rather than JSON serialisation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a pure query-shape correction against the same indexed fields with no mapping or index changes.

The fix is minimal and surgical: one compound push replaces two separate pushes. All other filters (city, party, topic, date, location) are untouched. The new test suite directly guards against the regression scenario, and the structural helper used in tests is robust to serialisation ordering. No index changes, no data-plane side effects.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/search/query.ts | Fixes person filter logic by wrapping introduced-by and spoke-in clauses in a single bool.should (OR), removing the accidental AND that caused zero results on profile pages. Also removes redundant bool.must wrapper around the nested clause. Comment added explaining why OR semantics are required. |
| src/lib/search/__tests__/query.test.ts | New test file with 5 tests covering: OR shape with minimum_should_match:1, regression guard against the AND bug, person+party combination, no-personIds case, and empty-personIds case. Uses structural property lookup (not JSON.stringify substring) in findPersonFilter, matching the approach recommended in a previous review thread. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(search): person filter matches subje..."](https://github.com/schemalabz/opencouncil/commit/b0bd1701f986609ad9de695bf2bcba0cf7cc04b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37569425)</sub>

<!-- /greptile_comment -->