### PR TITLE
fix(auth): configurable sign-in email sender + clearer Resend errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ NEXTAUTH_URL=http://localhost:3000
 # Required API Keys & Secrets
 # ---------------------------------
 RESEND_API_KEY=your_resend_api_key
+# Sender ("from") address for sign-in magic-link emails.
+# Local dev: use Resend's test sender so you don't need a verified domain.
+# Note: with onboarding@resend.dev, Resend only delivers to the email that owns
+# the API key, so sign in with that email (or set DEV_EMAIL_OVERRIDE below).
+AUTH_EMAIL_FROM="OpenCouncil <onboarding@resend.dev>"
 ANTHROPIC_API_KEY=your_anthropic_api_key
 GOOGLE_API_KEY=your_google_api_key
 TASK_API_URL=http://localhost:3005

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -71,6 +71,7 @@ These variables are used by the flake runner (`nix run .#dev`) to configure **lo
 | Variable | Description | Required | Default |
 |----------|-------------|----------|---------|
 | `RESEND_API_KEY` | API key for Resend email service. | Yes | - |
+| `AUTH_EMAIL_FROM` | Sender ("from") address for sign-in magic-link emails. For local dev, use a Resend test sender (see below). | No | `OpenCouncil <auth@opencouncil.gr>` |
 | `BASIC_AUTH_USERNAME` | Username for basic auth protection. | No | - |
 | `BASIC_AUTH_PASSWORD` | Password for basic auth protection. | No | - |
 | `NEXTAUTH_SECRET` | Secret used by NextAuth.js to hash tokens, sign/encrypt cookies, and generate cryptographic keys. | Yes | - |
@@ -88,6 +89,22 @@ These variables are used by the flake runner (`nix run .#dev`) to configure **lo
 | `BIRD_WEBHOOK_SECRET` | Shared secret for verifying HMAC signatures on inbound Bird webhook events. | No | - |
 
 For full setup instructions (workspace, channels, templates, API key, webhook subscription), see [bird-setup.md](./bird-setup.md).
