### PR TITLE
fix(ai): point default model off retired claude-sonnet-4-0

### DIFF
--- a/src/lib/__tests__/ai.test.ts
+++ b/src/lib/__tests__/ai.test.ts
@@ -51,7 +51,7 @@ describe('aiChat', () => {
     await aiChat(systemPrompt, userPrompt);
     
     expect(mockCreate).toHaveBeenCalledWith({
-      model: "claude-sonnet-4-0",
+      model: "claude-sonnet-4-5-20250929",
       max_tokens: 8192,
       system: systemPrompt,
       messages: [
@@ -69,7 +69,7 @@ describe('aiChat', () => {
     await aiChat(systemPrompt, userPrompt, prefill);
     
     expect(mockCreate).toHaveBeenCalledWith({
-      model: "claude-sonnet-4-0",
+      model: "claude-sonnet-4-5-20250929",
       max_tokens: 8192,
       system: systemPrompt,
       messages: [

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -26,7 +26,7 @@ export interface AIConfig {
 const DEFAULT_CONFIG: AIConfig = {
     maxTokens: 8192,
     temperature: 0,
-    model: "claude-sonnet-4-0",
+    model: "claude-sonnet-4-5-20250929",
     logPrompts: IS_DEV,
     promptsDir: path.join(process.cwd(), 'logs', 'prompts'),
     enableWebSearch: false,


### PR DESCRIPTION
## What

`DEFAULT_CONFIG.model` in `src/lib/ai.ts` was `claude-sonnet-4-0`, which aliases `claude-sonnet-4-20250514`. That model **retired on June 15, 2026** — calls to it now return 404.

This bumps the default to `claude-sonnet-4-5-20250929` (the dated Sonnet 4.5 ID already used in `src/app/api/chat/route.ts`).

## Why it matters

`DEFAULT_CONFIG` is merged in `aiChat` and `aiChatStream` via `{ ...DEFAULT_CONFIG, ...config }`. Any caller that doesn't set `model` inherits the default. Two production paths don't override it and were therefore hitting the retired model:

- `src/lib/search/filters.ts` (filter extraction — no config passed)
- `src/lib/cityCreatorAI.ts` (sets maxTokens/temperature/webSearch but not model)

(`prisma/import_administrations.ts` also relies on the default, but it's a one-off import script, not a request path.)

Callers that pin their own model are unaffected: chat route → Sonnet 4.5, unsubscribe → Haiku 4.5.

## Scope

Minimal, deliberately. Sonnet 4.5 still accepts `temperature` and assistant-message prefills, so no other call sites need to change. Only:

- `src/lib/ai.ts` — the default model string
- `src/lib/__tests__/ai.test.ts` — the two assertions that pinned the old string (otherwise CI breaks)

`npx jest src/lib/__tests__/ai.test.ts` passes (8 passed, 1 pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes production breakage caused by `DEFAULT_CONFIG.model` pointing at the retired `claude-sonnet-4-0` (alias for `claude-sonnet-4-20250514`, retired June 15 2026). The default is updated to the dated `claude-sonnet-4-5-20250929` ID already in use by the chat route.

- **`src/lib/ai.ts`**: Single-line bump of the default model string; callers that don't override `model` (`filters.ts`, `cityCreatorAI.ts`) now resolve to a live model.
- **`src/lib/__tests__/ai.test.ts`**: Two hardcoded model-string assertions updated to match the new default so CI passes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single string update to restore a working model ID, with a matching test fix.

Both changed lines are string literals with no logic change; the new model ID matches what the chat route already uses successfully in production, and the updated tests directly verify the default passes through correctly.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/ai.ts | Updates DEFAULT_CONFIG.model from the retired `claude-sonnet-4-0` to `claude-sonnet-4-5-20250929`; single-line change, correct and consistent with the model already used in the chat route. |
| src/lib/__tests__/ai.test.ts | Updates two model-string assertions in the `aiChat` test suite to match the new default; both assertions now reflect `claude-sonnet-4-5-20250929`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ai): point default model off retired..."](https://github.com/schemalabz/opencouncil/commit/7994987bc820eeb735b5b070b8bfa1129c1510e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37838087)</sub>

<!-- /greptile_comment -->