### PR TITLE
fix(admin): chunk review stats query to avoid bind-variable overflow

### DIFF
--- a/src/lib/db/reviews.ts
+++ b/src/lib/db/reviews.ts
@@ -715,6 +715,13 @@ function getEmptyAggregatedMeetingStats(): AggregatedMeetingStats {
   };
 }
 
+// Each meeting pair contributes 2 bind variables (cityId, meetingId) to the
+// raw queries below. PostgreSQL caps a prepared statement at 32767 bind
+// variables, so an unbounded VALUES list (e.g. when the "last 30 days" filter
+// is off and every reviewed meeting is included) overflows that limit and the
+// query throws. Chunking keeps each query well under the cap and bounds cost.
+const MEETING_STATS_BATCH_SIZE = 500;
+
 async function getAggregatedMeetingStatsBatch(
   meetings: MeetingId[]
 ): Promise<Map<string, AggregatedMeetingStats>> {
@@ -727,6 +734,18 @@ async function getAggregatedMeetingStatsBatch(
     statsByMeeting.set(getMeetingMapKey(meeting), getEmptyAggregatedMeetingStats());
   }
 
+  for (let i = 0; i < meetings.length; i += MEETING_STATS_BATCH_SIZE) {
+    const chunk = meetings.slice(i, i + MEETING_STATS_BATCH_SIZE);
+    await aggregateMeetingStatsChunk(chunk, statsByMeeting);
+  }
+
+  return statsByMeeting;
+}
+
+async function aggregateMeetingStatsChunk(
+  meetings: MeetingId[],
+  statsByMeeting: Map<string, AggregatedMeetingStats>
+): Promise<void> {
   const meetingPairs = Prisma.join(
     meetings.map((m) => Prisma.sql`(${m.cityId}::text, ${m.meetingId}::text)`)
   );
@@ -901,8 +920,6 @@ async function getAggregatedMeetingStatsBatch(
       primaryReviewer: reviewers.length > 0 ? reviewers[0] : null,
     });
   }
-
-  return statsByMeeting;
 }
 
 /**


### PR DESCRIPTION
## Why

With the "last 30 days" filter off, `getMeetingsNeedingReview` returns every reviewed meeting and hands the whole set to `getAggregatedMeetingStatsBatch`. That builds one raw-SQL `VALUES` list of `(cityId, meetingId)` pairs, 2 bind variables each. Past ~16383 meetings it crosses PostgreSQL's 32767 bind-variable cap, Prisma throws, and the admin Reviews page shows an error with no data.

## Fix

Aggregate in batches of 500 meetings through a new `aggregateMeetingStatsChunk` helper that merges into the shared result map. Per-query parameter count and statement size stay bounded no matter how many meetings there are.

## Testing

- Reproduced the failure: a single `VALUES` clause throws above 16383 pairs, the chunked path handles 50000 fine.
- `tsc --noEmit` clean, `npm test` passes.
- Manually checked the admin Reviews page renders with the filter off. Full scenarios in `plans/qa/issue-303-qa.md`.

Closes #303

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a PostgreSQL bind-variable overflow in the admin Reviews page by chunking the raw-SQL `VALUES` list that `getAggregatedMeetingStatsBatch` builds from meeting ID pairs. Without a filter the entire reviewed-meeting set could exceed the 32 767-variable cap and crash the page.

- Adds a `MEETING_STATS_BATCH_SIZE = 500` constant (1 000 bind variables per query, well within the cap) with a thorough inline explanation of the constraint.
- Extracts the query + merge logic from `getAggregatedMeetingStatsBatch` into a new private `aggregateMeetingStatsChunk` helper; the outer function loops over slices sequentially and merges results into the shared map.
- The refactor preserves the existing `getEmptyAggregatedMeetingStats` pre-initialisation and the two-step merge (stats rows first, then reviewer rows), so correctness for each individual meeting is unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a pure refactor of one private function with no interface changes and the fix is correctly scoped.

The chunking loop is straightforward: slices of the pre-populated meetings array are processed sequentially, each producing at most 1 000 bind variables per query. The pre-initialisation of statsByMeeting happens before the loop, so every meeting always has a baseline entry regardless of whether the DB returns a row for it. The two-stage merge (stats rows then reviewer rows) inside aggregateMeetingStatsChunk is identical to the original code and operates on non-overlapping keys across chunks, so no data can be double-counted or silently dropped. No schema, API, or type changes accompany the fix.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/db/reviews.ts | Introduces MEETING_STATS_BATCH_SIZE=500 constant and refactors getAggregatedMeetingStatsBatch to iterate over chunks, delegating SQL execution to a new aggregateMeetingStatsChunk helper; correctly bounds bind-variable count to ~1000 per query. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(admin): chunk review stats query to ..."](https://github.com/schemalabz/opencouncil/commit/7479a53aa63efed7f3fb532e086476b58b9a1873) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37833516)</sub>

<!-- /greptile_comment -->