### PR TITLE
fix(cache): isolate Valkey cache per environment and build

### DIFF
--- a/cache-handler.mjs
+++ b/cache-handler.mjs
@@ -46,37 +46,32 @@ CacheHandler.onCreation(async ({ buildId }) => {
   }
 
   if (client?.isReady) {
-    // Flush stale cached pages when a new build is deployed.
-    // Compares the current Next.js build ID against a sentinel key in Valkey.
-    // First instance to boot after a deploy flushes; others find the updated sentinel and skip.
-    const SENTINEL_KEY = 'oc:__build_id__';
-    try {
-      if (!buildId) {
-        console.warn('[cache-handler] No build ID available — skipping deploy flush check');
-      } else {
-        const storedBuildId = await client.get(SENTINEL_KEY);
-
-        if (storedBuildId !== buildId) {
-          console.info(
-            `[cache-handler] Build ID changed: ${storedBuildId ?? '(none)'} → ${buildId} — flushing cache`,
-          );
-          await client.flushDb();
-          await client.set(SENTINEL_KEY, buildId);
-        } else {
-          console.info(`[cache-handler] Build ID unchanged (${buildId}) — skipping flush`);
+    // Isolate cache entries per ENVIRONMENT and per BUILD. prod and staging can
+    // point at the same Valkey db, and Next's runtime `buildId` here is
+    // unreliable (frequently undefined → everything collapsed into one shared
+    // `nobuild` namespace). Either way, cached RSC rendered by one build/env was
+    // being served by another whose code has different server-action IDs →
+    // "Failed to find Server Action". The env key (explicit APP_ENV, else the
+    // NEXTAUTH_URL host) separates prod/staging; the build key (commit/build id)
+    // separates deploys, so a new build never reads the previous build's stale
+    // entries. keyPrefix and the shared-tags keys all use this namespace.
+    //
+    // We deliberately do NOT flushDb() anymore: on a shared db that wipes the
+    // *other* environment's cache. The per-build namespace makes superseded
+    // entries simply unreachable; they expire via their existing TTLs.
+    const envKey =
+      process.env.APP_ENV ||
+      (() => {
+        try {
+          return new URL(process.env.NEXTAUTH_URL).host;
+        } catch {
+          return process.env.NODE_ENV || 'unknown';
         }
-      }
-    } catch (error) {
-      console.warn('[cache-handler] Deploy flush check failed:', error.message);
-    }
-
-    // Namespace by buildId so old-build instances during a rolling deploy can't
-    // pollute the new build's cache (and vice-versa). Without this, an old
-    // instance writes HTML referencing its own chunk hashes into the shared
-    // cache, then new instances serve it and 404 on the chunks they don't have.
-    // sharedTagsKey is also namespaced so a revalidateTag from an old-build
-    // instance doesn't delete the new build's entries through the shared tag map.
-    const namespace = buildId || 'nobuild';
+      })();
+    const buildKey =
+      process.env.SOURCE_COMMIT || process.env.BUILD_ID || buildId || 'nobuild';
+    const namespace = `${envKey}:${buildKey}`;
+    console.info(`[cache-handler] Cache namespace: oc:${namespace}:`);
 
     // Forte's redis-strings handler fixes the @neshca issues that drove #358:
     //   • TTL-bound tag hashmap (sharedTagsTtlKey) — no unbounded growth from bot pollution

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,6 +22,10 @@ const nextConfig = {
         ? new URL('./cache-handler.mjs', import.meta.url).pathname
         : undefined,
     cacheMaxMemorySize: process.env.NODE_ENV === 'production' ? 0 : undefined,
+    // Deterministic build id (commit-based when available) so the Valkey cache
+    // namespace distinguishes different code and is stable across the instances
+    // of one deploy. Falls back to Next's default (random per build) otherwise.
+    generateBuildId: async () => process.env.SOURCE_COMMIT || process.env.BUILD_ID || null,
     images: {
         domains: ['townhalls-gr.fra1.digitaloceanspaces.com', 'data.opencouncil.gr', 'fra1.digitaloceanspaces.com'],
     },


### PR DESCRIPTION
## Problem
prod and staging point `CACHE_URL` at the **same Valkey db**, and Next's runtime `buildId` in the cache handler is unreliable (often undefined), so the cache namespace collapsed to a single shared `oc:nobuild:`. Cached RSC rendered by one build/environment then gets served by another whose code has **different Server Action IDs** → `Failed to find Server Action … older or newer deployment`, on **both prod and staging**, persistently. (Surfaced by the realm deploy, which changed component code and therefore the action IDs.)

## Fix
- **Namespace by environment AND build**: `oc:${env}:${build}:`. `env` = `APP_ENV` if set, else the `NEXTAUTH_URL` host (already differs between prod/staging); `build` = `SOURCE_COMMIT` / `BUILD_ID` / runtime `buildId` / `nobuild`. So prod and staging never share a namespace even when the build id is missing, and a new deploy never reads the previous build's stale entries.
- **Pin `generateBuildId`** to the commit (when available) so the build key is deterministic.
- **Drop `flushDb()`**: on a shared db it wiped the *other* environment's cache. The per-build namespace makes superseded entries unreachable; they expire via their existing TTLs.

Verified: namespaces differ across envs even in the worst case — `oc:opencouncil.gr:nobuild:` vs `oc:staging.opencouncil.gr:nobuild:`.

## Operational notes
- Optional but recommended: set `APP_ENV=production` / `staging` for an explicit env key, and/or give the two envs **separate Valkey dbs**.
- To reclaim the now-orphaned old entries, `FLUSHDB` the Valkey once after deploy (no longer automatic, by design).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production caching behavior for all multi-instance deploys; misconfigured env keys could still share a namespace, but the fix directly addresses a user-facing Server Action failure mode.
> 
> **Overview**
> Fixes cross-environment and cross-deploy cache collisions when prod and staging share one Valkey database, which was serving stale RSC with mismatched Server Action IDs.
> 
> The Valkey **key prefix** (and tag keys) now use `oc:${env}:${build}:` instead of build-only or a shared `nobuild` bucket. **Environment** comes from `APP_ENV`, else the `NEXTAUTH_URL` host; **build** from `SOURCE_COMMIT` / `BUILD_ID` / runtime `buildId` / `nobuild`. **`generateBuildId`** in `next.config.mjs` pins the build id to the commit when those env vars are set.
> 
> **Deploy `flushDb()` is removed** so flushing one environment on a shared db no longer wipes the other; old entries are left to expire under TTL in unused namespaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65a05bf8fbffbd4165bfa55400fdf037dc4acc32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a shared-namespace bug in the Valkey cache where prod and staging could write into the same `oc:nobuild:` key space, causing stale RSC payloads with mismatched Server Action IDs to cross environments. It also removes the `flushDb()` call that was wiping the other environment's cache on every new deploy.

- **Namespace isolation**: Cache keys are now prefixed with `oc:${envKey}:${buildKey}:`, where `envKey` is `APP_ENV` → `NEXTAUTH_URL` host → `NODE_ENV`, and `buildKey` is `SOURCE_COMMIT` → `BUILD_ID` → runtime `buildId` → `'nobuild'`. This prevents cross-environment and cross-build cache contamination.
- **Deterministic build ID**: `generateBuildId` in `next.config.mjs` now returns the commit SHA when available, making the build key stable across all instances of a single deploy and consistent with the cache handler's own `buildKey` lookup.
- **Dropped `flushDb()`**: Superseded entries are made unreachable by the new namespace and expire naturally via their existing TTLs; a one-time manual `FLUSHDB` is recommended post-deploy to reclaim the old orphaned keys.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The fix directly addresses a confirmed production bug and the new namespace logic is straightforward. The only edge case (URL host containing a port colon) is cosmetic and doesn't affect correctness in any deployed environment.

Both changed files are well-reasoned and the core logic — compound namespace, removal of cross-env flushDb, deterministic buildId — is sound. The one style note about localhost:3000 embedding a colon is harmless in practice since production hosts don't carry port numbers. No data loss or correctness risk introduced.

No files require special attention; cache-handler.mjs has the only minor observation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cache-handler.mjs | Replaces sentinel-key + flushDb() logic with a two-part namespace (envKey:buildKey) to isolate cache entries per environment and per build. Logic is sound; minor cosmetic concern with port numbers in URL-derived envKey. |
| next.config.mjs | Adds generateBuildId to pin the build ID to SOURCE_COMMIT/BUILD_ID at build time; returns null to fall back to Next's default random ID when neither env var is set. Straightforward and correct. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acache-handler.mjs%3A62-73%0A**URL%20host%20with%20port%20embeds%20extra%20%60%3A%60%20into%20namespace**%0A%0AWhen%20%60NEXTAUTH_URL%60%20is%20something%20like%20%60http%3A%2F%2Flocalhost%3A3000%60%2C%20%60new%20URL%28...%29.host%60%20returns%20%60%22localhost%3A3000%22%60.%20This%20embeds%20a%20literal%20%60%3A%60%20into%20the%20namespace%2C%20producing%20a%20key%20prefix%20like%20%60oc%3Alocalhost%3A3000%3Anobuild%3A%60%20%E2%80%94%20five%20colon-delimited%20segments%20instead%20of%20the%20expected%20three.%20Redis%2FValkey%20handles%20it%20fine%2C%20but%20it%20makes%20the%20key%20structure%20visually%20ambiguous%20and%20could%20trip%20up%20any%20tooling%20or%20scripts%20that%20parse%20the%20namespace%20by%20splitting%20on%20%60%3A%60.%0A%0A&repo=schemalabz%2Fopencouncil&pr=498&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
cache-handler.mjs:62-73
**URL host with port embeds extra `:` into namespace**

When `NEXTAUTH_URL` is something like `http://localhost:3000`, `new URL(...).host` returns `"localhost:3000"`. This embeds a literal `:` into the namespace, producing a key prefix like `oc:localhost:3000:nobuild:` — five colon-delimited segments instead of the expected three. Redis/Valkey handles it fine, but it makes the key structure visually ambiguous and could trip up any tooling or scripts that parse the namespace by splitting on `:`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cache): isolate Valkey cache per env..."](https://github.com/schemalabz/opencouncil/commit/65a05bf8fbffbd4165bfa55400fdf037dc4acc32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39237433)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->