### PR TITLE
fix(auth): point magic-link emails at the sign-in host

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -4,6 +4,7 @@ import { AuthEmail } from "./lib/email/templates/AuthEmail"
 import { renderReactEmailToHtml } from "./lib/email/render"
 import { env } from "./env.mjs"
 import { isTestUserEmail } from "./lib/dev/test-users"
+import { signInUrlForRequest } from "./lib/auth/signInUrl"
 
 // In development, use port-specific session cookie names to allow multiple
 // instances on different ports to have independent sessions. Without this,
@@ -25,8 +26,12 @@ export default {
         from: 'OpenCouncil <auth@opencouncil.gr>',
         apiKey: env.RESEND_API_KEY,
         sendVerificationRequest: async (params) => {
-            const { identifier: to, provider, url, theme } = params
-            const html = await renderReactEmailToHtml(AuthEmail({ url }))
+            const { identifier: to, provider, url, request } = params
+            // Point the magic link at the domain the user is signing in from
+            // (opencouncil.gr vs opencouncil.fr) instead of the single build-time
+            // NEXTAUTH_URL host, so the callback sets a cookie on the right domain.
+            const signInUrl = signInUrlForRequest(url, request)
+            const html = await renderReactEmailToHtml(AuthEmail({ url: signInUrl }))
 
             // Redirect test user emails to DEV_EMAIL_OVERRIDE if set
             // This allows testing different admin roles with a single real inbox
@@ -47,7 +52,7 @@ export default {
                     to: emailTo,
                     subject: `Συνδεθείτε στο OpenCouncil`,
                     html,
-                    text: `Συνδεθείτε στο OpenCouncil: ${url}`,
+                    text: `Συνδεθείτε στο OpenCouncil: ${signInUrl}`,
                 }),
             })
 

--- a/src/lib/auth/__tests__/signInUrl.test.ts
+++ b/src/lib/auth/__tests__/signInUrl.test.ts
@@ -1,0 +1,81 @@
+import { signInUrlForRequest } from '../signInUrl';
+
+const reqWith = (headers: Record<string, string>) =>
+    new Request('https://internal.local/api/auth/signin', { headers });
+
+describe('signInUrlForRequest', () => {
+    const greekUrl =
+        'https://opencouncil.gr/api/auth/callback/resend?callbackUrl=%2Fprofile&token=abc123&email=user%40example.com';
+
+    it('repoints the magic link to the French host when signing in on .fr', () => {
+        const result = signInUrlForRequest(greekUrl, reqWith({ host: 'opencouncil.fr' }));
+        const u = new URL(result);
+        expect(u.host).toBe('opencouncil.fr');
+        expect(u.protocol).toBe('https:');
+    });
+
+    it('preserves the path and query (token + callbackUrl) when rewriting', () => {
+        const result = signInUrlForRequest(greekUrl, reqWith({ host: 'opencouncil.fr' }));
+        const u = new URL(result);
+        expect(u.pathname).toBe('/api/auth/callback/resend');
+        expect(u.searchParams.get('token')).toBe('abc123');
+        expect(u.searchParams.get('email')).toBe('user@example.com');
+        expect(u.searchParams.get('callbackUrl')).toBe('/profile');
+    });
+
+    it('prefers x-forwarded-host over host (behind a proxy/LB)', () => {
+        const result = signInUrlForRequest(
+            greekUrl,
+            reqWith({ host: 'internal.local:8080', 'x-forwarded-host': 'opencouncil.fr' })
+        );
+        expect(new URL(result).host).toBe('opencouncil.fr');
+    });
+
+    it('uses x-forwarded-proto when provided', () => {
+        const result = signInUrlForRequest(
+            'http://opencouncil.gr/api/auth/callback/resend?token=t',
+            reqWith({ host: 'opencouncil.fr', 'x-forwarded-proto': 'https' })
+        );
+        expect(new URL(result).protocol).toBe('https:');
+    });
+
+    it('leaves the dev URL untouched (localhost over http, no forwarded headers)', () => {
+        const devUrl = 'http://localhost:3000/api/auth/callback/resend?token=t';
+        const result = signInUrlForRequest(devUrl, reqWith({ host: 'localhost:3000' }));
+        const u = new URL(result);
+        expect(u.protocol).toBe('http:');
+        expect(u.host).toBe('localhost:3000');
+        expect(result).toBe(devUrl);
+    });
+
+    it('is a no-op for the same host (.gr signing in on .gr)', () => {
+        const result = signInUrlForRequest(greekUrl, reqWith({ host: 'opencouncil.gr' }));
+        expect(result).toBe(greekUrl);
+    });
+
+    it('returns the original URL when no host header is present', () => {
+        const result = signInUrlForRequest(greekUrl, reqWith({}));
+        expect(result).toBe(greekUrl);
+    });
+
+    it('rejects an attacker-supplied host (not a known domain) and does not rewrite', () => {
+        const result = signInUrlForRequest(greekUrl, reqWith({ 'x-forwarded-host': 'evil.com' }));
+        expect(result).toBe(greekUrl);
+    });
+
+    it('allows a preview subdomain of a realm domain', () => {
+        const result = signInUrlForRequest(
+            greekUrl,
+            reqWith({ 'x-forwarded-host': 'pr-7.preview.opencouncil.fr' })
+        );
+        expect(new URL(result).host).toBe('pr-7.preview.opencouncil.fr');
+    });
+
+    it('takes the first value of a comma-separated forwarded header', () => {
+        const result = signInUrlForRequest(
+            greekUrl,
+            reqWith({ 'x-forwarded-host': 'opencouncil.fr, internal-lb.local' })
+        );
+        expect(new URL(result).host).toBe('opencouncil.fr');
+    });
+});

