### PR TITLE
fix(notifications): revalidate meeting cache before sending notifications

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -5,7 +5,7 @@
  */
 
 // Core caching utilities
-export { createCache } from './cache/index';
+export { createCache, revalidateMeeting } from './cache/index';
 
 // Cached query functions
 export * from './cache/queries';

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -1,5 +1,28 @@
-import { unstable_cache } from 'next/cache';
+import { revalidateTag, unstable_cache } from 'next/cache';
 import { IS_DEV } from '@/lib/utils';
+
+/**
+ * Revalidate all cached meeting data (subjects, statistics, derived status,
+ * task status). Mirrors the tag set used by getMeetingDataCore, so a single
+ * call busts everything the meeting and subject pages read.
+ *
+ * Call this immediately after persisting new meeting/subject data and BEFORE
+ * any slow side effects (e.g. rate-limited notification sends). Otherwise a
+ * recipient who clicks a notification before the send loop finishes can be
+ * served stale, pre-summarize content.
+ */
+export function revalidateMeeting(cityId: string, meetingId: string): void {
+  // revalidateTag throws ("static generation store missing") when called outside
+  // a request scope (e.g. background reprocessing, tests). A cache hiccup should
+  // never fail the surrounding task, so log and continue — matching the existing
+  // defensive handling in src/lib/tasks/tasks.ts.
+  try {
+    revalidateTag(`city:${cityId}:meetings`, 'max');
+    revalidateTag(`city:${cityId}:meeting:${meetingId}`, 'max');
+  } catch (error) {
+    console.error(`Error revalidating meeting cache for ${cityId}/${meetingId}:`, error);
+  }
+}
 
 /**
  * Creates a cached version of a function with logging.

--- a/src/lib/tasks/processAgenda.ts
+++ b/src/lib/tasks/processAgenda.ts
@@ -2,6 +2,7 @@
 
 import { ProcessAgendaResult } from "../apiTypes";
 import prisma from "../db/prisma";
+import { revalidateMeeting } from "../cache";
 import { saveSubjectsForMeeting } from "../db/utils";
 import { withUserAuthorizedToEdit } from "../auth";
 import { requestProcessAgendaInternal } from "./processAgendaInternal";
@@ -74,6 +75,12 @@ export async function handleProcessAgendaResult(taskId: string, response: Proces
         task.councilMeeting.cityId,
         task.councilMeeting.id
     );
+
+    // Bust the meeting/subject cache now that the new agenda subjects are persisted,
+    // BEFORE sending notifications below. The notification send is rate-limited
+    // (~500ms/recipient), so revalidating only after it finishes would let early
+    // recipients open the meeting and see stale content.
+    revalidateMeeting(task.councilMeeting.cityId, task.councilMeeting.id);
 
     // Create notifications if administrative body allows it
     const adminBody = task.councilMeeting.administrativeBody;

--- a/src/lib/tasks/summarize.ts
+++ b/src/lib/tasks/summarize.ts
@@ -7,6 +7,7 @@ import { startTask } from "./tasks";
 import { getCity } from "../db/cities";
 import { getCouncilMeeting } from "../db/meetings";
 import prisma from "../db/prisma";
+import { revalidateMeeting } from "../cache";
 import { getAvailableSpeakerSegmentIds, getSummarizeRequestBody, saveSubjectsForMeeting } from "../db/utils";
 import { withUserAuthorizedToEdit } from "../auth";
 
@@ -220,6 +221,12 @@ export async function handleSummarizeResult(taskId: string, response: SummarizeR
             console.log(`Saved ${validStatuses.length} utterance discussion statuses (${response.utteranceDiscussionStatuses.length - validStatuses.length} skipped/duplicates)`);
         }
     }
+
+    // Bust the meeting/subject cache now that all summarize results are persisted,
+    // BEFORE sending notifications below. The notification send is rate-limited
+    // (~500ms/recipient), so revalidating only after it finishes would let early
+    // recipients open the meeting and see stale, pre-summarize content.
+    revalidateMeeting(councilMeeting.cityId, councilMeeting.id);
 
     // Create notifications if administrative body allows it
     const adminBody = councilMeeting.administrativeBody;


### PR DESCRIPTION
## Problem

Ops reported that notification recipients sometimes open a meeting/subject and see content that **hasn't been updated with the summarize results yet** (stale, pre-summarize content).

### Root cause

When a `summarize` (afterMeeting) or `processAgenda` (beforeMeeting) task completes, the callback handler:

1. persists the new subjects via `saveSubjectsForMeeting()`, then
2. **inline** creates and releases notifications — `releaseNotifications()` is awaited and rate-limited to ~500ms per recipient (`src/lib/notifications/deliver.ts`), so for a meeting with many subscribers this loop runs for **minutes**.

Cache revalidation only happened *after* `processResult()` returned, in the generic task handler (`src/lib/tasks/tasks.ts`) — i.e. after the entire send loop finished. The meeting/subject pages read through `unstable_cache` (`getMeetingDataCore` → `getSubjectsForMeetingCached` / `getSubjectStatisticsCached`), so any recipient who clicked a notification **before the send loop completed** was served the stale cached version.

## Fix

Bust the meeting/subject cache **immediately after the new data is persisted and before notifications are created/sent**, in both task handlers.

- New `revalidateMeeting(cityId, meetingId)` helper in `src/lib/cache/index.ts` (re-exported from the `@/lib/cache` barrel). It mirrors the tag set used by `getMeetingDataCore` (`city:{id}:meetings` + `city:{id}:meeting:{id}`) so a single call busts everything the meeting and subject pages read.
- The helper wraps `revalidateTag` in try/catch — it throws "static generation store missing" outside a request scope (background reprocessing, tests) — matching the existing defensive handling in `tasks.ts`.
- Called in `summarize.ts` and `processAgenda.ts` right after `saveSubjectsForMeeting()`, before the notification block.

The redundant revalidation at the end of `tasks.ts` is harmless and left in place (it still covers `pollDecisions` and acts as a backstop).

## Scope

This addresses the **stale-content** symptom only. The separate **404 symptom** — notifications going out before an admin manually toggles `released: true`, so public users hit `notFound()` on unreleased meetings — is a distinct defect (notification triggering is decoupled from release) and is **not** addressed here.

## Testing

- `npx jest src/lib/tasks` — 103 passed
- `npx tsc --noEmit` clean for the changed files (an unrelated `cities/route.ts` error appears only due to a shared Prisma client generated against another branch's schema in this multi-worktree checkout)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted cache invalidation timing change in task callbacks; defensive error handling avoids failing tasks on revalidation errors.
> 
> **Overview**
> Fixes notification recipients sometimes seeing **stale meeting/subject content** (e.g. pre-summarize) when they open a link while the post-task notification send loop is still running.
> 
> Adds **`revalidateMeeting(cityId, meetingId)`**, which invalidates the same Next.js cache tags as `getMeetingDataCore` (`city:{id}:meetings` and `city:{id}:meeting:{id}`), with try/catch so revalidation failures outside a request scope do not fail the task. It is re-exported from `@/lib/cache`.
> 
> **`handleSummarizeResult`** and **`handleProcessAgendaResult`** now call `revalidateMeeting` immediately after **`saveSubjectsForMeeting`**, **before** creating/sending notifications, so cached pages reflect persisted data even if `releaseNotifications` takes minutes.
> 
> The existing revalidation at the end of the generic task handler in `tasks.ts` is unchanged as a backstop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7131c820f4514823f00db8bc5c986bbb1b11aaf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition where notification recipients could open a meeting/subject page and see stale, pre-summarize content. The root cause was that the cache revalidation in `tasks.ts` only fired after `processResult()` returned — after the entire rate-limited notification send loop (up to minutes), meaning early recipients hit `unstable_cache` entries written before the new data was persisted.

- Adds a `revalidateMeeting(cityId, meetingId)` helper in `src/lib/cache/index.ts` that calls `revalidateTag` for both the city-level meetings tag and the meeting-specific tag, wrapped in a try/catch to match the existing defensive pattern in `tasks.ts`.
- Calls `revalidateMeeting` immediately after `saveSubjectsForMeeting()` and before the notification block in both `handleSummarizeResult` (summarize.ts) and `handleProcessAgendaResult` (processAgenda.ts), ensuring the cache is warm with fresh data before the first notification is delivered.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is additive and scoped to cache invalidation timing, with no risk of data loss or regression.

The fix is minimal and correctly targeted: revalidateMeeting is called immediately after the DB write and before the slow notification loop in both handlers. The tag set covers all the unstable_cache entries that meeting and subject pages read. The try/catch mirrors the existing defensive pattern in tasks.ts, so a cache miss in a non-request context degrades gracefully to the backstop revalidation already in place. No new logic paths are introduced that could affect data persistence, notification delivery, or error handling.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/cache/index.ts | Adds revalidateMeeting helper that busts city-level and meeting-specific Next.js cache tags with defensive try/catch; tag set correctly covers all queries used by getSubjectsForMeetingCached and getSubjectStatisticsCached. |
| src/lib/cache.ts | Barrel file updated to re-export revalidateMeeting alongside createCache; straightforward addition. |
| src/lib/tasks/summarize.ts | revalidateMeeting called after all summarize results are persisted and before the notification send block; placement and import are correct. |
| src/lib/tasks/processAgenda.ts | revalidateMeeting called after saveSubjectsForMeeting and before the notification send block; placement mirrors the summarize.ts fix and is correct. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(notifications): revalidate meeting c..."](https://github.com/schemalabz/opencouncil/commit/7131c820f4514823f00db8bc5c986bbb1b11aaf7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38888106)</sub>

<!-- /greptile_comment -->