### PR TITLE
feat(decisions): one-time Diavgeia backfill for historical meetings

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "import:import": "tsx prisma/import_administrations.ts --mode import",
     "test:og": "tsx scripts/test_og_images.ts",
     "generate-seed": "tsx scripts/generate_seed_dump.ts",
+    "backfill:decisions": "tsx scripts/backfill-decisions.ts",
     "convert-regulation": "tsx scripts/convert-regulation-pdf.ts",
     "transform-regulation": "tsx scripts/transform-regulation-coordinates.ts"
   },

--- a/scripts/backfill-decisions.ts
+++ b/scripts/backfill-decisions.ts
@@ -1,0 +1,89 @@
+/**
+ * One-time backfill of Diavgeia decisions for historical meetings across all
+ * municipalities (issue #461).
+ *
+ * DRY-RUN BY DEFAULT. Nothing is dispatched unless `--execute` is passed, and
+ * `--execute` refuses to run against a production-looking database unless
+ * `--i-know-its-not-prod` is also passed.
+ *
+ * Usage:
+ *   tsx scripts/backfill-decisions.ts                 # dry run, all cities
+ *   tsx scripts/backfill-decisions.ts --city athens   # dry run, one city
+ *   tsx scripts/backfill-decisions.ts --execute --i-know-its-not-prod
+ *
+ * Flags:
+ *   --execute              Actually dispatch polls (default: false = dry run)
+ *   --i-know-its-not-prod  Required acknowledgement to --execute past the prod guard
+ *   --city <id>            Limit to a single city
+ *   --batch-size <n>       Meetings dispatched per batch (default 10)
+ *   --batch-delay-ms <ms>  Pause between batches (default 2000)
+ *   --skip-recent-days <n> Skip meetings polled within N days (default 7)
+ *   --limit <n>            Cap candidate meetings considered (trial runs)
+ */
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+import { runBackfill } from "@/lib/tasks/backfillDecisions";
+
+/** Heuristic: does the configured DATABASE_URL look like production? */
+function looksLikeProd(): boolean {
+    if (process.env.NODE_ENV === "production") return true;
+    const url = process.env.DATABASE_URL ?? "";
+    return /prod|amazonaws|supabase|neon\.tech|render\.com|\.rds\./i.test(url);
+}
+
+async function main() {
+    const argv = await yargs(hideBin(process.argv))
+        .option("execute", {
+            type: "boolean",
+            default: false,
+            describe: "Actually dispatch polls (default: dry run)",
+        })
+        .option("i-know-its-not-prod", {
+            type: "boolean",
+            default: false,
+            describe: "Acknowledge the target DB is not production (required with --execute on prod-looking DBs)",
+        })
+        .option("city", { type: "string", describe: "Limit to a single city id" })
+        .option("batch-size", { type: "number", default: 10 })
+        .option("batch-delay-ms", { type: "number", default: 2000 })
+        .option("skip-recent-days", { type: "number", default: 7 })
+        .option("limit", { type: "number", describe: "Cap candidate meetings considered" })
+        .check((a) => {
+            if (a["batch-size"] < 1) throw new Error("--batch-size must be >= 1");
+            if (a["batch-delay-ms"] < 0) throw new Error("--batch-delay-ms must be >= 0");
+            if (a["skip-recent-days"] < 0) throw new Error("--skip-recent-days must be >= 0");
+            if (a.limit !== undefined && a.limit < 1) throw new Error("--limit must be >= 1");
+            return true;
+        })
+        .strict()
+        .help().argv;
+
+    if (argv.execute && looksLikeProd() && !argv["i-know-its-not-prod"]) {
+        console.error(
+            "Refusing to --execute: the target database looks like production " +
+            "(NODE_ENV/DATABASE_URL). If you are certain it is NOT prod, re-run " +
+            "with --i-know-its-not-prod.",
+        );
+        process.exit(1);
+    }
+
+    const result = await runBackfill({
+        execute: argv.execute,
+        cityId: argv.city,
+        batchSize: argv["batch-size"],
+        batchDelayMs: argv["batch-delay-ms"],
+        skipRecentDays: argv["skip-recent-days"],
+        limit: argv.limit,
+    });
+
+    if (!result.executed && result.toDispatch === 0) {
+        console.log("\nNothing to dispatch.");
+    }
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error("Backfill failed:", error);
+        process.exit(1);
+    });