--- a/src/lib/auth/signInUrl.ts
+++ b/src/lib/auth/signInUrl.ts
@@ -1,0 +1,49 @@
+import { isKnownRealmHost } from '@/lib/realm';
+
+/**
+ * Forwarded headers can be comma-separated lists when a request passes through
+ * multiple proxies (e.g. `x-forwarded-host: opencouncil.fr, internal-lb`). The
+ * client-facing value is the first entry.
+ */
+function firstHeaderValue(value: string | null): string | null {
+    const first = value?.split(',')[0].trim();
+    return first || null;
+}
+
+/**
+ * Repoints a magic-link URL at the host the sign-in request actually arrived on.
+ *
+ * Auth.js builds the URL from a single build-time base (`NEXTAUTH_URL`), so on a
+ * multi-domain deployment (opencouncil.gr + opencouncil.fr) every magic link
+ * points at the Greek domain. A French user then can't complete sign-in on
+ * opencouncil.fr, because the callback would land on opencouncil.gr and set a
+ * cookie there instead. Rewriting the origin to the request's own host fixes that;
+ * the path and query string (the verification token and callbackUrl) are kept.
+ *
+ * SECURITY: only a host we recognise as one of our own domains is trusted. The
+ * Host / X-Forwarded-Host headers are attacker-controllable if a request ever
+ * reaches the origin directly or a proxy is misconfigured; since Auth.js email
+ * tokens are keyed by email and not host-scoped, a magic link sent to an
+ * attacker-controlled host would be enough to hijack the account. Unknown hosts
+ * (incl. `localhost` dev) fall back to the original NEXTAUTH_URL-based link.
+ *
+ * Reads only the passed `request` (no `next/headers`), so it stays edge/middleware
+ * bundle safe — `auth.config.ts` is reachable from `proxy.ts`.
+ */
+export function signInUrlForRequest(url: string, request: Request): string {
+    const host =
+        firstHeaderValue(request.headers.get('x-forwarded-host')) ??
+        firstHeaderValue(request.headers.get('host'));
+
+    if (!isKnownRealmHost(host)) return url;
+
+    const target = new URL(url);
+    // Fall back to the original URL's protocol when the platform doesn't set
+    // x-forwarded-proto (e.g. local http dev), so the dev link is left intact.
+    const proto =
+        firstHeaderValue(request.headers.get('x-forwarded-proto')) ??
+        target.protocol.replace(/:$/, '');
+    target.protocol = `${proto}:`;
+    target.host = host as string;
+    return target.toString();
+}

--- a/src/lib/realm.ts
+++ b/src/lib/realm.ts
@@ -22,14 +22,30 @@ export const REALMS = {
  * hosts like `pr-7.preview.opencouncil.fr` resolve correctly). Defaults to
  * `greece` for unknown hosts (localhost, the Greek production domain).
  */
