### PR TITLE
fix(summarize): run stale-data cleanup inside the repopulation transaction

### DIFF
--- a/src/lib/tasks/__tests__/summarizeForceCleanup.test.ts
+++ b/src/lib/tasks/__tests__/summarizeForceCleanup.test.ts
@@ -124,22 +124,22 @@ describe('handleSummarizeResult — always cleans up stale data on success', () 
     jest.clearAllMocks();
   });
 
-  it('deletes topic labels scoped to the meeting', async () => {
+  it('deletes topic labels scoped to the meeting segments', async () => {
     await handleSummarizeResult(TASK_ID, EMPTY_RESPONSE);
 
     expect(mockTopicLabelDeleteMany).toHaveBeenCalledWith({
       where: {
-        speakerSegment: { meetingId: MEETING_ID, cityId: CITY_ID },
+        speakerSegmentId: { in: [] },
       },
     });
   });
 
-  it('resets utterance discussion statuses scoped to the meeting', async () => {
+  it('resets utterance discussion statuses scoped to the meeting segments', async () => {
     await handleSummarizeResult(TASK_ID, EMPTY_RESPONSE);
 
     expect(mockUtteranceUpdateMany).toHaveBeenCalledWith({
       where: {
-        speakerSegment: { meetingId: MEETING_ID, cityId: CITY_ID },
+        speakerSegmentId: { in: [] },
       },
       data: {
         discussionStatus: null,
@@ -148,7 +148,25 @@ describe('handleSummarizeResult — always cleans up stale data on success', () 
     });
   });
 
-  it('cleans up before saving new data', async () => {
+  it('passes the cleanup ops into the same $transaction array (atomicity)', async () => {
+    // Sentinel return values so we can assert by identity that the cleanup ops are
+    // ELEMENTS of the array handed to $transaction — not awaited separately before it.
+    // A sequential-await version would still call all three mocks, so asserting only
+    // "was called" wouldn't actually guard the atomicity invariant this PR introduces.
+    const deleteOp = Symbol('deleteTopicLabels');
+    const resetOp = Symbol('resetUtterances');
+    mockTopicLabelDeleteMany.mockReturnValueOnce(deleteOp);
+    mockUtteranceUpdateMany.mockReturnValueOnce(resetOp);
+
+    await handleSummarizeResult(TASK_ID, EMPTY_RESPONSE);
+
+    expect(mockTransaction).toHaveBeenCalled();
+    const [transactionArg] = mockTransaction.mock.calls[0];
+    expect(transactionArg).toContain(deleteOp);
+    expect(transactionArg).toContain(resetOp);
+  });
+
+  it('builds cleanup before saving new data', async () => {
     const callOrder: string[] = [];
     mockTopicLabelDeleteMany.mockImplementation(() => { callOrder.push('deleteTopicLabels'); return Promise.resolve({ count: 0 }); });
     mockUtteranceUpdateMany.mockImplementation(() => { callOrder.push('resetUtterances'); return Promise.resolve({ count: 0 }); });

--- a/src/lib/tasks/summarize.ts
+++ b/src/lib/tasks/summarize.ts
@@ -44,34 +44,6 @@ export async function handleSummarizeResult(taskId: string, response: SummarizeR
 
     const { councilMeeting } = task;
 
-    // Clean up stale data before saving new results.
-    // This runs on every successful callback (not just force), ensuring the DB
-    // is consistent even if a previous run left partial data.
-    // Summaries use upsert (keyed on speakerSegmentId) so they're overwritten naturally.
-    // TopicLabels and utterance discussion statuses need explicit cleanup because:
-    // - TopicLabels: upsert only creates/updates matching pairs; old labels for topics
-    //   no longer assigned to a segment remain as stale data.
-    // - Utterance statuses: only utterances present in the new response get updated;
-    //   utterances that had statuses from the previous run but aren't in the new
-    //   response keep their old (now stale) values.
-    console.log(`Cleaning up stale summarize data for meeting ${councilMeeting.id}`);
-
-    await prisma.topicLabel.deleteMany({
-        where: {
-            speakerSegment: { meetingId: councilMeeting.id, cityId: councilMeeting.cityId }
-        }
-    });
-
-    await prisma.utterance.updateMany({
-        where: {
-            speakerSegment: { meetingId: councilMeeting.id, cityId: councilMeeting.cityId }
-        },
-        data: {
-            discussionStatus: null,
-            discussionSubjectId: null
-        }
-    });
-
     const availableSpeakerSegmentIds = await getAvailableSpeakerSegmentIds(councilMeeting.id, councilMeeting.cityId);
 
     // Pre-fetch all topics to avoid repeated queries
@@ -87,8 +59,22 @@ export async function handleSummarizeResult(taskId: string, response: SummarizeR
     });
     const topicByName = new Map(topics.map(t => [t.name, t]));
 
-    // Prepare all operations for batch execution
-    const operations: any[] = [];
+    // Prepare all operations for batch execution.
+    // Stale-data cleanup is PREPENDED so it runs in the SAME transaction as the
+    // repopulation below: if repopulation fails, the cleanup rolls back too and the
+    // meeting keeps its old data instead of being left empty. This runs on every
+    // successful callback (not just force) — summaries upsert by speakerSegmentId, but
+    // TopicLabels and utterance discussion statuses need explicit cleanup because old
+    // rows for segments/topics no longer in the new response would otherwise persist.
+    const operations: any[] = [
+        prisma.topicLabel.deleteMany({
+            where: { speakerSegmentId: { in: availableSpeakerSegmentIds } }
+        }),
+        prisma.utterance.updateMany({
+            where: { speakerSegmentId: { in: availableSpeakerSegmentIds } },
+            data: { discussionStatus: null, discussionSubjectId: null }
+        }),
+    ];
 
     for (const segmentSummary of response.speakerSegmentSummaries) {
         if (!availableSpeakerSegmentIds.includes(segmentSummary.speakerSegmentId)) {

--- a/src/lib/tasks/summarize.ts
+++ b/src/lib/tasks/summarize.ts
@@ -43,34 +43,6 @@ export async function handleSummarizeResult(taskId: string, response: SummarizeR
 
     const { councilMeeting } = task;
 
-    // Clean up stale data before saving new results.
-    // This runs on every successful callback (not just force), ensuring the DB
-    // is consistent even if a previous run left partial data.
-    // Summaries use upsert (keyed on speakerSegmentId) so they're overwritten naturally.
-    // TopicLabels and utterance discussion statuses need explicit cleanup because:
-    // - TopicLabels: upsert only creates/updates matching pairs; old labels for topics
-    //   no longer assigned to a segment remain as stale data.
-    // - Utterance statuses: only utterances present in the new response get updated;
-    //   utterances that had statuses from the previous run but aren't in the new
-    //   response keep their old (now stale) values.
-    console.log(`Cleaning up stale summarize data for meeting ${councilMeeting.id}`);
-
-    await prisma.topicLabel.deleteMany({
-        where: {
-            speakerSegment: { meetingId: councilMeeting.id, cityId: councilMeeting.cityId }
-        }
-    });
-
-    await prisma.utterance.updateMany({
-        where: {
-            speakerSegment: { meetingId: councilMeeting.id, cityId: councilMeeting.cityId }
-        },
-        data: {
-            discussionStatus: null,
-            discussionSubjectId: null
-        }
-    });
-
     const availableSpeakerSegmentIds = await getAvailableSpeakerSegmentIds(councilMeeting.id, councilMeeting.cityId);
 
     // Pre-fetch all topics to avoid repeated queries
@@ -86,8 +58,22 @@ export async function handleSummarizeResult(taskId: string, response: SummarizeR
     });
     const topicByName = new Map(topics.map(t => [t.name, t]));
 
-    // Prepare all operations for batch execution
-    const operations: any[] = [];
+    // Prepare all operations for batch execution.
+    // Stale-data cleanup is PREPENDED so it runs in the SAME transaction as the
+    // repopulation below: if repopulation fails, the cleanup rolls back too and the
+    // meeting keeps its old data instead of being left empty. This runs on every
+    // successful callback (not just force) — summaries upsert by speakerSegmentId, but
+    // TopicLabels and utterance discussion statuses need explicit cleanup because old
+    // rows for segments/topics no longer in the new response would otherwise persist.
+    const operations: any[] = [
+        prisma.topicLabel.deleteMany({
+            where: { speakerSegmentId: { in: availableSpeakerSegmentIds } }
+        }),
+        prisma.utterance.updateMany({
+            where: { speakerSegmentId: { in: availableSpeakerSegmentIds } },
+            data: { discussionStatus: null, discussionSubjectId: null }
+        }),
+    ];
 
     for (const segmentSummary of response.speakerSegmentSummaries) {
         if (!availableSpeakerSegmentIds.includes(segmentSummary.speakerSegmentId)) {


### PR DESCRIPTION
## What & why

Re-summarizing a meeting could leave it with no data. A force re-summarize already moved its stale-data cleanup out of `requestSummarize` and into `handleSummarizeResult` (so a failed task no longer wipes a meeting at request time). But the cleanup still ran as two separate awaited calls — `topicLabel.deleteMany` and `utterance.updateMany` — *before* the `$transaction` that repopulates summaries and topic labels.

So if the repopulation transaction failed, the cleanup had already committed: the meeting kept neither its old topic labels / discussion statuses nor any new ones.

## Changes

- `src/lib/tasks/summarize.ts`: prepend the two cleanup operations to the `operations` array, so cleanup and repopulation run in a single `$transaction`. If repopulation fails, the cleanup rolls back with it and the meeting keeps its previous data. Both cleanup ops now use the scalar `speakerSegmentId: { in: availableSpeakerSegmentIds }` form, consistent with how repopulation is scoped (equivalent coverage — that helper returns all of the meeting's segment ids).
- `src/lib/tasks/__tests__/summarizeForceCleanup.test.ts`: assert the scalar scoping and that cleanup is built into the same transaction as the save.

## Testing

- `npx jest summarizeForceCleanup` — 7 passing.
- `npx tsc --noEmit` — no errors in `summarize.ts`.

## Risks / notes

- Cleanup still runs on every successful callback (not only force), which keeps a normal re-run idempotent. The behavior change is purely the atomicity: same queries, now inside the transaction.
- Utterance discussion-status repopulation remains a separate best-effort pass (unchanged); this PR makes the topic-label/summary path atomic with its cleanup, which is where the "left empty on failure" risk was.

Closes #248



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a data-loss race condition in `handleSummarizeResult`: stale-data cleanup (`topicLabel.deleteMany`, `utterance.updateMany`) previously ran as two sequential awaited calls *before* the repopulation `$transaction`, so a failed repopulation would leave the meeting with neither old nor new data. The fix prepends the cleanup operations to the `operations` array so all writes (cleanup + repopulation) execute atomically in one `$transaction`.

- **`summarize.ts`**: Cleanup ops are now array elements in `operations`, guaranteeing rollback on repopulation failure. The scope changes from a relational `speakerSegment: { meetingId, cityId }` filter to `speakerSegmentId: { in: availableSpeakerSegmentIds }` — confirmed equivalent because `getAvailableSpeakerSegmentIds` returns all segment IDs for the meeting with no additional filtering.
- **`summarizeForceCleanup.test.ts`**: Adds a Symbol-sentinel atomicity test that verifies the cleanup return values are actual *elements* of the `$transaction` array (not separately awaited), directly guarding the invariant this PR introduces.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it tightens atomicity on an existing write path without changing observable behavior on the success case.
- The change is narrow and well-understood: two cleanup operations are prepended to an already-used $transaction array. The scope equivalence of speakerSegmentId: { in: availableSpeakerSegmentIds } vs the old relational filter is confirmed by reading getAvailableSpeakerSegmentIds, which performs a plain findMany with no extra predicates. The new Symbol-sentinel test actually guards the atomicity invariant rather than just asserting call counts. No new failure modes are introduced.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/tasks/summarize.ts | Cleanup ops (topicLabel.deleteMany, utterance.updateMany) moved from sequential pre-transaction awaits into the $transaction operations array; scope equivalence confirmed — getAvailableSpeakerSegmentIds returns all segment IDs for the meeting with no extra filtering. |
| src/lib/tasks/__tests__/summarizeForceCleanup.test.ts | Tests updated to assert scalar speakerSegmentId scoping; new Symbol-sentinel atomicity test properly verifies cleanup return values are elements of the $transaction array, not separately awaited. |

<sub>Reviews (4): Last reviewed commit: ["fix(summarize): run stale-data cleanup i..."](https://github.com/schemalabz/opencouncil/commit/7f5dd1a1e2c8f6c6e19a3d757f059ce4b0ddb1d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37570800)</sub>

<!-- /greptile_comment -->