--- a/scripts/backfill-decisions.ts
+++ b/scripts/backfill-decisions.ts
@@ -28,7 +28,7 @@ import { runBackfill } from "@/lib/tasks/backfillDecisions";
 function looksLikeProd(): boolean {
     if (process.env.NODE_ENV === "production") return true;
     const url = process.env.DATABASE_URL ?? "";
-    return /prod|amazonaws|supabase|neon\.tech|render\.com|\.rds\./i.test(url);
+    return /production|\bprod\b|amazonaws|supabase|neon\.tech|render\.com|\.rds\./i.test(url);
 }
 
 async function main() {
@@ -79,10 +79,12 @@ async function main() {
     if (!result.executed && result.toDispatch === 0) {
         console.log("\nNothing to dispatch.");
     }
+
+    return result;
 }
 
 main()
-    .then(() => process.exit(0))
+    .then((result) => process.exit(result.failed > 0 ? 1 : 0))
     .catch((error) => {
         console.error("Backfill failed:", error);
         process.exit(1);

--- a/src/lib/tasks/__tests__/backfillDecisions.test.ts
+++ b/src/lib/tasks/__tests__/backfillDecisions.test.ts
@@ -1,0 +1,125 @@
+import { selectBackfillMeetings, BackfillCandidate } from "../backfillDecisionsSelection";
+
+const daysAgo = (days: number) => new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+/** Base candidate: eligible, unlinked, never polled, not in progress → dispatches. */
+function candidate(overrides: Partial<BackfillCandidate> = {}): BackfillCandidate {
+    return {
+        cityId: "athens",
+        meetingId: "m1",
+        meetingName: "Δημοτικό Συμβούλιο",
+        dateTime: daysAgo(400),
+        eligibleSubjectCount: 5,
+        linkedDecisionCount: 0,
+        lastSucceededPollAt: null,
+        hasInProgressPoll: false,
+        ...overrides,
+    };
+}
+
+describe("selectBackfillMeetings", () => {
+    const opts = { skipRecentDays: 7 };
+
+    it("dispatches an eligible, unlinked, never-polled meeting", () => {
+        const [d] = selectBackfillMeetings([candidate()], opts);
+        expect(d.dispatch).toBe(true);
+        expect(d.skipReason).toBeUndefined();
+    });
+
+    it("skips a meeting with no eligible subjects", () => {
+        const [d] = selectBackfillMeetings([candidate({ eligibleSubjectCount: 0 })], opts);
+        expect(d.dispatch).toBe(false);
+        expect(d.skipReason).toBe("no eligible subjects");
+    });
+
+    it("skips a meeting where all eligible subjects are already linked", () => {
+        const [d] = selectBackfillMeetings(
+            [candidate({ eligibleSubjectCount: 3, linkedDecisionCount: 3 })],
+            opts,
+        );
+        expect(d.dispatch).toBe(false);
+        expect(d.skipReason).toBe("all eligible subjects already linked");
+    });
+
+    it("dispatches when some but not all subjects are linked", () => {
+        const [d] = selectBackfillMeetings(
+            [candidate({ eligibleSubjectCount: 5, linkedDecisionCount: 2 })],
+            opts,
+        );
+        expect(d.dispatch).toBe(true);
+    });
+
+    it("skips Λογοδοσία meetings (incl. combined names)", () => {
+        const [a] = selectBackfillMeetings([candidate({ meetingName: "Λογοδοσία" })], opts);
+        const [b] = selectBackfillMeetings(
+            [candidate({ meetingName: "Λογοδοσίας Δημάρχου" })],
+            opts,
+        );
+        const [c] = selectBackfillMeetings(
+            [candidate({ meetingName: "Λογοδοσία και Δημοτικό Συμβούλιο" })],
+            opts,
+        );
+        expect(a.skipReason).toBe("Λογοδοσία meeting");
+        expect(b.skipReason).toBe("Λογοδοσία meeting");
+        expect(c.skipReason).toBe("Λογοδοσία meeting");
+    });
+
+    it("skips a meeting with an in-progress poll", () => {
+        const [d] = selectBackfillMeetings([candidate({ hasInProgressPoll: true })], opts);
+        expect(d.dispatch).toBe(false);
+        expect(d.skipReason).toBe("poll already in progress");
+    });
+
+    it("skips a meeting polled within the skip-recent window", () => {
+        const [d] = selectBackfillMeetings(
+            [candidate({ lastSucceededPollAt: daysAgo(2) })],
+            opts,
+        );
+        expect(d.dispatch).toBe(false);
+        expect(d.skipReason).toContain("skip-recent window");
+    });
+
+    it("dispatches a meeting last polled before the skip-recent window", () => {
+        const [d] = selectBackfillMeetings(
+            [candidate({ lastSucceededPollAt: daysAgo(30) })],
+            opts,
+        );
+        expect(d.dispatch).toBe(true);
+    });
+
+    it("orders decisions oldest-first", () => {
+        const decisions = selectBackfillMeetings(
+            [
+                candidate({ meetingId: "newest", dateTime: daysAgo(10) }),
+                candidate({ meetingId: "oldest", dateTime: daysAgo(800) }),
+                candidate({ meetingId: "middle", dateTime: daysAgo(200) }),
+            ],
+            opts,
+        );
+        expect(decisions.map((d) => d.candidate.meetingId)).toEqual([
+            "oldest",
+            "middle",
+            "newest",
+        ]);
+    });
+
+    it("applies skip-reason precedence: no-subjects before all-linked before Λογοδοσία", () => {
+        // eligibleSubjectCount === 0 wins even if name is Λογοδοσία
+        const [d] = selectBackfillMeetings(
+            [candidate({ eligibleSubjectCount: 0, meetingName: "Λογοδοσία" })],
+            opts,
+        );
+        expect(d.skipReason).toBe("no eligible subjects");
+    });
+
+    it("respects an injected clock for the skip-recent check", () => {
+        const now = new Date("2026-06-15T00:00:00Z");
+        const polledFiveDaysBefore = new Date("2026-06-10T00:00:00Z");
+        const [d] = selectBackfillMeetings(
+            [candidate({ lastSucceededPollAt: polledFiveDaysBefore })],
+            { skipRecentDays: 7, now },
+        );
+        expect(d.dispatch).toBe(false);
+        expect(d.skipReason).toContain("skip-recent window");
+    });
+});

--- a/src/lib/tasks/backfillDecisions.ts
+++ b/src/lib/tasks/backfillDecisions.ts
@@ -1,6 +1,5 @@
 import prisma from "@/lib/db/prisma";
 import { DECISION_ELIGIBLE_SUBJECT_WHERE } from "@/lib/db/decisions";
-import { LOGODOSIA_NAME_PATTERN } from "@/lib/tasks/pollDecisionsBackoff";
 import { pollDecisionsForMeeting } from "@/lib/tasks/pollDecisions";
 import {
     selectBackfillMeetings,
@@ -89,13 +88,13 @@ export async function runBackfill(options: BackfillRunOptions = {}): Promise<Bac
         where: { diavgeiaUid: { not: null }, ...(cityId ? { id: cityId } : {}) },
     });
 
-    // Candidate meetings: configured city, not Λογοδοσία, with at least one
-    // eligible subject lacking a decision.
+    // Candidate meetings: configured city with at least one eligible subject
+    // lacking a decision. Λογοδοσία meetings are NOT filtered here — the pure
+    // selectBackfillMeetings owns that skip, so it shows up in the summary.
     const meetings = await prisma.councilMeeting.findMany({
         where: {
             ...(cityId ? { cityId } : {}),
             city: { diavgeiaUid: { not: null } },
-            NOT: { name: { contains: LOGODOSIA_NAME_PATTERN } },
             subjects: {
                 some: { ...DECISION_ELIGIBLE_SUBJECT_WHERE, decision: null },
             },

--- a/src/lib/tasks/backfillDecisions.ts
+++ b/src/lib/tasks/backfillDecisions.ts
@@ -1,0 +1,279 @@
+import prisma from "@/lib/db/prisma";
+import { DECISION_ELIGIBLE_SUBJECT_WHERE } from "@/lib/db/decisions";
+import { LOGODOSIA_NAME_PATTERN } from "@/lib/tasks/pollDecisionsBackoff";
+import { pollDecisionsForMeeting } from "@/lib/tasks/pollDecisions";
+import {
+    selectBackfillMeetings,
+    type BackfillCandidate,
+} from "@/lib/tasks/backfillDecisionsSelection";
+
+export {
+    selectBackfillMeetings,
+    type BackfillCandidate,
+    type BackfillSelectionOptions,
+    type BackfillDecision,
+} from "@/lib/tasks/backfillDecisionsSelection";
+
+/**
+ * One-time backfill of Diavgeia decisions for historical meetings.
+ *
+ * Unlike the cron (`pollDecisionsForRecentMeetings`), this ignores the 90-day
+ * window and the progressive backoff: decisions for old meetings are long
+ * published on Diavgeia, so a single poll per meeting suffices.
+ *
+ * Safety model (because `startTask` does NOT dedupe `pollDecisions` — it always
+ * fires a real backend call):
+ *   - The runner is DRY-RUN by default; nothing is dispatched without `execute`.
+ *   - Selection skips meetings recently polled (succeeded within `skipRecentDays`)
+ *     and meetings with an in-progress poll, so re-runs / overlaps don't
+ *     re-dispatch the same meeting.
+ *   - Dispatch is rate-limited (sequential within batches, delay between batches).
+ */
+
+// ─── Runner (DB + dispatch) ──────────────────────────────────────────
+
+export interface BackfillRunOptions {
+    /** When false (default), dry-run: nothing is dispatched. */
+    execute?: boolean;
+    /** Limit to a single city. */
+    cityId?: string;
+    /** Max meetings to dispatch per batch (sequential within batch). */
+    batchSize?: number;
+    /** Pause between batches, in ms (rate limit). */
+    batchDelayMs?: number;
+    /** Skip meetings whose last succeeded poll is within this many days. */
+    skipRecentDays?: number;
+    /** Cap the number of candidate meetings considered (for trial runs). */
+    limit?: number;
+    /** Logger sink — defaults to console.log. */
+    log?: (message: string) => void;
+}
+
+export interface BackfillRunResult {
+    citiesWithDiavgeia: number;
+    citiesWithoutDiavgeia: string[];
+    candidateCount: number;
+    toDispatch: number;
+    skippedByReason: Record<string, number>;
+    dispatched: number;
+    failed: number;
+    executed: boolean;
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Runs the backfill. Dry-run by default; pass `execute: true` to dispatch.
+ * Callers (CLI) are responsible for prod guards and auth — this function does
+ * not check either, matching `pollDecisionsForMeeting`.
+ */
+export async function runBackfill(options: BackfillRunOptions = {}): Promise<BackfillRunResult> {
+    const {
+        execute = false,
+        cityId,
+        batchSize = 10,
+        batchDelayMs = 2000,
+        skipRecentDays = 7,
+        limit,
+        log = (m: string) => console.log(m),
+    } = options;
+
+    // Side-output: cities that cannot be polled until configured.
+    const citiesWithoutDiavgeia = await prisma.city.findMany({
+        where: { diavgeiaUid: null, ...(cityId ? { id: cityId } : {}) },
+        select: { id: true },
+        orderBy: { id: "asc" },
+    });
+
+    const citiesWithDiavgeia = await prisma.city.count({
+        where: { diavgeiaUid: { not: null }, ...(cityId ? { id: cityId } : {}) },
+    });
+
+    // Candidate meetings: configured city, not Λογοδοσία, with at least one
+    // eligible subject lacking a decision.
+    const meetings = await prisma.councilMeeting.findMany({
+        where: {
+            ...(cityId ? { cityId } : {}),
+            city: { diavgeiaUid: { not: null } },
+            NOT: { name: { contains: LOGODOSIA_NAME_PATTERN } },
+            subjects: {
+                some: { ...DECISION_ELIGIBLE_SUBJECT_WHERE, decision: null },
+            },
+        },
+        select: { id: true, cityId: true, name: true, dateTime: true },
+        orderBy: { dateTime: "asc" }, // oldest first
+        ...(limit ? { take: limit } : {}),
+    });
+
+    if (meetings.length === 0) {
+        log("No candidate meetings found.");
+        return {
+            citiesWithDiavgeia,
+            citiesWithoutDiavgeia: citiesWithoutDiavgeia.map((c) => c.id),
+            candidateCount: 0,
+            toDispatch: 0,
+            skippedByReason: {},
+            dispatched: 0,
+            failed: 0,
+            executed: execute,
+        };
+    }
+
+    const meetingIds = meetings.map((m) => m.id);
+
+    // Eligible subject counts per meeting.
+    const eligibleCounts = await prisma.subject.groupBy({
+        by: ["councilMeetingId", "cityId"],
+        where: { councilMeetingId: { in: meetingIds }, ...DECISION_ELIGIBLE_SUBJECT_WHERE },
+        _count: true,
+    });
+    const eligibleByMeeting = new Map(
+        eligibleCounts.map((r) => [`${r.cityId}:${r.councilMeetingId}`, r._count]),
+    );
+
+    // Linked decision counts per meeting (eligible subjects with a decision).
+    const linkedCounts = await prisma.subject.groupBy({
+        by: ["councilMeetingId", "cityId"],
+        where: {
+            councilMeetingId: { in: meetingIds },
+            ...DECISION_ELIGIBLE_SUBJECT_WHERE,
+            decision: { isNot: null },
+        },
+        _count: true,
+    });
+    const linkedByMeeting = new Map(
+        linkedCounts.map((r) => [`${r.cityId}:${r.councilMeetingId}`, r._count]),
+    );
+
+    // Last succeeded poll per meeting.
+    const succeededPolls = await prisma.taskStatus.groupBy({
+        by: ["councilMeetingId", "cityId"],
+        where: { councilMeetingId: { in: meetingIds }, type: "pollDecisions", status: "succeeded" },
+        _max: { createdAt: true },
+    });
+    const lastPollByMeeting = new Map(
+        succeededPolls.map((r) => [`${r.cityId}:${r.councilMeetingId}`, r._max.createdAt]),
+    );
+
+    // In-progress polls per meeting (pending/running — anything not terminal).
+    const inProgressPolls = await prisma.taskStatus.findMany({
+        where: {
+            councilMeetingId: { in: meetingIds },
+            type: "pollDecisions",
+            status: { notIn: ["succeeded", "failed"] },
+        },
+        select: { councilMeetingId: true, cityId: true },
+        distinct: ["councilMeetingId", "cityId"],
+    });
+    const inProgressByMeeting = new Set(
+        inProgressPolls.map((r) => `${r.cityId}:${r.councilMeetingId}`),
+    );
+
+    const candidates: BackfillCandidate[] = meetings.map((m) => {
+        const key = `${m.cityId}:${m.id}`;
+        return {
+            cityId: m.cityId,
+            meetingId: m.id,
+            meetingName: m.name,
+            dateTime: m.dateTime,
+            eligibleSubjectCount: eligibleByMeeting.get(key) ?? 0,
+            linkedDecisionCount: linkedByMeeting.get(key) ?? 0,
+            lastSucceededPollAt: lastPollByMeeting.get(key) ?? null,
+            hasInProgressPoll: inProgressByMeeting.has(key),
+        };
+    });
+
+    const selection = selectBackfillMeetings(candidates, { skipRecentDays });
+
+    const skippedByReason: Record<string, number> = {};
+    for (const d of selection) {
+        if (!d.dispatch && d.skipReason) {
+            skippedByReason[d.skipReason] = (skippedByReason[d.skipReason] ?? 0) + 1;
+        }
+    }
+    const dispatchList = selection.filter((d) => d.dispatch);
+
+    // ── Summary ──
+    log(`Cities with diavgeiaUid:    ${citiesWithDiavgeia}`);
+    log(`Cities WITHOUT diavgeiaUid: ${citiesWithoutDiavgeia.length}`);
+    if (citiesWithoutDiavgeia.length > 0) {
+        log(`  (need manual config): ${citiesWithoutDiavgeia.map((c) => c.id).join(", ")}`);
+    }
+    log(`Candidate meetings:         ${candidates.length}`);
+    log(`To dispatch:                ${dispatchList.length}`);
+    log(`Skipped:                    ${candidates.length - dispatchList.length}`);
+    for (const [reason, count] of Object.entries(skippedByReason)) {
+        log(`  - ${reason}: ${count}`);
+    }
+
+    if (!execute) {
+        log("");
+        log("DRY RUN — nothing dispatched. Re-run with --execute to dispatch.");
+        const preview = dispatchList.slice(0, 10);
+        if (preview.length > 0) {
+            log(`First ${preview.length} meeting(s) that would be dispatched:`);
+            for (const d of preview) {
+                log(
+                    `  ${d.candidate.cityId}/${d.candidate.meetingId} ` +
+                    `(${d.candidate.dateTime.toISOString().split("T")[0]}) ` +
+                    `${d.candidate.linkedDecisionCount}/${d.candidate.eligibleSubjectCount} linked`,
+                );
+            }
+        }
+        return {
+            citiesWithDiavgeia,
+            citiesWithoutDiavgeia: citiesWithoutDiavgeia.map((c) => c.id),
+            candidateCount: candidates.length,
+            toDispatch: dispatchList.length,
+            skippedByReason,
+            dispatched: 0,
+            failed: 0,
+            executed: false,
+        };
+    }
+
+    // ── Execute: dispatch sequentially in rate-limited batches ──
+    log("");
+    log(`EXECUTING — dispatching ${dispatchList.length} poll(s) in batches of ${batchSize} ` +
+        `(${batchDelayMs}ms between batches)...`);
+
+    let dispatched = 0;
+    let failed = 0;
+
+    for (let i = 0; i < dispatchList.length; i += batchSize) {
+        const batch = dispatchList.slice(i, i + batchSize);
+        for (const d of batch) {
+            try {
+                await pollDecisionsForMeeting(d.candidate.cityId, d.candidate.meetingId, {
+                    silent: true,
+                });
+                dispatched++;
+                log(`  dispatched ${d.candidate.cityId}/${d.candidate.meetingId}`);
+            } catch (error) {
+                failed++;
+                const msg = error instanceof Error ? error.message : String(error);
+                log(`  FAILED ${d.candidate.cityId}/${d.candidate.meetingId}: ${msg}`);
+            }
+        }
+        const remaining = dispatchList.length - (i + batch.length);
+        if (remaining > 0 && batchDelayMs > 0) {
+            log(`  ...batch done (${dispatched} dispatched, ${failed} failed, ${remaining} remaining). ` +
+                `Waiting ${batchDelayMs}ms.`);
+            await sleep(batchDelayMs);
+        }
+    }
+
+    log("");
+    log(`Done. Dispatched: ${dispatched}, Failed: ${failed}.`);
+
+    return {
+        citiesWithDiavgeia,
+        citiesWithoutDiavgeia: citiesWithoutDiavgeia.map((c) => c.id),
+        candidateCount: candidates.length,
+        toDispatch: dispatchList.length,
+        skippedByReason,
+        dispatched,
+        failed,
+        executed: true,
+    };
+}

--- a/src/lib/tasks/backfillDecisionsSelection.ts
+++ b/src/lib/tasks/backfillDecisionsSelection.ts
@@ -1,0 +1,90 @@
+import { isLogodosiaMeeting } from "@/lib/tasks/pollDecisionsBackoff";
+
+/**
+ * Pure selection logic for the one-time decision backfill (issue #461).
+ *
+ * Kept free of DB/env imports so it can be unit-tested in isolation — the
+ * runner (`backfillDecisions.ts`) builds candidates from the DB and feeds them
+ * here. This is the single source of truth for "dispatch or skip, and why".
+ */
+
+export interface BackfillCandidate {
+    cityId: string;
+    meetingId: string;
+    meetingName: string;
+    dateTime: Date;
+    /** Eligible subjects (agenda or outOfAgenda, not withdrawn). */
+    eligibleSubjectCount: number;
+    /** Eligible subjects that already have a linked decision. */
+    linkedDecisionCount: number;
+    /** Most recent succeeded pollDecisions task for this meeting, if any. */
+    lastSucceededPollAt: Date | null;
+    /** True if a pollDecisions task is currently pending/running for this meeting. */
+    hasInProgressPoll: boolean;
+}
+
+export interface BackfillSelectionOptions {
+    /** Skip meetings whose last succeeded poll is newer than this many days. */
+    skipRecentDays: number;
+    /** Injectable clock for deterministic tests. Defaults to now. */
+    now?: Date;
+}
+
+export interface BackfillDecision {
+    candidate: BackfillCandidate;
+    dispatch: boolean;
+    skipReason?: string;
+}
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+/**
+ * Decides, per candidate, whether to dispatch a poll or skip (with a reason).
+ * Pure and deterministic.
+ *
+ * Returns decisions sorted oldest-first so the longest-missing meetings are
+ * dispatched before newer ones.
+ */
+export function selectBackfillMeetings(
+    candidates: BackfillCandidate[],
+    options: BackfillSelectionOptions,
+): BackfillDecision[] {
+    const now = (options.now ?? new Date()).getTime();
+    const skipRecentMs = options.skipRecentDays * MS_PER_DAY;
+
+    const decisions = candidates.map((candidate): BackfillDecision => {
+        if (candidate.eligibleSubjectCount === 0) {
+            return { candidate, dispatch: false, skipReason: "no eligible subjects" };
+        }
+
+        if (candidate.linkedDecisionCount >= candidate.eligibleSubjectCount) {
+            return { candidate, dispatch: false, skipReason: "all eligible subjects already linked" };
+        }
+
+        if (isLogodosiaMeeting(candidate.meetingName)) {
+            return { candidate, dispatch: false, skipReason: "Λογοδοσία meeting" };
+        }
+
+        if (candidate.hasInProgressPoll) {
+            return { candidate, dispatch: false, skipReason: "poll already in progress" };
+        }
+
+        if (
+            candidate.lastSucceededPollAt &&
+            now - candidate.lastSucceededPollAt.getTime() < skipRecentMs
+        ) {
+            const daysAgo = ((now - candidate.lastSucceededPollAt.getTime()) / MS_PER_DAY).toFixed(1);
+            return {
+                candidate,
+                dispatch: false,
+                skipReason: `polled ${daysAgo}d ago (< ${options.skipRecentDays}d skip-recent window)`,
+            };
+        }
+
+        return { candidate, dispatch: true };
+    });
+
+    return decisions.sort(
+        (a, b) => a.candidate.dateTime.getTime() - b.candidate.dateTime.getTime(),
+    );
+}


### PR DESCRIPTION
## Why

Decision polling only looks back 90 days (`pollDecisionsForRecentMeetings`, `MAX_POLLING_DAYS`). Anything older never gets linked decisions, including every meeting from before the decisions feature shipped in #103.

## What it does

A one-time backfill that polls decisions for past meetings that still have eligible unlinked subjects, across every city that has a `diavgeiaUid`. It runs through the existing `pollDecisionsForMeeting`, so matching, extraction, ADA conflict handling, and the Discord batch alerts all behave exactly like the cron does.

- `backfillDecisionsSelection.ts`: pure, DB-free `selectBackfillMeetings`. Drops meetings with no eligible subjects, fully-linked ones, Λογοδοσία meetings, in-progress polls, and recently-polled ones. No 90-day backoff, oldest first.
- `backfillDecisions.ts`: `runBackfill` builds candidates from the DB, prints a summary (including which cities have no `diavgeiaUid`), and only dispatches when `execute` is set, in rate-limited batches.
- `scripts/backfill-decisions.ts`: yargs CLI. Dry-run by default, with a prod guard on `--execute` that also needs `--i-know-its-not-prod`.
- `backfill:decisions` npm script.
- Unit tests for the selection logic.

## Safety

Dry-run by default, so it dispatches nothing unless you ask. The prod guard refuses `--execute` when `DATABASE_URL`/`NODE_ENV` look like production. I have not run this against any real database.

## Testing

- `jest backfillDecisions.test.ts`: 11 pass
- `jest pollDecisions.test.ts`: 57 pass, no regression
- `tsc --noEmit` clean for the new files

Closes #461

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a one-time Diavgeia decision backfill that polls decisions for historical meetings outside the existing 90-day cron window. It introduces a pure selection layer (`backfillDecisionsSelection.ts`), a DB-backed runner (`backfillDecisions.ts`), and a CLI script with a dry-run default and a prod guard.

- **Safety guards**: dry-run by default; `--execute` is blocked on prod-looking databases unless `--i-know-its-not-prod` is also passed; selection skips in-progress polls and recently-succeeded ones to prevent re-dispatch on re-runs.
- **Selection logic**: pure, DB-free `selectBackfillMeetings` handles all skip conditions (no subjects, fully linked, Λογοδοσία, in-progress, recently polled) with clear precedence and oldest-first ordering; 11 unit tests cover all paths.
- **Runner**: five sequential DB queries build the candidate list; the four lookup queries executed after `meetingIds` is determined are independent and could be parallelised with `Promise.all`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the backfill dispatches nothing without an explicit flag, and the existing polling pipeline is unchanged.

No new code paths are activated in production without `--execute`. The selection logic is pure and fully tested. The runner follows established codebase patterns and only touches the historical meetings backfill. The only findings are minor style suggestions that don't affect correctness.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/backfill-decisions.ts | CLI entry point with dry-run default, prod guard, and yargs argument validation; well-structured, previous issues now addressed |
| src/lib/tasks/backfillDecisions.ts | DB-backed runner: 5 separate sequential queries (4 of which are independent after meetingIds is built) drive the summary and dispatch loop; logic is correct |
| src/lib/tasks/backfillDecisionsSelection.ts | Pure, DB-free selection logic with clear skip-reason precedence, injectable clock, and oldest-first sort; clean separation from DB layer |
| src/lib/tasks/__tests__/backfillDecisions.test.ts | 11 unit tests covering all skip conditions, ordering, and the injectable clock; good coverage of selectBackfillMeetings |
| package.json | Adds backfill:decisions npm script pointing at the new CLI; no other changes |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(backfill): non-zero exit on partial ..."](https://github.com/schemalabz/opencouncil/commit/8aa6da945508ad6d4e7b4ba0c6a7dc3ff1333694) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37826460)</sub>

<!-- /greptile_comment -->