### PR TITLE
fix(tasks): exclude scheduled and live streams from livestream matching

### DIFF
--- a/src/lib/__tests__/youtube.test.ts
+++ b/src/lib/__tests__/youtube.test.ts
@@ -1,0 +1,68 @@
+/** @jest-environment node */
+
+const mockEnv: { YOUTUBE_API_KEY?: string } = { YOUTUBE_API_KEY: 'test-key' };
+jest.mock('@/env.mjs', () => ({ env: mockEnv }));
+
+const mockCacheGetJSON = jest.fn();
+const mockCacheSetJSON = jest.fn();
+jest.mock('@/lib/cache/valkey', () => ({
+    cacheGetJSON: (...args: unknown[]) => mockCacheGetJSON(...args),
+    cacheSetJSON: (...args: unknown[]) => mockCacheSetJSON(...args),
+}));
+
+import { listRecentChannelVideos } from '../youtube';
+
+function searchItem(videoId: string, liveBroadcastContent: string, title = videoId) {
+    return {
+        id: { videoId },
+        snippet: { title, publishedAt: '2026-06-10T20:00:00Z', liveBroadcastContent },
+    };
+}
+
+function mockFetchOnce(items: unknown[]) {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items }),
+    });
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockEnv.YOUTUBE_API_KEY = 'test-key';
+    mockCacheGetJSON.mockResolvedValue(null);
+    mockCacheSetJSON.mockResolvedValue(true);
+    global.fetch = jest.fn();
+});
+
+describe('listRecentChannelVideos', () => {
+    it('excludes scheduled ("upcoming") and live streams, keeping only finished videos', async () => {
+        mockFetchOnce([
+            searchItem('finished', 'none'),
+            searchItem('scheduled', 'upcoming'),
+            searchItem('broadcasting', 'live'),
+        ]);
+
+        const videos = await listRecentChannelVideos('UCchannel');
+
+        expect(videos.map(v => v.videoId)).toEqual(['finished']);
+    });
+
+    it('keeps videos with no liveBroadcastContent field (treated as finished)', async () => {
+        mockFetchOnce([
+            { id: { videoId: 'plain' }, snippet: { title: 'plain', publishedAt: '2026-06-10T20:00:00Z' } },
+        ]);
+
+        const videos = await listRecentChannelVideos('UCchannel');
+
+        expect(videos.map(v => v.videoId)).toEqual(['plain']);
+    });
+
+    it('returns the cached listing without hitting the API', async () => {
+        mockCacheGetJSON.mockResolvedValue([{ videoId: 'cached', title: 'c', publishedAt: 'x' }]);
+
+        const videos = await listRecentChannelVideos('UCchannel');
+
+        expect(videos.map(v => v.videoId)).toEqual(['cached']);
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -52,7 +52,14 @@ interface ChannelListResponse {
 interface SearchListResponse {
     items?: Array<{
         id?: { channelId?: string; videoId?: string };
-        snippet?: { title?: string; publishedAt?: string; description?: string };
+        snippet?: {
+            title?: string;
+            publishedAt?: string;
+            description?: string;
+            // "none" for a finished/regular upload, "live" while broadcasting,
+            // "upcoming" for a scheduled premiere/stream that hasn't started.
+            liveBroadcastContent?: string;
+        };
     }>;
 }
 
@@ -104,11 +111,16 @@ export async function resolveChannelId(channelUrl: string): Promise<string | nul
 }
 
 /**
- * Lists the channel's most recent videos (newest first), briefly cached in Valkey.
+ * Lists the channel's most recent *finished* videos (newest first), briefly cached
+ * in Valkey.
  *
  * Uses search.list ordered by date rather than filtering to live broadcasts:
  * council livestreams surface as ordinary recent uploads once finished, so the
  * broad listing is the safe superset and the LLM matcher picks the right one.
+ *
+ * Scheduled/in-progress streams (liveBroadcastContent "upcoming" or "live") are
+ * excluded: a stream that hasn't finished has no complete recording to transcribe,
+ * and matching a meeting to it would trigger transcription of a partial video.
  */
 export async function listRecentChannelVideos(channelId: string): Promise<YouTubeVideo[]> {
     const cacheKey = `oc:youtube:channel-videos:${channelId}`;
@@ -125,6 +137,11 @@ export async function listRecentChannelVideos(channelId: string): Promise<YouTub
 
     const videos: YouTubeVideo[] = (data.items ?? [])
         .filter(item => item.id?.videoId)
+        // Keep only finished videos; drop scheduled ("upcoming") and live streams.
+        .filter(item => {
+            const state = item.snippet?.liveBroadcastContent;
+            return state !== 'upcoming' && state !== 'live';
+        })
         .map(item => ({
             videoId: item.id!.videoId!,
             title: item.snippet?.title ?? '',


### PR DESCRIPTION
## Problem

`pollLivestreamsForRecentMeetings` runs on a ±12h window, so a meeting scheduled up to 12h in the future can already have an **upcoming premiere** or an **in-progress live broadcast** on the administrative body's YouTube channel. `listRecentChannelVideos` returned those alongside finished uploads, so the LLM matcher could match one and trigger transcription of a stream that hasn't finished — a video with no complete recording.

Observed in production: the poll tried to transcribe [`Wlg3BQctCMk`](https://www.youtube.com/watch?v=Wlg3BQctCMk) — a scheduled special session ("Ειδική συνεδρίαση… Δ. Αργιθέας | Παρασκευή 3/7/2026") set to start at 16:00 UTC that day. YouTube reported it as `isUpcoming: true`, `isLiveNow: false`, no end timestamp.

## Fix

`search.list` already returns `snippet.liveBroadcastContent` per video: `"none"` for a finished/regular upload, `"live"` while broadcasting, `"upcoming"` for a scheduled stream that hasn't started. `listRecentChannelVideos` now filters out `"upcoming"` and `"live"`, keeping only finished videos.

The filter lives at the source (the YouTube client) rather than in the poller, so it's a single choke point no consumer can bypass. Unfinished streams reappear as ordinary uploads once they end, so the affected meeting is simply retried on a later run.

## Tests

New `src/lib/__tests__/youtube.test.ts` covers:
- excluding `"upcoming"` and `"live"` streams, keeping only finished videos
- treating a missing `liveBroadcastContent` field as finished
- the cache short-circuit path

All poll-livestreams tests continue to pass; no type errors.

## Note / possible follow-up

The filter trusts `search.list`'s `liveBroadcastContent`, which is an eventually-consistent index. In the rare case it lags and reports `"none"` for a still-upcoming stream, a video could slip through. A bulletproof follow-up would add a cheap `videos.list` confirmation (1 quota unit for up to 50 ids) checking `liveStreamingDetails` — a stream with a start time but no `actualEndTime` is not finished. Not included here to keep the fix minimal; happy to add if preferred.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a production bug where `pollLivestreamsForRecentMeetings` could match an upcoming or in-progress YouTube livestream and attempt to transcribe a video with no complete recording. The fix adds a filter in `listRecentChannelVideos` to drop items whose `liveBroadcastContent` is `"live"` or `"upcoming"`, keeping only finished uploads.

- `src/lib/youtube.ts`: Extends the `SearchListResponse` interface with `liveBroadcastContent` and inserts a `.filter()` step before `.map()` to exclude unfinished streams; the cache layer is left intact so filtered-out streams reappear as normal uploads once they end.
- `src/lib/__tests__/youtube.test.ts`: New unit tests cover the three core scenarios — filtering live/upcoming, treating a missing field as finished, and the cache short-circuit path.

<h3>Confidence Score: 5/5</h3>

The change is minimal and targeted: a single filter step is inserted before the mapping stage, with correct handling of undefined (passes through), and the Valkey cache is unaffected.

The fix surgically addresses the root cause by filtering at the data-source level before anything is cached or forwarded to the LLM matcher. The filter correctly treats undefined as finished, matching the test and the YouTube API contract. The 5-minute cache TTL means previously cached live/upcoming entries expire quickly, and live streams that complete reappear naturally on the next cache miss.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/youtube.ts | Adds liveBroadcastContent to SearchListResponse and filters out "upcoming"/"live" items in listRecentChannelVideos; logic and types are correct, filter handles undefined gracefully. |
| src/lib/__tests__/youtube.test.ts | New test file covering filtering of upcoming/live streams, missing-field fallback, and cache short-circuit; setup/teardown is clean and assertions are complete. |

<sub>Reviews (1): Last reviewed commit: ["fix(tasks): exclude scheduled and live s..."](https://github.com/schemalabz/opencouncil/commit/0e1d093616ad33fd022fb7ec8b8de4461fbe6079) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41626131)</sub>

<!-- /greptile_comment -->