### PR TITLE
Auto-match council livestreams and trigger transcription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,9 +73,17 @@ DO_SPACES_BUCKET=your_do_spaces_bucket
 CDN_URL=https://data.opencouncil.gr
 
 # ---------------------------------
+# YouTube Data API
+# ---------------------------------
+# Optional. Used by the poll-livestreams cron to find council-meeting livestreams
+# on a body's YouTube channel. Create a key in Google Cloud Console (enable
+# "YouTube Data API v3"). When unset, the cron no-ops.
+YOUTUBE_API_KEY=
+
+# ---------------------------------
 # Cron Jobs
 # ---------------------------------
-# Secret for authenticating cron endpoints (e.g., /api/cron/poll-decisions)
+# Secret for authenticating cron endpoints (e.g., /api/cron/poll-decisions, /api/cron/poll-livestreams)
 # Generate with: openssl rand -base64 32
 CRON_SECRET=
 

--- a/docs/task-architecture.md
+++ b/docs/task-architecture.md
@@ -158,6 +158,46 @@ This returns per-decision data showing: when Diavgeia published it, when the cro
 - City must have `diavgeiaUid` set (configured in city settings)
 - Optionally, administrative bodies can have `diavgeiaUnitIds` for more precise matching
 
+### Livestream Auto-Transcription
+
+The `poll-livestreams` cron closes the manual gap between a meeting being livestreamed
+and its transcription: it finds the meeting's YouTube video and triggers `transcribe`
+automatically.
+
+**Endpoint:** `GET /api/cron/poll-livestreams` (`?dryRun=1` logs decisions without acting)
+**Authentication:** `Authorization: Bearer <CRON_SECRET>`
+
+**What it does (each run):**
+1. Finds candidate meetings: a `processAgenda` task has `succeeded`, `dateTime` is within
+   ±12h of now, `youtubeUrl` is still null, the administrative body has a `youtubeChannelUrl`,
+   and no `transcribe` task is already in flight.
+2. Lists recent videos for each distinct channel via the YouTube Data API v3 (resolved channel
+   id + listing are cached in Valkey, so meetings sharing a channel cost one API call per run).
+3. Asks Claude to match each meeting to a single video. The matcher **refuses to match a video
+   that appears to cover more than one council meeting** (e.g. a combined Λογοδοσία + Τακτική
+   Συνεδρίαση stream) — those are handled manually.
+4. On a confident single match (`confidence ≥ 0.8`): calls the internal transcribe path and posts
+   a "Livestream auto-matched" Discord alert (in addition to the standard transcribe "started"
+   alert). On a multi-meeting detection: posts a "needs manual handling" alert **once**,
+   deduplicated via a Valkey marker (`oc:livestream:multi-alert:{cityId}:{meetingId}`).
+
+**Requirements:**
+- `YOUTUBE_API_KEY` (Google Cloud, "YouTube Data API v3"). When unset, the cron no-ops.
+- `CACHE_URL` (Valkey). When unset, the cron still works but the multi-meeting alert may repeat.
+- Each administrative body that should be polled must have `youtubeChannelUrl` set.
+
+**Setup:** alongside the `poll-decisions` trigger, schedule:
+```bash
+# Every 10 minutes
+*/10 * * * * curl -s -H "Authorization: Bearer $CRON_SECRET" https://your-domain.com/api/cron/poll-livestreams
+```
+
+**Key files:**
+- `src/app/api/cron/poll-livestreams/route.ts` — cron API route
+- `src/lib/tasks/pollLivestreams.ts` — `pollLivestreamsForRecentMeetings()` + `matchMeetingToVideo()`
+- `src/lib/youtube.ts` — YouTube Data API client + channel-id resolution
+- `src/lib/cache/valkey.ts` — shared Valkey client used for dedup + listing cache
+
 ### Adding New Cron Tasks
 
 To add a new cron-triggered task:

