### PR TITLE
fix(transcript): resolve speaker timeline color as of the meeting date

### DIFF
--- a/src/components/meetings/TranscriptControls.tsx
+++ b/src/components/meetings/TranscriptControls.tsx
@@ -2,7 +2,7 @@
 import { Play, Pause, Loader, ChevronLeft, ChevronRight, Youtube } from "lucide-react"
 import { useTranslations } from 'next-intl';
 import { useVideo } from "./VideoProvider"
-import { cn, formatTimestamp } from "@/lib/utils";
+import { cn, formatTimestamp, getPartyFromRoles } from "@/lib/utils";
 import { useCouncilMeetingData } from "./CouncilMeetingDataContext";
 import { useTranscriptOptions } from "./options/OptionsContext";
 import { useHighlight } from "./HighlightContext";
@@ -68,7 +68,10 @@ export default function TranscriptControls({ className }: { className?: string }
         updateHoveredSpeaker(touchTime);
     };
 
-    const { getParty, getPerson, getSpeakerTag } = useCouncilMeetingData();
+    const { getParty, getPerson, getSpeakerTag, meeting } = useCouncilMeetingData();
+    // Resolve party color as of the meeting date so a councilor who later
+    // changed affiliation keeps their historical color on older meetings.
+    const meetingDate = meeting.dateTime;
     const [hoverTime, setHoverTime] = useState<number | null>(null);
     const [isExpanded, setIsExpanded] = useState(false);
 
