### PR TITLE
refactor(names): centralize name shortening into shared helpers

### DIFF
--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/opengraph-image.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/opengraph-image.tsx
@@ -5,6 +5,7 @@ import { getMeetingDataForOG } from "@/lib/db/meetings";
 import { getPeopleForCityCached, getSubjectsForMeetingCached, getSubjectStatisticsCached } from "@/lib/cache/queries";
 import { LOGO_BLACK_DATA_URI } from "@/lib/og/serverAssets";
 import { PersonWithRelations } from '@/lib/db/people';
+import { getInitials } from "@/lib/formatters/name";
 import { ColorPercentageRingProps } from "@/components/ui/color-percentage-ring";
 
 // Image configuration
@@ -371,12 +372,7 @@ export default async function SubjectOgImage({
                                     // Check if this is the introducer
                                     const isIntroducer = introducedByPerson && person.id === introducedByPerson.id;
 
-                                    // Get initials (first character of first name and first character of last name)
-                                    const nameParts = person.name.split(" ");
-                                    const initials =
-                                        nameParts.length > 1
-                                            ? `${nameParts[0].charAt(0)}${nameParts[nameParts.length - 1].charAt(0)}`
-                                            : person.name.substring(0, 2).toUpperCase();
+                                    const initials = getInitials(person.name);
 
                                     return (
                                         <div

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -10,6 +10,7 @@ import { RegulationData } from '@/components/consultations/types';
 import prisma from '@/lib/db/prisma';
 import { getPartiesForCity } from '@/lib/db/parties';
 import { getPeopleForCity, getPerson } from '@/lib/db/people';
+import { getInitials } from '@/lib/formatters/name';
 import { sortSubjectsByImportance } from '@/lib/utils';
 import { Container, MeetingMetaRow, OgHeader, SubjectPills, formatCityDisplayName } from '@/components/og/shared-components';
 import { tryAcquireOgSlot, getOgConcurrencyStats } from '@/lib/og/concurrency';
@@ -541,7 +542,7 @@ const PersonOGImage = async (cityId: string, personId: string) => {
                             style={{ borderRadius: '80px', objectFit: 'cover' }}
                         />
                     ) : (
-                        person.name.split(' ').map(n => n[0]).join('').toUpperCase()
+                        getInitials(person.name)
                     )}
                 </div>
 
@@ -687,7 +688,7 @@ const PeopleOGImage = async (cityId: string) => {
                                         style={{ borderRadius: '20px', objectFit: 'cover' }}
                                     />
                                 ) : (
-                                    person.name.split(' ').map(n => n[0]).join('').toUpperCase()
+                                    getInitials(person.name)
                                 )}
                             </div>
                             <div style={{

--- a/src/components/ImageOrInitials.tsx
+++ b/src/components/ImageOrInitials.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { getInitials } from "@/lib/formatters/name";
 
 
 interface ImageOrInitialsProps {
@@ -10,15 +11,7 @@ interface ImageOrInitialsProps {
     square?: boolean;
 }
 export const ImageOrInitials: React.FC<ImageOrInitialsProps> = ({ imageUrl, width, height, name, color, square }) => {
-    const getInitials = () => {
-        if (!name) return '';
-        const nameParts = name.split(' ');
-        if (nameParts.length <= 2) {
-            return nameParts.map(n => n[0]).join('').toUpperCase();
-        }
-        return (nameParts[0][0] + nameParts[nameParts.length - 1][0]).toUpperCase();
-    };
-    const displayInitials = getInitials();
+    const displayInitials = name ? getInitials(name) : '';
 
     return (
         <div

--- a/src/components/meetings/HighlightContext.tsx
+++ b/src/components/meetings/HighlightContext.tsx
@@ -7,6 +7,7 @@ import { useCouncilMeetingActions, useCouncilMeetingData } from './CouncilMeetin
 import { useVideo } from './VideoProvider';
 import { Utterance } from '@prisma/client';
 import { calculateUtteranceRange } from '@/lib/selection-utils';
+import { getShortName } from '@/lib/formatters/name';
 import { toast } from '@/hooks/use-toast';
 
 export interface HighlightUtterance {
@@ -151,7 +152,7 @@ export function HighlightProvider({ children }: { children: React.ReactNode }) {
         const segment = getSpeakerSegmentById(utterance.speakerSegmentId);
         const speakerTag = segment ? getSpeakerTag(segment.speakerTagId) : null;
         const person = speakerTag?.personId ? getPerson(speakerTag.personId) : undefined;
-        const speakerName = person ? person.name_short : speakerTag?.label || 'Unknown';
+        const speakerName = person ? (person.name_short || getShortName(person.name)) : speakerTag?.label || 'Unknown';
 
         utterances.push({
           id: utterance.id,

--- a/src/components/meetings/docx/CouncilMeetingDocx.tsx
+++ b/src/components/meetings/docx/CouncilMeetingDocx.tsx
@@ -2,6 +2,7 @@ import { el } from 'date-fns/locale';
 import { formatInTimeZone } from 'date-fns-tz';
 import { Document, Paragraph, TextRun, HeadingLevel, ExternalHyperlink, Packer, AlignmentType } from 'docx';
 import { getSpeakerDisplayInfo, simplifyRoleName, formatTimestamp } from '@/lib/utils';
+import { getShortName } from '@/lib/formatters/name';
 import { MeetingDataForExport } from '@/lib/export/meetings';
 
 const createTitlePage = ({ meeting, city }: Pick<MeetingDataForExport, 'meeting' | 'city'>) => {
@@ -88,7 +89,7 @@ const createTranscriptSection = ({ transcript, people, meeting }: Pick<MeetingDa
 
     transcript.forEach((speakerSegment) => {
         const speaker = speakerSegment.speakerTag.personId ? people.find(p => p.id === speakerSegment.speakerTag.personId) : null;
-        const speakerName = speaker ? `${speaker.name_short}` : speakerSegment.speakerTag.label;
+        const speakerName = speaker ? (speaker.name_short || getShortName(speaker.name)) : speakerSegment.speakerTag.label;
         const { party, role, isPartyHead } = speaker
             ? getSpeakerDisplayInfo(speaker.roles || [], new Date(meeting.dateTime))
             : { party: null, role: null, isPartyHead: false };

--- a/src/lib/formatters/name.test.ts
+++ b/src/lib/formatters/name.test.ts
@@ -1,0 +1,42 @@
+import { getInitials, getShortName } from './name';
+
+describe('getShortName', () => {
+    it('abbreviates a first name to its initial', () => {
+        expect(getShortName('Ιωάννης Μώραλης')).toBe('Ι. Μώραλης');
+    });
+
+    it('keeps middle parts in the surname tail', () => {
+        expect(getShortName('Έφη Μαρία Σπυροπούλου')).toBe('Έ. Μαρία Σπυροπούλου');
+    });
+
+    it('returns single-word names unchanged', () => {
+        expect(getShortName('Μώραλης')).toBe('Μώραλης');
+    });
+
+    it('collapses surrounding and inner whitespace', () => {
+        expect(getShortName('  Ιωάννης   Μώραλης  ')).toBe('Ι. Μώραλης');
+    });
+
+    it('returns an empty string for empty input', () => {
+        expect(getShortName('')).toBe('');
+    });
+});
+
+describe('getInitials', () => {
+    it('uses the first and last name parts', () => {
+        expect(getInitials('Ιωάννης Μώραλης')).toBe('ΙΜ');
+    });
+
+    it('skips middle parts', () => {
+        expect(getInitials('Έφη Μαρία Σπυροπούλου')).toBe('ΈΣ');
+    });
+
+    it('falls back to the first two characters for single-word names', () => {
+        // toUpperCase() preserves the Greek tonos, matching the prior behavior.
+        expect(getInitials('Μώραλης')).toBe('ΜΏ');
+    });
+
+    it('returns an empty string for empty input', () => {
+        expect(getInitials('   ')).toBe('');
+    });
+});

--- a/src/lib/formatters/name.ts
+++ b/src/lib/formatters/name.ts
@@ -30,6 +30,34 @@ export function extractFirstName(
 }
 
 /**
+ * Builds avatar initials from a full name: the first letter of the first and
+ * last name parts (e.g. "Ιωάννης Μώραλης" → "ΙΜ"). Single-word names fall back
+ * to their first two characters. Returns '' for empty input.
+ */
+export function getInitials(name: string): string {
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) return '';
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+/**
+ * Abbreviates a full name to first-initial + surname form
+ * (e.g. "Ιωάννης Μώραλης" → "Ι. Μώραλης"). Middle parts are kept in the
+ * surname tail; single-word names are returned unchanged.
+ *
+ * This is a fallback for the stored `name_short` field — prefer the stored
+ * value when present, since it can encode editorial choices this heuristic
+ * cannot infer.
+ */
+export function getShortName(name: string): string {
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    if (parts.length <= 1) return name.trim();
+    const [first, ...rest] = parts;
+    return `${first[0]}. ${rest.join(' ')}`;
+}
+
+/**
  * Detects whether a Greek first name is female based on its ending.
  *
  * Greek first names are strongly gendered by their suffix:


### PR DESCRIPTION
## What

Follow-up to a question about how short names are determined on OpenCouncil. The answer was: short names (`name_short`) are stored manually with no algorithm, and the only runtime name shortening — avatar initials — was reimplemented ad-hoc in **four** places with subtly different rules.

This centralizes name shortening into two helpers in [`src/lib/formatters/name.ts`](src/lib/formatters/name.ts):

- **`getInitials(name)`** — avatar fallback initials (first + last name part, e.g. `Ιωάννης Μώραλης` → `ΙΜ`).
- **`getShortName(name)`** — first-initial + surname form (`Ιωάννης Μώραλης` → `Ι. Μώραλης`), following the existing `Ε. Σπυροπούλου` convention.

## Changes

- `getInitials()` now backs all four avatar-initials sites: `ImageOrInitials`, the subject OG image, and both OG route templates. Behavior is unchanged for the common first/last cases; the OG route's 3+ letter initials are now normalized to first+last for consistency.
- `getShortName()` is used as a **fallback** for the stored `name_short` field when it's blank — highlight speaker names and the docx transcript export. The stored value is still preferred when present.
- Added unit tests for both helpers.

## Notes

- `name_short` remains a required, editor-controlled field — this PR does **not** auto-compute or overwrite any stored data. `getShortName` is purely a defensive fallback.
- `getInitials` preserves the Greek tonos under `toUpperCase()` (e.g. `ΜΏ`), matching the prior behavior exactly.

## Test plan

- [x] `npx jest src/lib/formatters/name.test.ts` — 9 passing
- [x] `npx tsc --noEmit` — no new errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only refactor with tests; minor visible change is OG initials for multi-part names (first+last instead of all initials).
> 
> **Overview**
> Adds **`getInitials`** and **`getShortName`** in `src/lib/formatters/name.ts` and replaces duplicated inline name logic across the app.
> 
> **`getInitials`** is now used for avatar fallbacks in `ImageOrInitials`, subject OG images, and person/people OG routes. OG images that previously used every word’s initial for 3+ part names now use **first + last** only, aligning with the other call sites.
> 
> **`getShortName`** supplies a heuristic when stored **`name_short`** is missing in highlight speaker labels and DOCX transcript export; **`name_short`** is still preferred when set.
> 
> Unit tests cover both helpers. No database or schema changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f91e1d13dd1b95ec880ffb1bbebf15fa84aa91b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes the previously ad-hoc avatar-initials logic (duplicated in four places with subtly different rules) into two shared helpers — `getInitials` and `getShortName` — in `src/lib/formatters/name.ts`, with unit tests for both.

- `getInitials` now backs all four avatar/OG-image sites; 3+-part name initials are intentionally normalized to first+last only (previously the OG route collected all initials).
- `getShortName` is introduced as a defensive fallback when `name_short` is blank in `HighlightContext` and the docx export; the stored value is still preferred when present.
- Both helpers correctly handle empty, whitespace-only, single-word, and multi-word inputs, and the 9 added unit tests cover all documented cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure display refactor with no schema, data, or API surface modifications.

Both new helpers are well-implemented and tested. The one intentional behavior change (3+-word names in OG images going from all-initials to first+last) is documented and is a consistency improvement. The name_short fallback pattern is conservative and only activates when the stored value is absent.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/formatters/name.ts | Adds `getInitials` and `getShortName` helpers; both handle empty/whitespace, single-word, and multi-word names correctly with consistent use of filter(Boolean). |
| src/lib/formatters/name.test.ts | 9 unit tests covering all documented cases; minor gap: no whitespace-only test for `getShortName` (though `getInitials` has one and behavior is equivalent). |
| src/components/ImageOrInitials.tsx | Delegates to shared `getInitials`; one subtle behavior change: single-word names now return 2 chars (e.g. "Foo" → "FO") instead of 1 char ("F"), which is intentional per PR description. |
| src/app/api/og/route.tsx | Replaces two inline implementations with `getInitials`; 3+-part names now produce first+last initials only (intentional normalization per PR notes). |
| src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/opengraph-image.tsx | Replaces inline initials logic with `getInitials`; behavior is equivalent for first/last cases and the single-word fallback aligns with the new standard. |
| src/components/meetings/HighlightContext.tsx | Uses `getShortName(person.name)` as a fallback when `name_short` is blank; `person.name` from Prisma is a non-null string so no runtime risk. |
| src/components/meetings/docx/CouncilMeetingDocx.tsx | Mirrors the same `name_short || getShortName(name)` fallback pattern for docx export; consistent with HighlightContext change. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(names): centralize name shorten..."](https://github.com/schemalabz/opencouncil/commit/4f91e1d13dd1b95ec880ffb1bbebf15fa84aa91b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38653270)</sub>

<!-- /greptile_comment -->