### PR TITLE
Crop, white-pad, and remove logos/photos on upload (#326)

### DIFF
--- a/messages/el.json
+++ b/messages/el.json
@@ -474,6 +474,12 @@
         "tabSegments": "Τοποθετήσεις",
         "tabSegmentsShort": "Τοποθετήσεις"
     },
+    "ImageCropDialog": {
+        "title": "Προσαρμογή εικόνας",
+        "save": "Αποθήκευση",
+        "cancel": "Ακύρωση",
+        "processingFailed": "Δεν ήταν δυνατή η επεξεργασία της εικόνας. Δοκιμάστε διαφορετικό αρχείο."
+    },
     "PartyForm": {
         "partyNamePlaceholder": "Όνομα Παράταξης",
         "partyNameDescription": "Εισάγετε το πλήρες όνομα της παράταξης.",

--- a/messages/el.json
+++ b/messages/el.json
@@ -474,6 +474,27 @@
         "tabSegments": "Τοποθετήσεις",
         "tabSegmentsShort": "Τοποθετήσεις"
     },
+    "PartyForm": {
+        "partyNamePlaceholder": "Όνομα Παράταξης",
+        "partyNameDescription": "Εισάγετε το πλήρες όνομα της παράταξης.",
+        "partyNameEnPlaceholder": "Όνομα Παράταξης (Αγγλικά)",
+        "partyNameEnDescription": "Εισάγετε το όνομα της παράταξης στα Αγγλικά.",
+        "partyShortNamePlaceholder": "Σύντομο Όνομα Παράταξης",
+        "partyShortNameDescription": "Εισάγετε το σύντομο όνομα της παράταξης.",
+        "partyShortNameEnPlaceholder": "Σύντομο Όνομα Παράταξης (Αγγλικά)",
+        "partyShortNameEnDescription": "Εισάγετε το σύντομο όνομα της παράταξης στα Αγγλικά.",
+        "logo": "Λογότυπο",
+        "logoDescription": "Ανεβάστε ένα λογότυπο για την παράταξη.",
+        "colorHex": "Χρώμα",
+        "colorHexDescription": "Επιλέξτε το χρώμα της παράταξης.",
+        "pickColor": "Επιλέξτε Χρώμα",
+        "submitting": "Υποβολή...",
+        "createParty": "Δημιουργία Παράταξης",
+        "updateParty": "Ενημέρωση Παράταξης",
+        "cancel": "Ακύρωση",
+        "failedToSaveParty": "Αποτυχία αποθήκευσης της παράταξης.",
+        "unexpectedError": "Απρόσμενο σφάλμα."
+    },
     "PersonForm": {
         "personNamePlaceholder": "Όνομα Μέλους",
         "personNameDescription": "Εισάγετε το πλήρες όνομα (Όνομα Επώνυμο). Για διπλά ονόματα ή επώνυμα χρησιμοποιήστε παύλα (π.χ. Μαρία-Ελένη, Παπαδοπούλου-Κωνσταντίνου).",

--- a/messages/en.json
+++ b/messages/en.json
@@ -437,6 +437,12 @@
         "detailsSummary": "What does signing up for notifications mean?",
         "sendTiming": "We send a heads-up before a meeting and a follow-up after it."
     },
+    "ImageCropDialog": {
+        "title": "Adjust image",
+        "save": "Save",
+        "cancel": "Cancel",
+        "processingFailed": "Could not process the image. Please try a different file."
+    },
     "PartyForm": {
         "partyNamePlaceholder": "Party Name",
         "partyNameDescription": "Enter the full party name.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -437,6 +437,27 @@
         "detailsSummary": "What does signing up for notifications mean?",
         "sendTiming": "We send a heads-up before a meeting and a follow-up after it."
     },
+    "PartyForm": {
+        "partyNamePlaceholder": "Party Name",
+        "partyNameDescription": "Enter the full party name.",
+        "partyNameEnPlaceholder": "Party Name (English)",
+        "partyNameEnDescription": "Enter the party name in English.",
+        "partyShortNamePlaceholder": "Party Short Name",
+        "partyShortNameDescription": "Enter the party's short name.",
+        "partyShortNameEnPlaceholder": "Party Short Name (English)",
+        "partyShortNameEnDescription": "Enter the party's short name in English.",
+        "logo": "Logo",
+        "logoDescription": "Upload a logo for the party.",
+        "colorHex": "Color",
+        "colorHexDescription": "Choose the party's color.",
+        "pickColor": "Pick a Color",
+        "submitting": "Submitting...",
+        "createParty": "Create Party",
+        "updateParty": "Update Party",
+        "cancel": "Cancel",
+        "failedToSaveParty": "Failed to save party.",
+        "unexpectedError": "Unexpected error."
+    },
     "PersonForm": {
         "personNamePlaceholder": "Member Name",
         "personNameDescription": "Enter the full name (Firstname Lastname). For double names or surnames, use a hyphen (e.g. Maria-Eleni, Papadopoulou-Konstantinou).",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -474,6 +474,27 @@
         "tabSegments": "Interventions",
         "tabSegmentsShort": "Interventions"
     },
