### PR TITLE
fix(tasks): list channel videos via uploads playlist, not search.list

### DIFF
--- a/docs/task-architecture.md
+++ b/docs/task-architecture.md
@@ -171,8 +171,10 @@ automatically.
 1. Finds candidate meetings: a `processAgenda` task has `succeeded`, `dateTime` is within
    ±12h of now, `youtubeUrl` is still null, the administrative body has a `youtubeChannelUrl`,
    and no `transcribe` task is already in flight.
-2. Lists recent videos for each distinct channel via the YouTube Data API v3 (resolved channel
-   id + listing are cached in Valkey, so meetings sharing a channel cost one API call per run).
+2. Lists recent videos for each distinct channel from the channel's uploads playlist
+   (`playlistItems.list` + `videos.list`) — reliable and immediate, unlike `search.list`,
+   whose index lags for just-finished livestreams and intermittently 403s. Resolved channel
+   id + listing are cached in Valkey, so meetings sharing a channel cost one lookup per run.
 3. Asks Claude to match each meeting to a single video. The matcher **refuses to match a video
    that appears to cover more than one council meeting** (e.g. a combined Λογοδοσία + Τακτική
    Συνεδρίαση stream) — those are handled manually.

--- a/src/lib/__tests__/youtube.test.ts
+++ b/src/lib/__tests__/youtube.test.ts
@@ -12,18 +12,61 @@ jest.mock('@/lib/cache/valkey', () => ({
 
 import { listRecentChannelVideos } from '../youtube';
 
-function searchItem(videoId: string, liveBroadcastContent: string, title = videoId) {
-    return {
-        id: { videoId },
-        snippet: { title, publishedAt: '2026-06-10T20:00:00Z', liveBroadcastContent },
-    };
+const CHANNEL_ID = 'UCX5CxaBSCrAJxQawnE1sKHw';
+
+// Route each mocked YouTube API call by endpoint. playlistItems returns the
+// ordered ids; videos returns per-id details keyed off `videosById`. When
+// `channelsUploads` is set, /channels resolves to that uploads-playlist id
+// (the non-UC fallback path).
+function installFetch(orderedIds: string[], videosById: Record<string, unknown>, channelsUploads?: string) {
+    global.fetch = jest.fn(async (input: unknown) => {
+        const url = String(input);
+        if (url.includes('/channels')) {
+            return {
+                ok: true,
+                json: async () => ({ items: [{ contentDetails: { relatedPlaylists: { uploads: channelsUploads } } }] }),
+            } as Response;
+        }
+        if (url.includes('/playlistItems')) {
+            return {
+                ok: true,
+                json: async () => ({ items: orderedIds.map(id => ({ contentDetails: { videoId: id } })) }),
+            } as Response;
+        }
+        if (url.includes('/videos')) {
+            const requested = new URL(url).searchParams.get('id')!.split(',');
+            return {
+                ok: true,
+                json: async () => ({ items: requested.map(id => videosById[id]).filter(Boolean) }),
+            } as Response;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+    }) as jest.Mock;
 }
 
-function mockFetchOnce(items: unknown[]) {
-    (global.fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ items }),
-    });
+function finished(id: string, title = id) {
+    return {
+        id,
+        snippet: { title, publishedAt: '2026-07-03T09:13:39Z', liveBroadcastContent: 'none' },
+        liveStreamingDetails: { actualStartTime: '2026-07-03T10:06:46Z', actualEndTime: '2026-07-03T12:40:21Z' },
+    };
+}
+function plainUpload(id: string, title = id) {
+    return { id, snippet: { title, publishedAt: '2026-07-03T09:13:39Z', liveBroadcastContent: 'none' } };
+}
+function live(id: string) {
+    return {
+        id,
+        snippet: { title: id, publishedAt: '2026-07-03T10:00:00Z', liveBroadcastContent: 'live' },
+        liveStreamingDetails: { actualStartTime: '2026-07-03T10:06:46Z' },
+    };
+}
+function upcoming(id: string) {
+    return {
+        id,
+        snippet: { title: id, publishedAt: '2026-07-03T09:00:00Z', liveBroadcastContent: 'upcoming' },
+        liveStreamingDetails: { scheduledStartTime: '2026-07-03T16:00:00Z' },
+    };
 }
 
 beforeEach(() => {
@@ -31,36 +74,71 @@ beforeEach(() => {
     mockEnv.YOUTUBE_API_KEY = 'test-key';
     mockCacheGetJSON.mockResolvedValue(null);
     mockCacheSetJSON.mockResolvedValue(true);
-    global.fetch = jest.fn();
 });
 
 describe('listRecentChannelVideos', () => {
-    it('excludes scheduled ("upcoming") and live streams, keeping only finished videos', async () => {
-        mockFetchOnce([
-            searchItem('finished', 'none'),
-            searchItem('scheduled', 'upcoming'),
-            searchItem('broadcasting', 'live'),
-        ]);
+    it('returns finished videos in uploads-playlist order', async () => {
+        installFetch(['a', 'b'], { a: finished('a'), b: plainUpload('b') });
 
-        const videos = await listRecentChannelVideos('UCchannel');
+        const videos = await listRecentChannelVideos(CHANNEL_ID);
 
-        expect(videos.map(v => v.videoId)).toEqual(['finished']);
+        expect(videos.map(v => v.videoId)).toEqual(['a', 'b']);
     });
 
-    it('keeps videos with no liveBroadcastContent field (treated as finished)', async () => {
-        mockFetchOnce([
-            { id: { videoId: 'plain' }, snippet: { title: 'plain', publishedAt: '2026-06-10T20:00:00Z' } },
-        ]);
+    it('excludes scheduled ("upcoming") and in-progress ("live") streams', async () => {
+        installFetch(['done', 'nowlive', 'later'], {
+            done: finished('done'),
+            nowlive: live('nowlive'),
+            later: upcoming('later'),
+        });
 
-        const videos = await listRecentChannelVideos('UCchannel');
+        const videos = await listRecentChannelVideos(CHANNEL_ID);
 
-        expect(videos.map(v => v.videoId)).toEqual(['plain']);
+        expect(videos.map(v => v.videoId)).toEqual(['done']);
+    });
+
+    it('excludes a broadcast that has started but not ended, even if flagged "none"', async () => {
+        // liveBroadcastContent lag: reports "none" but there is no actualEndTime yet.
+        const lagging = {
+            id: 'lagging',
+            snippet: { title: 'lagging', publishedAt: '2026-07-03T10:00:00Z', liveBroadcastContent: 'none' },
+            liveStreamingDetails: { actualStartTime: '2026-07-03T10:06:46Z' },
+        };
+        installFetch(['lagging', 'done'], { lagging, done: finished('done') });
+
+        const videos = await listRecentChannelVideos(CHANNEL_ID);
+
+        expect(videos.map(v => v.videoId)).toEqual(['done']);
+    });
+
+    it('derives the uploads playlist id (UC… → UU…) without a channels.list call', async () => {
+        installFetch(['a'], { a: finished('a') });
+
+        await listRecentChannelVideos(CHANNEL_ID);
+
+        const urls = (global.fetch as jest.Mock).mock.calls.map(c => String(c[0]));
+        expect(urls.find(u => u.includes('/playlistItems'))).toContain(`playlistId=UU${CHANNEL_ID.slice(2)}`);
+        // No channels.list needed for a standard UC… id.
+        expect(urls.some(u => u.includes('/channels'))).toBe(false);
+    });
+
+    it('resolves the uploads playlist via channels.list for a non-UC channel id', async () => {
+        installFetch(['a'], { a: finished('a') }, 'UUfromChannelsList');
+
+        const videos = await listRecentChannelVideos('HC0123456789abcdefghijkl');
+
+        expect(videos.map(v => v.videoId)).toEqual(['a']);
+        const urls = (global.fetch as jest.Mock).mock.calls.map(c => String(c[0]));
+        // Non-UC id can't be swapped → must ask channels.list, then use its uploads id.
+        expect(urls.some(u => u.includes('/channels'))).toBe(true);
+        expect(urls.find(u => u.includes('/playlistItems'))).toContain('playlistId=UUfromChannelsList');
     });
 
     it('returns the cached listing without hitting the API', async () => {
         mockCacheGetJSON.mockResolvedValue([{ videoId: 'cached', title: 'c', publishedAt: 'x' }]);
+        global.fetch = jest.fn();
 
-        const videos = await listRecentChannelVideos('UCchannel');
+        const videos = await listRecentChannelVideos(CHANNEL_ID);
 
         expect(videos.map(v => v.videoId)).toEqual(['cached']);
         expect(global.fetch).not.toHaveBeenCalled();

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -6,10 +6,10 @@ import { cacheGetJSON, cacheSetJSON } from '@/lib/cache/valkey';
  * Minimal YouTube Data API v3 client used by the poll-livestreams cron to locate
  * a meeting's livestream on an administrative body's channel.
  *
- * Quota notes (default 10k units/day): channels.list = 1 unit, search.list = 100
- * units. Channel-id resolution is cached long-term (ids are stable) and the recent
- * videos listing is cached briefly so multiple meetings sharing a channel cost a
- * single search per run.
+ * Quota notes (default 10k units/day): channels.list / playlistItems.list /
+ * videos.list = 1 unit each, search.list = 100 units. Channel-id resolution is
+ * cached long-term (ids are stable) and the recent videos listing is cached
+ * briefly so multiple meetings sharing a channel cost a single lookup per run.
  */
 
 const API_BASE = 'https://www.googleapis.com/youtube/v3';
@@ -17,6 +17,9 @@ const API_BASE = 'https://www.googleapis.com/youtube/v3';
 // Channel ids never change → cache aggressively. Recent-videos is volatile → short TTL.
 const CHANNEL_ID_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
 const CHANNEL_VIDEOS_TTL_SECONDS = 5 * 60; // 5 minutes
+// Must stay ≤ 50: both playlistItems.list (maxResults) and videos.list (comma-separated
+// ids) cap at 50 per request, and listRecentChannelVideos issues one call to each — a
+// larger value would 400 or silently drop tail videos.
 const MAX_RECENT_VIDEOS = 15;
 
 export interface YouTubeVideo {
@@ -52,6 +55,21 @@ interface ChannelListResponse {
 interface SearchListResponse {
     items?: Array<{
         id?: { channelId?: string; videoId?: string };
+        snippet?: { title?: string; publishedAt?: string; description?: string };
+    }>;
+}
+
+interface ChannelContentDetailsResponse {
+    items?: Array<{ contentDetails?: { relatedPlaylists?: { uploads?: string } } }>;
+}
+
+interface PlaylistItemsResponse {
+    items?: Array<{ contentDetails?: { videoId?: string } }>;
+}
+
+interface VideosListResponse {
+    items?: Array<{
+        id?: string;
         snippet?: {
             title?: string;
             publishedAt?: string;
@@ -59,6 +77,12 @@ interface SearchListResponse {
             // "none" for a finished/regular upload, "live" while broadcasting,
             // "upcoming" for a scheduled premiere/stream that hasn't started.
             liveBroadcastContent?: string;
+        };
+        // Present only for videos that are (or were) live broadcasts.
+        liveStreamingDetails?: {
+            scheduledStartTime?: string;
+            actualStartTime?: string;
+            actualEndTime?: string;
         };
     }>;
 }
@@ -111,42 +135,91 @@ export async function resolveChannelId(channelUrl: string): Promise<string | nul
 }
 
 /**
+ * A channel's auto-generated "uploads" playlist id. For every standard channel it
+ * is the channel id with the "UC" prefix swapped for "UU"; only non-standard ids
+ * need a channels.list lookup.
+ */
+async function resolveUploadsPlaylistId(channelId: string): Promise<string | null> {
+    if (channelId.startsWith('UC')) return `UU${channelId.slice(2)}`;
+
+    const data = await ytFetch<ChannelContentDetailsResponse>('channels', {
+        part: 'contentDetails',
+        id: channelId,
+    });
+    return data.items?.[0]?.contentDetails?.relatedPlaylists?.uploads ?? null;
+}
+
+/**
+ * True for a scheduled ("upcoming") or in-progress ("live") broadcast — a stream
+ * that has no complete recording to transcribe yet. A finished stream reports
+ * liveBroadcastContent "none" and carries an actualEndTime, so it passes.
+ */
+function isUnfinishedStream(video: NonNullable<VideosListResponse['items']>[number]): boolean {
+    const state = video.snippet?.liveBroadcastContent;
+    if (state === 'live' || state === 'upcoming') return true;
+
+    // Defensive: a broadcast that has started (or is only scheduled) but not ended
+    // is still in progress, even if liveBroadcastContent momentarily lags.
+    const details = video.liveStreamingDetails;
+    if (details && (details.actualStartTime || details.scheduledStartTime) && !details.actualEndTime) {
+        return true;
+    }
+    return false;
+}
+
+/**
  * Lists the channel's most recent *finished* videos (newest first), briefly cached
  * in Valkey.
  *
- * Uses search.list ordered by date rather than filtering to live broadcasts:
- * council livestreams surface as ordinary recent uploads once finished, so the
- * broad listing is the safe superset and the LLM matcher picks the right one.
+ * Reads the channel's uploads playlist via playlistItems.list rather than
+ * search.list. search.list queries YouTube's search index, which lags by
+ * minutes-to-hours, is unreliable for just-finished livestreams, and (observed
+ * on our key) intermittently 403s — so a council stream that ended within a
+ * meeting's polling window could be missed entirely. The uploads playlist is the
+ * channel's direct upload log: immediate, reliable, and far cheaper (1 unit vs 100).
  *
- * Scheduled/in-progress streams (liveBroadcastContent "upcoming" or "live") are
- * excluded: a stream that hasn't finished has no complete recording to transcribe,
- * and matching a meeting to it would trigger transcription of a partial video.
+ * A videos.list call then supplies each video's authoritative live status, so
+ * scheduled ("upcoming") and in-progress ("live") streams are excluded — they have
+ * no complete recording, and matching one would transcribe a partial video.
  */
 export async function listRecentChannelVideos(channelId: string): Promise<YouTubeVideo[]> {
     const cacheKey = `oc:youtube:channel-videos:${channelId}`;
     const cached = await cacheGetJSON<YouTubeVideo[]>(cacheKey);
     if (cached) return cached;
 
-    const data = await ytFetch<SearchListResponse>('search', {
-        part: 'snippet',
-        channelId,
-        type: 'video',
-        order: 'date',
+    const uploadsPlaylistId = await resolveUploadsPlaylistId(channelId);
+    if (!uploadsPlaylistId) return [];
+
+    const playlist = await ytFetch<PlaylistItemsResponse>('playlistItems', {
+        part: 'contentDetails',
+        playlistId: uploadsPlaylistId,
         maxResults: String(MAX_RECENT_VIDEOS),
     });
 
-    const videos: YouTubeVideo[] = (data.items ?? [])
-        .filter(item => item.id?.videoId)
-        // Keep only finished videos; drop scheduled ("upcoming") and live streams.
-        .filter(item => {
-            const state = item.snippet?.liveBroadcastContent;
-            return state !== 'upcoming' && state !== 'live';
-        })
-        .map(item => ({
-            videoId: item.id!.videoId!,
-            title: item.snippet?.title ?? '',
-            publishedAt: item.snippet?.publishedAt ?? '',
-            description: item.snippet?.description,
+    // Newest-first video ids from the uploads playlist.
+    const orderedIds = (playlist.items ?? [])
+        .map(item => item.contentDetails?.videoId)
+        .filter((id): id is string => Boolean(id));
+
+    if (orderedIds.length === 0) return [];
+
+    // One videos.list call (≤50 ids) for titles + authoritative live status.
+    const details = await ytFetch<VideosListResponse>('videos', {
+        part: 'snippet,liveStreamingDetails',
+        id: orderedIds.join(','),
+    });
+
+    const byId = new Map((details.items ?? []).map(v => [v.id, v] as const));
+
+    const videos: YouTubeVideo[] = orderedIds
+        .map(id => byId.get(id))
+        .filter((v): v is NonNullable<typeof v> => Boolean(v))
+        .filter(v => !isUnfinishedStream(v))
+        .map(v => ({
+            videoId: v.id!,
+            title: v.snippet?.title ?? '',
+            publishedAt: v.snippet?.publishedAt ?? '',
+            description: v.snippet?.description,
         }));
 
     await cacheSetJSON(cacheKey, videos, CHANNEL_VIDEOS_TTL_SECONDS);


### PR DESCRIPTION
Follow-up to #522.

## Why

#522 filtered `search.list` results by `liveBroadcastContent`, but reproducing the Athens miss locally surfaced the real root cause: **`search.list` itself is the problem**, not just what it returns.

`search.list` queries YouTube's search index, which:
1. **Lags minutes-to-hours** and is unreliable for just-finished livestreams, and
2. **Intermittently returns `403 "cannot act on behalf of the specified Google account"`** — measured at **~40% of calls on our key (9/15 succeeded)**, while `channels.list` / `playlistItems.list` / `videos.list` were **15/15**.

Either failure leaves a meeting unmatched within its ±12h polling window — the correct finished video is absent from the lagging index, or the whole listing errors out. This is what happened to Athens `jul3_2026`: video [`-jgt8v_lOeg`](https://www.youtube.com/watch?v=-jgt8v_lOeg) was never even presented to the matcher. It also explains the earlier preview run where meetings came back as `"error"` rather than `"no_match"`.

## What

`listRecentChannelVideos` now reads the channel's **uploads playlist** instead of searching:

- `playlistItems.list` → the channel's recent uploads directly (immediate, reliable)
- `videos.list` → titles + authoritative `liveStreamingDetails` for those ids

Scheduled (`upcoming`) and in-progress (`live`) streams are still excluded — a stream with no `actualEndTime` has no complete recording to transcribe. `search.list` is dropped from the hot path entirely (it remains only in `resolveChannelId`'s `/c/` vanity fallback).

**Result:** no dependence on the flaky/lagging search index, and **~2 quota units per channel per run instead of 100**.

## Verification

Reproduced end-to-end locally against the real Athens channel + live Claude matcher:
- current `search.list` path: 403'd on all attempts
- uploads-playlist path: returned `-jgt8v_lOeg` every time, newest-first
- real LLM matcher then matched it to the meeting at **0.98 confidence** ✅

Tests rewritten for the two-call flow (17 passing); `docs/task-architecture.md` updated.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the flaky, high-quota `search.list` hot path in `listRecentChannelVideos` with `playlistItems.list` + `videos.list`, eliminating both the search-index lag and the intermittent 403 that caused the Athens meeting to go unmatched.

- **`youtube.ts`**: New `resolveUploadsPlaylistId` derives the uploads playlist ID via a fast UC→UU string swap (no API call) or a single `channels.list` fallback for non-standard IDs; `isUnfinishedStream` adds a defensive `liveStreamingDetails` check so a broadcast with a lagging `liveBroadcastContent: \"none\"` is still excluded if its `actualEndTime` is absent; `MAX_RECENT_VIDEOS` gains a comment documenting the ≤50 constraint for both downstream calls.
- **`youtube.test.ts`**: Tests rewritten around an `installFetch` router that dispatches by endpoint; five scenarios cover playlist ordering, live/upcoming/lagging exclusion, UC→UU fast path, non-UC channels.list fallback, and cache hit.
- **`docs/task-architecture.md`**: Updated to reflect the new two-call lookup and its reliability/quota advantages.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core logic is correct, the new API path is well-tested, and the change eliminates the root cause of the production miss.

The two-call flow (playlistItems → videos) is straightforward; the UC→UU transformation is a well-known YouTube convention; isUnfinishedStream correctly handles both the liveBroadcastContent field and the lagging-state edge case; all five new test scenarios pass; quota footprint drops from ~100 units to 2 units per channel per run.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/youtube.ts | Core change: replaces search.list with playlistItems.list + videos.list; adds resolveUploadsPlaylistId and isUnfinishedStream helpers with correct UC→UU fast-path and defensive lagging-liveBroadcastContent handling. |
| src/lib/__tests__/youtube.test.ts | Tests rewritten for the two-call flow; installFetch helper routes by endpoint; covers ordering, live/upcoming exclusion, lagging liveBroadcastContent, UC→UU fast path, non-UC channels.list fallback, and cache hit. |
| docs/task-architecture.md | Documentation updated to reflect the switch to playlistItems.list + videos.list and the rationale for dropping search.list from the hot path. |

<sub>Reviews (2): Last reviewed commit: ["fix(tasks): list channel videos via uplo..."](https://github.com/schemalabz/opencouncil/commit/a66ac8dc5130fe39030876bb24e699b177dac742) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41636070)</sub>

<!-- /greptile_comment -->