+const hostMatchesDomain = (host: string, domain: string): boolean =>
+    host === domain || host.endsWith(`.${domain}`);
+
 export function realmForHost(host: string | null | undefined): Realm {
     const normalized = (host ?? '').split(':')[0].toLowerCase();
     for (const [realm, { domain }] of Object.entries(REALMS)) {
-        if (normalized === domain || normalized.endsWith(`.${domain}`)) {
+        if (hostMatchesDomain(normalized, domain)) {
             return realm as Realm;
         }
     }
     return 'greece';
+}
+
+/**
+ * Whether a Host header value is one of our own domains (apex or subdomain of a
+ * realm domain — so production and preview hosts match, but `localhost` and any
+ * attacker-supplied host do not). Unlike `realmForHost` (which defaults unknown
+ * hosts to `greece`), this is a strict membership check — use it before trusting
+ * a request's Host for anything sensitive, e.g. building a magic-link URL.
+ */
+export function isKnownRealmHost(host: string | null | undefined): boolean {
+    const normalized = (host ?? '').split(':')[0].toLowerCase();
+    if (!normalized) return false;
+    return Object.values(REALMS).some(({ domain }) => hostMatchesDomain(normalized, domain));
 }
 
 /**


### PR DESCRIPTION
## Problem
On the single multi-domain deployment (`opencouncil.gr` + `opencouncil.fr`), Auth.js builds the magic-link URL from the build-time `NEXTAUTH_URL`, so **every sign-in email points at the Greek domain**. A user signing in on `opencouncil.fr` can't actually complete login there — the callback lands on `opencouncil.gr` and sets the session cookie on the wrong domain.

(Sessions remain per-domain by design — different registrable domains can't share a cookie. This PR just makes each domain's login *work*; it is **not** a cross-domain SSO bridge.)

## Fix
`sendVerificationRequest` receives the `request` (Auth.js v5 passes it). New helper `signInUrlForRequest(url, request)` rewrites the magic-link **origin** to the host the request arrived on (via `x-forwarded-host`/`host` + `x-forwarded-proto`), preserving path + query (the verification token and `callbackUrl`).

- **Edge-safe:** reads headers off the passed `request` — no `next/headers`, so `auth.config.ts` (reachable from `proxy.ts`) stays out of the middleware bundle's way.
- **Graceful:** falls back to the original URL when no host header is present, so local dev (`localhost`/http) and the existing `.gr` flow are byte-identical. Worst case = today's behavior; it can't make login worse.

## Tests
`src/lib/auth/__tests__/signInUrl.test.ts` — rewrites `.gr → .fr`, preserves token/callbackUrl, `x-forwarded-host` precedence, dev no-op, same-host no-op, missing-host fallback. `tsc` clean; full suite **854 pass**.

## Out of scope / follow-up
`src/lib/auth/invite.ts` (admin invite links) still builds URLs from `NEXTAUTH_URL`. It has no request context (the invitee isn't on a domain yet) and the "right" domain depends on the invited realm — a separate decision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication email URLs and trusts forwarded Host headers, but rewrites are gated by `isKnownRealmHost` with a safe fallback to the original link.
> 
> **Overview**
> Fixes French-domain sign-in by rewriting magic-link **origins** to match the host the user actually used (`opencouncil.fr` vs `opencouncil.gr`), while keeping Auth.js path/query (token, `callbackUrl`) unchanged.
> 
> `sendVerificationRequest` now builds the email HTML and plain-text link via **`signInUrlForRequest`**, using `x-forwarded-host` / `host` and optional `x-forwarded-proto` from the Auth.js **`request`**. Rewrites only run when **`isKnownRealmHost`** accepts the host (realm apex/subdomains, including preview); unknown or spoofed hosts (e.g. `evil.com`, `localhost`) leave the original `NEXTAUTH_URL` link untouched.
> 
> Shared realm helpers extract **`hostMatchesDomain`** and add unit tests for cross-domain rewrite, proxy headers, same-host no-op, and rejection of untrusted hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 258b56459f90ee83d3a94c51542b234e8ba3ec08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes magic-link sign-in emails on the multi-domain deployment (`opencouncil.gr` + `opencouncil.fr`) by rewriting the Auth.js-generated URL origin to match the host the user actually signed in on, so the callback cookie lands on the correct domain.

- **`signInUrl.ts`**: New `signInUrlForRequest` helper reads `x-forwarded-host`/`host` and `x-forwarded-proto` from the passed `Request`, validates the host against an explicit allowlist (`isKnownRealmHost`), and rewrites only the URL origin — path and query (token, `callbackUrl`) are preserved. Falls back to the original URL when headers are absent or the host is unrecognised, keeping local dev and the `.gr` flow byte-identical.
- **`realm.ts`**: Extracts `hostMatchesDomain` as a shared predicate and adds `isKnownRealmHost` — a strict membership check (no default-to-greece fallback) for use before trusting request headers in security-sensitive contexts.
- **`auth.config.ts`**: Applies the rewritten URL to both the HTML and plain-text email bodies in `sendVerificationRequest`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is well-scoped, the fallback preserves today's behaviour on failure, and the host-rewrite path is gated behind an explicit domain allowlist.

The host-allowlist concern raised in a prior review has been directly addressed: isKnownRealmHost rejects any host that isn't an apex or subdomain of a known realm domain, and there is an explicit test confirming evil.com is rejected. The helper is edge-safe (no next/headers), falls back to the original URL whenever it can't determine a known host, and is covered by nine focused unit tests spanning every meaningful branch including the security path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/auth/signInUrl.ts | New helper that rewrites a magic-link URL's origin to the request host, with an explicit allowlist guard via isKnownRealmHost |
| src/lib/realm.ts | Extracts shared hostMatchesDomain predicate and adds isKnownRealmHost for strict membership checks before trusting request host headers |
| src/auth.config.ts | Integrates signInUrlForRequest into sendVerificationRequest; both HTML and plain-text email bodies now use the rewritten URL |
| src/lib/auth/__tests__/signInUrl.test.ts | Comprehensive test suite covering multi-domain rewrite, proxy header precedence, protocol rewriting, dev no-op, same-host no-op, missing-host fallback, evil-host rejection, preview subdomain allowance, and comma-separated header handling |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(auth): point magic-link emails at th..."](https://github.com/schemalabz/opencouncil/commit/258b56459f90ee83d3a94c51542b234e8ba3ec08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39263275)</sub>

<!-- /greptile_comment -->