+    "PartyForm": {
+        "partyNamePlaceholder": "Nom du groupe",
+        "partyNameDescription": "Saisissez le nom complet du groupe.",
+        "partyNameEnPlaceholder": "Nom du groupe (anglais)",
+        "partyNameEnDescription": "Saisissez le nom du groupe en anglais.",
+        "partyShortNamePlaceholder": "Nom court du groupe",
+        "partyShortNameDescription": "Saisissez le nom court du groupe.",
+        "partyShortNameEnPlaceholder": "Nom court du groupe (anglais)",
+        "partyShortNameEnDescription": "Saisissez le nom court du groupe en anglais.",
+        "logo": "Logo",
+        "logoDescription": "Téléversez un logo pour le groupe.",
+        "colorHex": "Couleur",
+        "colorHexDescription": "Choisissez la couleur du groupe.",
+        "pickColor": "Choisir une couleur",
+        "submitting": "Envoi...",
+        "createParty": "Créer le groupe",
+        "updateParty": "Mettre à jour le groupe",
+        "cancel": "Annuler",
+        "failedToSaveParty": "Échec de l'enregistrement du groupe.",
+        "unexpectedError": "Erreur inattendue."
+    },
     "PersonForm": {
         "personNamePlaceholder": "Nom du membre",
         "personNameDescription": "Saisissez le nom complet (Prénom Nom). Pour les prénoms ou noms composés, utilisez un trait d'union (p. ex. Maria-Eleni, Papadopoulou-Konstantinou).",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -474,6 +474,12 @@
         "tabSegments": "Interventions",
         "tabSegmentsShort": "Interventions"
     },
