### PR TITLE
fix(avatar): show person icon for un-linked speakers instead of "UN"

### DIFF
--- a/src/components/ImageOrInitials.tsx
+++ b/src/components/ImageOrInitials.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { User } from "lucide-react";
 import { getInitials } from "@/lib/formatters/name";
 
 
@@ -40,9 +41,13 @@ export const ImageOrInitials: React.FC<ImageOrInitialsProps> = ({ imageUrl, widt
                     className={`object-cover ${square ? 'rounded' : 'rounded-full'}`}
                     style={{ objectPosition: 'center center' }}
                 />
-            ) : (
+            ) : displayInitials ? (
                 <div className="w-full h-full flex items-center justify-center text-[40cqmin]">
-                    {name && displayInitials}
+                    {displayInitials}
+                </div>
+            ) : (
+                <div className="w-full h-full flex items-center justify-center">
+                    <User className="w-[55cqmin] h-[55cqmin]" aria-hidden />
                 </div>
             )}
         </div>

--- a/src/components/persons/PersonBadge.tsx
+++ b/src/components/persons/PersonBadge.tsx
@@ -76,7 +76,7 @@ function PersonDisplay({ person, speakerTag, segmentCount, short = false, prefer
                 />
                 <ImageOrInitials
                     imageUrl={person?.image || null}
-                    name={person?.name || "Unknown"}
+                    name={person?.name}
                     width={imageSize}
                     height={imageSize}
                     color={partyColor}

--- a/src/components/persons/PersonBadge.tsx
+++ b/src/components/persons/PersonBadge.tsx
@@ -78,7 +78,7 @@ function PersonDisplay({ person, speakerTag, segmentCount, short = false, prefer
                 />
                 <ImageOrInitials
                     imageUrl={person?.image || null}
-                    name={person?.name || "Unknown"}
+                    name={person?.name}
                     width={imageSize}
                     height={imageSize}
                     color={partyColor}


### PR DESCRIPTION
## Problem

When a speaker in a transcript has no linked `Person` in the DB, the avatar showed the initials **`UN`**.

The cause: `PersonBadge` passed the literal string `"Unknown"` to the avatar as the name, and `getInitials("Unknown")` returns `"UN"`. The text label next to the avatar already falls back to the speaker-tag label, but the avatar didn't.

## Fix

- **`PersonBadge.tsx`** — pass `person?.name` (possibly `undefined`) to the avatar instead of `person?.name || "Unknown"`, so an un-linked speaker yields no name → no initials.
- **`ImageOrInitials.tsx`** — when there are no usable initials, render a neutral lucide `User` icon instead of letters (or an empty circle).

I deliberately did **not** derive initials from the speaker-tag label, since the un-linked labels are overwhelmingly machine-generated placeholders (`New speaker segment`, `SPEAKER_1`, `Άγνωστος Ομιλητής 2`, …) that produce meaningless initials (`NS`, `SP`, `Ά2`). A neutral icon is the honest signal that the speaker isn't identified yet.

## Verification

- `PersonBadge` component tests pass (5/5)
- `npx tsc --noEmit` clean on both changed files

To see it live: `/el/xylokastro/nov18_2025` has an un-linked "Άγνωστος Ομιλητής" with 161 segments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the avatar display for unlinked speakers in transcripts: instead of showing misleading "UN" initials derived from the hardcoded fallback string `"Unknown"`, an unlinked speaker now shows a neutral lucide `User` icon.

- **`PersonBadge.tsx`**: Removes the `|| "Unknown"` fallback so that `person?.name` can be `undefined`, propagating the absence of a name to `ImageOrInitials`.
- **`ImageOrInitials.tsx`**: Splits the non-image branch into two: render initials when `displayInitials` is truthy, otherwise render the `User` icon — cleanly handling both no-name and empty-initials cases.

<h3>Confidence Score: 5/5</h3>

- This is a safe, narrow UI fix touching only two component files with no data-layer or side-effect changes.
- The change is minimal and the branching logic in `ImageOrInitials` is straightforward: `displayInitials` is derived from `name` and is falsy whenever `name` is absent or `getInitials` returns an empty string, so the icon fallback triggers correctly. Existing tests pass and TypeScript is clean.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/ImageOrInitials.tsx | Added a `User` lucide icon as a fallback when no initials are derivable (name is absent or yields empty initials). Logic is correct: `displayInitials` is falsy for both undefined names and empty strings, branching cleanly into the icon case. |
| src/components/persons/PersonBadge.tsx | Removed the `|| "Unknown"` fallback in the `name` prop passed to `ImageOrInitials`, so unlinked speakers now propagate `undefined` and trigger the new icon branch instead of the misleading "UN" initials. |

<sub>Reviews (2): Last reviewed commit: ["fix(avatar): show person icon for un-lin..."](https://github.com/schemalabz/opencouncil/commit/3da056c05afacec191bfe33c1b9946050f4f1c3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40056050)</sub>

<!-- /greptile_comment -->