+
+#### Resend setup for local development
+
+Sign-in uses a magic link sent through [Resend](https://resend.com). Two things commonly trip up new contributors and self-hosters:
+
+1. **The default `from` domain isn't yours.** The default `AUTH_EMAIL_FROM` is `OpenCouncil <auth@opencouncil.gr>`. Resend only lets you send from a domain you've verified on your own account, so on a fork every sign-in fails with **HTTP 403**. To avoid verifying a domain, set `AUTH_EMAIL_FROM` to Resend's test sender:
+
+   ```
+   AUTH_EMAIL_FROM="OpenCouncil <onboarding@resend.dev>"
+   ```
+
+2. **Test mode only delivers to the account owner.** While using `onboarding@resend.dev` (or any unverified setup), Resend will only deliver to the email address that owns your API key. So **sign in with that same email** — e.g. the address you registered your Resend account with. Sending to placeholder domains like `example@example.com` is blocked and returns **HTTP 422**.
+
+If you want every sign-in email (for any address) redirected to a single inbox you own, set `DEV_EMAIL_OVERRIDE` (see [Development Configuration](#development-configuration)) — note this only redirects the [test users](#test-users).
+
+When a send fails, the cause (status code + Resend message + a hint) is logged with the `[Auth][Resend]` prefix in your dev server console.
 
 #### NEXTAUTH_SECRET
 You can quickly create a good value on the command line via this openssl command:

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -71,6 +71,7 @@ These variables are used by the flake runner (`nix run .#dev`) to configure **lo
 | Variable | Description | Required | Default |
 |----------|-------------|----------|---------|
 | `RESEND_API_KEY` | API key for Resend email service. | Yes | - |
+| `AUTH_EMAIL_FROM` | Sender ("from") address for sign-in magic-link emails. For local dev, use a Resend test sender (see below). | No | `OpenCouncil <auth@opencouncil.gr>` |
 | `BASIC_AUTH_USERNAME` | Username for basic auth protection. | No | - |
 | `BASIC_AUTH_PASSWORD` | Password for basic auth protection. | No | - |
 | `NEXTAUTH_SECRET` | Secret used by NextAuth.js to hash tokens, sign/encrypt cookies, and generate cryptographic keys. | Yes | - |
@@ -90,6 +91,22 @@ These variables are used by the flake runner (`nix run .#dev`) to configure **lo
 | `BIRD_WEBHOOK_SECRET` | Shared secret for verifying HMAC signatures on inbound Bird webhook events. | No | - |
 
 For full setup instructions (workspace, channels, templates, API key, webhook subscription), see [bird-setup.md](./bird-setup.md).
+
+#### Resend setup for local development
+
+Sign-in uses a magic link sent through [Resend](https://resend.com). Two things commonly trip up new contributors and self-hosters:
+
+1. **The default `from` domain isn't yours.** The default `AUTH_EMAIL_FROM` is `OpenCouncil <auth@opencouncil.gr>`. Resend only lets you send from a domain you've verified on your own account, so on a fork every sign-in fails with **HTTP 403**. To avoid verifying a domain, set `AUTH_EMAIL_FROM` to Resend's test sender:
+
+   ```
+   AUTH_EMAIL_FROM="OpenCouncil <onboarding@resend.dev>"
+   ```
+
+2. **Test mode only delivers to the account owner.** While using `onboarding@resend.dev` (or any unverified setup), Resend will only deliver to the email address that owns your API key. So **sign in with that same email** — e.g. the address you registered your Resend account with. Sending to placeholder domains like `example@example.com` is blocked and returns **HTTP 422**.
+
+If you want every sign-in email (for any address) redirected to a single inbox you own, set `DEV_EMAIL_OVERRIDE` (see [Development Configuration](#development-configuration)) — note this only redirects the [test users](#test-users).
+
+When a send fails, the cause (status code + Resend message + a hint) is logged with the `[Auth][Resend]` prefix in your dev server console.
 
 #### NEXTAUTH_SECRET
 You can quickly create a good value on the command line via this openssl command:

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -4,6 +4,7 @@ import { AuthEmail } from "./lib/email/templates/AuthEmail"
 import { renderReactEmailToHtml } from "./lib/email/render"
 import { env } from "./env.mjs"
 import { isTestUserEmail } from "./lib/dev/test-users"
+import { buildResendAuthErrorMessage } from "./lib/email/authError"
 
 // In development, use port-specific session cookie names to allow multiple
 // instances on different ports to have independent sessions. Without this,
@@ -22,7 +23,7 @@ export default {
         },
     } : undefined,
     providers: [Resend({
-        from: 'OpenCouncil <auth@opencouncil.gr>',
+        from: env.AUTH_EMAIL_FROM,
         apiKey: env.RESEND_API_KEY,
         sendVerificationRequest: async (params) => {
             const { identifier: to, provider, url, theme } = params
@@ -51,8 +52,18 @@ export default {
                 }),
             })
 
-            if (!res.ok)
-                throw new Error("Resend error: " + JSON.stringify(await res.json()))
+            if (!res.ok) {
+                const body = await res.json().catch(() => ({})) as { name?: string; message?: string }
+                const errorMessage = buildResendAuthErrorMessage({
+                    status: res.status,
+                    from: provider.from,
+                    to: emailTo,
+                    body,
+                    statusText: res.statusText,
+                })
+                console.error(`[Auth][Resend] Failed to send sign-in email${body.name ? ` (${body.name})` : ''}: ${errorMessage}`)
+                throw new Error(errorMessage)
+            }
         }
     })],
 } satisfies NextAuthConfig

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -7,6 +7,7 @@ import { isTestUserEmail } from "./lib/dev/test-users"
 import { signInUrlForRequest } from "./lib/auth/signInUrl"
 import { localeForRequest } from "./lib/auth/requestLocale"
 import { devSessionCookieName } from "./lib/auth/sessionMirror"
+import { buildResendAuthErrorMessage } from "./lib/email/authError"
 
 // In development, use port-specific session cookie names to allow multiple
 // instances on different ports to have independent sessions. Without this,
@@ -25,7 +26,7 @@ export default {
         },
     } : undefined,
     providers: [Resend({
-        from: 'OpenCouncil <auth@opencouncil.gr>',
+        from: env.AUTH_EMAIL_FROM,
         apiKey: env.RESEND_API_KEY,
         sendVerificationRequest: async (params) => {
             const { identifier: to, provider, url, request } = params
@@ -62,8 +63,18 @@ export default {
                 }),
             })
 
-            if (!res.ok)
-                throw new Error("Resend error: " + JSON.stringify(await res.json()))
+            if (!res.ok) {
+                const body = await res.json().catch(() => ({})) as { name?: string; message?: string }
+                const errorMessage = buildResendAuthErrorMessage({
+                    status: res.status,
+                    from: provider.from,
+                    to: emailTo,
+                    body,
+                    statusText: res.statusText,
+                })
+                console.error(`[Auth][Resend] Failed to send sign-in email${body.name ? ` (${body.name})` : ''}: ${errorMessage}`)
+                throw new Error(errorMessage)
+            }
         }
     })],
 } satisfies NextAuthConfig

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -17,6 +17,10 @@ export const env = createEnv({
 
     // Auth
     RESEND_API_KEY: z.string().min(1),
+    // Sender ("from") address for sign-in magic-link emails. In local dev,
+    // set this to a Resend test sender (e.g. "OpenCouncil <onboarding@resend.dev>")
+    // since the production domain isn't verified on a fork's Resend account.
+    AUTH_EMAIL_FROM: z.string().min(1).default('OpenCouncil <auth@opencouncil.gr>'),
     NEXTAUTH_SECRET: z.string().min(1),
     NEXTAUTH_URL: z.string().url(),
     BASIC_AUTH_USERNAME: z.string().optional(),
@@ -102,6 +106,7 @@ export const env = createEnv({
     DATABASE_PASSWORD: process.env.DATABASE_PASSWORD,
     DATABASE_NAME: process.env.DATABASE_NAME,
     RESEND_API_KEY: process.env.RESEND_API_KEY,
+    AUTH_EMAIL_FROM: process.env.AUTH_EMAIL_FROM,
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
     BASIC_AUTH_USERNAME: process.env.BASIC_AUTH_USERNAME,

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -46,6 +46,10 @@ export const env = createEnv({
 
     // Auth
     RESEND_API_KEY: z.string().min(1),
+    // Sender ("from") address for sign-in magic-link emails. In local dev,
+    // set this to a Resend test sender (e.g. "OpenCouncil <onboarding@resend.dev>")
+    // since the production domain isn't verified on a fork's Resend account.
+    AUTH_EMAIL_FROM: z.string().min(1).default('OpenCouncil <auth@opencouncil.gr>'),
     NEXTAUTH_SECRET: z.string().min(1),
     NEXTAUTH_URL: z.string().url(),
     BASIC_AUTH_USERNAME: z.string().optional(),
@@ -145,6 +149,7 @@ export const env = createEnv({
     DATABASE_PASSWORD: process.env.DATABASE_PASSWORD,
     DATABASE_NAME: process.env.DATABASE_NAME,
     RESEND_API_KEY: process.env.RESEND_API_KEY,
+    AUTH_EMAIL_FROM: process.env.AUTH_EMAIL_FROM,
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
     BASIC_AUTH_USERNAME: process.env.BASIC_AUTH_USERNAME,

--- a/src/lib/email/__tests__/authError.test.ts
+++ b/src/lib/email/__tests__/authError.test.ts
@@ -1,0 +1,41 @@
+import { buildResendAuthErrorMessage } from '@/lib/email/authError'
+
+describe('buildResendAuthErrorMessage', () => {
+    it('adds a domain-verification hint for 403 responses (unverified "from")', () => {
+        const msg = buildResendAuthErrorMessage({
+            status: 403,
+            from: 'OpenCouncil <auth@opencouncil.gr>',
+            to: 'dev@example.org',
+            body: { name: 'validation_error', message: 'The opencouncil.gr domain is not verified.' },
+        })
+        expect(msg).toContain('Resend error (403)')
+        expect(msg).toContain('The opencouncil.gr domain is not verified.')
+        expect(msg).toContain('AUTH_EMAIL_FROM')
+        expect(msg).toContain('onboarding@resend.dev')
+        expect(msg).toContain('OpenCouncil <auth@opencouncil.gr>')
+        // Resend's message ends with a period; ours adds one — guard against ".."
+        expect(msg).not.toContain('..')
+    })
+
+    it('adds a recipient hint for 422 responses (placeholder domains)', () => {
+        const msg = buildResendAuthErrorMessage({
+            status: 422,
+            from: 'OpenCouncil <onboarding@resend.dev>',
+            to: 'example@example.com',
+            body: { message: 'Use our testing email address instead of domains like example.com.' },
+        })
+        expect(msg).toContain('Resend error (422)')
+        expect(msg).toContain('example@example.com')
+        expect(msg).toContain('DEV_EMAIL_OVERRIDE')
+    })
+
+    it('falls back to statusText when no Resend message is present', () => {
+        const msg = buildResendAuthErrorMessage({
+            status: 500,
+            from: 'OpenCouncil <onboarding@resend.dev>',
+            to: 'dev@example.org',
+            statusText: 'Internal Server Error',
+        })
+        expect(msg).toBe('Resend error (500): Internal Server Error.')
+    })
+})

--- a/src/lib/email/authError.ts
+++ b/src/lib/email/authError.ts
@@ -1,0 +1,30 @@
+/**
+ * Builds a clear, actionable error message for a failed Resend sign-in email send.
+ *
+ * Resend's most common local-dev failures are opaque by default:
+ * - 403: the "from" domain in AUTH_EMAIL_FROM isn't verified on this account.
+ * - 422: the recipient is a test/placeholder domain Resend blocks.
+ *
+ * Surfacing the status code, Resend's message, and a concrete next step turns a
+ * generic "Server error" into something a contributor can fix.
+ */
+export function buildResendAuthErrorMessage(params: {
+    status: number
+    from: string | undefined
+    to: string
+    body?: { name?: string; message?: string }
+    statusText?: string
+}): string {
+    const { status, from, to, body, statusText } = params
+    // Resend messages often already end with a period ("...is not verified."), so
+    // strip a trailing period before we add our own to avoid a doubled ".." artifact.
+    const message = (body?.message || statusText || 'Unknown error').replace(/\.+$/, '')
+
+    let hint = ''
+    if (status === 403)
+        hint = ` The "from" domain in AUTH_EMAIL_FROM ("${from}") is likely not verified on this Resend account. For local dev set AUTH_EMAIL_FROM to a Resend test sender, e.g. "OpenCouncil <onboarding@resend.dev>".`
+    else if (status === 422)
+        hint = ` Resend rejected the recipient ("${to}"). Use a real inbox you own (or set DEV_EMAIL_OVERRIDE) instead of placeholder domains like example.com.`
+
+    return `Resend error (${status}): ${message}.${hint}`
+}


### PR DESCRIPTION
## What & why

New contributors and self-hosters couldn't sign in locally. Two Resend failures, both opaque:

- 403 — the sign-in `from` address was hardcoded to the production domain (`auth@opencouncil.gr`), which isn't verified on a fork's Resend account, so every send was blocked.
- 422 — sending magic links to placeholder recipients like `example@example.com` is rejected by Resend.

The `from` address wasn't configurable, and Resend's error was rethrown as an unhelpful JSON blob, so contributors just saw a generic server error.

## Changes

- `src/env.mjs`: add `AUTH_EMAIL_FROM` server env var (default `OpenCouncil <auth@opencouncil.gr>`, so production is unchanged when unset), wired into `runtimeEnv`.
- `src/auth.config.ts`: use `env.AUTH_EMAIL_FROM` for the Resend provider's `from`; on a failed send, log an actionable message (status code + Resend message + a fix hint) under an `[Auth][Resend]` prefix and rethrow it.
- `src/lib/email/authError.ts` (new): pure helper that builds the error message (403 → sender-domain hint, 422 → recipient hint, fallback to statusText), so it's unit-testable.
- `src/lib/email/__tests__/authError.test.ts` (new): 3 tests for the 403/422/fallback paths.
- `.env.example`: add `AUTH_EMAIL_FROM="OpenCouncil <onboarding@resend.dev>"` with a note about Resend test mode.
- `docs/environment-variables.md`: document `AUTH_EMAIL_FROM` and a "Resend setup for local development" section (resend.dev sender + own-email recipient rule).

## Testing

- `npx jest src/lib/email/__tests__/authError.test.ts` — 3 passing.
- `npx tsc --noEmit` — no errors in the changed files.
- Manual 403/422 reproduction steps are in the QA notes.

## Risks / notes

- Default keeps the current production sender, so leaving it unset is a no-op in prod.
- The sign-in page still shows the existing generic message; the richer detail lands in the server logs, where someone debugging locally will look. A user-facing error-page rework overlaps with #69 and is out of scope here.

Closes #56



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two common local-dev/self-hosting sign-in failures caused by a hardcoded `from` address and opaque Resend error messages. It makes the sender address configurable via `AUTH_EMAIL_FROM` (defaulting to the existing production value so deployed environments are unaffected) and replaces the raw JSON blob rethrow with structured, hint-bearing error messages.

- **`AUTH_EMAIL_FROM` env var** added to `src/env.mjs` with a production-safe default; `src/auth.config.ts` uses it in place of the hardcoded string.
- **Improved Resend error handling** in `auth.config.ts`: JSON body is parsed defensively, a structured log line is emitted under `[Auth][Resend]`, and the thrown error carries a human-readable message built by the new `buildResendAuthErrorMessage` helper.
- **New pure helper + tests** in `src/lib/email/authError.ts` and its test file cover the 403 (unverified domain), 422 (blocked recipient), and fallback paths; trailing-period stripping prevents `..` artifacts in the output string.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the change is backward-compatible (production sender is unchanged when AUTH_EMAIL_FROM is unset) and the error-handling path only affects failed sends.
- All changed code paths are focused and low-risk: the env default keeps production behavior identical, the Resend error branch only fires on already-failed sends, and the new helper is pure and covered by unit tests. No data, auth, or session logic is altered.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/env.mjs | Adds AUTH_EMAIL_FROM server env var with sensible default; properly wired into runtimeEnv. Validation is a simple non-empty string check, which is sufficient since Resend will report format errors at send time. |
| src/auth.config.ts | Replaces hardcoded "from" with env.AUTH_EMAIL_FROM and wraps the Resend error path with defensive JSON parsing, structured logging, and a rethrown actionable error. The catch(() => ({})) guard on res.json() is correct. |
| src/lib/email/authError.ts | New pure helper builds actionable error messages for 403/422/fallback Resend failures. Trailing-period stripping via .replace(/\.+$/, '') correctly prevents double-period artifacts. |
| src/lib/email/__tests__/authError.test.ts | Three tests cover the 403 (domain hint), 422 (recipient hint), and fallback (statusText) paths. The 403 test explicitly guards against the double-period artifact. The 500 fallback test uses toBe for exact match. |
| .env.example | Adds AUTH_EMAIL_FROM with the onboarding@resend.dev test sender and a clear note about the Resend test-mode delivery restriction. |
| docs/environment-variables.md | Documents AUTH_EMAIL_FROM in the table and adds a "Resend setup for local development" section explaining the 403 and 422 failure modes with clear fix instructions. |

<sub>Reviews (5): Last reviewed commit: ["fix(auth): configurable sign-in email se..."](https://github.com/schemalabz/opencouncil/commit/34f79deb92b7eba948fee96a3585778c2e77c02f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37570712)</sub>

<!-- /greptile_comment -->