### PR TITLE
fix(notifications): store full message body from Bird webhooks

### DIFF
--- a/src/app/api/webhooks/bird/__tests__/extract.test.ts
+++ b/src/app/api/webhooks/bird/__tests__/extract.test.ts
@@ -255,8 +255,17 @@ describe('extractPhone', () => {
 // ---------------------------------------------------------------------------
 
 describe('extractBody', () => {
-    it('prefers preview.text', () => {
-        expect(extractBody({ preview: { text: 'preview wins' }, text: 'loses' })).toBe('preview wins');
+    it('prefers the full body over the truncated preview snippet', () => {
+        expect(extractBody({ preview: { text: 'truncated…' }, text: 'full body wins' })).toBe('full body wins');
+        expect(extractBody({ preview: { text: 'truncated…' }, body: { text: { text: 'nested full' } } })).toBe('nested full');
+    });
+
+    it('falls back to preview.text when no body is present', () => {
+        expect(extractBody({ preview: { text: 'preview fallback' } })).toBe('preview fallback');
+    });
+
+    it('prefers a plain-string body over the truncated preview snippet', () => {
+        expect(extractBody({ preview: { text: 'truncated…' }, body: 'full string body' })).toBe('full string body');
     });
 
     it('reads body.text.text (nested object form)', () => {

--- a/src/app/api/webhooks/bird/extract.ts
+++ b/src/app/api/webhooks/bird/extract.ts
@@ -162,11 +162,15 @@ export function extractPhone(
 }
 
 export function extractBody(message: BirdMessageLike | undefined): string {
+    // Prefer the full message body. `preview.text` is Bird's conversation-list
+    // snippet — truncated to ~140 chars — so it's only a last-resort fallback
+    // for events that carry no body at all.
     return (
-        message?.preview?.text ??
         extractBodyText(message?.body) ??
         message?.text ??
-        (typeof message?.body === 'string' ? message.body : '')
+        (typeof message?.body === 'string' && message.body ? message.body : undefined) ??
+        message?.preview?.text ??
+        ''
     );
 }
 


### PR DESCRIPTION
# Replace the truncated preview with the message body

The extractBody preferred Bird's preview.text — a ~140-char conversation-list snippet — over the actual message body, so persisted Message rows held a truncated body (e.g. the auto-reply text: `Δεν υποστηρίζεται ακόμα η απάντηση σε μηνύματα. Όμως, μπορείτε να απεγγραφείτε από τις ειδοποιήσεις στέλνοντας "ΣΤΟΠ", "Θέλω να απεγγραφώ" κλπ.` cut mid-word at "κλπ." → "κ"). Reorder to prefer the full body and fall back to preview.text only when no body is present.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where `extractBody` was persisting Bird's truncated `preview.text` (~140-char conversation-list snippet) instead of the actual message body, causing auto-reply texts to be stored cut mid-word.

- **`extract.ts`**: Reorders the `??` chain in `extractBody` so `extractBodyText(body)`, `message.text`, and the plain-string `body` form are all tried before falling back to `message.preview.text`. The empty-string guard on the string-body branch (`&& message.body`) now correctly falls through to `preview.text` when body is `''`, which is a mild improvement over the old behaviour.
- **`extract.test.ts`**: Replaces the old "prefers preview.text" assertion with three new test cases covering the corrected priority (object body, top-level `text`, and plain-string body all beating preview), plus a dedicated fallback test when no body field is present.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a straightforward priority reorder in a pure extraction function, fully covered by updated unit tests.

The reordering is correct: `extractBodyText` already returns `undefined` for string bodies, so the chain falls through as intended; tests exercise every branch including the previously untested plain-string body vs preview case. No callers or schema are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/api/webhooks/bird/extract.ts | Reorders `extractBody` priority so the full body (`extractBodyText`, `text`, plain-string `body`) is preferred over `preview.text`; logic is correct and empty-string body now properly falls through to preview. |
| src/app/api/webhooks/bird/__tests__/extract.test.ts | Updates and extends `extractBody` tests to cover the new priority order, including the plain-string body vs preview case that was raised in a prior review thread. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(notifications): store full message b..."](https://github.com/schemalabz/opencouncil/commit/43a7a935f547b8f32564fae0a39687972ad37bf6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37622569)</sub>

<!-- /greptile_comment -->