@@ -77,7 +80,7 @@ export default function TranscriptControls({ className }: { className?: string }
             if (time >= segment.startTimestamp && time <= segment.endTimestamp) {
                 const speakerTag = getSpeakerTag(segment.speakerTagId);
                 const person = speakerTag?.personId ? getPerson(speakerTag.personId) : undefined;
-                const party = person?.roles?.find(role => role.party)?.party;
+                const party = person ? getPartyFromRoles(person.roles, meetingDate) : null;
                 let speakerColor = party?.colorHex || '#D3D3D3';
                 let speakerName = person ? person.name_short : speakerTag?.label || 'Unknown';
 
@@ -142,7 +145,7 @@ export default function TranscriptControls({ className }: { className?: string }
             if (currentTime >= segment.startTimestamp && currentTime <= segment.endTimestamp) {
                 const speakerTag = getSpeakerTag(segment.speakerTagId);
                 const person = speakerTag?.personId ? getPerson(speakerTag.personId) : undefined;
-                const party = person?.roles?.find(role => role.party)?.party;
+                const party = person ? getPartyFromRoles(person.roles, meetingDate) : null;
                 let speakerColor = party?.colorHex || '#D3D3D3';
                 let speakerName = person ? person.name_short : speakerTag?.label || 'Unknown';
 
@@ -308,7 +311,7 @@ export default function TranscriptControls({ className }: { className?: string }
                     {speakerSegments.map((segment, index) => {
                         const speakerTag = getSpeakerTag(segment.speakerTagId);
                         const person = speakerTag?.personId ? getPerson(speakerTag.personId) : undefined;
-                        const party = person?.roles?.find(role => role.party)?.party;
+                        const party = person ? getPartyFromRoles(person.roles, meetingDate) : null;
                         let speakerColor = party?.colorHex || '#D3D3D3';
                         let speakerName = person ? person.name_short : speakerTag?.label;
 

--- a/src/components/meetings/transcript/SpeakerSegment.tsx
+++ b/src/components/meetings/transcript/SpeakerSegment.tsx
@@ -174,7 +174,10 @@ const SpeakerSegment = React.memo(({ segment, isFirstSegment }: {
 }) => {
     // useCouncilMeetingMeta() — not useCouncilMeetingData() — so this
     // component bails on transcript-only edits.
-    const { getPerson, getSpeakerTag, getSpeakerSegmentCount, people, speakerTags } = useCouncilMeetingMeta();
+    const { getPerson, getSpeakerTag, getSpeakerSegmentCount, people, speakerTags, meeting } = useCouncilMeetingMeta();
+    // Resolve party color as of the meeting date so a councilor who later
+    // changed affiliation keeps their historical color on older meetings.
+    const meetingDate = meeting.dateTime;
     const { updateSpeakerTagPerson, updateSpeakerTagLabel, deleteEmptySegment } = useCouncilMeetingActions();
     const { options } = useTranscriptOptions();
     const { data: session } = useSession();
@@ -228,7 +231,7 @@ const SpeakerSegment = React.memo(({ segment, isFirstSegment }: {
     // tags / segment counts change.
     const speakerTag = getSpeakerTag(segment.speakerTagId);
     const person = speakerTag?.personId ? getPerson(speakerTag.personId) : undefined;
-    const party = person ? getPartyFromRoles(person.roles) : null;
+    const party = person ? getPartyFromRoles(person.roles, meetingDate) : null;
     const borderColor = party?.colorHex || '#D3D3D3';
     const segmentCount = speakerTag ? getSpeakerSegmentCount(speakerTag.id) : 0;
     const headerData = { speakerTag, person, party, borderColor, segmentCount };
@@ -288,6 +291,7 @@ const SpeakerSegment = React.memo(({ segment, isFirstSegment }: {
                                             speakerTag={headerData.speakerTag}
                                             variant="inline"
                                             className="flex-1 min-w-0"
+                                            date={meetingDate}
                                         />
                                         <div className='flex items-center gap-1.5 shrink-0'>
                                             <span className='text-[10px] text-muted-foreground font-medium'>
@@ -313,9 +317,10 @@ const SpeakerSegment = React.memo(({ segment, isFirstSegment }: {
                                                     nextUnknownLabel={nextUnknownLabel}
                                                     availablePeople={people.map(p => ({
                                                         ...p,
-                                                        party: getPartyFromRoles(p.roles)
+                                                        party: getPartyFromRoles(p.roles, meetingDate)
                                                     }))}
                                                     size="sm"
+                                                    date={meetingDate}
                                                 />
                                             )}
                                         </div>

--- a/src/components/meetings/transcript/SpeakersOverviewSheet.tsx
+++ b/src/components/meetings/transcript/SpeakersOverviewSheet.tsx
@@ -30,7 +30,7 @@ interface SpeakerStat {
 }
 
 function SpeakerStatsContent() {
-    const { transcript, getSpeakerTag, getPerson } = useCouncilMeetingData();
+    const { transcript, getSpeakerTag, getPerson, meeting } = useCouncilMeetingData();
     const { seekTo } = useVideo();
     const t = useTranslations('editing');
     const [expandedSpeakerId, setExpandedSpeakerId] = useState<string | null>(null);
@@ -48,7 +48,7 @@ function SpeakerStatsContent() {
 
             if (!stats.has(key)) {
                 const person = personId ? getPerson(personId) : null;
-                const party = person ? getPartyFromRoles(person.roles) : null;
+                const party = person ? getPartyFromRoles(person.roles, meeting.dateTime) : null;
                 
                 let name = "Unknown";
                 if (person) {
@@ -90,7 +90,7 @@ function SpeakerStatsContent() {
         });
 
         return Array.from(stats.values()).sort((a, b) => a.firstAppearance - b.firstAppearance);
-    }, [transcript, getSpeakerTag, getPerson]);
+    }, [transcript, getSpeakerTag, getPerson, meeting.dateTime]);
 
     const toggleExpand = (id: string) => {
         setExpandedSpeakerId(prev => prev === id ? null : id);

--- a/src/components/persons/PersonBadge.tsx
+++ b/src/components/persons/PersonBadge.tsx
@@ -26,12 +26,14 @@ interface PersonDisplayProps {
     editable?: boolean;
     onClick?: () => void;
     nonInteractive?: boolean;
+    /** Resolve the party color as of this date (e.g. the meeting date) instead of today. */
+    date?: Date;
 }
 
 // A simpler version of PersonBadge used in search results
-function PersonDisplay({ person, speakerTag, segmentCount, short = false, preferFullName = false, size = 'md', editable = false, onClick, nonInteractive = false }: PersonDisplayProps) {
+function PersonDisplay({ person, speakerTag, segmentCount, short = false, preferFullName = false, size = 'md', editable = false, onClick, nonInteractive = false, date }: PersonDisplayProps) {
     const activeRoles = person ? filterActiveRoles(person.roles) : [];
-    const party = person ? getPartyFromRoles(person.roles) : null;
+    const party = person ? getPartyFromRoles(person.roles, date) : null;
     const partyColor = party?.colorHex || 'gray';
 
     const imageSizes = {
@@ -141,6 +143,7 @@ function PersonBadge({
     size = 'md',
     variant = 'default',
     disableNavigation = false,
+    date,
 }: PersonBadgeProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
@@ -193,7 +196,7 @@ function PersonBadge({
 
     // Inline variant - minimal display with just party dot and name
     if (variant === 'inline') {
-        const party = person ? getPartyFromRoles(person.roles) : null;
+        const party = person ? getPartyFromRoles(person.roles, date) : null;
         return (
             <div className={cn("flex items-center gap-2.5 min-w-0", className)}>
                 {party && (
@@ -243,6 +246,7 @@ function PersonBadge({
                 size={size}
                 editable={editable}
                 nonInteractive={disableNavigation && !editable}
+                date={date}
             />
             {editable && (
                 <Button
@@ -316,6 +320,7 @@ function PersonBadge({
                                             <PersonDisplay
                                                 person={p}
                                                 size="sm"
+                                                date={date}
                                             />
                                         </CommandItem>
                                     ))}

--- a/src/lib/utils/__tests__/roles.test.ts
+++ b/src/lib/utils/__tests__/roles.test.ts
@@ -1,5 +1,5 @@
 import { Role, Party } from '@prisma/client';
-import { getSpeakerDisplayInfo, isRoleActiveAt, sortRolesByPriority, getPrimaryRole, simplifyRoleName } from '../roles';
+import { getSpeakerDisplayInfo, getPartyFromRoles, isRoleActiveAt, sortRolesByPriority, getPrimaryRole, simplifyRoleName } from '../roles';
 
 function makeRole(overrides: Partial<Role> & { party?: Party | null } = {}): Role & { party?: Party | null; cityId?: string | null } {
   return {
@@ -310,6 +310,44 @@ describe('getSpeakerDisplayInfo', () => {
       expect(result.role!.name).toBe('Αντιδήμαρχος');
       expect(result.isPartyHead).toBe(true);
     });
+  });
+});
+
+describe('getPartyFromRoles', () => {
+  // Mirrors issue #309: a councilor who became independent (party role ended).
+  // The timeline color must reflect affiliation as of the meeting date — old
+  // meetings keep the party color, later meetings fall back to independent.
+  const party = makeParty({ id: 'old-party', colorHex: '#123456' });
+  const affiliationEnd = new Date('2025-11-01');
+  const rolesAfterLeaving = [
+    makeRole({ partyId: 'old-party', party, startDate: null, endDate: affiliationEnd }),
+  ];
+
+  it('returns the old party for a meeting before the affiliation ended', () => {
+    const result = getPartyFromRoles(rolesAfterLeaving, new Date('2025-10-15'));
+    expect(result?.id).toBe('old-party');
+    expect(result?.colorHex).toBe('#123456');
+  });
+
+  it('returns null (independent) for a meeting after the affiliation ended', () => {
+    const result = getPartyFromRoles(rolesAfterLeaving, new Date('2025-11-15'));
+    expect(result).toBeNull();
+  });
+
+  it('treats the end date as exclusive (independent on the day it ends)', () => {
+    const result = getPartyFromRoles(rolesAfterLeaving, affiliationEnd);
+    expect(result).toBeNull();
+  });
+
+  // Guards against the Server -> Client serialization bug: meeting.dateTime
+  // arrives as an ISO string, which must still compare correctly against the
+  // role's dates (Date vs string comparisons would otherwise yield NaN/false).
+  it('resolves correctly when the date is an ISO string (serialized)', () => {
+    const before = getPartyFromRoles(rolesAfterLeaving, '2025-10-15T10:00:00.000Z' as unknown as Date);
+    expect(before?.id).toBe('old-party');
+
+    const after = getPartyFromRoles(rolesAfterLeaving, '2025-11-15T10:00:00.000Z' as unknown as Date);
+    expect(after).toBeNull();
   });
 });
 

--- a/src/lib/utils/roles.ts
+++ b/src/lib/utils/roles.ts
@@ -90,27 +90,29 @@ export function validateRoles(
  * @returns true if role is active at the given date
  */
 export function isRoleActiveAt(role: { startDate: Date | null, endDate: Date | null }, date: Date): boolean {
-  // Normalize dates to handle string values from JSON serialization (e.g. unstable_cache).
+  // Normalize dates to handle string values from JSON serialization (e.g. unstable_cache,
+  // or a meeting.dateTime serialized when passed to a Client Component).
   // new Date(Date) is a no-op, new Date(isoString) correctly parses strings.
   const start = role.startDate ? new Date(role.startDate) : null;
   const end = role.endDate ? new Date(role.endDate) : null;
+  const at = new Date(date);
 
   // Both dates null = active
   if (!start && !end) return true;
 
   // Only start date set - active if date is after start
   if (start && !end) {
-    return start <= date;
+    return start <= at;
   }
 
   // Only end date set - active if date is before end
   if (!start && end) {
-    return end > date;
+    return end > at;
   }
 
   // Both dates set - active if date is within range
   if (start && end) {
-    return start <= date && end > date;
+    return start <= at && end > at;
   }
 
   return false;


### PR DESCRIPTION
Fixes #309

## Problem

The speaker timeline resolved each councilor's party color with `getPartyFromRoles(person.roles)` — **without a date** — so it always used the *current* affiliation. After Dimitris Tselempis (Orestiada) became independent, his old party color no longer matched the affiliation valid at the time of each meeting.

The date-aware logic already existed (`getPartyFromRoles(roles, date)` + `isRoleActiveAt`); the UI call sites simply weren't passing the meeting date.

## Fix

Thread the meeting date into the in-meeting speaker timeline surfaces:

- **`PersonBadge`** — add an optional, backwards-compatible `date?: Date` prop, used for party-color resolution in `PersonDisplay` (avatar/initials), the `inline` variant (party dot), and the people-picker list. Callers that omit it keep today's behavior.
- **`SpeakerSegment`** — pass `meeting.dateTime` to the segment's colored left border and both `PersonBadge` renders.
- **`SpeakersOverviewSheet`** — pass `meeting.dateTime` to the per-meeting speaker stats.

## Historical accuracy preserved

`isRoleActiveAt` treats `endDate` as **exclusive** (`end > date`):

- Meeting **before** the affiliation ended → old party role active → **old color preserved**.
- Meeting **on/after** the affiliation ended → role inactive → falls back to the default independent color.

Added `getPartyFromRoles` unit tests covering the before / after / on-the-boundary cases.

## Scope

Display-only fix; relies on the DB already holding the correct role `endDate` (per the issue, the data is already correct). Search results, person profile pages, and subject cards are intentionally untouched — those show *current* affiliation and are outside the timeline.

## Verification

- Role tests: 46 passed (3 new)
- Full suite: 834 passed
- `npx tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the speaker timeline party-color resolution so it uses the affiliation valid at the time of each meeting rather than the current affiliation. The root serialization bug (ISO-string `meeting.dateTime` causing `NaN` comparisons) was caught in a prior review round and fixed centrally in `isRoleActiveAt` by normalizing the `date` parameter with `new Date(date)`.

- **`isRoleActiveAt`** now wraps `date` in `new Date(...)` so ISO strings serialized during Server→Client Component prop passing compare correctly against role dates.
- **`getPartyFromRoles`** call sites in `TranscriptControls`, `SpeakerSegment`, and `SpeakersOverviewSheet` are updated to pass `meeting.dateTime`, and `PersonBadge` gains an optional backwards-compatible `date` prop threaded through to `PersonDisplay`.
- **Tests** cover the before/after/on-boundary cases and a dedicated ISO-string regression test for the serialization fix.

<h3>Confidence Score: 5/5</h3>

Display-only fix with no data mutations; the change is isolated to party-color resolution in the transcript UI.

The serialization issue raised in prior review rounds is fixed centrally and covered by a new regression test. All six changed files make narrow, targeted adjustments with clear backwards compatibility; the only behavioral difference is that older meetings now show the historically-correct party color instead of the current one.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/utils/roles.ts | Adds `const at = new Date(date)` normalization in `isRoleActiveAt` so ISO strings from Next.js Client Component prop serialization are handled correctly — the central fix. |
| src/lib/utils/__tests__/roles.test.ts | Adds three boundary tests for `getPartyFromRoles` (before/after/on-endDate) plus an ISO-string regression test that guards the serialization fix. |
| src/components/meetings/TranscriptControls.tsx | Threads `meeting.dateTime` into three `getPartyFromRoles` call sites (hover tooltip, current speaker, segment timeline strip) in place of the naïve first-party-role lookup. |
| src/components/meetings/transcript/SpeakerSegment.tsx | Passes `meetingDate` to the border-color calculation and both `PersonBadge` renders (inline header and people-picker). |
| src/components/meetings/transcript/SpeakersOverviewSheet.tsx | Passes `meeting.dateTime` to `getPartyFromRoles` and adds it to the `useMemo` dependency array so the stats recompute if the meeting object changes. |
| src/components/persons/PersonBadge.tsx | Adds optional backwards-compatible `date?: Date` prop threaded through `PersonDisplayProps` → `PersonBadgeProps` → `PersonDisplay` and the `inline` variant — no breaking change to existing callers. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(transcript): resolve speaker timelin..."](https://github.com/schemalabz/opencouncil/commit/f670e2ab777cfc2c5e2eabcd5ba7260401fd10eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38353658)</sub>

<!-- /greptile_comment -->