--- a/src/app/api/cron/poll-livestreams/route.ts
+++ b/src/app/api/cron/poll-livestreams/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { env } from "@/env.mjs";
+import { pollLivestreamsForRecentMeetings } from "@/lib/tasks/pollLivestreams";
+
+export async function GET(request: NextRequest) {
+    const authHeader = request.headers.get("authorization");
+
+    if (!env.CRON_SECRET) {
+        return NextResponse.json(
+            { error: "CRON_SECRET not configured" },
+            { status: 503 }
+        );
+    }
+
+    if (authHeader !== `Bearer ${env.CRON_SECRET}`) {
+        return NextResponse.json(
+            { error: "Unauthorized" },
+            { status: 401 }
+        );
+    }
+
+    // ?dryRun=1 logs decisions without triggering transcription or posting alerts.
+    const dryRun = request.nextUrl.searchParams.get("dryRun") === "1";
+
+    const result = await pollLivestreamsForRecentMeetings({ dryRun });
+
+    return NextResponse.json(result);
+}

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -25,6 +25,9 @@ export const env = createEnv({
     // Services
     ANTHROPIC_API_KEY: z.string().min(1),
     GOOGLE_API_KEY: z.string().min(1),
+    // YouTube Data API v3 key (used by the poll-livestreams cron to find meeting
+    // livestreams). Optional — when unset, the cron no-ops.
+    YOUTUBE_API_KEY: z.string().optional(),
 
     // Storage
     DO_SPACES_ENDPOINT: z.string().min(1),
@@ -108,6 +111,7 @@ export const env = createEnv({
     BASIC_AUTH_PASSWORD: process.env.BASIC_AUTH_PASSWORD,
     ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
     GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+    YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY,
     DO_SPACES_ENDPOINT: process.env.DO_SPACES_ENDPOINT,
     DO_SPACES_KEY: process.env.DO_SPACES_KEY,
     DO_SPACES_SECRET: process.env.DO_SPACES_SECRET,

--- a/src/lib/cache/valkey.ts
+++ b/src/lib/cache/valkey.ts
@@ -1,0 +1,102 @@
+import { createClient } from 'redis';
+import { env } from '@/env.mjs';
+
+/**
+ * Shared Valkey/Redis client for application-level caching and dedup markers.
+ *
+ * Mirrors the singleton + connection handling used by the Next.js cache handler
+ * (cache-handler.mjs) and the cache-stats route. When CACHE_URL is unset (dev /
+ * single-instance), every helper degrades gracefully: reads return null and
+ * writes no-op, so callers don't need their own guards.
+ */
+
+// Module-level singleton — reused across requests, avoids connect/disconnect overhead.
+let client: ReturnType<typeof createClient> | null = null;
+let connectingPromise: Promise<ReturnType<typeof createClient> | null> | null = null;
+
+async function getClient(): Promise<ReturnType<typeof createClient> | null> {
+    if (client?.isReady) return client;
+    // Deduplicate concurrent connect attempts.
+    if (connectingPromise) return connectingPromise;
+
+    const cacheUrl = env.CACHE_URL;
+    if (!cacheUrl) return null;
+
+    connectingPromise = (async () => {
+        // Disconnect stale client before replacing (prevents leaked reconnection timers).
+        if (client) {
+            client.disconnect().catch(() => {});
+        }
+        // The `redis` npm package uses rediss:// for TLS; DO Valkey uses valkeys://.
+        const normalizedUrl = cacheUrl.replace(/^valkeys:\/\//, 'rediss://');
+        // pingInterval keeps the TCP connection warm against DO Valkey's ~300s idle
+        // timeout — same reasoning as cache-handler.mjs.
+        client = createClient({ url: normalizedUrl, pingInterval: 60_000 });
+        client.on('error', (error) => {
+            console.error('[valkey] client error:', error.message);
+        });
+        await client.connect();
+        return client;
+    })();
+
+    try {
+        return await connectingPromise;
+    } catch (error) {
+        // Reset on connect failure so the next call retries instead of reusing a dead client.
+        console.error('[valkey] connect failed:', error instanceof Error ? error.message : error);
+        if (client && !client.isReady) {
+            client.disconnect().catch(() => {});
+        }
+        client = null;
+        return null;
+    } finally {
+        connectingPromise = null;
+    }
+}
+
+/**
+ * Read and JSON-parse a cached value. Returns null when CACHE_URL is unset, the
+ * key is missing, or anything fails (cache is best-effort, never a hard dependency).
+ */
+export async function cacheGetJSON<T>(key: string): Promise<T | null> {
+    try {
+        const redis = await getClient();
+        if (!redis) return null;
+        const raw = await redis.get(key);
+        return raw ? (JSON.parse(raw) as T) : null;
+    } catch (error) {
+        console.error(`[valkey] get failed for ${key}:`, error instanceof Error ? error.message : error);
+        return null;
+    }
+}
+
+/**
+ * JSON-serialize and store a value with a TTL (seconds). No-ops when CACHE_URL is
+ * unset or on any failure. Returns true when the write landed.
+ */
+export async function cacheSetJSON(key: string, value: unknown, ttlSeconds: number): Promise<boolean> {
+    try {
+        const redis = await getClient();
+        if (!redis) return false;
+        await redis.set(key, JSON.stringify(value), { EX: ttlSeconds });
+        return true;
+    } catch (error) {
+        console.error(`[valkey] set failed for ${key}:`, error instanceof Error ? error.message : error);
+        return false;
+    }
+}
+
+/**
+ * Whether a key exists. Returns false when CACHE_URL is unset or on failure.
+ * Used for one-shot dedup markers (e.g. "did we already alert about this?").
+ */
+export async function cacheHas(key: string): Promise<boolean> {
+    try {
+        const redis = await getClient();
+        if (!redis) return false;
+        return (await redis.exists(key)) === 1;
+    } catch (error) {
+        console.error(`[valkey] exists failed for ${key}:`, error instanceof Error ? error.message : error);
+        return false;
+    }
+}

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -811,6 +811,112 @@ export async function sendTranscriptSendFailedAdminAlert(data: {
 }
 
 /**
+ * Send admin alert when the poll-livestreams cron auto-matched a meeting to a
+ * YouTube video and triggered transcription. Lets a human sanity-check the match.
+ */
+export async function sendLivestreamMatchedAlert(data: {
+    cityId: string;
+    cityName: string;
+    meetingId: string;
+    meetingName: string;
+    videoUrl: string;
+    videoTitle: string;
+    confidence: number;
+    reasoning: string;
+}): Promise<void> {
+    await sendAdminAlert({
+        title: `🎥 Livestream auto-matched - ${data.cityId}`,
+        description: `Transcription triggered for ${data.meetingId}`,
+        color: 0x2ecc71, // Green
+        fields: [
+            {
+                name: 'Municipality',
+                value: data.cityName,
+                inline: true,
+            },
+            {
+                name: 'Confidence',
+                value: data.confidence.toFixed(2),
+                inline: true,
+            },
+            {
+                name: 'Meeting',
+                value: data.meetingName,
+                inline: false,
+            },
+            {
+                name: 'Matched Video',
+                value: `[${truncateField(data.videoTitle, 256)}](${data.videoUrl})`,
+                inline: false,
+            },
+            {
+                name: 'Reasoning',
+                value: truncateField(data.reasoning),
+                inline: false,
+            },
+            {
+                name: 'Admin Panel',
+                value: `[Open Meeting Admin](${meetingAdminUrl(data.cityId, data.meetingId)})`,
+                inline: false,
+            },
+        ],
+    });
+}
+
+/**
+ * Send admin alert when the poll-livestreams cron found a video that appears to
+ * cover MORE THAN ONE council meeting (e.g. a combined λογοδοσία + τακτική stream).
+ * These are handled manually — fired once per meeting (dedup via Valkey at the call site).
+ */
+export async function sendLivestreamMultipleMeetingsAlert(data: {
+    cityId: string;
+    cityName: string;
+    meetingId: string;
+    meetingName: string;
+    channelUrl: string;
+    videoUrl?: string;
+    reasoning: string;
+}): Promise<void> {
+    await sendAdminAlert({
+        title: `⚠️ Livestream needs manual handling - ${data.cityId}`,
+        description: `A candidate video appears to cover multiple meetings for ${data.meetingId}`,
+        color: 0xf39c12, // Yellow/orange
+        fields: [
+            {
+                name: 'Municipality',
+                value: data.cityName,
+                inline: true,
+            },
+            {
+                name: 'Meeting',
+                value: data.meetingName,
+                inline: false,
+            },
+            ...(data.videoUrl ? [{
+                name: 'Candidate Video',
+                value: data.videoUrl,
+                inline: false,
+            }] : []),
+            {
+                name: 'Channel',
+                value: data.channelUrl,
+                inline: false,
+            },
+            {
+                name: 'Reasoning',
+                value: truncateField(data.reasoning),
+                inline: false,
+            },
+            {
+                name: 'Admin Panel',
+                value: `[Open Meeting Admin](${meetingAdminUrl(data.cityId, data.meetingId)})`,
+                inline: false,
+            },
+        ],
+    });
+}
+
+/**
  * Generic error alert for unexpected failures anywhere in the app.
  * Context entries are rendered as inline fields for quick triage.
  */

--- a/src/lib/tasks/__tests__/pollLivestreams.test.ts
+++ b/src/lib/tasks/__tests__/pollLivestreams.test.ts
@@ -1,0 +1,240 @@
+/** @jest-environment node */
+
+const mockMeetingFindMany = jest.fn();
+const mockTaskFindMany = jest.fn();
+jest.mock('../../db/prisma', () => ({
+    __esModule: true,
+    default: {
+        councilMeeting: { findMany: (...args: unknown[]) => mockMeetingFindMany(...args) },
+        taskStatus: { findMany: (...args: unknown[]) => mockTaskFindMany(...args) },
+    },
+}));
+
+const mockAiChat = jest.fn();
+jest.mock('../../ai', () => ({ aiChat: (...args: unknown[]) => mockAiChat(...args) }));
+
+const mockResolveChannelId = jest.fn();
+const mockListRecentChannelVideos = jest.fn();
+jest.mock('../../youtube', () => ({
+    resolveChannelId: (...args: unknown[]) => mockResolveChannelId(...args),
+    listRecentChannelVideos: (...args: unknown[]) => mockListRecentChannelVideos(...args),
+    watchUrl: (id: string) => `https://www.youtube.com/watch?v=${id}`,
+}));
+
+const mockCacheHas = jest.fn();
+const mockCacheSetJSON = jest.fn();
+jest.mock('../../cache/valkey', () => ({
+    cacheHas: (...args: unknown[]) => mockCacheHas(...args),
+    cacheSetJSON: (...args: unknown[]) => mockCacheSetJSON(...args),
+    cacheGetJSON: jest.fn(),
+}));
+
+const mockRequestTranscribeInternal = jest.fn();
+jest.mock('../transcribeInternal', () => ({
+    requestTranscribeInternal: (...args: unknown[]) => mockRequestTranscribeInternal(...args),
+}));
+
+const mockMatchedAlert = jest.fn().mockResolvedValue(undefined);
+const mockMultiAlert = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../discord', () => ({
+    sendLivestreamMatchedAlert: (...args: unknown[]) => mockMatchedAlert(...args),
+    sendLivestreamMultipleMeetingsAlert: (...args: unknown[]) => mockMultiAlert(...args),
+}));
+
+// Mutable so individual tests can flip YOUTUBE_API_KEY off.
+const mockEnv: { YOUTUBE_API_KEY?: string; NEXTAUTH_URL: string } = {
+    YOUTUBE_API_KEY: 'test-key',
+    NEXTAUTH_URL: 'http://test',
+};
+jest.mock('@/env.mjs', () => ({ env: mockEnv }));
+
+import { pollLivestreamsForRecentMeetings, matchMeetingToVideo } from '../pollLivestreams';
+
+const CHANNEL = 'https://www.youtube.com/@cityofathens.youtube';
+
+function meeting(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 'm1',
+        cityId: 'athens',
+        name: '21η Τακτική Συνεδρίαση 10/06/2026',
+        name_en: '21st Regular Council Session',
+        dateTime: new Date('2026-06-10T18:00:00Z'),
+        administrativeBody: { name: 'Δημοτικό Συμβούλιο', youtubeChannelUrl: CHANNEL },
+        city: { name: 'Athens' },
+        subjects: [{ name: 'Subject A' }, { name: 'Subject B' }],
+        ...overrides,
+    };
+}
+
+const VIDEO = { videoId: 'v1', title: '21η Τακτική Συνεδρίαση 10/06/2026', publishedAt: '2026-06-10T20:00:00Z' };
+
+function aiDecision(decision: Record<string, unknown>) {
+    mockAiChat.mockResolvedValue({ result: decision, usage: {} });
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockEnv.YOUTUBE_API_KEY = 'test-key';
+    mockResolveChannelId.mockResolvedValue('UCchannel');
+    mockListRecentChannelVideos.mockResolvedValue([VIDEO]);
+    mockCacheHas.mockResolvedValue(false);
+    mockCacheSetJSON.mockResolvedValue(true);
+    mockRequestTranscribeInternal.mockResolvedValue(undefined);
+});
+
+// processAgenda succeeded, no transcribe in flight.
+function processAgendaDone(meetingId = 'm1', cityId = 'athens') {
+    return [{ councilMeetingId: meetingId, cityId, type: 'processAgenda', status: 'succeeded' }];
+}
+
+describe('matchMeetingToVideo', () => {
+    it('short-circuits to no_match without calling the LLM when there are no videos', async () => {
+        const result = await matchMeetingToVideo(
+            { name: 'x', name_en: 'x', dateTime: new Date(), administrativeBodyName: 'b', subjectNames: [] },
+            [],
+        );
+        expect(result.decision).toBe('no_match');
+        expect(mockAiChat).not.toHaveBeenCalled();
+    });
+
+    it('passes the LLM decision through', async () => {
+        aiDecision({ decision: 'match', videoId: 'v1', confidence: 0.9, reasoning: 'aligned' });
+        const result = await matchMeetingToVideo(
+            { name: 'x', name_en: 'x', dateTime: new Date(), administrativeBodyName: 'b', subjectNames: ['s'] },
+            [VIDEO],
+        );
+        expect(result).toEqual({ decision: 'match', videoId: 'v1', confidence: 0.9, reasoning: 'aligned' });
+        expect(mockAiChat).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('pollLivestreamsForRecentMeetings', () => {
+    it('no-ops when YOUTUBE_API_KEY is unset', async () => {
+        mockEnv.YOUTUBE_API_KEY = undefined;
+        const summary = await pollLivestreamsForRecentMeetings();
+        expect(summary.candidates).toBe(0);
+        expect(mockMeetingFindMany).not.toHaveBeenCalled();
+    });
+
+    it('triggers transcription and alerts on a confident match', async () => {
+        mockMeetingFindMany.mockResolvedValue([meeting()]);
+        mockTaskFindMany.mockResolvedValue(processAgendaDone());
+        aiDecision({ decision: 'match', videoId: 'v1', confidence: 0.95, reasoning: 'title+date align' });
+
+        const summary = await pollLivestreamsForRecentMeetings();
+
+        expect(mockRequestTranscribeInternal).toHaveBeenCalledWith(
+            'https://www.youtube.com/watch?v=v1', 'm1', 'athens',
+        );
+        expect(mockMatchedAlert).toHaveBeenCalledTimes(1);
+        expect(summary.matched).toBe(1);
+        expect(summary.results[0].action).toBe('transcribe_triggered');
+    });
+
+    it('does not transcribe when confidence is below threshold', async () => {
+        mockMeetingFindMany.mockResolvedValue([meeting()]);
+        mockTaskFindMany.mockResolvedValue(processAgendaDone());
+        aiDecision({ decision: 'match', videoId: 'v1', confidence: 0.5, reasoning: 'unsure' });
+
+        const summary = await pollLivestreamsForRecentMeetings();
+
+        expect(mockRequestTranscribeInternal).not.toHaveBeenCalled();
+        expect(summary.matched).toBe(0);
+        expect(summary.skipped).toBe(1);
+    });
+
+    it('ignores a videoId the channel did not actually return', async () => {
+        mockMeetingFindMany.mockResolvedValue([meeting()]);
+        mockTaskFindMany.mockResolvedValue(processAgendaDone());
+        aiDecision({ decision: 'match', videoId: 'hallucinated', confidence: 0.99, reasoning: 'made up' });
+
+        const summary = await pollLivestreamsForRecentMeetings();
+
+        expect(mockRequestTranscribeInternal).not.toHaveBeenCalled();
+        expect(summary.matched).toBe(0);
+        expect(summary.skipped).toBe(1);
+    });
+
+    it('alerts once for a multi-meeting stream and dedups via cache', async () => {
+        mockMeetingFindMany.mockResolvedValue([meeting()]);
+        mockTaskFindMany.mockResolvedValue(processAgendaDone());
+        aiDecision({ decision: 'multiple_meetings', videoId: 'v1', confidence: 0.9, reasoning: 'λογοδοσία + τακτική' });
+
+        const summary = await pollLivestreamsForRecentMeetings();
+
+        expect(mockMultiAlert).toHaveBeenCalledTimes(1);
+        expect(mockCacheSetJSON).toHaveBeenCalledWith(
+            'oc:livestream:multi-alert:athens:m1', 1, expect.any(Number),
+        );
+        expect(mockRequestTranscribeInternal).not.toHaveBeenCalled();
+        expect(summary.multipleMeetings).toBe(1);
+        expect(summary.results[0].action).toBe('alerted_multiple');
+    });
+
+    it('does not re-alert a multi-meeting stream already alerted', async () => {
+        mockMeetingFindMany.mockResolvedValue([meeting()]);
+        mockTaskFindMany.mockResolvedValue(processAgendaDone());
+        mockCacheHas.mockResolvedValue(true);
+        aiDecision({ decision: 'multiple_meetings', videoId: 'v1', confidence: 0.9, reasoning: 'combined' });
+
+        const summary = await pollLivestreamsForRecentMeetings();
+
+        expect(mockMultiAlert).not.toHaveBeenCalled();
+        expect(mockCacheSetJSON).not.toHaveBeenCalled();
+        expect(summary.results[0].action).toBe('alerted_multiple_skipped');
+    });
+
+    it('skips meetings without a succeeded processAgenda', async () => {
+        mockMeetingFindMany.mockResolvedValue([meeting()]);
+        mockTaskFindMany.mockResolvedValue([]); // no processAgenda
+        aiDecision({ decision: 'match', videoId: 'v1', confidence: 0.95, reasoning: 'x' });
+
+        const summary = await pollLivestreamsForRecentMeetings();
+
+        expect(summary.candidates).toBe(0);
+        expect(mockAiChat).not.toHaveBeenCalled();
+    });
+
+    it('skips meetings with a transcribe already in flight', async () => {
+        mockMeetingFindMany.mockResolvedValue([meeting()]);
+        mockTaskFindMany.mockResolvedValue([
+            ...processAgendaDone(),
+            { councilMeetingId: 'm1', cityId: 'athens', type: 'transcribe', status: 'pending' },
+        ]);
+
+        const summary = await pollLivestreamsForRecentMeetings();
+
+        expect(summary.candidates).toBe(0);
+        expect(mockAiChat).not.toHaveBeenCalled();
+    });
+
+    it('dry run records a match without triggering transcription or alerts', async () => {
+        mockMeetingFindMany.mockResolvedValue([meeting()]);
+        mockTaskFindMany.mockResolvedValue(processAgendaDone());
+        aiDecision({ decision: 'match', videoId: 'v1', confidence: 0.95, reasoning: 'x' });
+
+        const summary = await pollLivestreamsForRecentMeetings({ dryRun: true });
+
+        expect(mockRequestTranscribeInternal).not.toHaveBeenCalled();
+        expect(mockMatchedAlert).not.toHaveBeenCalled();
+        expect(summary.matched).toBe(1);
+        expect(summary.results[0].action).toBe('dry_run');
+    });
+
+    it('resolves + lists each channel only once across meetings sharing it', async () => {
+        mockMeetingFindMany.mockResolvedValue([
+            meeting({ id: 'm1' }),
+            meeting({ id: 'm2', name: '22η Ειδική Συνεδρίαση 18/06/2026' }),
+        ]);
+        mockTaskFindMany.mockResolvedValue([
+            { councilMeetingId: 'm1', cityId: 'athens', type: 'processAgenda', status: 'succeeded' },
+            { councilMeetingId: 'm2', cityId: 'athens', type: 'processAgenda', status: 'succeeded' },
+        ]);
+        aiDecision({ decision: 'no_match', confidence: 0.9, reasoning: 'none' });
+
+        await pollLivestreamsForRecentMeetings();
+
+        expect(mockResolveChannelId).toHaveBeenCalledTimes(1);
+        expect(mockListRecentChannelVideos).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/lib/tasks/pollLivestreams.ts
+++ b/src/lib/tasks/pollLivestreams.ts
@@ -1,0 +1,322 @@
+import prisma from "../db/prisma";
+import { env } from "@/env.mjs";
+import { aiChat } from "../ai";
+import { resolveChannelId, listRecentChannelVideos, watchUrl, type YouTubeVideo } from "../youtube";
+import { cacheHas, cacheSetJSON } from "../cache/valkey";
+import { requestTranscribeInternal } from "./transcribeInternal";
+import { sendLivestreamMatchedAlert, sendLivestreamMultipleMeetingsAlert } from "../discord";
+
+/** ±12h around a meeting's scheduled time — the window in which its livestream appears. */
+const WINDOW_MS = 12 * 60 * 60 * 1000;
+/** Only auto-trigger transcription at/above this match confidence; below → treat as no match. */
+const MATCH_CONFIDENCE_THRESHOLD = 0.8;
+/** Safety cap on transcriptions triggered per cron invocation. */
+const MAX_TRANSCRIBES_PER_RUN = 10;
+/** TTL for the "already alerted about a multi-meeting stream" dedup marker. */
+const MULTI_ALERT_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+/** Transcribe statuses that mean "already handled" — anything but a failed attempt. */
+const TRANSCRIBE_ACTIVE_STATUSES = new Set(["pending", "processing", "running", "succeeded"]);
+
+function meetingKey(cityId: string, meetingId: string): string {
+    return `${cityId}:${meetingId}`;
+}
+
+/**
+ * The matcher's structured verdict. `multiple_meetings` is a deliberate refusal:
+ * the best candidate appears to cover more than one council meeting (e.g. a combined
+ * λογοδοσία + τακτική συνεδρίαση stream), which we never auto-match.
+ */
+export interface LivestreamMatchDecision {
+    decision: 'match' | 'no_match' | 'multiple_meetings';
+    videoId?: string;
+    confidence: number;
+    reasoning: string;
+}
+
+const MATCH_SYSTEM_PROMPT = `You match a Greek municipal council meeting to its livestream video on the body's official YouTube channel.
+
+You are given one meeting (title, scheduled date/time, administrative body, agenda subjects) and a list of recent videos from the channel (id, title, publish date).
+
+Decide which single video IS the recording/livestream of THIS specific meeting, and return ONLY a JSON object:
+{
+  "decision": "match" | "no_match" | "multiple_meetings",
+  "videoId": "<the matching video id, only when decision is 'match'>",
+  "confidence": <number 0..1>,
+  "reasoning": "<one or two sentences>"
+}
+
+Rules:
+- "match": exactly one video clearly corresponds to this meeting (title and date align). Set videoId and a confidence reflecting certainty.
+- "no_match": no video corresponds to this meeting (it may not be uploaded yet). Use this when unsure rather than guessing.
+- "multiple_meetings": the best-matching video appears to cover MORE THAN ONE council meeting in a single stream (e.g. a "Λογοδοσία" special session combined with a "Τακτική Συνεδρίαση", or two numbered sessions in one title). Do NOT pick such a video as a match — these are handled manually. Set videoId to the offending video and explain.
+- Greek council titles often include a session number and a date (e.g. "21η Τακτική Συνεδρίαση 10/06/2026"). Use both the title and the publish date to judge alignment.
+- Return strictly valid JSON, no markdown, no extra text.`;
+
+/**
+ * Asks the LLM to match a meeting to one of the channel's recent videos.
+ * Returns a structured decision, including the multi-meeting refusal case.
+ */
+export async function matchMeetingToVideo(
+    meeting: {
+        name: string;
+        name_en: string;
+        dateTime: Date;
+        administrativeBodyName: string;
+        subjectNames: string[];
+    },
+    videos: YouTubeVideo[],
+): Promise<LivestreamMatchDecision> {
+    if (videos.length === 0) {
+        return { decision: 'no_match', confidence: 1, reasoning: 'No recent videos on the channel.' };
+    }
+
+    const userPrompt = JSON.stringify({
+        meeting: {
+            title: meeting.name,
+            title_en: meeting.name_en,
+            scheduledAt: meeting.dateTime.toISOString(),
+            administrativeBody: meeting.administrativeBodyName,
+            agendaSubjects: meeting.subjectNames.slice(0, 20),
+        },
+        candidateVideos: videos.map(v => ({
+            videoId: v.videoId,
+            title: v.title,
+            publishedAt: v.publishedAt,
+        })),
+    }, null, 2);
+
+    const { result } = await aiChat<LivestreamMatchDecision>(
+        MATCH_SYSTEM_PROMPT,
+        userPrompt,
+        undefined,
+        undefined,
+        { maxTokens: 500 },
+    );
+
+    return result;
+}
+
+export interface PollLivestreamsMeetingResult {
+    cityId: string;
+    meetingId: string;
+    decision: LivestreamMatchDecision['decision'] | 'error';
+    videoId?: string;
+    confidence?: number;
+    action: 'transcribe_triggered' | 'alerted_multiple' | 'alerted_multiple_skipped' | 'skipped' | 'dry_run' | 'error';
+    error?: string;
+}
+
+export interface PollLivestreamsSummary {
+    candidates: number;
+    matched: number;
+    multipleMeetings: number;
+    skipped: number;
+    errors: number;
+    dryRun: boolean;
+    results: PollLivestreamsMeetingResult[];
+}
+
+/**
+ * Finds meetings whose livestream should now exist, matches each to a YouTube video
+ * via the LLM, and triggers transcription for confident single-meeting matches.
+ *
+ * Candidate = processAgenda succeeded, scheduled within ±12h of now, no youtubeUrl yet,
+ * the administrative body has a youtubeChannelUrl, and no transcribe is already in flight.
+ *
+ * Called by the poll-livestreams cron. Pass { dryRun: true } to log decisions without
+ * triggering transcription or posting alerts.
+ */
+export async function pollLivestreamsForRecentMeetings(
+    options: { dryRun?: boolean } = {},
+): Promise<PollLivestreamsSummary> {
+    const dryRun = options.dryRun ?? false;
+    const empty: PollLivestreamsSummary = {
+        candidates: 0, matched: 0, multipleMeetings: 0, skipped: 0, errors: 0, dryRun, results: [],
+    };
+
+    if (!env.YOUTUBE_API_KEY) {
+        console.log('[pollLivestreams] YOUTUBE_API_KEY not configured — skipping');
+        return empty;
+    }
+
+    const now = new Date();
+    const windowStart = new Date(now.getTime() - WINDOW_MS);
+    const windowEnd = new Date(now.getTime() + WINDOW_MS);
+
+    const meetings = await prisma.councilMeeting.findMany({
+        where: {
+            dateTime: { gte: windowStart, lte: windowEnd },
+            youtubeUrl: null,
+            administrativeBody: { youtubeChannelUrl: { not: null } },
+        },
+        include: {
+            administrativeBody: true,
+            city: { select: { name: true } },
+            subjects: { select: { name: true }, orderBy: { agendaItemIndex: 'asc' } },
+        },
+        orderBy: { dateTime: 'desc' },
+        take: 50,
+    });
+
+    if (meetings.length === 0) return empty;
+
+    // Batch-fetch processAgenda + transcribe task history for all candidates in one query.
+    const meetingIds = meetings.map(m => m.id);
+    const taskStatuses = await prisma.taskStatus.findMany({
+        where: {
+            councilMeetingId: { in: meetingIds },
+            type: { in: ['processAgenda', 'transcribe'] },
+        },
+        select: { councilMeetingId: true, cityId: true, type: true, status: true },
+    });
+
+    const processAgendaSucceeded = new Set<string>();
+    const transcribeActive = new Set<string>();
+    for (const t of taskStatuses) {
+        const key = meetingKey(t.cityId, t.councilMeetingId);
+        if (t.type === 'processAgenda' && t.status === 'succeeded') {
+            processAgendaSucceeded.add(key);
+        }
+        if (t.type === 'transcribe' && TRANSCRIBE_ACTIVE_STATUSES.has(t.status)) {
+            transcribeActive.add(key);
+        }
+    }
+
+    const candidates = meetings.filter(m => {
+        const key = meetingKey(m.cityId, m.id);
+        return processAgendaSucceeded.has(key) && !transcribeActive.has(key);
+    });
+
+    if (candidates.length === 0) {
+        return { ...empty, candidates: 0 };
+    }
+
+    // Resolve + list videos once per distinct channel (quota-friendly).
+    const channelVideos = new Map<string, YouTubeVideo[]>();
+    const channelErrors = new Map<string, string>();
+    async function getChannelVideos(channelUrl: string): Promise<YouTubeVideo[]> {
+        if (channelVideos.has(channelUrl)) return channelVideos.get(channelUrl)!;
+        if (channelErrors.has(channelUrl)) throw new Error(channelErrors.get(channelUrl)!);
+        try {
+            const channelId = await resolveChannelId(channelUrl);
+            if (!channelId) throw new Error(`Could not resolve channel id from ${channelUrl}`);
+            const videos = await listRecentChannelVideos(channelId);
+            channelVideos.set(channelUrl, videos);
+            return videos;
+        } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            channelErrors.set(channelUrl, msg);
+            throw error;
+        }
+    }
+
+    const results: PollLivestreamsMeetingResult[] = [];
+    let matched = 0;
+    let multipleMeetings = 0;
+    let skipped = 0;
+    let errors = 0;
+    let transcribesTriggered = 0;
+
+    for (const meeting of candidates) {
+        const cityId = meeting.cityId;
+        const meetingId = meeting.id;
+        const channelUrl = meeting.administrativeBody!.youtubeChannelUrl!;
+
+        try {
+            const videos = await getChannelVideos(channelUrl);
+            const decision = await matchMeetingToVideo(
+                {
+                    name: meeting.name,
+                    name_en: meeting.name_en,
+                    dateTime: meeting.dateTime,
+                    administrativeBodyName: meeting.administrativeBody!.name,
+                    subjectNames: meeting.subjects.map(s => s.name),
+                },
+                videos,
+            );
+
+            // Guard: only honor a videoId the channel actually returned.
+            const matchedVideo = decision.videoId
+                ? videos.find(v => v.videoId === decision.videoId)
+                : undefined;
+
+            if (
+                decision.decision === 'match' &&
+                matchedVideo &&
+                decision.confidence >= MATCH_CONFIDENCE_THRESHOLD
+            ) {
+                if (transcribesTriggered >= MAX_TRANSCRIBES_PER_RUN) {
+                    skipped++;
+                    results.push({ cityId, meetingId, decision: 'match', videoId: matchedVideo.videoId, confidence: decision.confidence, action: 'skipped', error: 'per-run cap reached' });
+                    continue;
+                }
+
+                if (dryRun) {
+                    results.push({ cityId, meetingId, decision: 'match', videoId: matchedVideo.videoId, confidence: decision.confidence, action: 'dry_run' });
+                    matched++;
+                    continue;
+                }
+
+                const videoUrl = watchUrl(matchedVideo.videoId);
+                await requestTranscribeInternal(videoUrl, meetingId, cityId);
+                transcribesTriggered++;
+                matched++;
+                sendLivestreamMatchedAlert({
+                    cityId,
+                    cityName: meeting.city.name,
+                    meetingId,
+                    meetingName: meeting.name,
+                    videoUrl,
+                    videoTitle: matchedVideo.title,
+                    confidence: decision.confidence,
+                    reasoning: decision.reasoning,
+                }).catch(err => console.error('[pollLivestreams] matched alert failed:', err));
+
+                results.push({ cityId, meetingId, decision: 'match', videoId: matchedVideo.videoId, confidence: decision.confidence, action: 'transcribe_triggered' });
+            } else if (decision.decision === 'multiple_meetings') {
+                multipleMeetings++;
+                const dedupKey = `oc:livestream:multi-alert:${cityId}:${meetingId}`;
+                const alreadyAlerted = await cacheHas(dedupKey);
+
+                if (dryRun) {
+                    results.push({ cityId, meetingId, decision: 'multiple_meetings', videoId: decision.videoId, action: 'dry_run' });
+                } else if (alreadyAlerted) {
+                    results.push({ cityId, meetingId, decision: 'multiple_meetings', videoId: decision.videoId, action: 'alerted_multiple_skipped' });
+                } else {
+                    const videoUrl = matchedVideo ? watchUrl(matchedVideo.videoId) : undefined;
+                    await sendLivestreamMultipleMeetingsAlert({
+                        cityId,
+                        cityName: meeting.city.name,
+                        meetingId,
+                        meetingName: meeting.name,
+                        channelUrl,
+                        videoUrl,
+                        reasoning: decision.reasoning,
+                    });
+                    // Set the dedup marker only after a successful alert.
+                    await cacheSetJSON(dedupKey, 1, MULTI_ALERT_TTL_SECONDS);
+                    results.push({ cityId, meetingId, decision: 'multiple_meetings', videoId: decision.videoId, action: 'alerted_multiple' });
+                }
+            } else {
+                // no_match, or a match below the confidence threshold → retry next run.
+                skipped++;
+                results.push({ cityId, meetingId, decision: decision.decision, confidence: decision.confidence, action: 'skipped' });
+            }
+        } catch (error) {
+            errors++;
+            const msg = error instanceof Error ? error.message : String(error);
+            console.error(`[pollLivestreams] error for ${cityId}/${meetingId}:`, msg);
+            results.push({ cityId, meetingId, decision: 'error', action: 'error', error: msg });
+        }
+    }
+
+    return {
+        candidates: candidates.length,
+        matched,
+        multipleMeetings,
+        skipped,
+        errors,
+        dryRun,
+        results,
+    };
+}

--- a/src/lib/tasks/pollLivestreams.ts
+++ b/src/lib/tasks/pollLivestreams.ts
@@ -120,8 +120,9 @@ export interface PollLivestreamsSummary {
  * Finds meetings whose livestream should now exist, matches each to a YouTube video
  * via the LLM, and triggers transcription for confident single-meeting matches.
  *
- * Candidate = processAgenda succeeded, scheduled within ±12h of now, no youtubeUrl yet,
- * the administrative body has a youtubeChannelUrl, and no transcribe is already in flight.
+ * Candidate = processAgenda succeeded, scheduled within ±12h of now, the administrative body
+ * has a youtubeChannelUrl, and no transcribe is succeeded or in flight (a failed-only meeting
+ * is retried).
  *
  * Called by the poll-livestreams cron. Pass { dryRun: true } to log decisions without
  * triggering transcription or posting alerts.
@@ -143,10 +144,13 @@ export async function pollLivestreamsForRecentMeetings(
     const windowStart = new Date(now.getTime() - WINDOW_MS);
     const windowEnd = new Date(now.getTime() + WINDOW_MS);
 
+    // Note: candidacy is NOT gated on `youtubeUrl: null`. requestTranscribeInternal writes
+    // youtubeUrl before startTask, so a failed/never-started transcribe would otherwise leave
+    // the meeting with a non-null youtubeUrl and permanently excluded. Instead we gate on the
+    // transcribe task status below (retry on failed, skip on succeeded/in-flight).
     const meetings = await prisma.councilMeeting.findMany({
         where: {
             dateTime: { gte: windowStart, lte: windowEnd },
-            youtubeUrl: null,
             administrativeBody: { youtubeChannelUrl: { not: null } },
         },
         include: {
@@ -182,6 +186,8 @@ export async function pollLivestreamsForRecentMeetings(
         }
     }
 
+    // Candidate = processAgenda succeeded AND no transcribe that is succeeded or in flight.
+    // A meeting whose only prior transcribe attempts failed is eligible again (auto-retry).
     const candidates = meetings.filter(m => {
         const key = meetingKey(m.cityId, m.id);
         return processAgendaSucceeded.has(key) && !transcribeActive.has(key);

--- a/src/lib/tasks/transcribe.ts
+++ b/src/lib/tasks/transcribe.ts
@@ -1,147 +1,22 @@
 "use server";
-import { TranscribeRequest, TranscribeResult, Voiceprint } from "../apiTypes";
-import { startTask } from "./tasks";
-import { CouncilMeeting, Prisma, SpeakerSegment } from "@prisma/client";
+import { TranscribeResult } from "../apiTypes";
+import { CouncilMeeting, SpeakerSegment } from "@prisma/client";
 import { Utterance as ApiUtterance } from "../apiTypes";
 import prisma from "../db/prisma";
 import { withUserAuthorizedToEdit } from "../auth";
-import { getPeopleForMeeting } from "@/lib/db/people";
-import { buildUnknownSpeakerLabel, getRoleTypePriority } from "../utils";
-import { getStatisticsFor } from "../statistics";
+import { buildUnknownSpeakerLabel } from "../utils";
+import { requestTranscribeInternal, deleteExistingSpeakerData } from "./transcribeInternal";
 
-async function deleteExistingSpeakerData(
-    meetingId: string,
-    cityId: string,
-    db: Prisma.TransactionClient | typeof prisma = prisma
-) {
-    console.log(`Deleting existing speaker data for meeting ${meetingId}`);
-
-    // Get all unique speakerTagIds used by this meeting's segments
-    const speakerSegments = await db.speakerSegment.findMany({
-        where: {
-            meetingId,
-            cityId
-        },
-        select: {
-            speakerTagId: true
-        }
-    });
-
-    const speakerTagIds = [...new Set(speakerSegments.map(s => s.speakerTagId))];
-
-    // Delete the SpeakerTags, which will cascade delete the SpeakerSegments
-    if (speakerTagIds.length > 0) {
-        await db.speakerTag.deleteMany({
-            where: {
-                id: { in: speakerTagIds }
-            }
-        });
-        console.log(`Deleted ${speakerTagIds.length} speaker tags and their associated segments`);
-    }
-}
-
-export async function requestTranscribe(youtubeUrl: string, councilMeetingId: string, cityId: string, {
-    force = false
-}: {
+/**
+ * Public entry point for transcription. Authorizes the caller, then delegates to
+ * requestTranscribeInternal (which the unauthenticated poll-livestreams cron also calls).
+ */
+export async function requestTranscribe(youtubeUrl: string, councilMeetingId: string, cityId: string, options: {
     force?: boolean;
 } = {}) {
     await withUserAuthorizedToEdit({ cityId });
 
-    console.log(`Requesting transcription for ${youtubeUrl}`);
-    const councilMeeting = await prisma.councilMeeting.findUnique({
-        where: {
-            cityId_id: {
-                id: councilMeetingId,
-                cityId
-            }
-        },
-        include: {
-            city: {
-                include: {
-                    persons: true,
-                    parties: true
-                }
-            },
-            speakerSegments: {
-                select: {
-                    id: true
-                },
-                take: 1
-            }
-        }
-    });
-
-    if (!councilMeeting) {
-        throw new Error("Council meeting not found");
-    }
-
-    if (councilMeeting.speakerSegments.length > 0) {
-        if (force) {
-            await deleteExistingSpeakerData(councilMeetingId, cityId);
-        } else {
-            console.log(`Meeting already has speaker segments`);
-            throw new Error('Meeting already has speaker segments');
-        }
-    }
-
-    const city = councilMeeting.city;
-
-    // Get voiceprints for relevant people based on meeting's administrative body
-    const people = await getPeopleForMeeting(cityId, councilMeeting.administrativeBodyId);
-    const peopleWithVoiceprints = people
-        .filter(person => person.voicePrints && person.voicePrints.length > 0);
-
-    // Pyannote.ai supports max 50 voiceprints per request.
-    // When over the limit, people are already sorted by role priority from getPeopleForMeeting
-    // (mayors, deputy mayors, council heads, etc.). Use speaking time as tiebreaker within
-    // the same role priority tier.
-    const MAX_VOICEPRINTS = 50;
-    if (peopleWithVoiceprints.length > MAX_VOICEPRINTS) {
-        const stats = await getStatisticsFor({ cityId }, ["person"]);
-        const speakingByPerson = new Map(
-            (stats.people ?? []).map(s => [s.item.id, s.speakingSeconds])
-        );
-        peopleWithVoiceprints.sort((a, b) => {
-            const priorityA = Math.min(...a.roles.map(getRoleTypePriority));
-            const priorityB = Math.min(...b.roles.map(getRoleTypePriority));
-            if (priorityA !== priorityB) return priorityA - priorityB;
-            return (speakingByPerson.get(b.id) ?? 0) - (speakingByPerson.get(a.id) ?? 0);
-        });
-        console.warn(
-            `Found ${peopleWithVoiceprints.length} voiceprints but pyannote.ai supports max ${MAX_VOICEPRINTS}, ` +
-            `sending top by role priority + speaking time`
-        );
-    }
-
-    const voiceprints: Voiceprint[] = peopleWithVoiceprints
-        .slice(0, MAX_VOICEPRINTS)
-        .map(person => ({
-            personId: person.id,
-            voiceprint: person.voicePrints![0].embedding
-        }));
-
-    console.log(`Sending ${voiceprints.length} voiceprints for meeting (${peopleWithVoiceprints.length} total with voiceprints)`);
-
-    const body: Omit<TranscribeRequest, 'callbackUrl'> = {
-        youtubeUrl,
-        voiceprints: voiceprints.length > 0 ? voiceprints : undefined,
-        cityLanguage: city.language,
-    }
-
-    await prisma.councilMeeting.update({
-        where: {
-            cityId_id: {
-                id: councilMeetingId,
-                cityId
-            }
-        },
-        data: {
-            youtubeUrl
-        }
-    });
-
-    console.log(`Transcribe body: ${JSON.stringify(body)}`);
-    return startTask('transcribe', body, councilMeetingId, cityId, { force });
+    return requestTranscribeInternal(youtubeUrl, councilMeetingId, cityId, options);
 }
 
 export async function handleTranscribeResult(taskId: string, response: TranscribeResult, options?: { force?: boolean }) {

--- a/src/lib/tasks/transcribeInternal.ts
+++ b/src/lib/tasks/transcribeInternal.ts
@@ -1,0 +1,149 @@
+import { TranscribeRequest, Voiceprint } from "../apiTypes";
+import { startTask } from "./tasks";
+import { Prisma } from "@prisma/client";
+import prisma from "../db/prisma";
+import { getPeopleForMeeting } from "@/lib/db/people";
+import { getRoleTypePriority } from "../utils";
+import { getStatisticsFor } from "../statistics";
+
+/**
+ * Core transcribe logic without auth checks.
+ *
+ * NOT in a "use server" file — this must not be callable as a Server Action.
+ * Only called from:
+ *   - requestTranscribe (after withUserAuthorizedToEdit), in ./transcribe
+ *   - the poll-livestreams cron (unauthenticated background job)
+ */
+
+export async function deleteExistingSpeakerData(
+    meetingId: string,
+    cityId: string,
+    db: Prisma.TransactionClient | typeof prisma = prisma
+) {
+    console.log(`Deleting existing speaker data for meeting ${meetingId}`);
+
+    // Get all unique speakerTagIds used by this meeting's segments
+    const speakerSegments = await db.speakerSegment.findMany({
+        where: {
+            meetingId,
+            cityId
+        },
+        select: {
+            speakerTagId: true
+        }
+    });
+
+    const speakerTagIds = [...new Set(speakerSegments.map(s => s.speakerTagId))];
+
+    // Delete the SpeakerTags, which will cascade delete the SpeakerSegments
+    if (speakerTagIds.length > 0) {
+        await db.speakerTag.deleteMany({
+            where: {
+                id: { in: speakerTagIds }
+            }
+        });
+        console.log(`Deleted ${speakerTagIds.length} speaker tags and their associated segments`);
+    }
+}
+
+export async function requestTranscribeInternal(youtubeUrl: string, councilMeetingId: string, cityId: string, {
+    force = false
+}: {
+    force?: boolean;
+} = {}) {
+    console.log(`Requesting transcription for ${youtubeUrl}`);
+    const councilMeeting = await prisma.councilMeeting.findUnique({
+        where: {
+            cityId_id: {
+                id: councilMeetingId,
+                cityId
+            }
+        },
+        include: {
+            city: {
+                include: {
+                    persons: true,
+                    parties: true
+                }
+            },
+            speakerSegments: {
+                select: {
+                    id: true
+                },
+                take: 1
+            }
+        }
+    });
+
+    if (!councilMeeting) {
+        throw new Error("Council meeting not found");
+    }
+
+    if (councilMeeting.speakerSegments.length > 0) {
+        if (force) {
+            await deleteExistingSpeakerData(councilMeetingId, cityId);
+        } else {
+            console.log(`Meeting already has speaker segments`);
+            throw new Error('Meeting already has speaker segments');
+        }
+    }
+
+    const city = councilMeeting.city;
+
+    // Get voiceprints for relevant people based on meeting's administrative body
+    const people = await getPeopleForMeeting(cityId, councilMeeting.administrativeBodyId);
+    const peopleWithVoiceprints = people
+        .filter(person => person.voicePrints && person.voicePrints.length > 0);
+
+    // Pyannote.ai supports max 50 voiceprints per request.
+    // When over the limit, people are already sorted by role priority from getPeopleForMeeting
+    // (mayors, deputy mayors, council heads, etc.). Use speaking time as tiebreaker within
+    // the same role priority tier.
+    const MAX_VOICEPRINTS = 50;
+    if (peopleWithVoiceprints.length > MAX_VOICEPRINTS) {
+        const stats = await getStatisticsFor({ cityId }, ["person"]);
+        const speakingByPerson = new Map(
+            (stats.people ?? []).map(s => [s.item.id, s.speakingSeconds])
+        );
+        peopleWithVoiceprints.sort((a, b) => {
+            const priorityA = Math.min(...a.roles.map(getRoleTypePriority));
+            const priorityB = Math.min(...b.roles.map(getRoleTypePriority));
+            if (priorityA !== priorityB) return priorityA - priorityB;
+            return (speakingByPerson.get(b.id) ?? 0) - (speakingByPerson.get(a.id) ?? 0);
+        });
+        console.warn(
+            `Found ${peopleWithVoiceprints.length} voiceprints but pyannote.ai supports max ${MAX_VOICEPRINTS}, ` +
+            `sending top by role priority + speaking time`
+        );
+    }
+
+    const voiceprints: Voiceprint[] = peopleWithVoiceprints
+        .slice(0, MAX_VOICEPRINTS)
+        .map(person => ({
+            personId: person.id,
+            voiceprint: person.voicePrints![0].embedding
+        }));
+
+    console.log(`Sending ${voiceprints.length} voiceprints for meeting (${peopleWithVoiceprints.length} total with voiceprints)`);
+
+    const body: Omit<TranscribeRequest, 'callbackUrl'> = {
+        youtubeUrl,
+        voiceprints: voiceprints.length > 0 ? voiceprints : undefined,
+        cityLanguage: city.language,
+    }
+
+    await prisma.councilMeeting.update({
+        where: {
+            cityId_id: {
+                id: councilMeetingId,
+                cityId
+            }
+        },
+        data: {
+            youtubeUrl
+        }
+    });
+
+    console.log(`Transcribe body: ${JSON.stringify(body)}`);
+    return startTask('transcribe', body, councilMeetingId, cityId, { force });
+}

--- a/src/lib/utils/__tests__/youtube.test.ts
+++ b/src/lib/utils/__tests__/youtube.test.ts
@@ -1,0 +1,71 @@
+/** @jest-environment node */
+import { parseChannelRef, isValidYouTubeUrl } from '../youtube';
+
+describe('parseChannelRef', () => {
+    it('extracts a canonical channel id from /channel/UC… URLs', () => {
+        expect(parseChannelRef('https://www.youtube.com/channel/UCX5CxaBSCrAJxQawnE1sKHw')).toEqual({
+            kind: 'id',
+            value: 'UCX5CxaBSCrAJxQawnE1sKHw',
+        });
+    });
+
+    it('extracts a handle from /@handle URLs', () => {
+        expect(parseChannelRef('https://www.youtube.com/@cityofathens.youtube')).toEqual({
+            kind: 'handle',
+            value: 'cityofathens.youtube',
+        });
+    });
+
+    it('extracts a handle from /@handle URLs with trailing path/query', () => {
+        expect(parseChannelRef('https://www.youtube.com/@cityofathens.youtube/streams?foo=bar')).toEqual({
+            kind: 'handle',
+            value: 'cityofathens.youtube',
+        });
+    });
+
+    it('extracts a legacy username from /user/ URLs', () => {
+        expect(parseChannelRef('https://www.youtube.com/user/cityofathens')).toEqual({
+            kind: 'user',
+            value: 'cityofathens',
+        });
+    });
+
+    it('extracts a vanity name from /c/ URLs', () => {
+        expect(parseChannelRef('https://www.youtube.com/c/CityOfAthens')).toEqual({
+            kind: 'custom',
+            value: 'CityOfAthens',
+        });
+    });
+
+    it('treats a bare handle (with @) as a handle', () => {
+        expect(parseChannelRef('@cityofathens')).toEqual({ kind: 'handle', value: 'cityofathens' });
+    });
+
+    it('treats a bare name (no @, no slash) as a handle', () => {
+        expect(parseChannelRef('cityofathens')).toEqual({ kind: 'handle', value: 'cityofathens' });
+    });
+
+    it('handles m. and missing-www hosts', () => {
+        expect(parseChannelRef('https://m.youtube.com/@foo')).toEqual({ kind: 'handle', value: 'foo' });
+        expect(parseChannelRef('https://youtube.com/channel/UCabc')).toEqual({ kind: 'id', value: 'UCabc' });
+    });
+
+    it('returns null for empty or unrecognized input', () => {
+        expect(parseChannelRef('')).toBeNull();
+        expect(parseChannelRef('https://www.youtube.com/watch?v=abc')).toBeNull();
+        expect(parseChannelRef('not a url /')).toBeNull();
+    });
+});
+
+describe('isValidYouTubeUrl', () => {
+    it('accepts watch, live, shorts, and youtu.be URLs', () => {
+        expect(isValidYouTubeUrl('https://www.youtube.com/watch?v=abc123')).toBe(true);
+        expect(isValidYouTubeUrl('https://www.youtube.com/live/abc123')).toBe(true);
+        expect(isValidYouTubeUrl('https://youtu.be/abc123')).toBe(true);
+    });
+
+    it('rejects channel URLs and non-YouTube URLs', () => {
+        expect(isValidYouTubeUrl('https://www.youtube.com/@foo')).toBe(false);
+        expect(isValidYouTubeUrl('https://example.com/watch?v=abc')).toBe(false);
+    });
+});

--- a/src/lib/utils/__tests__/youtube.test.ts
+++ b/src/lib/utils/__tests__/youtube.test.ts
@@ -55,6 +55,20 @@ describe('parseChannelRef', () => {
         expect(parseChannelRef('https://www.youtube.com/watch?v=abc')).toBeNull();
         expect(parseChannelRef('not a url /')).toBeNull();
     });
+
+    it('rejects channel-like paths on non-YouTube hosts', () => {
+        expect(parseChannelRef('https://example.com/@otherchannel')).toBeNull();
+        expect(parseChannelRef('https://evil.com/channel/UCabc')).toBeNull();
+        expect(parseChannelRef('https://notyoutube.com/user/foo')).toBeNull();
+        // Substring/look-alike hosts must not pass the suffix check.
+        expect(parseChannelRef('https://youtube.com.evil.com/@foo')).toBeNull();
+        expect(parseChannelRef('https://fakeyoutube.com/@foo')).toBeNull();
+    });
+
+    it('accepts youtube-nocookie.com and music.youtube.com hosts', () => {
+        expect(parseChannelRef('https://www.youtube-nocookie.com/channel/UCabc')).toEqual({ kind: 'id', value: 'UCabc' });
+        expect(parseChannelRef('https://music.youtube.com/channel/UCabc')).toEqual({ kind: 'id', value: 'UCabc' });
+    });
 });
 
 describe('isValidYouTubeUrl', () => {

--- a/src/lib/utils/youtube.ts
+++ b/src/lib/utils/youtube.ts
@@ -11,3 +11,57 @@ export function isValidYouTubeUrl(url: string): boolean {
   return YOUTUBE_URL_REGEX.test(url)
 }
 
+/**
+ * How a stored YouTube channel URL identifies its channel.
+ * - `id`:     /channel/UC… — the canonical channel id, usable directly with the Data API
+ * - `handle`: /@handle      — needs resolution via channels?forHandle
+ * - `user`:   /user/name    — legacy username, needs resolution via channels?forUsername
+ * - `custom`: /c/name       — vanity URL, only resolvable via search
+ */
+export type ChannelRef =
+  | { kind: 'id'; value: string }
+  | { kind: 'handle'; value: string }
+  | { kind: 'user'; value: string }
+  | { kind: 'custom'; value: string }
+
+/**
+ * Parses a YouTube channel URL into a typed reference the Data API can resolve.
+ * Accepts bare handles ("@city" or "city") too. Returns null when nothing usable
+ * can be extracted.
+ */
+export function parseChannelRef(channelUrl: string): ChannelRef | null {
+  if (!channelUrl) return null
+  const trimmed = channelUrl.trim()
+
+  // Bare handle, with or without the leading @ (no scheme/host).
+  if (!/^https?:\/\//i.test(trimmed) && !trimmed.includes('/')) {
+    const handle = trimmed.replace(/^@/, '')
+    return handle ? { kind: 'handle', value: handle } : null
+  }
+
+  let pathname: string
+  try {
+    pathname = new URL(trimmed).pathname
+  } catch {
+    return null
+  }
+
+  // /@handle
+  const handleMatch = pathname.match(/^\/@([^/]+)/)
+  if (handleMatch) return { kind: 'handle', value: decodeURIComponent(handleMatch[1]) }
+
+  // /channel/UC…
+  const idMatch = pathname.match(/^\/channel\/([^/]+)/)
+  if (idMatch) return { kind: 'id', value: idMatch[1] }
+
+  // /user/name (legacy)
+  const userMatch = pathname.match(/^\/user\/([^/]+)/)
+  if (userMatch) return { kind: 'user', value: decodeURIComponent(userMatch[1]) }
+
+  // /c/name (vanity)
+  const customMatch = pathname.match(/^\/c\/([^/]+)/)
+  if (customMatch) return { kind: 'custom', value: decodeURIComponent(customMatch[1]) }
+
+  return null
+}
+

--- a/src/lib/utils/youtube.ts
+++ b/src/lib/utils/youtube.ts
@@ -39,12 +39,24 @@ export function parseChannelRef(channelUrl: string): ChannelRef | null {
     return handle ? { kind: 'handle', value: handle } : null
   }
 
-  let pathname: string
+  let url: URL
   try {
-    pathname = new URL(trimmed).pathname
+    url = new URL(trimmed)
   } catch {
     return null
   }
+
+  // Only trust channel references from real YouTube hosts. The admin field accepts any
+  // valid URL, so without this a value like https://example.com/@otherchannel would be
+  // resolved through the YouTube API and could point the cron at an unintended channel.
+  const host = url.hostname.toLowerCase()
+  const isYouTubeHost =
+    host === 'youtube.com' || host.endsWith('.youtube.com') ||
+    host === 'youtu.be' ||
+    host === 'youtube-nocookie.com' || host.endsWith('.youtube-nocookie.com')
+  if (!isYouTubeHost) return null
+
+  const pathname = url.pathname
 
   // /@handle
   const handleMatch = pathname.match(/^\/@([^/]+)/)

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -1,0 +1,142 @@
+import { env } from '@/env.mjs';
+import { parseChannelRef } from '@/lib/utils/youtube';
+import { cacheGetJSON, cacheSetJSON } from '@/lib/cache/valkey';
+
+/**
+ * Minimal YouTube Data API v3 client used by the poll-livestreams cron to locate
+ * a meeting's livestream on an administrative body's channel.
+ *
+ * Quota notes (default 10k units/day): channels.list = 1 unit, search.list = 100
+ * units. Channel-id resolution is cached long-term (ids are stable) and the recent
+ * videos listing is cached briefly so multiple meetings sharing a channel cost a
+ * single search per run.
+ */
+
+const API_BASE = 'https://www.googleapis.com/youtube/v3';
+
+// Channel ids never change → cache aggressively. Recent-videos is volatile → short TTL.
+const CHANNEL_ID_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+const CHANNEL_VIDEOS_TTL_SECONDS = 5 * 60; // 5 minutes
+const MAX_RECENT_VIDEOS = 15;
+
+export interface YouTubeVideo {
+    videoId: string;
+    title: string;
+    publishedAt: string;
+    description?: string;
+}
+
+function requireApiKey(): string {
+    if (!env.YOUTUBE_API_KEY) {
+        throw new Error('YOUTUBE_API_KEY is not configured');
+    }
+    return env.YOUTUBE_API_KEY;
+}
+
+async function ytFetch<T>(path: string, params: Record<string, string>): Promise<T> {
+    const url = new URL(`${API_BASE}/${path}`);
+    url.search = new URLSearchParams({ ...params, key: requireApiKey() }).toString();
+
+    const response = await fetch(url, { headers: { Accept: 'application/json' } });
+    if (!response.ok) {
+        const text = await response.text().catch(() => '');
+        throw new Error(`YouTube API ${path} failed: ${response.status} ${response.statusText} ${text.slice(0, 300)}`);
+    }
+    return (await response.json()) as T;
+}
+
+interface ChannelListResponse {
+    items?: Array<{ id: string }>;
+}
+
+interface SearchListResponse {
+    items?: Array<{
+        id?: { channelId?: string; videoId?: string };
+        snippet?: { title?: string; publishedAt?: string; description?: string };
+    }>;
+}
+
+/**
+ * Resolves a stored channel URL (handle, /channel/UC…, /user, or /c vanity) to a
+ * canonical channel id. Cached in Valkey keyed by the input URL. Returns null when
+ * the channel can't be resolved.
+ */
+export async function resolveChannelId(channelUrl: string): Promise<string | null> {
+    const ref = parseChannelRef(channelUrl);
+    if (!ref) return null;
+
+    // A canonical id needs no API call.
+    if (ref.kind === 'id') return ref.value;
+
+    const cacheKey = `oc:youtube:channel-id:${channelUrl.trim()}`;
+    const cached = await cacheGetJSON<string>(cacheKey);
+    if (cached) return cached;
+
+    let channelId: string | null = null;
+
+    if (ref.kind === 'handle') {
+        const data = await ytFetch<ChannelListResponse>('channels', {
+            part: 'id',
+            forHandle: `@${ref.value}`,
+        });
+        channelId = data.items?.[0]?.id ?? null;
+    } else if (ref.kind === 'user') {
+        const data = await ytFetch<ChannelListResponse>('channels', {
+            part: 'id',
+            forUsername: ref.value,
+        });
+        channelId = data.items?.[0]?.id ?? null;
+    } else {
+        // Vanity /c/ URLs aren't directly resolvable — fall back to channel search.
+        const data = await ytFetch<SearchListResponse>('search', {
+            part: 'id',
+            type: 'channel',
+            q: ref.value,
+            maxResults: '1',
+        });
+        channelId = data.items?.[0]?.id?.channelId ?? null;
+    }
+
+    if (channelId) {
+        await cacheSetJSON(cacheKey, channelId, CHANNEL_ID_TTL_SECONDS);
+    }
+    return channelId;
+}
+
+/**
+ * Lists the channel's most recent videos (newest first), briefly cached in Valkey.
+ *
+ * Uses search.list ordered by date rather than filtering to live broadcasts:
+ * council livestreams surface as ordinary recent uploads once finished, so the
+ * broad listing is the safe superset and the LLM matcher picks the right one.
+ */
+export async function listRecentChannelVideos(channelId: string): Promise<YouTubeVideo[]> {
+    const cacheKey = `oc:youtube:channel-videos:${channelId}`;
+    const cached = await cacheGetJSON<YouTubeVideo[]>(cacheKey);
+    if (cached) return cached;
+
+    const data = await ytFetch<SearchListResponse>('search', {
+        part: 'snippet',
+        channelId,
+        type: 'video',
+        order: 'date',
+        maxResults: String(MAX_RECENT_VIDEOS),
+    });
+
+    const videos: YouTubeVideo[] = (data.items ?? [])
+        .filter(item => item.id?.videoId)
+        .map(item => ({
+            videoId: item.id!.videoId!,
+            title: item.snippet?.title ?? '',
+            publishedAt: item.snippet?.publishedAt ?? '',
+            description: item.snippet?.description,
+        }));
+
+    await cacheSetJSON(cacheKey, videos, CHANNEL_VIDEOS_TTL_SECONDS);
+    return videos;
+}
+
+/** Canonical watch URL for a video id. */
+export function watchUrl(videoId: string): string {
+    return `https://www.youtube.com/watch?v=${videoId}`;
+}


### PR DESCRIPTION
## Summary

Adds automated livestream detection and transcription triggering via a new `poll-livestreams` cron job. When a council meeting's scheduled time passes, the system searches the administrative body's YouTube channel, uses Claude to match the meeting to a video, and automatically triggers transcription for confident matches. Videos covering multiple meetings are flagged for manual review.

## Key Changes

- **New cron endpoint** (`GET /api/cron/poll-livestreams`): Finds candidate meetings within ±12h of now, lists recent videos from their YouTube channels, matches each meeting to a video via LLM, and triggers transcription for confident single-meeting matches (≥0.8 confidence). Supports `?dryRun=1` for testing.

- **YouTube Data API client** (`src/lib/youtube.ts`): Minimal v3 client for resolving channel URLs (handles, legacy usernames, vanity URLs, canonical IDs) and listing recent videos. Caches channel IDs long-term (30 days) and video listings briefly (5 minutes) to minimize quota usage.

- **LLM-based meeting-to-video matcher** (`matchMeetingToVideo`): Asks Claude to match a meeting (title, date, administrative body, agenda subjects) to one of the channel's recent videos. Returns structured decisions: `match` (with videoId and confidence), `no_match`, or `multiple_meetings` (deliberate refusal for combined streams like Λογοδοσία + Τακτική Συνεδρίαση).

- **Transcription request extraction** (`src/lib/tasks/transcribeInternal.ts`): Extracted core transcription logic from `requestTranscribe` into a new `requestTranscribeInternal` function callable by both the authenticated user endpoint and the unauthenticated cron. Includes voiceprint selection (up to 50 by role priority + speaking time) and speaker data cleanup.

- **Discord alerts**: Two new alert types for admins:
  - `sendLivestreamMatchedAlert`: Green alert when a match is auto-triggered (includes confidence, reasoning, link to admin panel)
  - `sendLivestreamMultipleMeetingsAlert`: Yellow alert when a video appears to cover multiple meetings (deduped via Valkey cache for 30 days)

- **Valkey/Redis cache layer** (`src/lib/cache/valkey.ts`): Shared client for application-level caching and dedup markers. Gracefully degrades when `CACHE_URL` is unset (dev/single-instance).

- **YouTube URL parsing utilities** (`src/lib/utils/youtube.ts`): `parseChannelRef` extracts channel identifiers from various URL formats (/@handle, /channel/UC…, /user, /c vanity); `isValidYouTubeUrl` validates watch/live/shorts/youtu.be links.

- **Comprehensive test coverage** (`src/lib/tasks/__tests__/pollLivestreams.test.ts`): Tests for the matcher (empty video list, LLM passthrough), poll function (no-op when API key missing, transcription triggering, confidence threshold, hallucinated videoIds, multi-meeting dedup, processAgenda prerequisite, per-run cap, dry-run mode, channel errors).

- **Documentation** (`docs/task-architecture.md`): Added "Livestream Auto-Transcription" section explaining the cron's workflow, candidate criteria, matching logic, and alert behavior.

- **Environment configuration**: Added `YOUTUBE_API_KEY` (optional) to `.env.example` and `src/env.mjs`.

## Implementation Details

- **Candidate filtering**: Only meetings with succeeded `processAgenda`, no existing `youtubeUrl`, an administrative body with `youtubeChannelUrl`, and no in-flight `transcribe` task are considered.
- **Quota efficiency**: Channel resolution and video listing are cached and deduplicated per distinct channel, so multiple meetings sharing a channel cost one API call per run.
- **Safety guards**: The matcher's returned `videoId` is validated against the actual channel videos before triggering transcription. Videos claiming to cover multiple meetings are never auto-matched.
- **Rate limiting**: Max 10 transcriptions per cron

https://claude.ai/code/session_01CPbJiy6pNsZPuZS7SNHN34

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The cron can auto-start costly `transcribe` jobs from LLM YouTube matches (wrong video or pre-meeting uploads), though guards include confidence thresholds, videoId validation, multi-meeting refusal, and CRON_SECRET-only access.
> 
> **Overview**
> Adds a **`poll-livestreams`** cron (`GET /api/cron/poll-livestreams`, `CRON_SECRET`, optional `?dryRun=1`) that finds meetings near their scheduled time with a succeeded `processAgenda`, a body **`youtubeChannelUrl`**, and no active/succeeded `transcribe` task, then tries to attach the right YouTube recording and start transcription without manual admin steps.
> 
> Each run resolves channel URLs via a new **YouTube Data API v3** client (optional **`YOUTUBE_API_KEY`**; no-ops when unset), lists recent uploads with **Valkey-backed** caching/dedup, and uses **Claude** (`matchMeetingToVideo`) to pick a single video. Confident matches (≥ **0.8**, validated `videoId`, cap **10**/run) call **`requestTranscribeInternal`** and send a Discord “auto-matched” alert; combined-stream cases return **`multiple_meetings`** and alert once via Valkey (`oc:livestream:multi-alert:…`).
> 
> **Transcription** setup is moved into **`transcribeInternal.ts`** (not a Server Action); **`requestTranscribe`** still enforces **`withUserAuthorizedToEdit`** then delegates. **`parseChannelRef`** is extended to reject non-YouTube hosts. Docs/env (`.env.example`, `task-architecture.md`) and Jest coverage for polling and URL parsing are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de7bb45fd3ef9638ffd3bf3486bb74ed50322da6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic livestream matching and transcription for council meetings. The main changes are:

- New `poll-livestreams` cron endpoint with dry-run support.
- YouTube channel resolution, video listing, and cache helpers.
- LLM-based meeting-to-video matching with multi-meeting refusal.
- Shared internal transcription path used by the cron and authorized user action.
- Discord alerts for auto-matches and multi-meeting manual handling.
- Tests, docs, and environment configuration for the new workflow.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/tasks/pollLivestreams.ts | Adds the polling workflow, candidate filtering, LLM matching, transcription triggering, and multi-meeting alert handling. |
| src/lib/utils/youtube.ts | Adds YouTube channel parsing with host allowlisting and video URL validation helpers. |
| src/app/api/cron/poll-livestreams/route.ts | Adds the protected cron route and dry-run query handling. |
| src/lib/tasks/transcribeInternal.ts | Extracts shared transcription startup logic for the authorized action and cron workflow. |
| src/lib/youtube.ts | Adds YouTube Data API calls for channel resolution and recent video listing with caching. |

<sub>Reviews (2): Last reviewed commit: ["fix(tasks): harden livestream auto-match..."](https://github.com/schemalabz/opencouncil/commit/de7bb45fd3ef9638ffd3bf3486bb74ed50322da6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40806960)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Context used - .cursorrules ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=8f01574a-2b8a-490a-a6a8-5bb80f6f984c))
- Context used - CLAUDE.md ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=a3ddaa95-717d-48e6-81cd-93c42696bbed))
- Context used - .cursor/rules/auth.mdc ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=6a7ded42-d418-476c-bfad-dae6c4739471))
- Context used - .cursor/rules/general.mdc ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=dc2172bf-e821-4a8e-b26f-cd165ffe6599))
</details>

<!-- /greptile_comment -->