### PR TITLE
fix(about): derive SubjectDemo demo URLs from openness feature config

### DIFF
--- a/messages/el.json
+++ b/messages/el.json
@@ -445,6 +445,7 @@
         "mayor": "Δήμαρχος",
         "president": "Πρόεδρος",
         "member": "Μέλος",
+        "partyLeaderShort": "Επικ.",
         "history": "Ιστορικό",
         "items": "{count, plural, =0 {Κανένα μέλος} =1 {1 μέλος} other {# μέλη}}",
         "addItem": "Προσθήκη Μέλους",

--- a/messages/el.json
+++ b/messages/el.json
@@ -444,6 +444,7 @@
         "partyLeader": "Επικεφαλής",
         "mayor": "Δήμαρχος",
         "president": "Πρόεδρος",
+        "member": "Μέλος",
         "history": "Ιστορικό",
         "items": "{count, plural, =0 {Κανένα μέλος} =1 {1 μέλος} other {# μέλη}}",
         "addItem": "Προσθήκη Μέλους",

--- a/messages/en.json
+++ b/messages/en.json
@@ -820,6 +820,7 @@
         "mayor": "Mayor",
         "president": "President",
         "member": "Member",
+        "partyLeaderShort": "Leader",
         "history": "History",
         "items": "{count, plural, =0 {No members} =1 {1 member} other {# members}}",
         "addItem": "Add Member",

--- a/messages/en.json
+++ b/messages/en.json
@@ -819,6 +819,7 @@
         "partyLeader": "Party Leader",
         "mayor": "Mayor",
         "president": "President",