+    "ImageCropDialog": {
+        "title": "Ajuster l'image",
+        "save": "Enregistrer",
+        "cancel": "Annuler",
+        "processingFailed": "Impossible de traiter l'image. Veuillez essayer un autre fichier."
+    },
     "PartyForm": {
         "partyNamePlaceholder": "Nom du groupe",
         "partyNameDescription": "Saisissez le nom complet du groupe.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "react-colorful": "^5.6.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^19.2.6",
+        "react-easy-crop": "^6.0.2",
         "react-hook-form": "^7.53.0",
         "react-icons": "^5.5.0",
         "react-international-phone": "^4.4.0",
@@ -20265,6 +20266,12 @@
         "svg-arc-to-cubic-bezier": "^3.0.0"
       }
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -21883,6 +21890,19 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/react-easy-crop": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-6.0.2.tgz",
+      "integrity": "sha512-nY/YiNEuRjc851+/PsOR6Q7XoshmnXMl+oEOsxp3Ah0PrhECi5388jjRnHwsTFx3W0o2zPwvq85oljzUqZNpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
+      }
     },
     "node_modules/react-hook-form": {
       "version": "7.53.0",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "react-colorful": "^5.6.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^19.2.6",
+    "react-easy-crop": "^6.0.2",
     "react-hook-form": "^7.53.0",
     "react-icons": "^5.5.0",
     "react-international-phone": "^4.4.0",

--- a/src/app/api/cities/[cityId]/parties/[partyId]/route.ts
+++ b/src/app/api/cities/[cityId]/parties/[partyId]/route.ts
@@ -36,6 +36,7 @@ export async function PUT(
         const name_short_en = formData.get('name_short_en') as string
         const colorHex = formData.get('colorHex') as string
         const logo = formData.get('logo') as File | null
+        const removeLogo = formData.get('removeLogo') === 'true'
 
         let logoUrl: string | undefined = undefined
 
@@ -55,7 +56,7 @@ export async function PUT(
             name_short,
             name_short_en,
             colorHex,
-            ...(logoUrl && { logo: logoUrl }),
+            ...(logoUrl ? { logo: logoUrl } : removeLogo ? { logo: null } : {}),
         })
 
         revalidateTag(`city:${params.cityId}:parties`, 'max');

--- a/src/app/api/cities/[cityId]/people/[personId]/route.ts
+++ b/src/app/api/cities/[cityId]/people/[personId]/route.ts
@@ -49,6 +49,7 @@ export async function PUT(
     const name_short = formData.get('name_short') as string
     const name_short_en = formData.get('name_short_en') as string
     const image = formData.get('image') as File | null
+    const removeImage = formData.get('removeImage') === 'true'
     const profileUrl = formData.get('profileUrl') as string
     const rolesJson = formData.get('roles') as string
     console.log('Raw roles JSON:', rolesJson)
@@ -101,7 +102,7 @@ export async function PUT(
             name_en,
             name_short,
             name_short_en,
-            ...(imageUrl && { image: imageUrl }),
+            ...(imageUrl ? { image: imageUrl } : removeImage ? { image: null } : {}),
             profileUrl: profileUrl || null,
             roles
         })

--- a/src/app/api/cities/[cityId]/route.ts
+++ b/src/app/api/cities/[cityId]/route.ts
@@ -48,6 +48,7 @@ export async function PUT(request: Request, props: { params: Promise<{ cityId: s
         const messageIsActive = formData.get('messageIsActive') === 'true'
 
         // Upload logo if provided
+        const removeLogoImage = formData.get('removeLogoImage') === 'true'
         let logoImageUrl: string | undefined = undefined
         if (data.logoImage) {
             try {
@@ -66,7 +67,11 @@ export async function PUT(request: Request, props: { params: Promise<{ cityId: s
             ...(data.name_municipality !== undefined && { name_municipality: data.name_municipality }),
             ...(data.name_municipality_en !== undefined && { name_municipality_en: data.name_municipality_en }),
             ...(data.timezone !== undefined && { timezone: data.timezone }),
-            ...(logoImageUrl !== undefined && { logoImage: logoImageUrl }),
+            ...(logoImageUrl !== undefined
+                ? { logoImage: logoImageUrl }
+                : removeLogoImage
+                    ? { logoImage: null }
+                    : {}),
             ...(data.authorityType !== undefined && { authorityType: data.authorityType }),
             ...(data.supportsNotifications !== undefined && { supportsNotifications: data.supportsNotifications }),
             ...(data.consultationsEnabled !== undefined && { consultationsEnabled: data.consultationsEnabled }),

--- a/src/components/cities/CityForm.tsx
+++ b/src/components/cities/CityForm.tsx
@@ -18,7 +18,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { SheetClose } from "@/components/ui/sheet"
 import { City, AdministrativeBodyType, CityMessage, NotificationBehavior } from '@prisma/client'
-import { Loader2, ChevronDown, ChevronUp } from "lucide-react"
+import { Loader2, ChevronDown, ChevronUp, Trash2 } from "lucide-react"
 import Image from 'next/image'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
@@ -31,6 +31,7 @@ import InputWithDerivatives from '@/components/InputWithDerivatives'
 import { toPhoneticLatin as toGreeklish } from 'greek-utils'
 import AdministrativeBodiesList from './AdministrativeBodiesList'
 import CityMessageForm, { MessageFormState } from './CityMessageForm'
+import { ImageCropDialog } from '@/components/ui/ImageCropDialog'
 
 // Use shared schema from lib/schemas/city.ts
 const formSchema = cityFormSchema
@@ -45,6 +46,8 @@ export default function CityForm({ city, cityMessage, onSuccess }: CityFormProps
     const router = useRouter()
     const { data: session } = useSession()
     const [logoImage, setLogoImage] = useState<File | null>(null)
+    const [removeLogoImage, setRemoveLogoImage] = useState(false)
+    const [cropFile, setCropFile] = useState<File | null>(null)
     const [isSubmitting, setIsSubmitting] = useState(false)
     const [formError, setFormError] = useState<string | null>(null)
     const [logoPreview, setLogoPreview] = useState<string | null>(city?.logoImage || null)
@@ -150,6 +153,9 @@ export default function CityForm({ city, cityMessage, onSuccess }: CityFormProps
         if (logoImage) {
             formData.append('logoImage', logoImage)
         }
+        if (removeLogoImage && !logoImage) {
+            formData.append('removeLogoImage', 'true')
+        }
 
         // Add message data if superadmin and message data exists
         if (isSuperAdmin && messageData) {
@@ -188,18 +194,23 @@ export default function CityForm({ city, cityMessage, onSuccess }: CityFormProps
         }
     }
 
-    const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0] || null
+    const handleCroppedLogo = (file: File) => {
         setLogoImage(file)
-        if (file) {
-            const reader = new FileReader()
-            reader.onloadend = () => {
-                setLogoPreview(reader.result as string)
-            }
-            reader.readAsDataURL(file)
-        } else {
-            setLogoPreview(city?.logoImage || null)
+        form.setValue('logoImage', file)
+        setRemoveLogoImage(false)
+        const reader = new FileReader()
+        reader.onloadend = () => {
+            setLogoPreview(reader.result as string)
         }
+        reader.readAsDataURL(file)
+        setCropFile(null)
+    }
+
+    const handleRemoveLogo = () => {
+        setLogoImage(null)
+        form.setValue('logoImage', undefined)
+        setLogoPreview(null)
+        setRemoveLogoImage(true)
     }
 
     const refreshAdminBodies = () => {
@@ -287,17 +298,21 @@ export default function CityForm({ city, cityMessage, onSuccess }: CityFormProps
                             <FormControl>
                                 <Input
                                     type="file"
+                                    accept="image/*"
                                     onChange={(e) => {
-                                        handleLogoChange(e)
-                                        field.onChange(e.target.files?.[0] || null)
+                                        const file = e.target.files?.[0]
+                                        if (file) setCropFile(file)
+                                        e.target.value = ''
                                     }}
                                 />
                             </FormControl>
-                            <FormDescription>
-                                {t('logoImageDescription')}
-                            </FormDescription>
+                            {!logoPreview && (
+                                <FormDescription>
+                                    {t('logoImageDescription')}
+                                </FormDescription>
+                            )}
                             {logoPreview && (
-                                <div className="mt-2">
+                                <div className="mt-2 flex items-end gap-2">
                                     <Image
                                         src={logoPreview}
                                         alt={t('logoPreview')}
@@ -305,11 +320,28 @@ export default function CityForm({ city, cityMessage, onSuccess }: CityFormProps
                                         height={100}
                                         className="object-contain"
                                     />
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="icon"
+                                        aria-label="Remove logo"
+                                        onClick={handleRemoveLogo}
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </Button>
                                 </div>
                             )}
                             <FormMessage />
                         </FormItem>
                     )}
+                />
+
+                <ImageCropDialog
+                    file={cropFile}
+                    cropShape="rect"
+                    title={t('logoImage')}
+                    onCancel={() => setCropFile(null)}
+                    onConfirm={handleCroppedLogo}
                 />
 
                 {/* City Message Section - SuperAdmin Only */}

--- a/src/components/parties/PartyForm.tsx
+++ b/src/components/parties/PartyForm.tsx
@@ -17,8 +17,9 @@ import {
 } from "../../components/ui/form"
 import { Input } from "../../components/ui/input"
 import { SheetClose } from "../../components/ui/sheet"
+import { ImageCropDialog } from "@/components/ui/ImageCropDialog"
 import { Party } from '@prisma/client'
-import { Loader2 } from "lucide-react"
+import { Loader2, Trash2 } from "lucide-react"
 import { useTranslations } from 'next-intl'
 import InputWithDerivatives from '../../components/InputWithDerivatives'
 import React from "react";
@@ -53,6 +54,8 @@ interface PartyFormProps {
 export default function PartyForm({ party, onSuccess, cityId }: PartyFormProps) {
     const router = useRouter()
     const [logo, setLogo] = useState<File | null>(null)
+    const [removeLogo, setRemoveLogo] = useState(false)
+    const [cropFile, setCropFile] = useState<File | null>(null)
     const [isSubmitting, setIsSubmitting] = useState(false)
     const [formError, setFormError] = useState<string | null>(null)
     const [logoPreview, setLogoPreview] = useState<string | null>(party?.logo || null)
@@ -87,6 +90,10 @@ export default function PartyForm({ party, onSuccess, cityId }: PartyFormProps) 
         // Append logo if it exists
         if (logo) {
             formData.append('logo', logo)
+        }
+        // Signal removal of an existing logo
+        if (removeLogo && !logo) {
+            formData.append('removeLogo', 'true')
         }
 
         try {
@@ -149,20 +156,51 @@ export default function PartyForm({ party, onSuccess, cityId }: PartyFormProps) 
                         <FormItem>
                             <FormLabel>{t('logo')}</FormLabel>
                             <FormControl>
-                                <Input type="file" onChange={(e) => {
-                                    if (e.target.files && e.target.files[0]) {
-                                        setLogo(e.target.files[0])
-                                        setLogoPreview(URL.createObjectURL(e.target.files[0]))
-                                    }
+                                <Input type="file" accept="image/*" onChange={(e) => {
+                                    const file = e.target.files?.[0]
+                                    if (file) setCropFile(file)
+                                    e.target.value = ''
                                 }} />
                             </FormControl>
-                            {logoPreview && <Image src={logoPreview} alt="Logo preview" width={200} height={200} className="mt-2 object-contain" unoptimized />}
-                            <FormDescription>
-                                {t('logoDescription')}
-                            </FormDescription>
+                            {logoPreview && (
+                                <div className="mt-2 flex items-end gap-2">
+                                    <Image src={logoPreview} alt="Logo preview" width={200} height={200} className="object-contain" unoptimized />
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="icon"
+                                        aria-label="Remove logo"
+                                        onClick={() => {
+                                            setLogo(null)
+                                            setLogoPreview(null)
+                                            setRemoveLogo(true)
+                                        }}
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                </div>
+                            )}
+                            {!logoPreview && (
+                                <FormDescription>
+                                    {t('logoDescription')}
+                                </FormDescription>
+                            )}
                             <FormMessage />
                         </FormItem>
                     )}
+                />
+
+                <ImageCropDialog
+                    file={cropFile}
+                    cropShape="rect"
+                    title={t('logo')}
+                    onCancel={() => setCropFile(null)}
+                    onConfirm={(processed) => {
+                        setLogo(processed)
+                        setLogoPreview(URL.createObjectURL(processed))
+                        setRemoveLogo(false)
+                        setCropFile(null)
+                    }}
                 />
 
                 <FormField
@@ -175,7 +213,7 @@ export default function PartyForm({ party, onSuccess, cityId }: PartyFormProps) 
                                 <>
                                     <div className="flex justify-center">
                                         <details className="w-full">
-                                            <summary className="cursor-pointer text-center py-2 bg-gray-200 rounded-md">Pick a Color</summary>
+                                            <summary className="cursor-pointer text-center py-2 bg-gray-200 rounded-md">{t('pickColor')}</summary>
                                             <div className="flex justify-center py-4">
                                                 <HexColorPicker color={field.value} onChange={field.onChange} />
                                             </div>

--- a/src/components/persons/PersonForm.tsx
+++ b/src/components/persons/PersonForm.tsx
@@ -19,13 +19,14 @@ import { Input } from "../../components/ui/input"
 import { SheetClose } from "../../components/ui/sheet"
 import { Party, Person, Role, AdministrativeBody } from '@prisma/client'
 import { RoleWithRelations } from '@/lib/db/types'
-import { Loader2, Check } from "lucide-react"
+import { Loader2, Check, Trash2 } from "lucide-react"
 import { useTranslations } from 'next-intl'
 import React, { useRef } from "react"
 import InputWithDerivatives from "../../components/InputWithDerivatives"
 // @ts-ignore
 import { toPhoneticLatin as toGreeklish } from 'greek-utils'
 import { useToast } from "@/hooks/use-toast"
+import { ImageCropDialog } from "@/components/ui/ImageCropDialog"
 import RolesList from './RolesList'
 
 const formSchema = z.object({
@@ -56,6 +57,8 @@ interface PersonFormProps {
 export default function PersonForm({ person, parties, administrativeBodies, onSuccess, cityId }: PersonFormProps) {
     const router = useRouter()
     const [image, setImage] = useState<File | null>(null)
+    const [removeImage, setRemoveImage] = useState(false)
+    const [cropFile, setCropFile] = useState<File | null>(null)
     const [isSubmitting, setIsSubmitting] = useState(false)
     const [isSuccess, setIsSuccess] = useState(false)
     const [imagePreview, setImagePreview] = useState<string | null>(person?.image || null)
@@ -125,6 +128,10 @@ export default function PersonForm({ person, parties, administrativeBodies, onSu
             console.log('Appending image:', image.name, image.size)
             formData.append('image', image)
         }
+        // Signal removal of an existing image
+        if (removeImage && !image) {
+            formData.append('removeImage', 'true')
+        }
 
         console.log('FormData created, sending request to:', url)
 
@@ -161,6 +168,7 @@ export default function PersonForm({ person, parties, administrativeBodies, onSu
                     })
                     setImage(null)
                     setImagePreview(null)
+                    setRemoveImage(false)
                     // Do not reset roles ever, for easier data entry
                     // setRoles([])
                     nameInputRef.current?.focus()
@@ -245,20 +253,51 @@ export default function PersonForm({ person, parties, administrativeBodies, onSu
                         <FormItem>
                             <FormLabel>{t('image')}</FormLabel>
                             <FormControl>
-                                <Input type="file" onChange={(e) => {
-                                    if (e.target.files && e.target.files[0]) {
-                                        setImage(e.target.files[0])
-                                        setImagePreview(URL.createObjectURL(e.target.files[0]))
-                                    }
+                                <Input type="file" accept="image/*" onChange={(e) => {
+                                    const file = e.target.files?.[0]
+                                    if (file) setCropFile(file)
+                                    e.target.value = ''
                                 }} />
                             </FormControl>
-                            {imagePreview && <Image src={imagePreview} alt="Image preview" width={200} height={200} className="mt-2 object-contain" unoptimized />}
-                            <FormDescription>
-                                {t('imageDescription')}
-                            </FormDescription>
+                            {imagePreview && (
+                                <div className="mt-2 flex items-end gap-2">
+                                    <Image src={imagePreview} alt="Image preview" width={200} height={200} className="object-contain rounded-full" unoptimized />
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="icon"
+                                        aria-label="Remove image"
+                                        onClick={() => {
+                                            setImage(null)
+                                            setImagePreview(null)
+                                            setRemoveImage(true)
+                                        }}
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                </div>
+                            )}
+                            {!imagePreview && (
+                                <FormDescription>
+                                    {t('imageDescription')}
+                                </FormDescription>
+                            )}
                             <FormMessage />
                         </FormItem>
                     )}
+                />
+
+                <ImageCropDialog
+                    file={cropFile}
+                    cropShape="round"
+                    title={t('image')}
+                    onCancel={() => setCropFile(null)}
+                    onConfirm={(processed) => {
+                        setImage(processed)
+                        setImagePreview(URL.createObjectURL(processed))
+                        setRemoveImage(false)
+                        setCropFile(null)
+                    }}
                 />
 
                 <FormField

--- a/src/components/ui/ImageCropDialog.tsx
+++ b/src/components/ui/ImageCropDialog.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import Cropper, { Area } from "react-easy-crop"
 import { ZoomIn, ZoomOut, Loader2 } from "lucide-react"
+import { useTranslations } from "next-intl"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "./dialog"
 import { Button } from "./button"
 import { renderCroppedImageFile } from "@/lib/utils/normalizeImage"
@@ -18,9 +19,11 @@ export interface ImageCropDialogProps {
     cropShape?: "rect" | "round"
     /** Output square dimension in pixels. Defaults to 512. */
     outputSize?: number
-    /** Dialog title. */
+    /** Dialog title. Falls back to a translated default. */
     title?: string
+    /** Confirm button label. Falls back to a translated default. */
     confirmLabel?: string
+    /** Cancel button label. Falls back to a translated default. */
     cancelLabel?: string
     onCancel: () => void
     onConfirm: (file: File) => void
@@ -30,17 +33,19 @@ export function ImageCropDialog({
     file,
     cropShape = "rect",
     outputSize = 512,
-    title = "Adjust image",
-    confirmLabel = "Save",
-    cancelLabel = "Cancel",
+    title,
+    confirmLabel,
+    cancelLabel,
     onCancel,
     onConfirm,
 }: ImageCropDialogProps) {
+    const t = useTranslations("ImageCropDialog")
     const [imageUrl, setImageUrl] = React.useState<string | null>(null)
     const [crop, setCrop] = React.useState({ x: 0, y: 0 })
     const [zoom, setZoom] = React.useState(1)
     const [croppedAreaPixels, setCroppedAreaPixels] = React.useState<Area | null>(null)
     const [isProcessing, setIsProcessing] = React.useState(false)
+    const [error, setError] = React.useState<string | null>(null)
 
     // Create (and clean up) an object URL for the selected file. Reset the
     // crop/zoom state each time a new file comes in.
@@ -54,6 +59,7 @@ export function ImageCropDialog({
         setCrop({ x: 0, y: 0 })
         setZoom(1)
         setCroppedAreaPixels(null)
+        setError(null)
         return () => URL.revokeObjectURL(url)
     }, [file])
 
@@ -68,19 +74,25 @@ export function ImageCropDialog({
     const handleConfirm = React.useCallback(async () => {
         if (!file || !croppedAreaPixels) return
         setIsProcessing(true)
+        setError(null)
         try {
             const result = await renderCroppedImageFile(file, croppedAreaPixels, { size: outputSize })
             onConfirm(result)
+        } catch (err) {
+            // Keep the dialog open and surface the failure instead of silently
+            // uploading an unprocessed file.
+            console.error("Image processing failed:", err)
+            setError(t("processingFailed"))
         } finally {
             setIsProcessing(false)
         }
-    }, [file, croppedAreaPixels, outputSize, onConfirm])
+    }, [file, croppedAreaPixels, outputSize, onConfirm, t])
 
     return (
         <Dialog open={!!file} onOpenChange={(open) => { if (!open) onCancel() }}>
             <DialogContent className="sm:max-w-md">
                 <DialogHeader>
-                    <DialogTitle>{title}</DialogTitle>
+                    <DialogTitle>{title ?? t("title")}</DialogTitle>
                 </DialogHeader>
 
                 <div className="relative w-full h-72 rounded-md overflow-hidden bg-white">
@@ -126,13 +138,17 @@ export function ImageCropDialog({
                     </Button>
                 </div>
 
+                {error && (
+                    <p className="text-sm text-destructive" role="alert">{error}</p>
+                )}
+
                 <DialogFooter>
                     <Button type="button" variant="outline" onClick={onCancel} disabled={isProcessing}>
-                        {cancelLabel}
+                        {cancelLabel ?? t("cancel")}
                     </Button>
                     <Button type="button" onClick={handleConfirm} disabled={!croppedAreaPixels || isProcessing}>
                         {isProcessing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                        {confirmLabel}
+                        {confirmLabel ?? t("save")}
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/src/components/ui/ImageCropDialog.tsx
+++ b/src/components/ui/ImageCropDialog.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import * as React from "react"
+import Cropper, { Area } from "react-easy-crop"
+import { ZoomIn, ZoomOut, Loader2 } from "lucide-react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "./dialog"
+import { Button } from "./button"
+import { renderCroppedImageFile } from "@/lib/utils/normalizeImage"
+
+const MIN_ZOOM = 0.4
+const MAX_ZOOM = 4
+const ZOOM_STEP = 0.2
+
+export interface ImageCropDialogProps {
+    /** The image to crop. When non-null the dialog is open. */
+    file: File | null
+    /** Frame shape: square for logos, round for avatars/photos. Defaults to 'rect'. */
+    cropShape?: "rect" | "round"
+    /** Output square dimension in pixels. Defaults to 512. */
+    outputSize?: number
+    /** Dialog title. */
+    title?: string
+    confirmLabel?: string
+    cancelLabel?: string
+    onCancel: () => void
+    onConfirm: (file: File) => void
+}
+
+export function ImageCropDialog({
+    file,
+    cropShape = "rect",
+    outputSize = 512,
+    title = "Adjust image",
+    confirmLabel = "Save",
+    cancelLabel = "Cancel",
+    onCancel,
+    onConfirm,
+}: ImageCropDialogProps) {
+    const [imageUrl, setImageUrl] = React.useState<string | null>(null)
+    const [crop, setCrop] = React.useState({ x: 0, y: 0 })
+    const [zoom, setZoom] = React.useState(1)
+    const [croppedAreaPixels, setCroppedAreaPixels] = React.useState<Area | null>(null)
+    const [isProcessing, setIsProcessing] = React.useState(false)
+
+    // Create (and clean up) an object URL for the selected file. Reset the
+    // crop/zoom state each time a new file comes in.
+    React.useEffect(() => {
+        if (!file) {
+            setImageUrl(null)
+            return
+        }
+        const url = URL.createObjectURL(file)
+        setImageUrl(url)
+        setCrop({ x: 0, y: 0 })
+        setZoom(1)
+        setCroppedAreaPixels(null)
+        return () => URL.revokeObjectURL(url)
+    }, [file])
+
+    const onCropComplete = React.useCallback((_: Area, areaPixels: Area) => {
+        setCroppedAreaPixels(areaPixels)
+    }, [])
+
+    const adjustZoom = React.useCallback((delta: number) => {
+        setZoom((z) => Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, Number((z + delta).toFixed(2)))))
+    }, [])
+
+    const handleConfirm = React.useCallback(async () => {
+        if (!file || !croppedAreaPixels) return
+        setIsProcessing(true)
+        try {
+            const result = await renderCroppedImageFile(file, croppedAreaPixels, { size: outputSize })
+            onConfirm(result)
+        } finally {
+            setIsProcessing(false)
+        }
+    }, [file, croppedAreaPixels, outputSize, onConfirm])
+
+    return (
+        <Dialog open={!!file} onOpenChange={(open) => { if (!open) onCancel() }}>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>{title}</DialogTitle>
+                </DialogHeader>
+
+                <div className="relative w-full h-72 rounded-md overflow-hidden bg-white">
+                    {imageUrl && (
+                        <Cropper
+                            image={imageUrl}
+                            crop={crop}
+                            zoom={zoom}
+                            aspect={1}
+                            cropShape={cropShape}
+                            showGrid={cropShape === "rect"}
+                            minZoom={MIN_ZOOM}
+                            maxZoom={MAX_ZOOM}
+                            zoomSpeed={0.2}
+                            restrictPosition={false}
+                            objectFit="contain"
+                            onCropChange={setCrop}
+                            onZoomChange={setZoom}
+                            onCropComplete={onCropComplete}
+                            style={{ containerStyle: { background: "#ffffff" } }}
+                        />
+                    )}
+                </div>
+
+                <div className="flex items-center justify-center gap-4 pt-2">
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={() => adjustZoom(-ZOOM_STEP)}
+                        aria-label="Zoom out"
+                    >
+                        <ZoomOut className="h-4 w-4" />
+                    </Button>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={() => adjustZoom(ZOOM_STEP)}
+                        aria-label="Zoom in"
+                    >
+                        <ZoomIn className="h-4 w-4" />
+                    </Button>
+                </div>
+
+                <DialogFooter>
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isProcessing}>
+                        {cancelLabel}
+                    </Button>
+                    <Button type="button" onClick={handleConfirm} disabled={!croppedAreaPixels || isProcessing}>
+                        {isProcessing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                        {confirmLabel}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/lib/db/people.ts
+++ b/src/lib/db/people.ts
@@ -73,7 +73,7 @@ export async function editPerson(id: string, data: {
     name_en: string;
     name_short: string;
     name_short_en: string;
-    image?: string;
+    image?: string | null;
     profileUrl: string | null;
     roles: Role[];
 }): Promise<Person> {
@@ -93,7 +93,7 @@ export async function editPerson(id: string, data: {
                     name_en: data.name_en,
                     name_short: data.name_short,
                     name_short_en: data.name_short_en,
-                    ...(data.image && { image: data.image }),
+                    ...(data.image !== undefined && { image: data.image }),
                     profileUrl: data.profileUrl,
                     roles: {
                         create: data.roles.map(role => ({

--- a/src/lib/utils/normalizeImage.ts
+++ b/src/lib/utils/normalizeImage.ts
@@ -38,7 +38,7 @@ export async function renderCroppedImageFile(
 
     const ctx = canvas.getContext('2d')
     if (!ctx) {
-        return file
+        throw new Error('Could not obtain 2D canvas context')
     }
 
     // Fill the background first so transparent areas and padding become solid.
@@ -62,7 +62,7 @@ export async function renderCroppedImageFile(
 
     const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'))
     if (!blob) {
-        return file
+        throw new Error('Canvas toBlob returned null')
     }
 
     const baseName = file.name.replace(/\.[^/.]+$/, '') || 'image'

--- a/src/lib/utils/normalizeImage.ts
+++ b/src/lib/utils/normalizeImage.ts
@@ -1,0 +1,86 @@
+export interface CroppedAreaPixels {
+    x: number
+    y: number
+    width: number
+    height: number
+}
+
+export interface RenderCropOptions {
+    /** Output square dimension in pixels. Defaults to 512. */
+    size?: number
+    /** Background/padding color (any CSS color). Defaults to white. */
+    background?: string
+}
+
+/**
+ * Renders a cropped region of an image onto a square canvas with a solid
+ * (white by default) background and returns it as a PNG File.
+ *
+ * The crop region (in the source image's natural pixels, as produced by
+ * react-easy-crop) is mapped to fill the output square. When the user has
+ * zoomed out so the crop window extends beyond the image bounds, the
+ * uncovered area keeps the background color — i.e. the image is padded with
+ * white instead of being cropped. Any transparency in the source is flattened
+ * onto the background as well.
+ */
+export async function renderCroppedImageFile(
+    file: File,
+    croppedAreaPixels: CroppedAreaPixels,
+    options: RenderCropOptions = {}
+): Promise<File> {
+    const { size = 512, background = '#ffffff' } = options
+
+    const image = await loadImage(file)
+
+    const canvas = document.createElement('canvas')
+    canvas.width = size
+    canvas.height = size
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+        return file
+    }
+
+    // Fill the background first so transparent areas and padding become solid.
+    ctx.fillStyle = background
+    ctx.fillRect(0, 0, size, size)
+
+    // Map the crop window to the full canvas. Rather than using drawImage's
+    // source-rectangle cropping (which mishandles regions outside the image),
+    // scale the whole image and translate it so the crop window aligns to the
+    // canvas. Anything outside the image simply isn't drawn and stays white.
+    const scale = size / croppedAreaPixels.width
+    ctx.imageSmoothingEnabled = true
+    ctx.imageSmoothingQuality = 'high'
+    ctx.drawImage(
+        image,
+        -croppedAreaPixels.x * scale,
+        -croppedAreaPixels.y * scale,
+        image.width * scale,
+        image.height * scale
+    )
+
+    const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'))
+    if (!blob) {
+        return file
+    }
+
+    const baseName = file.name.replace(/\.[^/.]+$/, '') || 'image'
+    return new File([blob], `${baseName}.png`, { type: 'image/png' })
+}
+
+export function loadImage(file: File): Promise<HTMLImageElement> {
+    return new Promise((resolve, reject) => {
+        const url = URL.createObjectURL(file)
+        const image = new window.Image()
+        image.onload = () => {
+            URL.revokeObjectURL(url)
+            resolve(image)
+        }
+        image.onerror = () => {
+            URL.revokeObjectURL(url)
+            reject(new Error('Could not load image'))
+        }
+        image.src = url
+    })
+}


### PR DESCRIPTION
## Summary

Fixes #326 — party/municipality logos and counselor photos were cropped or distorted by fixed-size containers. Instead of changing only the display, this processes images **at upload time** in the admin forms so the stored image already fits cleanly.

### What changed

- **Interactive crop/zoom dialog** (`ImageCropDialog`, using `react-easy-crop`): drag to position, zoom in/out. Square frame for party/city logos, round frame for counselor photos. Confirming renders the framed region onto a **512×512 white-background PNG** via canvas — zooming out pads the image with white instead of cropping it, so full landscape logos stay intact.
- Wired the dialog into the **party, person, and city** forms in place of the raw file input.
- **Remove-image action** (trash button) on each form; the edit routes clear the stored field (`editPerson` now accepts a `null` image).
- **Hide the upload-hint description** once an image is selected.
- **i18n:** the `PartyForm` namespace was missing entirely (the form rendered raw `PartyForm.*` keys) — added it to `el`/`en`/`fr` and localized the previously hardcoded "Pick a Color" label.

### Verification

- `npm run build` — passes
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- Image normalization math verified to produce a 512×512 white-padded square (landscape logo preserved, transparency flattened to white)

> Note: `src/i18n.ts` loads `messages/<locale>.json` via cached `import()`, so the new translations require a dev-server restart to appear locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes image display issues by processing uploads at save time: a new `ImageCropDialog` lets users interactively crop and zoom images before they are rendered onto a 512×512 white-padded PNG via canvas, and a trash button on each form allows removing an existing image. The `PartyForm` i18n namespace was also added, fixing raw translation keys that were visible to users.

- **New `ImageCropDialog` + `normalizeImage` utility**: the dialog handles object-URL lifecycle correctly (creates/revokes in `useEffect`), surfaces canvas errors as a translated in-dialog message rather than silently uploading the raw file, and uses `t("save")`/`t("cancel")` so button labels are locale-aware.
- **Remove-image flow** wired through all three API routes: each route reads a `remove*` flag from the form data and passes `null` to the DB layer when no new upload is present; `editParty` and `editCity` already accept `Partial<Party/City>` so null is valid without additional type changes; `editPerson` was explicitly updated to accept `string | null`.
- **i18n**: `PartyForm`, `ImageCropDialog` namespaces added to all three locales; "Pick a Color" label is now localised.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three image-management flows (upload, crop, remove) are consistently implemented across party, person, and city forms and their API routes.

The canvas error handling throws instead of silently falling back, object URLs are properly created and revoked, the remove-image flag is correctly gated so it never fires alongside a new upload, and Prisma null propagation is type-safe through all three routes.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/ui/ImageCropDialog.tsx | New crop/zoom dialog component using react-easy-crop; properly creates/revokes object URLs in useEffect, surfaces canvas errors via i18n'd error state, and uses t("save")/t("cancel") for button labels. |
| src/lib/utils/normalizeImage.ts | New image normalisation utility; correctly throws on null canvas context or null toBlob result, properly revokes object URLs in loadImage on both load and error paths. |
| src/lib/db/people.ts | Changed image field type to string | null and updated spread guard from truthy check to !== undefined, correctly allowing null to clear the stored image via Prisma. |
| src/app/api/cities/[cityId]/parties/[partyId]/route.ts | Reads removeLogo flag from form data and uses it in a ternary to set logo: null when no new upload is present; editParty accepts Partial<Party> so null is valid. |
| src/app/api/cities/[cityId]/people/[personId]/route.ts | Same removeImage flag pattern as the party route; consistent with the editPerson signature update in people.ts. |
| src/app/api/cities/[cityId]/route.ts | Reads removeLogoImage flag and applies the same upload-or-null-or-no-op ternary pattern; consistent with party/person routes. |
| src/components/parties/PartyForm.tsx | Wires ImageCropDialog, adds removeLogo state, fixes previously missing PartyForm i18n namespace, and localises the "Pick a Color" label. |
| src/components/persons/PersonForm.tsx | Wires ImageCropDialog for round avatar crop, adds removeImage state, explicitly resets removeImage on success reset block. |
| src/components/cities/CityForm.tsx | Wires ImageCropDialog, uses FileReader for preview (consistent with existing pattern), correctly gates removeLogoImage submission with !logoImage check. |
| messages/en.json | Adds ImageCropDialog and PartyForm namespaces; save/cancel keys present and consumed by t("save")/t("cancel") fallbacks in the component. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/parties/PartyForm.tsx`, line 441-447 ([link](https://github.com/schemalabz/opencouncil/blob/23afe34f4dc4a3c067fb2b55d082da56557a8855/src/components/parties/PartyForm.tsx#L441-L447)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Object URL created for preview is never revoked**

   `URL.createObjectURL(processed)` allocates a URL tied to the document lifetime. If the user re-selects and crops a second image, the first preview URL is overwritten in state but never passed to `URL.revokeObjectURL`, leaking the blob reference for the page lifetime. The same pattern appears in `PersonForm.tsx` at its `onConfirm` callback. Consider revoking the previous preview URL before replacing it, or switching to a `FileReader` data URL as `CityForm` already does.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/parties/PartyForm.tsx
   Line: 441-447

   Comment:
   **Object URL created for preview is never revoked**

   `URL.createObjectURL(processed)` allocates a URL tied to the document lifetime. If the user re-selects and crops a second image, the first preview URL is overwritten in state but never passed to `URL.revokeObjectURL`, leaking the blob reference for the page lifetime. The same pattern appears in `PersonForm.tsx` at its `onConfirm` callback. Consider revoking the previous preview URL before replacing it, or switching to a `FileReader` data URL as `CityForm` already does.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2Fparties%2FPartyForm.tsx%0ALine%3A%20441-447%0A%0AComment%3A%0A**Object%20URL%20created%20for%20preview%20is%20never%20revoked**%0A%0A%60URL.createObjectURL%28processed%29%60%20allocates%20a%20URL%20tied%20to%20the%20document%20lifetime.%20If%20the%20user%20re-selects%20and%20crops%20a%20second%20image%2C%20the%20first%20preview%20URL%20is%20overwritten%20in%20state%20but%20never%20passed%20to%20%60URL.revokeObjectURL%60%2C%20leaking%20the%20blob%20reference%20for%20the%20page%20lifetime.%20The%20same%20pattern%20appears%20in%20%60PersonForm.tsx%60%20at%20its%20%60onConfirm%60%20callback.%20Consider%20revoking%20the%20previous%20preview%20URL%20before%20replacing%20it%2C%20or%20switching%20to%20a%20%60FileReader%60%20data%20URL%20as%20%60CityForm%60%20already%20does.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=schemalabz%2Fopencouncil&pr=504&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(uploads): surface image-processing f..."](https://github.com/schemalabz/opencouncil/commit/7ff980df54bed6c4f146637ec99d6a48302b90ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39814019)</sub>

<!-- /greptile_comment -->