### PR TITLE
feat(realm): tenant data isolation by host (greece/france)

### DIFF
--- a/prisma/migrations/20260621120000_add_topic_realm/migration.sql
+++ b/prisma/migrations/20260621120000_add_topic_realm/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+-- Existing rows default to the Greek realm (the platform's original taxonomy).
+ALTER TABLE "Topic" ADD COLUMN     "realm" "Realm" NOT NULL DEFAULT 'greece';
+
+-- CreateIndex
+CREATE INDEX "Topic_realm_idx" ON "Topic"("realm");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -406,15 +406,18 @@ model Topic {
   icon        String?
   description String   @default("")
   deprecated  Boolean  @default(false)
+  realm       Realm    @default(greece)  // Tenant the topic taxonomy belongs to
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   topicLabels TopicLabel[]
   subjects Subject[]
-  
+
   // Add relation to notification preferences
   notificationPreferences NotificationPreference[] @relation("NotificationTopic")
+
+  @@index([realm])
 }
 
 model Summary {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,0 @@
-User-agent: *
-Allow: /
-
-# Prevent indexing of raw transcript pages (content is surfaced via subject pages)
-Disallow: /*/*/transcript
-
-Sitemap: https://opencouncil.gr/sitemap.xml

--- a/src/app/[locale]/(admin)/admin/topics/page.tsx
+++ b/src/app/[locale]/(admin)/admin/topics/page.tsx
@@ -1,7 +1,14 @@
 import { getAllTopicsWithSubjectCount } from "@/lib/db/topics";
+import { getRealm } from "@/lib/realm.server";
 import { TopicsTable } from "@/components/admin/topics/topics-table";
 
 export default async function TopicsAdminPage() {
-    const topics = await getAllTopicsWithSubjectCount();
-    return <TopicsTable initialTopics={topics} />;
+    // Admin is cross-realm (shows every realm grouped), but new topics default to
+    // the realm of the host the admin is on, so a topic created on .fr lands in
+    // the France realm rather than silently defaulting to Greece.
+    const [topics, realm] = await Promise.all([
+        getAllTopicsWithSubjectCount(),
+        getRealm(),
+    ]);
+    return <TopicsTable initialTopics={topics} defaultRealm={realm} />;
 }

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
@@ -88,7 +88,7 @@ export async function generateMetadata(
     return {
         title: optimizedTitle,
         description,
-        alternates: buildHreflangAlternates(`/${cityId}/${meetingId}`, locale),
+        alternates: await buildHreflangAlternates(`/${cityId}/${meetingId}`, locale),
         openGraph: {
             title: optimizedTitle,
             description,

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
@@ -36,7 +36,7 @@ export async function generateMetadata(
     return {
         title,
         description,
-        alternates: buildHreflangAlternates(
+        alternates: await buildHreflangAlternates(
             `/${params.cityId}/${params.meetingId}/subjects/${params.subjectId}`,
             params.locale
         ),

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/consultations/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/consultations/page.tsx
@@ -4,7 +4,6 @@ import { isUserAuthorizedToEdit } from "@/lib/auth";
 import CityConsultations from "@/components/cities/CityConsultations";
 import { getCityCached } from "@/lib/cache";
 import { getAllConsultationsForCity, isConsultationActive } from "@/lib/db/consultations";
-import { env } from "@/env.mjs";
 import { buildHreflangAlternates } from '@/lib/utils/hreflang';
 
 interface PageProps {
@@ -39,7 +38,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
         : `Δεν υπάρχουν διαβουλεύσεις στον Δήμο ${city.name} αυτή τη στιγμή. Ελέγχετε ξανά σύντομα για νέες ευκαιρίες συμμετοχής.`;
 
     // Generate OG image URL for city
-    const ogImageUrl = `${env.NEXTAUTH_URL}/api/og?cityId=${params.cityId}`;
+    const ogImageUrl = `/api/og?cityId=${params.cityId}`;
 
     return {
         title: `Δημόσιες Διαβουλεύσεις | ${city.name} | OpenCouncil`,
@@ -77,7 +76,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
             description,
             images: [ogImageUrl],
         },
-        alternates: buildHreflangAlternates(`/${params.cityId}/consultations`, params.locale),
+        alternates: await buildHreflangAlternates(`/${params.cityId}/consultations`, params.locale),
         other: {
             'consultations:total': totalConsultationsCount.toString(),
             'consultations:active': activeConsultationsCount.toString(),

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/page.tsx
@@ -4,7 +4,6 @@ import { isUserAuthorizedToEdit } from "@/lib/auth";
 import CityMeetings from "@/components/cities/CityMeetings";
 import { getCityCached, getCouncilMeetingsForCityCached } from "@/lib/cache";
 import { buildHreflangAlternates } from "@/lib/utils/hreflang";
-import { env } from "@/env.mjs";
 
 export async function generateMetadata(
     props: {
@@ -24,12 +23,12 @@ export async function generateMetadata(
         return {
             title: "Δήμος δεν βρέθηκε | OpenCouncil",
             description: "Ο δήμος που αναζητάτε δεν είναι διαθέσιμος.",
-            alternates: buildHreflangAlternates(`/${cityId}`, locale),
+            alternates: await buildHreflangAlternates(`/${cityId}`, locale),
         };
     }
 
     const description = `Συνεδριάσεις του Δήμου ${city.name}: βίντεο, απομαγνητοφωνήσεις, θέματα ημερήσιας διάταξης και αποφάσεις, εξηγημένα απλά.`;
-    const ogImageUrl = `${env.NEXTAUTH_URL}/api/og?cityId=${cityId}`;
+    const ogImageUrl = `/api/og?cityId=${cityId}`;
 
     return {
         title: `${city.name} | OpenCouncil`,
@@ -63,7 +62,7 @@ export async function generateMetadata(
             description,
             images: [ogImageUrl],
         },
-        alternates: buildHreflangAlternates(`/${cityId}`, locale),
+        alternates: await buildHreflangAlternates(`/${cityId}`, locale),
     };
 }
 

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/people/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/people/page.tsx
@@ -3,7 +3,6 @@ import { isUserAuthorizedToEdit } from "@/lib/auth";
 import CityPeople from "@/components/cities/CityPeople";
 import { getPartiesForCityCached, getPeopleForCityCached, getAdministrativeBodiesForCityCached, getCityCached } from "@/lib/cache";
 import { Metadata } from "next";
-import { env } from '@/env.mjs';
 import { buildHreflangAlternates } from '@/lib/utils/hreflang';
 
 export async function generateMetadata(props: { params: Promise<{ cityId: string; locale: string }> }): Promise<Metadata> {
@@ -28,7 +27,7 @@ export async function generateMetadata(props: { params: Promise<{ cityId: string
     const description = `Λίστα όλων των δημοτικών συμβούλων και αντιδημάρχων | ${city.name}. ${peopleCount} συμβούλους από ${partiesCount} κόμματα και παρατάξεις, τα προφίλ τους και τη δραστηριότητά τους στο δημοτικό συμβούλιο.`;
 
     // Generate OG image URL
-    const ogImageUrl = `${env.NEXTAUTH_URL}/api/og?cityId=${params.cityId}&pageType=people`;
+    const ogImageUrl = `/api/og?cityId=${params.cityId}&pageType=people`;
 
     return {
         title: `Δημοτικοί Σύμβουλοι | ${city.name} | OpenCouncil`,
@@ -67,7 +66,7 @@ export async function generateMetadata(props: { params: Promise<{ cityId: string
             description,
             images: [ogImageUrl],
         },
-        alternates: buildHreflangAlternates(`/${params.cityId}/people`, params.locale),
+        alternates: await buildHreflangAlternates(`/${params.cityId}/people`, params.locale),
         other: {
             'people:count': peopleCount.toString(),
             'people:parties': partiesCount.toString(),

--- a/src/app/[locale]/(city)/[cityId]/(other)/parties/[partyId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/parties/[partyId]/page.tsx
@@ -6,7 +6,6 @@ import { getParty } from "@/lib/db/parties";
 import { notFound } from "next/navigation";
 import { getAdministrativeBodiesForCity } from "@/lib/db/administrativeBodies";
 import { Metadata } from "next";
-import { env } from "@/env.mjs";
 import { buildHreflangAlternates } from "@/lib/utils/hreflang";
 
 // Request-scoped dedup so generateMetadata and PartyPage share a single fetch.
@@ -31,7 +30,7 @@ export async function generateMetadata(
     }
 
     const description = `Η παράταξη ${party.name} στο Δημοτικό Συμβούλιο του Δήμου ${city.name}. Δείτε τα μέλη, τις τοποθετήσεις και τη δραστηριότητά της στις συνεδριάσεις.`;
-    const ogImageUrl = `${env.NEXTAUTH_URL}/api/og?cityId=${params.cityId}`;
+    const ogImageUrl = `/api/og?cityId=${params.cityId}`;
 
     return {
         title: `${party.name} | ${city.name} | OpenCouncil`,
@@ -67,7 +66,7 @@ export async function generateMetadata(
             description,
             images: [ogImageUrl],
         },
-        alternates: buildHreflangAlternates(
+        alternates: await buildHreflangAlternates(
             `/${params.cityId}/parties/${params.partyId}`,
             params.locale,
         ),

--- a/src/app/[locale]/(city)/[cityId]/(other)/people/[personId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/people/[personId]/page.tsx
@@ -9,7 +9,6 @@ import { getCity } from "@/lib/db/cities";
 import { getStatisticsFor } from "@/lib/statistics";
 import { isUserAuthorizedToEdit } from "@/lib/auth";
 import { Metadata } from "next";
-import { env } from '@/env.mjs';
 import { buildHreflangAlternates } from '@/lib/utils/hreflang';
 
 export async function generateMetadata(
@@ -42,7 +41,7 @@ export async function generateMetadata(
     const description = `Προφίλ του προσώπου ${person.name} ${roleDescription} | ${city.name} | Στατιστικά συμμετοχής, τοποθετήσεις, δραστηριότητα στο δημοτικό συμβούλιο.`;
 
     // Generate OG image URL
-    const ogImageUrl = `${env.NEXTAUTH_URL}/api/og?cityId=${params.cityId}&personId=${params.personId}`;
+    const ogImageUrl = `/api/og?cityId=${params.cityId}&personId=${params.personId}`;
 
     return {
         title: `${person.name} | ${city.name} | OpenCouncil`,
@@ -80,7 +79,7 @@ export async function generateMetadata(
             description,
             images: [ogImageUrl],
         },
-        alternates: buildHreflangAlternates(`/${params.cityId}/people/${params.personId}`, params.locale),
+        alternates: await buildHreflangAlternates(`/${params.cityId}/people/${params.personId}`, params.locale),
         other: {
             'person:name': person.name,
             'person:city': city.name,

--- a/src/app/[locale]/(city)/[cityId]/consultation/[id]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/consultation/[id]/page.tsx
@@ -4,9 +4,9 @@ import { getConsultationById, getConsultationComments, fetchRegulationData } fro
 import { notFound } from "next/navigation";
 import { ConsultationViewer } from "@/components/consultations";
 import { auth } from "@/auth";
-import { env } from "@/env.mjs";
 import { Suspense } from "react";
 import { buildHreflangAlternates } from '@/lib/utils/hreflang';
+import { getRealmBaseUrlFromRequest } from '@/lib/realm.server';
 
 interface PageProps {
     params: Promise<{ cityId: string; id: string; locale: string }>;
@@ -43,7 +43,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
     const description = `${isActive ? 'Ενεργή δημόσια διαβούλευση' : 'Δημόσια διαβούλευση που έχει λήξει'} για "${title}" στον Δήμο ${city.name}. ${chaptersCount > 0 ? `Περιλαμβάνει ${chaptersCount} κεφάλαια${geosetsCount > 0 ? ` και ${geosetsCount} γεωγραφικές περιοχές` : ''}.` : ''} Μάθετε περισσότερα και συμμετέχετε στη διαβούλευση.`;
 
     // Generate OG image URL
-    const ogImageUrl = `${env.NEXTAUTH_URL}/api/og?cityId=${params.cityId}&consultationId=${params.id}`;
+    const ogImageUrl = `/api/og?cityId=${params.cityId}&consultationId=${params.id}`;
 
     return {
         title: `${title} | ${city.name} | OpenCouncil`,
@@ -79,7 +79,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
             description,
             images: [ogImageUrl],
         },
-        alternates: buildHreflangAlternates(`/${params.cityId}/consultation/${params.id}`, params.locale),
+        alternates: await buildHreflangAlternates(`/${params.cityId}/consultation/${params.id}`, params.locale),
         other: {
             'consultation:status': isActive ? 'active' : 'expired',
             'consultation:endDate': consultation.endDate.toISOString(),
@@ -118,10 +118,11 @@ export default async function ConsultationPage(props: PageProps) {
         getConsultationComments(params.id, params.cityId, session)
     ]);
 
-    // Base URL for permalinks
+    // Base URL for permalinks — the realm's canonical domain (per request Host)
+    const realmBaseUrl = await getRealmBaseUrlFromRequest();
     const baseUrl = `/${params.cityId}/consultation/${params.id}`;
-    const consultationUrl = new URL(baseUrl, env.NEXTAUTH_URL);
-    const cityUrl = new URL(`/${params.cityId}`, env.NEXTAUTH_URL);
+    const consultationUrl = new URL(baseUrl, realmBaseUrl);
+    const cityUrl = new URL(`/${params.cityId}`, realmBaseUrl);
 
 
     // Generate structured data for SEO

--- a/src/app/[locale]/(city)/[cityId]/feed/route.ts
+++ b/src/app/[locale]/(city)/[cityId]/feed/route.ts
@@ -5,8 +5,8 @@ import { formatInTimeZone } from 'date-fns-tz';
 import sanitizeHtml from 'sanitize-html';
 import { getCityCached, getCouncilMeetingsForCityPublicCached } from '@/lib/cache/queries';
 import { stripMarkdown } from '@/lib/formatters/markdown';
-import { env } from '@/env.mjs';
-import { routing } from '@/i18n/routing';
+import { REALMS } from '@/lib/realm';
+import { getRealm, getRealmBaseUrlFromRequest } from '@/lib/realm.server';
 
 export async function GET(
     request: NextRequest,
@@ -20,15 +20,21 @@ export async function GET(
 
     const city = await getCityCached(cityId);
 
-    if (!city) {
+    // Tenant isolation: route handlers don't run the [cityId] layout's realm
+    // guard, so enforce it here — a city from another realm 404s even when its
+    // slug is known (e.g. a French commune's feed requested on opencouncil.gr).
+    const realm = await getRealm();
+    if (!city || city.realm !== realm) {
         const t = await getTranslations({ locale, namespace: 'RSS' });
         return new NextResponse(t('cityNotFound'), { status: 404 });
     }
 
     const meetings = await getCouncilMeetingsForCityPublicCached(cityId, { limit });
 
-    const baseUrl = env.NEXTAUTH_URL;
-    const isDefaultLocale = locale === routing.defaultLocale;
+    // The feed is served on the realm's domain and its default locale (el for
+    // greece, fr for france) is the unprefixed one.
+    const baseUrl = await getRealmBaseUrlFromRequest();
+    const isDefaultLocale = locale === REALMS[realm].defaultLocale;
     const cityUrl = isDefaultLocale
         ? `${baseUrl}/${cityId}`
         : `${baseUrl}/${locale}/${cityId}`;

--- a/src/app/[locale]/(city)/[cityId]/layout.tsx
+++ b/src/app/[locale]/(city)/[cityId]/layout.tsx
@@ -1,4 +1,5 @@
 import { getAllCityIdsCached } from "@/lib/cache";
+import { getRealm } from "@/lib/realm.server";
 import { notFound } from "next/navigation";
 
 const VALID_CITY_ID = /^[a-z][a-z0-9_-]*$/;
@@ -28,7 +29,9 @@ export default async function CityLayout(
     // The previous getCityCached(cityId) existence check was itself a cached
     // per-city query, so every junk slug that passed the regex (e.g. /wp-admin)
     // wrote a `city:<junk>:basic` entry to the shared cache before 404ing (#358).
-    const cityIds = await getAllCityIdsCached();
+    // Scoped to the request realm: a city from the other realm (e.g. a French
+    // city on opencouncil.gr) isn't in this set, so it 404s — tenant isolation.
+    const cityIds = await getAllCityIdsCached(await getRealm());
     if (!cityIds.includes(cityId)) {
         notFound();
     }

--- a/src/app/[locale]/(interfaces)/chat/page.tsx
+++ b/src/app/[locale]/(interfaces)/chat/page.tsx
@@ -1,7 +1,6 @@
 import { ChatInterface } from "@/components/chat/ChatInterface";
 import { Suspense } from "react";
 import { Metadata } from "next";
-import { env } from '@/env.mjs';
 import { buildHreflangAlternates } from '@/lib/utils/hreflang';
 
 export async function generateMetadata(
@@ -37,7 +36,7 @@ export async function generateMetadata(
             siteName: 'OpenCouncil',
             images: [
                 {
-                    url: `${env.NEXTAUTH_URL}/api/og?pageType=chat`,
+                    url: `/api/og?pageType=chat`,
                     width: 1200,
                     height: 630,
                     alt: "OpenCouncil AI - Συνομιλήστε για τα Δημοτικά Συμβούλια",
@@ -49,11 +48,11 @@ export async function generateMetadata(
             card: 'summary_large_image',
             title: "OpenCouncil AI",
             description: "Συνομιλήστε με την τεχνητή νοημοσύνη για να μάθετε για δημοτικά συμβούλια και θέματα πολιτικής",
-            images: [`${env.NEXTAUTH_URL}/api/og?pageType=chat`],
+            images: [`/api/og?pageType=chat`],
             creator: '@opencouncil',
             site: '@opencouncil'
         },
-        alternates: buildHreflangAlternates('/chat', locale),
+        alternates: await buildHreflangAlternates('/chat', locale),
         other: {
             'chat:type': 'ai-assistant',
             'chat:domain': 'municipal-politics',

--- a/src/app/[locale]/(interfaces)/search/page.tsx
+++ b/src/app/[locale]/(interfaces)/search/page.tsx
@@ -2,7 +2,6 @@
 import { default as SearchPageComponent } from "@/components/search/SearchPage";
 import { Suspense } from "react";
 import { Metadata } from "next";
-import { env } from '@/env.mjs';
 import { buildHreflangAlternates } from '@/lib/utils/hreflang';
 
 export async function generateMetadata(
@@ -18,7 +17,7 @@ export async function generateMetadata(
 
     const description = "Αναζητήστε στα δημοτικά συμβούλια του OpenCouncil. Βρείτε αναφορές σε θέματα, τοποθετήσεις συμβούλων, στατιστικά και πολλά άλλα χρησιμοποιώντας την έξυπνη αναζήτηση του OpenCouncil.";
 
-    const ogImageUrl = `${env.NEXTAUTH_URL}/api/og?pageType=search`;
+    const ogImageUrl = `/api/og?pageType=search`;
 
     return {
         title: "Αναζήτηση | OpenCouncil",
@@ -58,7 +57,7 @@ export async function generateMetadata(
             creator: '@opencouncil',
             site: '@opencouncil'
         },
-        alternates: buildHreflangAlternates('/search', locale),
+        alternates: await buildHreflangAlternates('/search', locale),
         other: {
             'search:type': 'intelligent',
             'search:scope': 'municipal-councils',

--- a/src/app/[locale]/(other)/about/page.tsx
+++ b/src/app/[locale]/(other)/about/page.tsx
@@ -1,11 +1,9 @@
 import About from "@/components/about/AboutPage"
 import { Metadata } from "next"
-import { headers } from 'next/headers'
 import { getTranslations } from 'next-intl/server'
-import { env } from '@/env.mjs'
 import { getSupportedCitiesWithLogosCached, getAboutPageStatsCached, getGitHubStatsCached } from '@/lib/cache/queries'
 import { buildHreflangAlternates } from '@/lib/utils/hreflang'
-import { isFrenchDomainHost } from '@/lib/host'
+import { getRealm } from '@/lib/realm.server'
 
 export async function generateMetadata(
     props: {
@@ -24,7 +22,7 @@ export async function generateMetadata(
     const description = t('description')
     const keywords = t('keywords').split(',')
 
-    const ogImageUrl = `${env.NEXTAUTH_URL}/api/og?pageType=about`;
+    const ogImageUrl = `/api/og?pageType=about`;
 
     return {
         title,
@@ -53,7 +51,7 @@ export async function generateMetadata(
             creator: '@opencouncil',
             site: '@opencouncil'
         },
-        alternates: buildHreflangAlternates('/about', locale),
+        alternates: await buildHreflangAlternates('/about', locale),
         other: {
             'about:mission': 'transparency',
             'about:technology': 'artificial-intelligence',
@@ -63,15 +61,15 @@ export async function generateMetadata(
 }
 
 export default async function AboutPage() {
+    const realm = await getRealm();
     // On the French realm (opencouncil.fr, any locale) we hide pricing.
-    const hidePricing = isFrenchDomainHost((await headers()).get('host'))
-
+    const hidePricing = realm === 'france';
     const [citiesWithLogos, stats, githubStats] = await Promise.all([
-        getSupportedCitiesWithLogosCached().catch(error => {
+        getSupportedCitiesWithLogosCached(realm).catch(error => {
             console.error('Failed to fetch cities with logos:', error);
             return [];
         }),
-        getAboutPageStatsCached().catch(error => {
+        getAboutPageStatsCached(realm).catch(error => {
             console.error('Failed to fetch about page stats:', error);
             return null;
         }),

--- a/src/app/[locale]/(other)/page.tsx
+++ b/src/app/[locale]/(other)/page.tsx
@@ -3,6 +3,7 @@ import { Landing } from "@/components/landing/landing";
 import { LandingCity } from "@/lib/db/landing";
 import { fetchLatestSubstackPostCached, getAllCitiesMinimalCached, getCouncilMeetingsForCityPublicCached } from "@/lib/cache/queries";
 import { buildHreflangAlternates } from "@/lib/utils/hreflang";
+import { getRealm } from "@/lib/realm.server";
 
 export async function generateMetadata(
     props: {
@@ -16,7 +17,7 @@ export async function generateMetadata(
     } = params;
 
     return {
-        alternates: buildHreflangAlternates('', locale),
+        alternates: await buildHreflangAlternates('', locale),
     };
 }
 
@@ -32,8 +33,9 @@ export default async function HomePage(
     } = params;
 
     // Fetch all cities (minimal data) and substack post in parallel
+    const realm = await getRealm();
     const [allCities, latestPost] = await Promise.all([
-        getAllCitiesMinimalCached().catch(error => {
+        getAllCitiesMinimalCached(realm).catch(error => {
             console.error('Failed to fetch cities:', error);
             return [];
         }),

--- a/src/app/[locale]/(other)/petition/page.tsx
+++ b/src/app/[locale]/(other)/petition/page.tsx
@@ -4,6 +4,7 @@ import { CheckCircle2 } from 'lucide-react';
 import { PetitionMunicipalitySelector } from "@/components/onboarding/selectors/PetitionMunicipalitySelector";
 import { OpenCouncilDescription } from "@/components/landing/OpenCouncilDescription";
 import { getAllCitiesMinimalCached } from "@/lib/cache/queries";
+import { getRealm } from "@/lib/realm.server";
 
 export const metadata: Metadata = {
     title: "Υποστήριξη Δήμου | OpenCouncil",
@@ -12,7 +13,7 @@ export const metadata: Metadata = {
 
 export default async function PetitionPage() {
     // Fetch all cities
-    const cities = await getAllCitiesMinimalCached().catch(error => {
+    const cities = await getAllCitiesMinimalCached(await getRealm()).catch(error => {
         console.error('Failed to fetch cities:', error);
         return [];
     });

--- a/src/app/api/cities/map/route.ts
+++ b/src/app/api/cities/map/route.ts
@@ -1,49 +1,62 @@
 import { NextResponse } from 'next/server'
 import { attachGeometryToCities } from '@/lib/db/cities'
 import prisma from '@/lib/db/prisma'
+import { createCache } from '@/lib/cache'
+import { getRealm } from '@/lib/realm.server'
 
-// Enable caching - revalidate every 1 hour
-export const revalidate = 3600;
+// Host-derived realm means the response varies per domain, so it can't use the
+// URL-keyed route-segment cache (it would serve .gr data on .fr). Render
+// dynamically and rely on the realm-keyed data-layer cache below instead.
+export const dynamic = 'force-dynamic';
 
 export async function GET() {
     try {
-        // Get ALL cities - query with fields needed for map display
-        const cities = await prisma.city.findMany({
-            select: {
-                id: true,
-                name: true,
-                name_en: true,
-                name_municipality: true,
-                name_municipality_en: true,
-                logoImage: true,
-                timezone: true,
-                createdAt: true,
-                updatedAt: true,
-                officialSupport: true,
-                status: true,
-                authorityType: true,
-                wikipediaId: true,
-                supportsNotifications: true,
-                consultationsEnabled: true,
-                peopleOrdering: true,
-                highlightCreationPermission: true,
-                _count: {
-                    select: {
-                        councilMeetings: true
-                    }
-                }
-            },
-            where: {
-                status: 'listed'
-            },
-            orderBy: [
-                { status: 'desc' },
-                { name: 'asc' }
-            ]
-        });
+        const realm = await getRealm();
 
-        // Enrich with geometry data
-        const citiesWithGeometry = await attachGeometryToCities(cities);
+        const citiesWithGeometry = await createCache(
+            async () => {
+                // Get cities for this realm - query with fields needed for map display
+                const cities = await prisma.city.findMany({
+                    select: {
+                        id: true,
+                        name: true,
+                        name_en: true,
+                        name_municipality: true,
+                        name_municipality_en: true,
+                        logoImage: true,
+                        timezone: true,
+                        createdAt: true,
+                        updatedAt: true,
+                        officialSupport: true,
+                        status: true,
+                        authorityType: true,
+                        wikipediaId: true,
+                        supportsNotifications: true,
+                        consultationsEnabled: true,
+                        peopleOrdering: true,
+                        highlightCreationPermission: true,
+                        _count: {
+                            select: {
+                                councilMeetings: true
+                            }
+                        }
+                    },
+                    where: {
+                        status: 'listed',
+                        realm
+                    },
+                    orderBy: [
+                        { status: 'desc' },
+                        { name: 'asc' }
+                    ]
+                });
+
+                // Enrich with geometry data
+                return attachGeometryToCities(cities);
+            },
+            ['cities', 'map', realm],
+            { tags: ['cities:all', `realm:${realm}:cities:all`] }
+        )();
 
         return NextResponse.json(citiesWithGeometry);
     } catch (error) {
@@ -51,4 +64,3 @@ export async function GET() {
         return NextResponse.json({ error: 'Failed to fetch cities' }, { status: 500 });
     }
 }
-

--- a/src/app/api/map/subjects/route.ts
+++ b/src/app/api/map/subjects/route.ts
@@ -1,12 +1,15 @@
 import { NextResponse } from 'next/server'
 import prisma from '@/lib/db/prisma'
 import { Prisma } from '@prisma/client'
+import { getRealm } from '@/lib/realm.server'
 
 // Disable caching for dynamic queries with different filters
 export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request) {
     try {
+        const realm = await getRealm();
+
         // Parse query parameters
         const { searchParams } = new URL(request.url);
         const monthsBackParam = searchParams.get('monthsBack');
@@ -35,7 +38,8 @@ export async function GET(request: Request) {
             },
             councilMeeting: {
                 city: {
-                    officialSupport: true
+                    officialSupport: true,
+                    realm
                 },
                 released: true,
                 dateTime: {

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -1,12 +1,15 @@
 import { NextResponse } from 'next/server'
 import { getTopics } from '@/lib/db/topics'
+import { getRealm } from '@/lib/realm.server'
 
-// Enable caching - topics rarely change, revalidate every 24 hours
-export const revalidate = 86400;
+// Topics are realm-specific and resolved from the request Host, so the response
+// varies per domain — render dynamically rather than sharing one cached payload
+// across .gr and .fr. (getTopics itself is a cheap query.)
+export const dynamic = 'force-dynamic';
 
 export async function GET() {
     try {
-        const topics = await getTopics();
+        const topics = await getTopics(await getRealm());
         return NextResponse.json(topics);
     } catch (error) {
         console.error('Error fetching topics:', error);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,34 +10,44 @@ import { inter, roboto, robotoMono } from "@/lib/fonts";
 import { routing, LOCALE_OVERRIDE_HEADER } from "@/i18n/routing";
 import { getLocale, getTranslations } from "next-intl/server";
 import { headers } from "next/headers";
+import { Metadata } from "next";
+import { getRealmBaseUrlFromRequest } from "@/lib/realm.server";
 
-export const metadata = {
-    title: 'OpenCouncil',
-    description: 'Ανοιχτή τοπική αυτοδιοίκηση',
-    icons: {
-        icon: '/favicon.ico',
-    },
-    metadataBase: new URL('https://opencouncil.gr'),
-    openGraph: {
+export async function generateMetadata(): Promise<Metadata> {
+    // metadataBase is the realm's canonical domain (resolved from the request
+    // Host), so opencouncil.gr and opencouncil.fr each resolve their own
+    // relative OG-image / canonical URLs. Child pages set relative `/api/og`
+    // image URLs that get resolved against this base per host.
+    const baseUrl = await getRealmBaseUrlFromRequest();
+
+    return {
         title: 'OpenCouncil',
         description: 'Ανοιχτή τοπική αυτοδιοίκηση',
-        type: 'website',
-        url: 'https://opencouncil.gr',
-        images: [
-            {
-                url: '/oc-theme.png',
-                width: 500,
-                height: 500,
-                alt: 'OpenCouncil Logo',
-            },
-        ],
-    },
-    twitter: {
-        card: 'summary_large_image',
-        title: 'OpenCouncil',
-        description: 'Ανοιχτή τοπική αυτοδιοίκηση',
-        images: ['/oc-theme.png'],
-    },
+        icons: {
+            icon: '/favicon.ico',
+        },
+        metadataBase: new URL(baseUrl),
+        openGraph: {
+            title: 'OpenCouncil',
+            description: 'Ανοιχτή τοπική αυτοδιοίκηση',
+            type: 'website',
+            url: baseUrl,
+            images: [
+                {
+                    url: '/oc-theme.png',
+                    width: 500,
+                    height: 500,
+                    alt: 'OpenCouncil Logo',
+                },
+            ],
+        },
+        twitter: {
+            card: 'summary_large_image',
+            title: 'OpenCouncil',
+            description: 'Ανοιχτή τοπική αυτοδιοίκηση',
+            images: ['/oc-theme.png'],
+        },
+    };
 }
 
 export const viewport = {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,22 @@
+import { MetadataRoute } from 'next'
+import { getRealmBaseUrlFromRequest } from '@/lib/realm.server'
+
+// Dynamic per realm: each domain advertises its own sitemap and canonical host,
+// resolved from the request Host (opencouncil.gr vs opencouncil.fr). Forced
+// dynamic so it isn't statically generated at build time (no Host → greece).
+export const dynamic = 'force-dynamic'
+
+export default async function robots(): Promise<MetadataRoute.Robots> {
+    const baseUrl = await getRealmBaseUrlFromRequest()
+
+    return {
+        rules: {
+            userAgent: '*',
+            allow: '/',
+            // Raw transcript pages are surfaced via subject pages; don't index them.
+            disallow: '/*/*/transcript',
+        },
+        sitemap: `${baseUrl}/sitemap.xml`,
+        host: baseUrl,
+    }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,8 +1,13 @@
 import { MetadataRoute } from 'next'
 import prisma from '@/lib/db/prisma'
-import { env } from '@/env.mjs'
+import { Realm } from '@prisma/client'
+import { REALMS } from '@/lib/realm'
+import { getRealm, getRealmBaseUrlFromRequest } from '@/lib/realm.server'
 
-const baseUrl = env.NEXTAUTH_URL
+// Resolves the realm from the request Host, so it must render per request rather
+// than being statically generated at build time (where no Host is available and
+// realmForHost would fall back to greece, serving Greek URLs on .fr).
+export const dynamic = 'force-dynamic'
 
 type SitemapCity = {
     id: string
@@ -12,19 +17,23 @@ type SitemapCity = {
     }>
 }
 
-function buildAlternates(path: string) {
+// Each realm exposes its own default locale (unprefixed) plus English (`/en`).
+// Alternates stay within the realm's own domain — cities exist in exactly one
+// realm, so there is no cross-domain (`.gr`↔`.fr`) hreflang.
+function buildAlternates(baseUrl: string, defaultLocale: string, path: string) {
     return {
         languages: {
-            el: `${baseUrl}${path}`,
+            [defaultLocale]: `${baseUrl}${path}`,
             en: `${baseUrl}/en${path}`
         }
     }
 }
 
-async function fetchSitemapData(): Promise<SitemapCity[]> {
+async function fetchSitemapData(realm: Realm): Promise<SitemapCity[]> {
     return prisma.city.findMany({
         where: {
             status: 'listed',
+            realm,
         },
         select: {
             id: true,
@@ -42,36 +51,42 @@ async function fetchSitemapData(): Promise<SitemapCity[]> {
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-    if (!baseUrl || process.env.SKIP_FULL_SITEMAP === 'true') {
+    if (process.env.SKIP_FULL_SITEMAP === 'true') {
         return []
     }
 
-    const cities = await fetchSitemapData()
+    // Resolve the realm and its canonical base from the request Host, so
+    // opencouncil.gr and opencouncil.fr each emit their own realm's URLs.
+    const realm = await getRealm()
+    const baseUrl = await getRealmBaseUrlFromRequest()
+    const defaultLocale = REALMS[realm].defaultLocale
+
+    const cities = await fetchSitemapData(realm)
 
     const staticEntries: MetadataRoute.Sitemap = [
         {
             url: baseUrl,
             changeFrequency: 'daily',
             priority: 1,
-            alternates: buildAlternates('')
+            alternates: buildAlternates(baseUrl, defaultLocale, '')
         },
         {
             url: `${baseUrl}/about`,
             changeFrequency: 'weekly',
             priority: 0.8,
-            alternates: buildAlternates('/about')
+            alternates: buildAlternates(baseUrl, defaultLocale, '/about')
         },
         {
             url: `${baseUrl}/explain`,
             changeFrequency: 'weekly',
             priority: 0.8,
-            alternates: buildAlternates('/explain')
+            alternates: buildAlternates(baseUrl, defaultLocale, '/explain')
         },
         {
             url: `${baseUrl}/corrections`,
             changeFrequency: 'weekly',
             priority: 0.8,
-            alternates: buildAlternates('/corrections')
+            alternates: buildAlternates(baseUrl, defaultLocale, '/corrections')
         }
     ]
 
@@ -79,7 +94,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         url: `${baseUrl}/${city.id}`,
         changeFrequency: 'daily',
         priority: 0.9,
-        alternates: buildAlternates(`/${city.id}`)
+        alternates: buildAlternates(baseUrl, defaultLocale, `/${city.id}`)
     }))
 
     const meetingEntries: MetadataRoute.Sitemap = cities.flatMap(city =>
@@ -87,7 +102,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
             url: `${baseUrl}/${city.id}/${meeting.id}`,
             changeFrequency: 'weekly',
             priority: 0.7,
-            alternates: buildAlternates(`/${city.id}/${meeting.id}`)
+            alternates: buildAlternates(baseUrl, defaultLocale, `/${city.id}/${meeting.id}`)
         }))
     )
 
@@ -97,7 +112,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
                 url: `${baseUrl}/${city.id}/${meeting.id}/subjects/${subject.id}`,
                 changeFrequency: 'weekly',
                 priority: 0.6,
-                alternates: buildAlternates(`/${city.id}/${meeting.id}/subjects/${subject.id}`)
+                alternates: buildAlternates(baseUrl, defaultLocale, `/${city.id}/${meeting.id}/subjects/${subject.id}`)
             }))
         )
     )

--- a/src/components/admin/topics/topic-dialog.tsx
+++ b/src/components/admin/topics/topic-dialog.tsx
@@ -13,8 +13,15 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
 import { useEffect, useState } from "react";
-import { Topic } from "@prisma/client";
+import { Realm, Topic } from "@prisma/client";
 import { toast } from "@/hooks/use-toast";
 import { IconInput, isValidIconName } from "@/components/admin/icon-input";
 import { Sparkles } from "lucide-react";
@@ -24,12 +31,16 @@ interface TopicDialogProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     topic?: Topic;
+    /** Realm a newly-created topic defaults to (the admin's current host realm). */
+    defaultRealm: Realm;
     existingColors: string[];
     onSaved: () => void;
 }
 const NONE_ICON = "__none__";
+const REALM_OPTIONS: Realm[] = ["greece", "france"];
+const realmLabel = (realm: Realm) => (realm === "france" ? "France" : "Greece");
 
-export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved }: TopicDialogProps) {
+export function TopicDialog({ open, onOpenChange, topic, defaultRealm, existingColors, onSaved }: TopicDialogProps) {
     const isEditing = !!topic;
     const [loading, setLoading] = useState(false);
 
@@ -40,6 +51,7 @@ export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved
     const [iconInput, setIconInput] = useState("");
     const [description, setDescription] = useState("");
     const [deprecated, setDeprecated] = useState(false);
+    const [realm, setRealm] = useState<Realm>("greece");
     const [suggestedHistory, setSuggestedHistory] = useState<string[]>([]);
 
     useEffect(() => {
@@ -52,9 +64,10 @@ export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved
             setIconInput(topicIcon === NONE_ICON ? "" : topicIcon);
             setDescription(topic?.description ?? "");
             setDeprecated(topic?.deprecated ?? false);
+            setRealm(topic?.realm ?? defaultRealm);
             setSuggestedHistory([]);
         }
-    }, [open, topic]);
+    }, [open, topic, defaultRealm]);
 
     function onManualColorChange(value: string) {
         setColorHex(value);
@@ -115,6 +128,7 @@ export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved
             icon: icon === NONE_ICON ? null : icon,
             description: description.trim(),
             deprecated,
+            realm,
         };
 
         try {
@@ -220,6 +234,26 @@ export function TopicDialog({ open, onOpenChange, topic, existingColors, onSaved
                                 color={colorHex}
                             />
                         </div>
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="realm">Realm</Label>
+                        <Select value={realm} onValueChange={(v) => setRealm(v as Realm)}>
+                            <SelectTrigger id="realm">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {REALM_OPTIONS.map((r) => (
+                                    <SelectItem key={r} value={r}>
+                                        {realmLabel(r)}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <p className="text-xs text-muted-foreground">
+                            Topics are realm-specific: only shown for cities in this realm and passed to the
+                            LLM for those cities&apos; meetings.
+                        </p>
                     </div>
 
                     <div className="space-y-2">

--- a/src/components/admin/topics/topics-table.tsx
+++ b/src/components/admin/topics/topics-table.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { Realm } from "@prisma/client";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -36,14 +37,26 @@ import { Badge } from "@/components/ui/badge";
 
 interface TopicsTableProps {
     initialTopics: TopicWithSubjectCount[];
+    defaultRealm: Realm;
 }
 
-export function TopicsTable({ initialTopics: topics }: TopicsTableProps) {
+// Render realms in a stable, meaningful order (mirrors the cities admin).
+const REALM_ORDER: Realm[] = ["greece", "france"];
+const realmLabel = (realm: Realm) => (realm === "france" ? "France" : "Greece");
+
+export function TopicsTable({ initialTopics: topics, defaultRealm }: TopicsTableProps) {
     const router = useRouter();
     const [dialogOpen, setDialogOpen] = useState(false);
     const [selectedTopic, setSelectedTopic] = useState<TopicWithSubjectCount | undefined>();
     const [topicToDelete, setTopicToDelete] = useState<TopicWithSubjectCount | null>(null);
     const [deleting, setDeleting] = useState(false);
+
+    const groupedByRealm = useMemo(() => {
+        // Realm is a closed enum, so iterate it in fixed order and drop empty groups.
+        return REALM_ORDER
+            .map((realm) => ({ realm, topics: topics.filter((t) => t.realm === realm) }))
+            .filter((group) => group.topics.length > 0);
+    }, [topics]);
 
     function onCreate() {
         setSelectedTopic(undefined);
@@ -102,31 +115,32 @@ export function TopicsTable({ initialTopics: topics }: TopicsTableProps) {
                     </Button>
                 </div>
 
-                <Card>
-                    <CardHeader>
-                        <CardTitle>All topics ({topics.length})</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        <Table>
-                            <TableHeader>
-                                <TableRow>
-                                    <TableHead className="w-20">Symbol</TableHead>
-                                    <TableHead>Name</TableHead>
-                                    <TableHead>Name (EN)</TableHead>
-                                    <TableHead className="w-24 text-right">Subjects</TableHead>
-                                    <TableHead>Description</TableHead>
-                                    <TableHead className="w-32 text-right">Actions</TableHead>
-                                </TableRow>
-                            </TableHeader>
-                            <TableBody>
-                                {topics.length === 0 ? (
-                                    <TableRow>
-                                        <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
-                                            No topics yet. Create one to get started.
-                                        </TableCell>
-                                    </TableRow>
-                                ) : (
-                                    topics.map((topic) => {
+                {groupedByRealm.length === 0 ? (
+                    <Card>
+                        <CardContent className="py-8 text-center text-muted-foreground">
+                            No topics yet. Create one to get started.
+                        </CardContent>
+                    </Card>
+                ) : (
+                    groupedByRealm.map(({ realm, topics: realmTopics }) => (
+                        <Card key={realm}>
+                            <CardHeader>
+                                <CardTitle>{realmLabel(realm)} ({realmTopics.length})</CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead className="w-20">Symbol</TableHead>
+                                            <TableHead>Name</TableHead>
+                                            <TableHead>Name (EN)</TableHead>
+                                            <TableHead className="w-24 text-right">Subjects</TableHead>
+                                            <TableHead>Description</TableHead>
+                                            <TableHead className="w-32 text-right">Actions</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {realmTopics.map((topic) => {
                                         const subjectCount = topic._count.subjects;
                                         const labelCount = topic._count.topicLabels;
                                         const notificationCount = topic._count.notificationPreferences;
@@ -223,17 +237,19 @@ export function TopicsTable({ initialTopics: topics }: TopicsTableProps) {
                                                 </TableCell>
                                             </TableRow>
                                         );
-                                    })
-                                )}
-                            </TableBody>
-                        </Table>
-                    </CardContent>
-                </Card>
+                                        })}
+                                    </TableBody>
+                                </Table>
+                            </CardContent>
+                        </Card>
+                    ))
+                )}
 
                 <TopicDialog
                     open={dialogOpen}
                     onOpenChange={setDialogOpen}
                     topic={selectedTopic}
+                    defaultRealm={defaultRealm}
                     existingColors={topics
                         .filter((t) => t.id !== selectedTopic?.id)
                         .map((t) => t.colorHex)}

--- a/src/components/filters/__tests__/TopicFilter.test.tsx
+++ b/src/components/filters/__tests__/TopicFilter.test.tsx
@@ -24,6 +24,7 @@ const makeTopic = (overrides: Partial<Topic> & { id: string; name: string }): To
     name_en: '',
     description: '',
     deprecated: false,
+    realm: 'greece',
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,

--- a/src/components/layout/CountrySwitcher.tsx
+++ b/src/components/layout/CountrySwitcher.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { useState } from "react"
+import { Globe, ChevronDown } from "lucide-react"
+import { Realm } from "@prisma/client"
+import { getRealmBaseUrl, realmForHost } from "@/lib/realm"
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+// Country names shown in their own language (endonyms), matching the realm order
+// used elsewhere in the app.
+const REALM_ORDER: Realm[] = ["greece", "france"]
+const COUNTRY_LABEL: Record<Realm, string> = {
+    greece: "Ελλάδα",
+    france: "France",
+}
+
+/**
+ * Small footer control showing the current country with a dropdown to switch to
+ * the other realm's domain. The realm is derived from the browser host so the
+ * control reflects whichever domain the user is actually on; selecting another
+ * country navigates to that domain's root (content differs across realms, so the
+ * current path may not exist there).
+ */
+export default function CountrySwitcher() {
+    // Read the host synchronously so the client's first paint shows the correct
+    // country (no flash). SSR has no window and renders greece; the trigger label
+    // is suppressHydrationWarning so the .fr client value doesn't warn on mismatch.
+    const [realm] = useState<Realm>(() =>
+        typeof window !== "undefined" ? realmForHost(window.location.hostname) : "greece"
+    )
+
+    function switchTo(target: Realm) {
+        if (target === realm) return
+        window.location.href = getRealmBaseUrl(target)
+    }
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors focus:outline-none">
+                <Globe className="w-3.5 h-3.5" />
+                <span suppressHydrationWarning>{COUNTRY_LABEL[realm]}</span>
+                <ChevronDown className="w-3 h-3" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="center" className="min-w-[8rem]">
+                {REALM_ORDER.map((r) => (
+                    <DropdownMenuItem
+                        key={r}
+                        onClick={() => switchTo(r)}
+                        className={r === realm ? "font-medium" : undefined}
+                    >
+                        {COUNTRY_LABEL[r]}
+                    </DropdownMenuItem>
+                ))}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    )
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,6 +3,7 @@
 import { Link } from "@/i18n/routing"
 import { useTranslations } from "next-intl"
 import Logo from "./Logo"
+import CountrySwitcher from "./CountrySwitcher"
 import { Phone, Mail, ExternalLink } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
@@ -160,8 +161,9 @@ export default function Footer({ className }: FooterProps = {}) {
                         </a>
                     </Button>
                 </div>
-                <div className="mt-6 pt-6 border-t border-border text-center text-xs text-muted-foreground">
-                    © {new Date().getFullYear()} OpenCouncil
+                <div className="mt-6 pt-6 border-t border-border flex flex-col sm:flex-row items-center justify-center gap-2 sm:gap-4 text-center text-xs text-muted-foreground">
+                    <span>© {new Date().getFullYear()} OpenCouncil</span>
+                    <CountrySwitcher />
                 </div>
             </div>
         </footer>

--- a/src/lib/cache/queries.ts
+++ b/src/lib/cache/queries.ts
@@ -1,4 +1,4 @@
-import { AdministrativeBodyType } from "@prisma/client";
+import { AdministrativeBodyType, Realm } from "@prisma/client";
 import { isUserAuthorizedToEdit } from "@/lib/auth";
 import { getCity, getAllCitiesMinimal, getAllCityIds, getSupportedCitiesWithLogos, getAboutPageStats } from "@/lib/db/cities";
 import { getGitHubStats } from "@/lib/github";
@@ -19,11 +19,11 @@ import { fetchLatestSubstackPost } from "@/lib/db/landing";
  * function: per-city caches key by cityId, so a junk slug (bot probe) would
  * otherwise write a `city:<junk>:*` entry to the shared cache (#358).
  */
-export async function getAllCityIdsCached() {
+export async function getAllCityIdsCached(realm: Realm) {
   return createCache(
-    () => getAllCityIds(),
-    ['cities', 'ids'],
-    { tags: ['cities:all'] }
+    () => getAllCityIds(realm),
+    ['cities', 'ids', realm],
+    { tags: ['cities:all', `realm:${realm}:cities:all`] }
   )();
 }
 
@@ -128,22 +128,22 @@ export async function fetchLatestSubstackPostCached() {
   )();
 }
 
-export async function getAllCitiesMinimalCached() {
+export async function getAllCitiesMinimalCached(realm: Realm) {
   return createCache(
-    () => getAllCitiesMinimal(),
-    ['cities', 'all'],
-    { tags: ['cities:all'] }
+    () => getAllCitiesMinimal(realm),
+    ['cities', 'all', realm],
+    { tags: ['cities:all', `realm:${realm}:cities:all`] }
   )();
 }
 
 /**
  * Cached version of getSupportedCitiesWithLogos
  */
-export async function getSupportedCitiesWithLogosCached() {
+export async function getSupportedCitiesWithLogosCached(realm: Realm) {
   return createCache(
-    () => getSupportedCitiesWithLogos(),
-    ['cities', 'supported-with-logos'],
-    { tags: ['cities:all'] }
+    () => getSupportedCitiesWithLogos(realm),
+    ['cities', 'supported-with-logos', realm],
+    { tags: ['cities:all', `realm:${realm}:cities:all`] }
   )();
 }
 
@@ -191,11 +191,11 @@ export async function getSubjectStatisticsCached(
 /**
  * Cached aggregate stats for the about page (municipality count, subject count, meeting hours)
  */
-export async function getAboutPageStatsCached() {
+export async function getAboutPageStatsCached(realm: Realm) {
   return createCache(
-    () => getAboutPageStats(),
-    ['about', 'stats'],
-    { tags: ['cities:all'] }
+    () => getAboutPageStats(realm),
+    ['about', 'stats', realm],
+    { tags: ['cities:all', `realm:${realm}:cities:all`] }
   )();
 }
 

--- a/src/lib/db/cities.ts
+++ b/src/lib/db/cities.ts
@@ -1,5 +1,5 @@
 "use server";
-import { City, CouncilMeeting, Prisma } from '@prisma/client';
+import { City, CouncilMeeting, Prisma, Realm } from '@prisma/client';
 import prisma from "./prisma";
 import { isUserAuthorizedToEdit, withUserAuthorizedToEdit, getCurrentUser } from "../auth";
 import { UnauthorizedError } from "../api/errors";
@@ -182,9 +182,10 @@ export async function getFullCity(
     return await attachGeometryToCity(city);
 }
 
-export async function getAllCitiesMinimal(): Promise<CityMinimalWithCounts[]> {
+export async function getAllCitiesMinimal(realm?: Realm): Promise<CityMinimalWithCounts[]> {
     try {
         const cities = await prisma.city.findMany({
+            where: realm ? { realm } : undefined,
             select: {
                 id: true,
                 name: true,
@@ -212,15 +213,18 @@ export async function getAllCitiesMinimal(): Promise<CityMinimalWithCounts[]> {
  * against the known set before any per-city cached query runs, so junk slugs
  * (bot probes) never create per-city cache entries.
  */
-export async function getAllCityIds(): Promise<string[]> {
-    const cities = await prisma.city.findMany({ select: { id: true } });
+export async function getAllCityIds(realm?: Realm): Promise<string[]> {
+    const cities = await prisma.city.findMany({
+        where: realm ? { realm } : undefined,
+        select: { id: true }
+    });
     return cities.map(c => c.id);
 }
 
 /**
  * Retrieves cities based on user permissions and city status.
  */
-export async function getCities({ includeUnlisted = false, includePending = false }: { includeUnlisted?: boolean, includePending?: boolean } = {}): Promise<CityWithCounts[]> {
+export async function getCities({ includeUnlisted = false, includePending = false }: { includeUnlisted?: boolean, includePending?: boolean } = {}, realm?: Realm): Promise<CityWithCounts[]> {
     // Get current user for authorization
     const currentUser = includeUnlisted ? await getCurrentUser() : null;
 
@@ -263,6 +267,13 @@ export async function getCities({ includeUnlisted = false, includePending = fals
     }
     // Superadmin mode: show all cities (no additional filter needed)
 
+    // Tenant isolation: restrict to a single realm when one is supplied. Callers
+    // serving a public, host-scoped page pass the request realm; cross-realm admin
+    // views omit it to see every realm.
+    if (realm) {
+        whereClause.realm = realm;
+    }
+
     try {
         const cities = await prisma.city.findMany({
             where: whereClause,
@@ -278,7 +289,7 @@ export async function getCities({ includeUnlisted = false, includePending = fals
     }
 }
 
-export async function getCitiesWithCouncilMeetings({ includeUnlisted = false, includePending = false }: { includeUnlisted?: boolean, includePending?: boolean } = {}): Promise<CityWithCouncilMeeting[]> {
+export async function getCitiesWithCouncilMeetings({ includeUnlisted = false, includePending = false }: { includeUnlisted?: boolean, includePending?: boolean } = {}, realm?: Realm): Promise<CityWithCouncilMeeting[]> {
     if (includeUnlisted) {
         await withUserAuthorizedToEdit({});
     }
@@ -294,8 +305,12 @@ export async function getCitiesWithCouncilMeetings({ includeUnlisted = false, in
         }
         // If both are true, show all (no filter)
 
+        const whereClause: Prisma.CityWhereInput = {};
+        if (statusFilter) whereClause.status = statusFilter;
+        if (realm) whereClause.realm = realm;
+
         const cities = await prisma.city.findMany({
-            where: statusFilter ? { status: statusFilter } : {},
+            where: whereClause,
             include: {
                 councilMeetings: true
             },
@@ -379,7 +394,7 @@ export async function canUseCityCreator(cityId: string): Promise<boolean> {
  * Fetches cities with logos for display purposes (e.g., infinite scroller).
  * Returns only listed cities that have logos.
  */
-export async function getSupportedCitiesWithLogos(): Promise<Array<{ id: string; logoImage: string; name_municipality: string }>> {
+export async function getSupportedCitiesWithLogos(realm?: Realm): Promise<Array<{ id: string; logoImage: string; name_municipality: string }>> {
     try {
         const cities = await prisma.city.findMany({
             where: {
@@ -387,7 +402,8 @@ export async function getSupportedCitiesWithLogos(): Promise<Array<{ id: string;
                 status: 'listed',
                 logoImage: {
                     not: null
-                }
+                },
+                ...(realm ? { realm } : {})
             },
             select: {
                 id: true,
@@ -419,17 +435,23 @@ export interface AboutPageStats {
  * - Total subject count across all released meetings
  * - Total meeting hours (estimated from speaker segment timestamps)
  */
-export async function getAboutPageStats(): Promise<AboutPageStats> {
+export async function getAboutPageStats(realm?: Realm): Promise<AboutPageStats> {
     try {
+        // Realm-scoped join for the raw duration query (the Prisma queries below
+        // express realm via the typed `where`).
+        const realmJoin = realm
+            ? Prisma.sql`JOIN "City" c ON c.id = cm."cityId" AND c.realm = ${realm}::"Realm"`
+            : Prisma.empty;
+
         const [municipalityCount, subjectCount, meetingDurations] = await Promise.all([
             // Count officially supported cities
             prisma.city.count({
-                where: { officialSupport: true }
+                where: { officialSupport: true, ...(realm ? { realm } : {}) }
             }),
             // Count subjects in released meetings only
             prisma.subject.count({
                 where: {
-                    councilMeeting: { released: true }
+                    councilMeeting: { released: true, ...(realm ? { city: { realm } } : {}) }
                 }
             }),
             // Get min/max timestamps per meeting to calculate duration
@@ -439,6 +461,7 @@ export async function getAboutPageStats(): Promise<AboutPageStats> {
                     SELECT (MAX(ss."endTimestamp") - MIN(ss."startTimestamp")) / 3600.0 as meeting_hours
                     FROM "CouncilMeeting" cm
                     JOIN "SpeakerSegment" ss ON ss."meetingId" = cm.id AND ss."cityId" = cm."cityId"
+                    ${realmJoin}
                     WHERE cm.released = true
                     GROUP BY cm.id, cm."cityId"
                 ) meetings

--- a/src/lib/db/topics.ts
+++ b/src/lib/db/topics.ts
@@ -1,5 +1,5 @@
 "use server";
-import { Prisma, Topic } from '@prisma/client';
+import { Prisma, Realm, Topic } from '@prisma/client';
 import prisma from "./prisma";
 import { withUserAuthorizedToEdit } from "../auth";
 import { ConflictError } from "../api/errors";
@@ -17,13 +17,16 @@ const topicWithSubjectCountInclude = {
 export type TopicWithSubjectCount = Prisma.TopicGetPayload<{ include: typeof topicWithSubjectCountInclude }>;
 
 /**
- * Returns all active (non-deprecated) topics.
- * For admin views that need deprecated topics too, use getAllTopicsWithSubjectCount.
+ * Returns all active (non-deprecated) topics for a realm. Topics are a
+ * realm-specific taxonomy (the Greek set references Greek-only institutions),
+ * so callers must pass the city's / request's realm.
+ * For admin views that need deprecated + cross-realm topics, use
+ * getAllTopicsWithSubjectCount.
  */
-export async function getTopics(): Promise<Topic[]> {
+export async function getTopics(realm: Realm): Promise<Topic[]> {
     try {
         const topics = await prisma.topic.findMany({
-            where: { deprecated: false },
+            where: { deprecated: false, realm },
             orderBy: { name: 'asc' }
         });
         return topics;
@@ -46,7 +49,7 @@ export async function getAllTopicsWithSubjectCount(): Promise<TopicWithSubjectCo
     }
 }
 
-export type TopicInput = Pick<Prisma.TopicCreateInput, 'name' | 'name_en' | 'colorHex' | 'icon' | 'description' | 'deprecated'>;
+export type TopicInput = Pick<Prisma.TopicCreateInput, 'name' | 'name_en' | 'colorHex' | 'icon' | 'description' | 'deprecated' | 'realm'>;
 
 
 export async function createTopic(data: TopicInput): Promise<Topic> {

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -41,12 +41,14 @@ export async function getRequestOnTranscriptRequestBody(councilMeetingId: string
     // People filtered by meeting's administrative body (for LLM context)
     const meetingPeople = await getPeopleForMeeting(cityId, councilMeeting.administrativeBodyId);
     const parties = await getPartiesForCity(cityId);
-    const topics = await getTopics();
     const city = await getCity(cityId);
 
     if (!city) {
         throw new Error('City not found');
     }
+
+    // Realm-scoped taxonomy — use the city's realm, not a global topic set.
+    const topics = await getTopics(city.realm);
 
     return {
         transcript: transcript.map(segment => {
@@ -156,7 +158,15 @@ export async function getAvailableSpeakerSegmentIds(councilMeetingId: string, ci
 // --- Internal helpers for saveSubjectsForMeeting ---
 
 async function validateSubjectPersons(subjects: Subject[], cityId: string) {
-    const topics = await prisma.topic.findMany({ where: { deprecated: false } });
+    // Topics are realm-specific, so scope the name->topic map to the city's realm.
+    // Otherwise a subject's topicLabel could resolve to another realm's
+    // identically-named topic, and Object.fromEntries would pick a duplicate name
+    // non-deterministically.
+    const city = await prisma.city.findUnique({ where: { id: cityId }, select: { realm: true } });
+    if (!city) {
+        throw new Error(`City not found: ${cityId}`);
+    }
+    const topics = await prisma.topic.findMany({ where: { deprecated: false, realm: city.realm } });
     const topicsByName = Object.fromEntries(topics.map(t => [t.name, t]));
 
     const speakerIds = subjects

--- a/src/lib/getMeetingData.ts
+++ b/src/lib/getMeetingData.ts
@@ -9,7 +9,8 @@ import { SubjectWithRelations } from '@/lib/db/subject';
 import { Statistics } from '@/lib/statistics';
 import { getMeetingTaskStatus, MeetingTaskStatus } from '@/lib/db/tasks';
 import { createCache } from '@/lib/cache';
-import { SpeakerTag } from '@prisma/client';
+import { getRealm } from '@/lib/realm.server';
+import { Realm, SpeakerTag } from '@prisma/client';
 import { Party } from '@prisma/client';
 
 const EMPTY_STATISTICS: Statistics = {
@@ -66,7 +67,12 @@ export const getMeetingDataCore = async (cityId: string, meetingId: string): Pro
         .slice(2, 5)
         .map(l => l.trim())
         .join(' ← ') ?? 'unknown';
-    const key = `${cityId}/${meetingId}`;
+    // Key by realm too: the realm guard lives inside fetchMeetingDataCore, so a
+    // deduped waiter reuses the leader's promise and skips it. Without realm in
+    // the key, a concurrent .fr request for a French slug could coalesce with a
+    // .gr request for the same ids and receive the other realm's payload.
+    const realm = await getRealm();
+    const key = `${realm}/${cityId}/${meetingId}`;
 
     const existing = coreInflight.get(key);
     if (existing) {
@@ -75,7 +81,7 @@ export const getMeetingDataCore = async (cityId: string, meetingId: string): Pro
     }
 
     console.log(`getMeetingDataCore ${key} LEADER from: ${callerHint}`);
-    const promise = fetchMeetingDataCore(cityId, meetingId);
+    const promise = fetchMeetingDataCore(cityId, meetingId, realm);
     coreInflight.set(key, promise);
     // The cleanup fork: .finally() returns a NEW promise that also rejects
     // when the fetch fails. Callers handle the original `promise`; nothing
@@ -85,14 +91,14 @@ export const getMeetingDataCore = async (cityId: string, meetingId: string): Pro
     return promise;
 };
 
-async function fetchMeetingDataCore(cityId: string, meetingId: string): Promise<MeetingDataCore> {
+async function fetchMeetingDataCore(cityId: string, meetingId: string, realm: Realm): Promise<MeetingDataCore> {
     // Validate cityId against the known set (single shared cache key) before
     // any per-city cached query runs. Next renders nested segments in
     // parallel, so this fetch can start before the [cityId] layout's own
     // validation 404s — without this guard, junk slugs (e.g. /admin/settings
     // resolving to cityId='admin') write `city:<junk>:*` entries to the
     // shared cache (#358). Callers already treat this throw as notFound().
-    const cityIds = await getAllCityIdsCached();
+    const cityIds = await getAllCityIdsCached(realm);
     if (!cityIds.includes(cityId)) {
         throw new Error('Required data not found');
     }

--- a/src/lib/host.ts
+++ b/src/lib/host.ts
@@ -1,15 +1,14 @@
-// The French production domain (apex + any subdomain). Scoped to opencouncil.fr
-// rather than a bare `.fr` suffix so an unrelated `*.fr` host (staging, internal
-// tooling, a typo'd preview) can't accidentally be treated as the French realm.
-export const FRENCH_DOMAIN = 'opencouncil.fr';
+import { REALMS, realmForHost } from './realm';
+
+// The French production domain (apex + any subdomain). Re-exported from the
+// shared realm config so there is a single literal for the domain.
+export const FRENCH_DOMAIN = REALMS.france.domain;
 
 /**
  * Whether a `Host` header value belongs to the French domain (`opencouncil.fr`
- * or a subdomain of it). The port is stripped so `localhost`-style `host:port`
- * and real domains both work, and a spoofed `Host: opencouncil.fr` header can be
- * used to test locally.
+ * or a subdomain of it). Thin wrapper over the shared `realmForHost` mapping (the
+ * single source of truth for host→realm) so host-parsing isn't duplicated.
  */
 export function isFrenchDomainHost(hostHeader: string | null | undefined): boolean {
-    const host = (hostHeader ?? '').split(':')[0].toLowerCase();
-    return host === FRENCH_DOMAIN || host.endsWith(`.${FRENCH_DOMAIN}`);
+    return realmForHost(hostHeader) === 'france';
 }

--- a/src/lib/realm.server.ts
+++ b/src/lib/realm.server.ts
@@ -1,0 +1,27 @@
+// Server-only by convention: uses next/headers, so it can only run in a request
+// scope (server components / route handlers / generateMetadata). Keep it out of
+// client bundles and out of unstable_cache callbacks.
+import { headers } from 'next/headers';
+import { Realm } from '@prisma/client';
+import { getRealmBaseUrl, realmForHost } from './realm';
+
+/**
+ * Resolves the current request's realm from its Host header.
+ *
+ * Server-only: reads `headers()`, so it cannot be called inside `unstable_cache`
+ * (`createCache`). Resolve realm at the call site (server component / route
+ * handler / `generateMetadata`) and pass it into cached functions as an explicit
+ * argument folded into the cache key.
+ *
+ * The `.fr`-host rewrite in `proxy.ts` preserves the original Host header, so this
+ * returns `france` for `.fr` requests even though the path was rewritten to `/fr`.
+ */
+export async function getRealm(): Promise<Realm> {
+    const host = (await headers()).get('host');
+    return realmForHost(host);
+}
+
+/** Canonical absolute base URL for the current request's realm. */
+export async function getRealmBaseUrlFromRequest(): Promise<string> {
+    return getRealmBaseUrl(await getRealm());
+}

--- a/src/lib/realm.ts
+++ b/src/lib/realm.ts
@@ -1,0 +1,42 @@
+import { Realm } from '@prisma/client';
+
+/**
+ * Realm (tenant) configuration. A single deployment serves both domains off one
+ * database; the realm a request belongs to is resolved from its Host header (see
+ * `realmForHost`). This is the single source of truth mapping each realm to its
+ * canonical production domain and default UI locale.
+ *
+ * Pure module — no `next/headers`/server-only imports — so it is safe to use from
+ * client components (the footer country-switcher) and the edge/middleware bundle
+ * (`proxy.ts`). The request-scoped resolver lives in `realm.server.ts`.
+ */
+export const REALMS = {
+    greece: { domain: 'opencouncil.gr', defaultLocale: 'el' },
+    france: { domain: 'opencouncil.fr', defaultLocale: 'fr' },
+} as const satisfies Record<Realm, { domain: string; defaultLocale: 'el' | 'fr' }>;
+
+/**
+ * Resolves the realm for a Host header value. The port is stripped and the host
+ * lowercased so `localhost:3000`-style hosts and a spoofed `Host: opencouncil.fr`
+ * both work; each realm's domain matches as the apex or any subdomain (so preview
+ * hosts like `pr-7.preview.opencouncil.fr` resolve correctly). Defaults to
+ * `greece` for unknown hosts (localhost, the Greek production domain).
+ */
+export function realmForHost(host: string | null | undefined): Realm {
+    const normalized = (host ?? '').split(':')[0].toLowerCase();
+    for (const [realm, { domain }] of Object.entries(REALMS)) {
+        if (normalized === domain || normalized.endsWith(`.${domain}`)) {
+            return realm as Realm;
+        }
+    }
+    return 'greece';
+}
+
+/**
+ * Canonical absolute base URL for a realm (e.g. `https://opencouncil.fr`). Used
+ * for SEO metadata, sitemaps, hreflang/canonical links and the footer switcher's
+ * cross-domain redirect.
+ */
+export function getRealmBaseUrl(realm: Realm): string {
+    return `https://${REALMS[realm].domain}`;
+}

--- a/src/lib/tasks/processAgendaInternal.ts
+++ b/src/lib/tasks/processAgendaInternal.ts
@@ -36,7 +36,8 @@ export async function requestProcessAgendaInternal(agendaUrl: string, councilMee
             city: {
                 select: {
                     name: true,
-                    language: true
+                    language: true,
+                    realm: true
                 }
             }
         }
@@ -53,7 +54,8 @@ export async function requestProcessAgendaInternal(agendaUrl: string, councilMee
 
     // Get relevant people for the meeting (filtered by administrative body)
     const people = await getPeopleForMeeting(cityId, councilMeeting.administrativeBodyId);
-    const topicLabels = await getTopics();
+    // Realm-scoped taxonomy: a French commune gets French topics, not the Greek set.
+    const topicLabels = await getTopics(councilMeeting.city.realm);
 
     // Build people array with deduplication by ID (keep last entry)
     const peopleMap = new Map();

--- a/src/lib/utils/hreflang.ts
+++ b/src/lib/utils/hreflang.ts
@@ -1,29 +1,37 @@
 import { Metadata } from 'next';
-import { env } from '@/env.mjs';
-
-const baseUrl = env.NEXTAUTH_URL;
+import { getRealmBaseUrl, REALMS } from '@/lib/realm';
+import { getRealm } from '@/lib/realm.server';
 
 /**
- * Builds canonical + hreflang alternates for a page.
+ * Builds canonical + hreflang alternates for a page, scoped to the request's
+ * realm (resolved from the Host header).
  *
- * Greek is the default locale and served unprefixed (`/path`); English lives at
- * `/en/path`. `x-default` points at the Greek URL so search engines surface the
- * Greek variant by default. Each locale self-references its own canonical to
- * avoid sending Google a canonical signal that contradicts the hreflang cluster.
+ * Each realm self-references its own domain only — a city/meeting page exists in
+ * exactly one realm, so there is no cross-domain (`.gr`↔`.fr`) hreflang cluster.
+ * The realm's default locale is served unprefixed (`/path`); English lives at
+ * `/en/path`. `x-default` points at the default-locale URL. Each locale
+ * self-references its own canonical to avoid contradicting the hreflang cluster.
+ *
+ * - greece → `el` (default, unprefixed) + `en`, on `https://opencouncil.gr`
+ * - france → `fr` (default, unprefixed) + `en`, on `https://opencouncil.fr`
  *
  * @param path locale-agnostic path beginning with `/`, or `''` for the homepage
- * @param locale current request locale (`'el'` | `'en'`)
+ * @param locale current request locale (`'el'` | `'en'` | `'fr'`)
  */
-export function buildHreflangAlternates(path: string, locale: string): Metadata['alternates'] {
-    const elUrl = `${baseUrl}${path}`;
+export async function buildHreflangAlternates(path: string, locale: string): Promise<Metadata['alternates']> {
+    const realm = await getRealm();
+    const baseUrl = getRealmBaseUrl(realm);
+    const defaultLocale = REALMS[realm].defaultLocale;
+
+    const defaultUrl = `${baseUrl}${path}`;
     const enUrl = `${baseUrl}/en${path}`;
 
     return {
-        canonical: locale === 'en' ? enUrl : elUrl,
+        canonical: locale === 'en' ? enUrl : defaultUrl,
         languages: {
-            el: elUrl,
+            [defaultLocale]: defaultUrl,
             en: enUrl,
-            'x-default': elUrl,
+            'x-default': defaultUrl,
         },
     };
 }

--- a/src/lib/zod-schemas/__tests__/topic.test.ts
+++ b/src/lib/zod-schemas/__tests__/topic.test.ts
@@ -5,6 +5,7 @@ const validTopic = {
     name_en: 'Environment',
     colorHex: '#4f46e5',
     description: 'Topics related to the environment',
+    realm: 'greece' as const,
 };
 
 describe('createTopicSchema', () => {

--- a/src/lib/zod-schemas/topic.ts
+++ b/src/lib/zod-schemas/topic.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { Realm } from '@prisma/client';
 import { HEX_REGEX } from '@/lib/utils/colorSuggestion';
 
 const trimmedString = z.string().transform(val => val.trim());
@@ -10,6 +11,7 @@ const baseTopicFields = {
     description: z.string(),
     icon: z.string().nullable().optional().transform(val => val || null),
     deprecated: z.boolean().optional().transform(val => val ?? false),
+    realm: z.nativeEnum(Realm),
 };
 
 export const createTopicSchema = z.object(baseTopicFields);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,7 +3,7 @@ import { routing, LOCALE_OVERRIDE_HEADER } from './i18n/routing';
 import { NextResponse, NextRequest } from 'next/server';
 import { auth } from './auth'
 import { env } from '@/env.mjs';
-import { isFrenchDomainHost } from '@/lib/host';
+import { realmForHost } from './lib/realm';
 
 const i18nMiddleware = createIntlMiddleware(routing);
 
@@ -137,11 +137,13 @@ function isHttpBasicAuthAuthenticated(req: Request) {
 
 /**
  * Whether the request arrived on the French domain (`opencouncil.fr` or a
- * subdomain of it). Delegates to the shared host helper so the proxy and
- * server components agree on what counts as the French realm.
+ * subdomain of it). Delegates to the shared `realmForHost` mapping (the single
+ * source of truth for host→realm), which strips the port and matches the apex or
+ * any subdomain — so `localhost`-style `host:port`, real domains and a spoofed
+ * `Host: opencouncil.fr` header all work for local testing.
  */
 function isFrenchHost(req: NextRequest): boolean {
-    return isFrenchDomainHost(req.headers.get('host'));
+    return realmForHost(req.headers.get('host')) === 'france';
 }
 
 /**


### PR DESCRIPTION
Follow-up to #491. `opencouncil.gr` and `opencouncil.fr` are one deployment over one database; #491 added the `City.realm` model but nothing filtered on it. This PR makes the app behave as **isolated tenants** ("realms"), resolved **per request from the Host header** (never from locale).

Base branch: `feat/french-expansion` (merge after #491).

## What changed

**1. Realm resolution** — pure `src/lib/realm.ts` (`REALMS` map, `realmForHost`, `getRealmBaseUrl`; safe for client + edge) and server-only `src/lib/realm.server.ts` (`getRealm`, `getRealmBaseUrlFromRequest`). `proxy.ts` `isFrenchHost` now delegates to the shared map.

**2. City data + cache isolation** — optional `realm?` filter on the cross-city queries; the realm is folded into the **cache keys** of the four shared city wrappers so `.gr` and `.fr` never share a cached entry on the shared Valkey backend. `getRealm()` uses `headers()` so it is resolved at the call site and passed into cached functions explicitly. Consumers (city-layout 404 guard, landing, petition, about, meeting-data loader) and the map routes pass the realm. **Cross-realm city slug → 404** via the realm-scoped id guard.

**3. Realm-scoped topics** — `Topic.realm` (additive migration, defaults existing rows to `greece`); `getTopics(realm)` required; agenda/transcript task payloads pass the city's realm; `/api/topics` and `/admin/topics` (grouped, with a realm selector) are realm-aware.

**4. Multi-domain SEO** — absolute URLs were built from build-time `NEXTAUTH_URL` (wrong for one domain; no `fr` hreflang). Now host-derived: realm-aware hreflang (`el`+`en` / `fr`+`en`, same-domain only), host-derived `metadataBase` with relative OG image URLs, per-realm sitemap + RSS, and a dynamic `robots.ts` replacing the static `public/robots.txt`.

**5. Footer country-switcher** — minimal control to switch between `.gr` and `.fr` (redirects to the other domain's root).

## Out of scope (separate tickets/PRs)
- **Search isolation** — Elasticsearch still spans all cities (separate ticket).
- **Notification/email links** — still `NEXTAUTH_URL` + hardcoded `/el/`.
- Other internal server-to-server URLs (task callbacks, Discord, auth invites).

## Verification
- `npx tsc --noEmit` clean; full unit suite **840 passed**.
- Live host-spoof / browser checks not yet run (the `Topic.realm` migration is unapplied on the shared dev DB; `City.realm` is already applied). Acceptance bar for review: on `.gr` no French cities/topics in dropdowns/map/sitemap and a French slug 404s; on `.fr` (spoof `Host: opencouncil.fr`) only French data; cache keys differ per host; the Greek site stays byte-identical.

## Note for reviewers
The `Topic.realm` migration (`20260621120000_add_topic_realm`) still needs applying to the shared dev DB before topic routes work there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tenant boundaries (404 guards, cache keys, topic assignment on save) and SEO canonicals; additive DB migration is low risk but must be applied before topic routes work in dev.
> 
> **Overview**
> Introduces **host-based realms** (`opencouncil.gr` vs `opencouncil.fr`) so one deployment serves isolated tenants: realm comes from the **Host** header via `realm.ts` / `realm.server.ts`, not from locale.
> 
> **Data & routing:** City lists, map APIs, landing/petition/about, and shared Valkey cache keys are **realm-scoped**; the `[cityId]` layout and city RSS feed **404** when the slug belongs to another realm. Meeting-data inflight dedup keys include realm.
> 
> **Topics:** Adds `Topic.realm` (migration defaults existing rows to `greece`); `getTopics(realm)` is required end-to-end (API, agenda/transcript tasks, subject save validation). Admin topics are grouped by realm with a realm selector; new topics default to the admin host’s realm.
> 
> **SEO:** Replaces build-time `NEXTAUTH_URL` with per-request `metadataBase`, async realm-aware hreflang, dynamic `sitemap.ts` / `robots.ts` (static `public/robots.txt` removed), and relative OG URLs.
> 
> **UX:** Footer **country switcher** jumps to the other realm’s root domain; French about page hides pricing via `realm === 'france'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0cced84f85b25e4b24c6c209112a14df815962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements host-derived tenant isolation across a single deployment serving both `opencouncil.gr` and `opencouncil.fr`. A new `realm.ts` / `realm.server.ts` pair maps the `Host` header to a `Realm` enum value that gates city lists, topic taxonomies, city-ID guards, sitemaps, RSS feeds, and SEO metadata — with the realm folded into all shared Valkey cache keys so the two domains never share a cached entry.

- **Data isolation**: `getAllCityIds`, `getAllCitiesMinimal`, `getSupportedCitiesWithLogos`, and `getAboutPageStats` all take an optional `realm` filter; the cached wrappers make it required and incorporate it into cache tags. The `[cityId]` layout guard and `getMeetingDataCore` inflight-dedup key are both realm-scoped.
- **Topic taxonomy**: `Topic.realm` column added (additive migration, defaults to `greece`); `getTopics` now requires realm; `validateSubjectPersons` fetches the city's realm before resolving `topicLabel → topicId`, closing the previously-flagged cross-realm topic assignment bug.
- **SEO**: root layout `generateMetadata` is now async and derives `metadataBase` from the request host; `sitemap.ts` / `robots.ts` add `force-dynamic` (addressing previous review comments); `buildHreflangAlternates` is async and realm-aware; a footer `CountrySwitcher` handles cross-domain navigation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all tenant isolation paths are correctly guarded and previous review findings are addressed.

The realm resolution, cache-key isolation, cross-realm 404 guards, and topic taxonomy scoping are all consistent across the changed files. The two previously flagged issues (cross-realm topic assignment in validateSubjectPersons, and the sitemap/robots missing force-dynamic) are fixed. The only findings here are two dead revalidatePath calls that became no-ops when the target route was switched to force-dynamic.

No files require special attention beyond the two dead revalidatePath('/api/topics') calls in the admin topics routes.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/realm.ts | New pure module defining realm-to-domain mapping and host resolver; clean, edge-safe, well-documented |
| src/lib/realm.server.ts | Server-only realm resolver reading Host header via next/headers; correctly documented as unsafe inside unstable_cache |
| src/lib/db/utils.ts | validateSubjectPersons now fetches city realm before building topicsByName, closing the previously-flagged cross-realm topic assignment bug |
| src/lib/getMeetingData.ts | coreInflight map key now includes realm, closing the previously-flagged cross-realm dedup coalescing gap |
| src/lib/cache/queries.ts | All four shared city-aggregate wrappers now take required realm arg folded into cache keys and tags; correct isolation on shared Valkey backend |
| src/lib/db/cities.ts | Optional realm filter added to all public city queries; raw SQL in getAboutPageStats uses Prisma.sql template literal for parameterized JOIN — correct |
| src/lib/db/topics.ts | getTopics now requires realm arg; TopicInput type includes realm; updateTopic accepts Partial so realm is optional on updates — all correct |
| src/app/sitemap.ts | Adds force-dynamic (addressing previous review comment), filters cities by realm, and builds realm-scoped hreflang alternates |
| src/app/robots.ts | New dynamic robots route replaces static public/robots.txt; force-dynamic and host-derived baseUrl — addresses previous review concern |
| src/app/api/cities/map/route.ts | Converted from revalidate=3600 to force-dynamic with realm-keyed data-layer cache; correctly scopes map data to requesting domain's realm |
| src/app/api/topics/route.ts | Converted from revalidate=86400 to force-dynamic; now passes realm to getTopics — correct tenant isolation |
| src/lib/utils/hreflang.ts | buildHreflangAlternates made async to resolve realm from Host; all callers properly await it; hreflang stays within the realm's own domain |
| src/components/layout/CountrySwitcher.tsx | New client component; uses lazy useState initialiser with window.location.hostname for SSR-safe realm detection; suppressHydrationWarning on label |
| src/app/api/admin/topics/route.ts | POST validates with createTopicSchema (now requires realm); revalidatePath('/api/topics') is a no-op since that route is force-dynamic |
| src/app/layout.tsx | Root layout generateMetadata now async, sets metadataBase from realm-derived host; relative /api/og URLs in child pages resolve correctly against this base |
| prisma/migrations/20260621120000_add_topic_realm/migration.sql | Additive migration: NOT NULL with DEFAULT 'greece' ensures zero-downtime deploy; index on realm column included |
| src/app/[locale]/(city)/[cityId]/feed/route.ts | Feed route now validates city.realm against request realm (404 on cross-realm slug); uses REALMS[realm].defaultLocale for correct locale prefix logic |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib/getMeetingData.ts`, line 53-86 ([link](https://github.com/schemalabz/opencouncil/blob/f3187576229877c3194e110f66d0ba85c72f11db/src/lib/getMeetingData.ts#L53-L86)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Process-level inflight map is not realm-scoped**

   `coreInflight` keys on `${cityId}/${meetingId}` with no realm segment. If two concurrent requests hit the server simultaneously — one from `.fr` for a French city and one from `.gr` that somehow shares the same `cityId` — the second caller coalesces onto the first promise and skips the realm-scoped city-ID validation (`getAllCityIdsCached(realm)` in line 96). The city-layout guard already prevents a cross-realm slug from reaching this code path, but a defense-in-depth key like `${realm}/${cityId}/${meetingId}` would close the gap without any performance cost.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/getMeetingData.ts
   Line: 53-86

   Comment:
   **Process-level inflight map is not realm-scoped**

   `coreInflight` keys on `${cityId}/${meetingId}` with no realm segment. If two concurrent requests hit the server simultaneously — one from `.fr` for a French city and one from `.gr` that somehow shares the same `cityId` — the second caller coalesces onto the first promise and skips the realm-scoped city-ID validation (`getAllCityIdsCached(realm)` in line 96). The city-layout guard already prevents a cross-realm slug from reaching this code path, but a defense-in-depth key like `${realm}/${cityId}/${meetingId}` would close the gap without any performance cost.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2FgetMeetingData.ts%0ALine%3A%2053-86%0A%0AComment%3A%0A**Process-level%20inflight%20map%20is%20not%20realm-scoped**%0A%0A%60coreInflight%60%20keys%20on%20%60%24%7BcityId%7D%2F%24%7BmeetingId%7D%60%20with%20no%20realm%20segment.%20If%20two%20concurrent%20requests%20hit%20the%20server%20simultaneously%20%E2%80%94%20one%20from%20%60.fr%60%20for%20a%20French%20city%20and%20one%20from%20%60.gr%60%20that%20somehow%20shares%20the%20same%20%60cityId%60%20%E2%80%94%20the%20second%20caller%20coalesces%20onto%20the%20first%20promise%20and%20skips%20the%20realm-scoped%20city-ID%20validation%20%28%60getAllCityIdsCached%28realm%29%60%20in%20line%2096%29.%20The%20city-layout%20guard%20already%20prevents%20a%20cross-realm%20slug%20from%20reaching%20this%20code%20path%2C%20but%20a%20defense-in-depth%20key%20like%20%60%24%7Brealm%7D%2F%24%7BcityId%7D%2F%24%7BmeetingId%7D%60%20would%20close%20the%20gap%20without%20any%20performance%20cost.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=schemalabz%2Fopencouncil&pr=494&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `src/lib/db/utils.ts`, line 160-162 ([link](https://github.com/schemalabz/opencouncil/blob/d7e4ebb87b3759de26c4ace9ba1f1d7f226d08ad/src/lib/db/utils.ts#L160-L162)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cross-realm topic assignment via unscoped `topicsByName` lookup**

   `validateSubjectPersons` builds `topicsByName` from all non-deprecated topics across every realm. When `saveSubjectsForMeeting` uses that map to resolve `incoming.topicLabel → topicId`, it can silently link a French meeting's subject to a Greek `Topic` row (or vice-versa) if both realms happen to share a topic name. `Object.fromEntries` keeps only the last entry for duplicate keys, so the winning row is undefined.

   The LLM is already given realm-scoped topic labels (via `getTopics(city.realm)` in `processAgendaInternal.ts` and `getRequestOnTranscriptRequestBody`), so the returned names are drawn from the correct realm. However the save path does not re-apply that constraint. Adding `realm` to the `findMany` call — e.g. by fetching the city's realm inside `validateSubjectPersons` using the `cityId` that is already available — closes the gap without a schema change.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/lib/db/utils.ts
   Line: 160-162

   Comment:
   **Cross-realm topic assignment via unscoped `topicsByName` lookup**

   `validateSubjectPersons` builds `topicsByName` from all non-deprecated topics across every realm. When `saveSubjectsForMeeting` uses that map to resolve `incoming.topicLabel → topicId`, it can silently link a French meeting's subject to a Greek `Topic` row (or vice-versa) if both realms happen to share a topic name. `Object.fromEntries` keeps only the last entry for duplicate keys, so the winning row is undefined.

   The LLM is already given realm-scoped topic labels (via `getTopics(city.realm)` in `processAgendaInternal.ts` and `getRequestOnTranscriptRequestBody`), so the returned names are drawn from the correct realm. However the save path does not re-apply that constraint. Adding `realm` to the `findMany` call — e.g. by fetching the city's realm inside `validateSubjectPersons` using the `cityId` that is already available — closes the gap without a schema change.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Flib%2Fdb%2Futils.ts%0ALine%3A%20160-162%0A%0AComment%3A%0A**Cross-realm%20topic%20assignment%20via%20unscoped%20%60topicsByName%60%20lookup**%0A%0A%60validateSubjectPersons%60%20builds%20%60topicsByName%60%20from%20all%20non-deprecated%20topics%20across%20every%20realm.%20When%20%60saveSubjectsForMeeting%60%20uses%20that%20map%20to%20resolve%20%60incoming.topicLabel%20%E2%86%92%20topicId%60%2C%20it%20can%20silently%20link%20a%20French%20meeting's%20subject%20to%20a%20Greek%20%60Topic%60%20row%20%28or%20vice-versa%29%20if%20both%20realms%20happen%20to%20share%20a%20topic%20name.%20%60Object.fromEntries%60%20keeps%20only%20the%20last%20entry%20for%20duplicate%20keys%2C%20so%20the%20winning%20row%20is%20undefined.%0A%0AThe%20LLM%20is%20already%20given%20realm-scoped%20topic%20labels%20%28via%20%60getTopics%28city.realm%29%60%20in%20%60processAgendaInternal.ts%60%20and%20%60getRequestOnTranscriptRequestBody%60%29%2C%20so%20the%20returned%20names%20are%20drawn%20from%20the%20correct%20realm.%20However%20the%20save%20path%20does%20not%20re-apply%20that%20constraint.%20Adding%20%60realm%60%20to%20the%20%60findMany%60%20call%20%E2%80%94%20e.g.%20by%20fetching%20the%20city's%20realm%20inside%20%60validateSubjectPersons%60%20using%20the%20%60cityId%60%20that%20is%20already%20available%20%E2%80%94%20closes%20the%20gap%20without%20a%20schema%20change.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=schemalabz%2Fopencouncil&pr=494&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["feat(realm): add a footer country switch..."](https://github.com/schemalabz/opencouncil/commit/bd0cced84f85b25e4b24c6c209112a14df815962) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38897828)</sub>

<!-- /greptile_comment -->