+        "member": "Member",
         "history": "History",
         "items": "{count, plural, =0 {No members} =1 {1 member} other {# members}}",
         "addItem": "Add Member",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -443,7 +443,8 @@
     "Person": {
         "partyLeader": "Chef de groupe",
         "mayor": "Maire",
-        "president": "Président",
+        "president": "Président(e)",
+        "member": "Membre",
         "history": "Historique",
         "items": "{count, plural, =0 {Aucun membre} =1 {1 membre} other {# membres}}",
         "addItem": "Ajouter un membre",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -445,6 +445,7 @@
         "mayor": "Maire",
         "president": "Président(e)",
         "member": "Membre",
+        "partyLeaderShort": "Chef",
         "history": "Historique",
         "items": "{count, plural, =0 {Aucun membre} =1 {1 membre} other {# membres}}",
         "addItem": "Ajouter un membre",

--- a/src/components/about/SubjectDemo.tsx
+++ b/src/components/about/SubjectDemo.tsx
@@ -4,7 +4,10 @@ import type { Realm } from '@prisma/client'
 import { ColorPercentageRing } from '@/components/ui/color-percentage-ring'
 import { getRealmDomain } from '@/lib/realm'
 import BrowserFrame from './BrowserFrame'
+import { OPENNESS_FEATURES, demoUrlForRealm } from './config'
 import { Link } from '@/i18n/routing'
+
+const SUBJECTS_FEATURE = OPENNESS_FEATURES.find(f => f.id === 'subjects')
 
 // ─── Mock Data (non-translatable) ───────────────────────────────────────
 
@@ -62,6 +65,8 @@ function AnnotationBox({ label, labelRight, children }: {
 export default function SubjectDemo({ realm }: { realm: Realm }) {
     const t = useTranslations('about.demos.subject')
 
+    const demoUrl = SUBJECTS_FEATURE ? demoUrlForRealm(SUBJECTS_FEATURE, realm) : undefined
+
     const parties = PARTY_KEYS.map((key, i) => ({
         name: t(`parties.${key}`),
         color: PARTY_COLORS[i],
@@ -69,7 +74,7 @@ export default function SubjectDemo({ realm }: { realm: Realm }) {
     }))
 
     return (
-        <BrowserFrame url={`${getRealmDomain(realm)}/chania/apr29_2026/subjects/...`} className="w-full">
+        <BrowserFrame url={`${getRealmDomain(realm)}${demoUrl?.replace(/[^/]+$/, '...') ?? ''}`} className="w-full">
             <div className="p-4 md:p-6 space-y-5 bg-white">
                 {/* Section 1: Header */}
                 <AnnotationBox label={t('callouts.header')}>
@@ -206,15 +211,17 @@ export default function SubjectDemo({ realm }: { realm: Realm }) {
                 </AnnotationBox>
 
                 {/* CTA */}
-                <div className="pt-2">
-                    <Link
-                        href="/chania/apr29_2026/subjects/cmocx5sqp03k4grw512nudanu"
-                        className="inline-flex items-center gap-1.5 text-sm font-medium text-orange hover:text-orange/80 transition-colors group"
-                    >
-                        {t('viewRealSubject')}
-                        <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
-                    </Link>
-                </div>
+                {demoUrl && (
+                    <div className="pt-2">
+                        <Link
+                            href={demoUrl}
+                            className="inline-flex items-center gap-1.5 text-sm font-medium text-orange hover:text-orange/80 transition-colors group"
+                        >
+                            {t('viewRealSubject')}
+                            <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
+                        </Link>
+                    </div>
+                )}
             </div>
         </BrowserFrame>
     )

--- a/src/components/persons/RoleDisplay.tsx
+++ b/src/components/persons/RoleDisplay.tsx
@@ -142,7 +142,7 @@ export function RoleDisplay({
                                 borderless && "text-sm"
                             )}>
                                 {primaryRole.party.name_short}
-                                {primaryRole.isHead && <span className="hidden sm:inline"> (Επικ.)</span>}
+                                {primaryRole.isHead && <span className="hidden sm:inline"> ({t('partyLeaderShort')})</span>}
                             </span>
                         </Badge>
                     </Link>

--- a/src/components/persons/RoleDisplay.tsx
+++ b/src/components/persons/RoleDisplay.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/routing';
 import { Badge } from '../ui/badge';
 import { cn, sortRolesByPriority, getPrimaryRole } from '@/lib/utils';
@@ -40,24 +41,24 @@ const getRoleIconColor = (role: RoleWithRelations) => {
     return "text-muted-foreground/70";
 };
 
-const getRoleText = (role: RoleWithRelations) => {
+const getRoleText = (role: RoleWithRelations, t: ReturnType<typeof useTranslations>) => {
     // Party roles (has partyId)
     if (role.partyId && role.party) {
         const text = role.party.name;
-        if (role.isHead) return `${text} (Επικεφαλής)`;
+        if (role.isHead) return `${text} (${t('partyLeader')})`;
         if (role.name) return `${text} - ${role.name}`;
         return text;
     }
 
     // Administrative body roles (has administrativeBodyId)
     if (role.administrativeBodyId && role.administrativeBody) {
-        // For administrative body roles, show role name first (e.g., "Πρόεδρος"), then body name
+        // For administrative body roles, show role name first (e.g., "President"), then body name
         if (role.name) {
             return `${role.name} - ${role.administrativeBody.name}`;
         }
-        // If no role name but is head, use "Πρόεδρος"
+        // If no role name but is head, use the localized "president" label
         if (role.isHead) {
-            return `Πρόεδρος - ${role.administrativeBody.name}`;
+            return `${t('president')} - ${role.administrativeBody.name}`;
         }
         // Otherwise just show the administrative body name
         return role.administrativeBody.name;
@@ -65,11 +66,11 @@ const getRoleText = (role: RoleWithRelations) => {
 
     // City-level roles (has cityId but no partyId or administrativeBodyId, e.g., mayor)
     if (role.cityId && !role.partyId && !role.administrativeBodyId) {
-        if (role.isHead) return 'Δήμαρχος';
-        return role.name || 'Μέλος';
+        if (role.isHead) return t('mayor');
+        return role.name || t('member');
     }
 
-    return role.name || 'Μέλος';
+    return role.name || t('member');
 };
 
 const getRoleVariant = (role: RoleWithRelations) => {
@@ -89,6 +90,8 @@ export function RoleDisplay({
     fullText = false,
     className
 }: RoleDisplayProps) {
+    const t = useTranslations('Person');
+
     if (!roles.length) return null;
 
     const displayRoles = sortRolesByPriority(roles);
@@ -152,7 +155,7 @@ export function RoleDisplay({
                             "text-muted-foreground truncate min-w-0",
                             borderless && "text-sm"
                         )}>
-                            {getRoleText(primaryRole)}
+                            {getRoleText(primaryRole, t)}
                         </span>
                     </div>
                 )}
@@ -164,7 +167,7 @@ export function RoleDisplay({
         <div className={cn(layoutClasses[layout], sizeClasses[size], className)}>
             {displayRoles.map((role, index) => {
                 const RoleIcon = showIcons ? getRoleIcon(role) : null;
-                const roleText = getRoleText(role);
+                const roleText = getRoleText(role, t);
                 const textSmall = truncateWithEllipsis(roleText, BADGE_MAX_CHARS_SMALL);
                 const textLg = truncateWithEllipsis(roleText, BADGE_MAX_CHARS_LG);
                 const displayText = fullText ? (
@@ -211,7 +214,7 @@ export function RoleDisplay({
                                                 <div className="w-3 h-3" />
                                             )}
                                         </div>
-                                        {getRoleText(role)}
+                                        {getRoleText(role, t)}
                                     </span>
                                 </Badge>
                             </Link>


### PR DESCRIPTION
## Summary

`SubjectDemo` hardcoded the Chania demo subject in two places — the `BrowserFrame` address bar and the CTA link — so the French realm (`opencouncil.fr`) showed Greek URLs. This derives both from the `subjects` entry in `OPENNESS_FEATURES` via `demoUrlForRealm(feature, realm)`, the same lookup `OpennessFeatures.tsx` already uses for the feature-row links.

- Browser frame shows `getRealmDomain(realm)` + the realm's demo path with the subject ID truncated to `...` (same display style as before)
- CTA links to the realm's demo subject and only renders when a demo URL exists

## Test plan

- `npx tsc --noEmit` and `npm test` (58 suites, 905 tests) pass
- Verified rendering on a local dev server:
  - Greek: frame shows `opencouncil.gr/chania/apr29_2026/subjects/...`, CTA links to the Chania subject (unchanged)
  - French (`Host: opencouncil.fr`): frame shows `opencouncil.fr/rennes/apr27_2026/subjects/...`, CTA links to the Rennes subject, no Chania references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the about-page subject demo and role labels realm-aware and localized. The main changes are:

- Derives the subject demo frame URL from the openness feature config.
- Links the subject demo CTA to the realm-specific demo subject.
- Adds localized role fallback labels for people.
- Updates Greek, English, and French message entries used by role display.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/about/SubjectDemo.tsx | Uses the subjects openness feature config to show and link the active realm's demo subject. |
| src/components/persons/RoleDisplay.tsx | Uses the `Person` translation namespace for role fallback labels and compact party-leader text. |
| messages/el.json | Adds Greek labels required by the localized role display. |
| messages/en.json | Adds English labels required by the localized role display. |
| messages/fr.json | Adds French labels required by the localized role display and updates the president label. |

<sub>Reviews (3): Last reviewed commit: ["fix(persons): localize party-leader abbr..."](https://github.com/schemalabz/opencouncil/commit/83232aea4cdddd6a020dc15f498856f31fcfb71c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41316169)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Context used - .cursorrules ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=8f01574a-2b8a-490a-a6a8-5bb80f6f984c))
- Context used - CLAUDE.md ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=a3ddaa95-717d-48e6-81cd-93c42696bbed))
- Context used - .cursor/rules/auth.mdc ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=6a7ded42-d418-476c-bfad-dae6c4739471))
- Context used - .cursor/rules/general.mdc ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=dc2172bf-e821-4a8e-b26f-cd165ffe6599))
</details>

<!-- /greptile_comment -->