### PR TITLE
feat(subjects): hide vote section from the public, keep it for counselors

### DIFF
--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -421,8 +421,8 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                     )}
                 </CollapsibleCard>
 
-                {/* Voting Section (skip for withdrawn subjects) */}
-                {!subject.withdrawn && <CollapsibleCard
+                {/* Voting Section (skip for withdrawn subjects; counselors only, hidden from the public) */}
+                {!subject.withdrawn && options.editsAllowed && <CollapsibleCard
                     icon={<CheckSquare className="w-4 h-4" />}
                     title={
                         voteResult && voteResult.totalVotes > 0 ? (


### PR DESCRIPTION
## What

Hides the **Voting** section on a subject's detail page from the public. The section now only renders for counselors — i.e. users authorized to edit the city/council (city/party/person administrators and superadmins).

## How

Gated the voting `CollapsibleCard` in [`subject.tsx`](src/components/meetings/subject/subject.tsx) on `options.editsAllowed` — the same `editable` flag (from `isUserAuthorizedToEdit({ cityId })`) that already hides the admin-details block elsewhere on this page.

```jsx
{!subject.withdrawn && options.editsAllowed && <CollapsibleCard ...>
    <VotingSection ... />
</CollapsibleCard>}
```

- `VotingSection` has a single usage site (this file), so there's no other public entry point for vote data.
- `npx tsc --noEmit` is clean.

## Note

This is a client-side UI gate: the vote data is still included in the page props, so it hides the section but is not a hard server-side access barrier. If votes need to be fully inaccessible to the public, the data fetch should be gated server-side instead — happy to follow up if that's the intent.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hides the **Voting** section on a subject's detail page from public visitors by adding `options.editsAllowed` to the render condition in `subject.tsx`. The flag reuses the same `isUserAuthorizedToEdit`-backed `editable` prop that already protects other admin UI on this page.

- **Single-line change** in `subject.tsx`: `!subject.withdrawn && options.editsAllowed && <CollapsibleCard …>` — consistent with how editing controls are gated throughout the meeting components.
- **Acknowledged limitation**: The gate is client-side only; `subject.votes` and `subject.attendance` are still serialised into the Next.js hydration payload. A server-side exclusion of vote data from the page props would be needed if the votes must be fully inaccessible to the public.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the stated goal of hiding the UI; vote data remains in the client payload, which the author has already flagged as a known follow-up.

The change correctly hides the voting section for public visitors and is consistent with the existing admin-gate pattern. The only open question — whether vote data should also be withheld from the page props server-side — is explicitly acknowledged in the PR description as out of scope here.

No files require special attention beyond the noted client-side-only nature of the gate in `subject.tsx`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/meetings/subject/subject.tsx | Voting CollapsibleCard is now gated behind `options.editsAllowed` — a client-side UI flag — which correctly hides the section for non-counselors; the raw vote data is still present in the hydrated page props. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/meetings/subject/subject.tsx`, line 424-446 ([link](https://github.com/schemalabz/opencouncil/blob/9b90fd6dbd8f964fda43cb64448791fd3023375d/src/components/meetings/subject/subject.tsx#L424-L446)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Client-side-only gate — vote data still reachable in page props**

   As the PR description acknowledges, `options.editsAllowed` is a React-state flag set during SSR hydration (`TranscriptOptionsProvider editable={editable}`). The raw `subject.votes` and `subject.attendance` arrays are still serialised into the page's React tree and visible in the client-side hydration payload, so any visitor can read them via the browser's DevTools or by inspecting `__NEXT_DATA__`. If the intent is to make vote data inaccessible to the public — not just invisible — the data fetch for `votes`/`attendance` should be gated server-side (e.g. in `getMeetingData` or its Prisma queries) based on `isUserAuthorizedToEdit`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/meetings/subject/subject.tsx
   Line: 424-446

   Comment:
   **Client-side-only gate — vote data still reachable in page props**

   As the PR description acknowledges, `options.editsAllowed` is a React-state flag set during SSR hydration (`TranscriptOptionsProvider editable={editable}`). The raw `subject.votes` and `subject.attendance` arrays are still serialised into the page's React tree and visible in the client-side hydration payload, so any visitor can read them via the browser's DevTools or by inspecting `__NEXT_DATA__`. If the intent is to make vote data inaccessible to the public — not just invisible — the data fetch for `votes`/`attendance` should be gated server-side (e.g. in `getMeetingData` or its Prisma queries) based on `isUserAuthorizedToEdit`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2Fmeetings%2Fsubject%2Fsubject.tsx%0ALine%3A%20424-446%0A%0AComment%3A%0A**Client-side-only%20gate%20%E2%80%94%20vote%20data%20still%20reachable%20in%20page%20props**%0A%0AAs%20the%20PR%20description%20acknowledges%2C%20%60options.editsAllowed%60%20is%20a%20React-state%20flag%20set%20during%20SSR%20hydration%20%28%60TranscriptOptionsProvider%20editable%3D%7Beditable%7D%60%29.%20The%20raw%20%60subject.votes%60%20and%20%60subject.attendance%60%20arrays%20are%20still%20serialised%20into%20the%20page's%20React%20tree%20and%20visible%20in%20the%20client-side%20hydration%20payload%2C%20so%20any%20visitor%20can%20read%20them%20via%20the%20browser's%20DevTools%20or%20by%20inspecting%20%60__NEXT_DATA__%60.%20If%20the%20intent%20is%20to%20make%20vote%20data%20inaccessible%20to%20the%20public%20%E2%80%94%20not%20just%20invisible%20%E2%80%94%20the%20data%20fetch%20for%20%60votes%60%2F%60attendance%60%20should%20be%20gated%20server-side%20%28e.g.%20in%20%60getMeetingData%60%20or%20its%20Prisma%20queries%29%20based%20on%20%60isUserAuthorizedToEdit%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=schemalabz%2Fopencouncil&pr=503&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2Fmeetings%2Fsubject%2Fsubject.tsx%3A424-446%0A**Client-side-only%20gate%20%E2%80%94%20vote%20data%20still%20reachable%20in%20page%20props**%0A%0AAs%20the%20PR%20description%20acknowledges%2C%20%60options.editsAllowed%60%20is%20a%20React-state%20flag%20set%20during%20SSR%20hydration%20%28%60TranscriptOptionsProvider%20editable%3D%7Beditable%7D%60%29.%20The%20raw%20%60subject.votes%60%20and%20%60subject.attendance%60%20arrays%20are%20still%20serialised%20into%20the%20page's%20React%20tree%20and%20visible%20in%20the%20client-side%20hydration%20payload%2C%20so%20any%20visitor%20can%20read%20them%20via%20the%20browser's%20DevTools%20or%20by%20inspecting%20%60__NEXT_DATA__%60.%20If%20the%20intent%20is%20to%20make%20vote%20data%20inaccessible%20to%20the%20public%20%E2%80%94%20not%20just%20invisible%20%E2%80%94%20the%20data%20fetch%20for%20%60votes%60%2F%60attendance%60%20should%20be%20gated%20server-side%20%28e.g.%20in%20%60getMeetingData%60%20or%20its%20Prisma%20queries%29%20based%20on%20%60isUserAuthorizedToEdit%60.%0A%0A&repo=schemalabz%2Fopencouncil&pr=503&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/components/meetings/subject/subject.tsx:424-446
**Client-side-only gate — vote data still reachable in page props**

As the PR description acknowledges, `options.editsAllowed` is a React-state flag set during SSR hydration (`TranscriptOptionsProvider editable={editable}`). The raw `subject.votes` and `subject.attendance` arrays are still serialised into the page's React tree and visible in the client-side hydration payload, so any visitor can read them via the browser's DevTools or by inspecting `__NEXT_DATA__`. If the intent is to make vote data inaccessible to the public — not just invisible — the data fetch for `votes`/`attendance` should be gated server-side (e.g. in `getMeetingData` or its Prisma queries) based on `isUserAuthorizedToEdit`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(subjects): hide vote section from t..."](https://github.com/schemalabz/opencouncil/commit/9b90fd6dbd8f964fda43cb64448791fd3023375d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39790419)</sub>

<!-- /greptile_comment -->