### PR TITLE
fix(tasks): retry flaky search.list in channel-id resolution

### DIFF
--- a/src/lib/__tests__/resolveChannelId.test.ts
+++ b/src/lib/__tests__/resolveChannelId.test.ts
@@ -1,0 +1,65 @@
+/** @jest-environment node */
+
+const mockEnv: { YOUTUBE_API_KEY?: string } = { YOUTUBE_API_KEY: 'test-key' };
+jest.mock('@/env.mjs', () => ({ env: mockEnv }));
+
+const mockCacheGetJSON = jest.fn();
+const mockCacheSetJSON = jest.fn();
+jest.mock('@/lib/cache/valkey', () => ({
+    cacheGetJSON: (...args: unknown[]) => mockCacheGetJSON(...args),
+    cacheSetJSON: (...args: unknown[]) => mockCacheSetJSON(...args),
+}));
+
+import { resolveChannelId } from '../youtube';
+
+const forbidden = () => ({ ok: false, status: 403, statusText: 'Forbidden', text: async () => 'cannot act on behalf' } as Response);
+const ok = (body: unknown) => ({ ok: true, json: async () => body } as Response);
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockEnv.YOUTUBE_API_KEY = 'test-key';
+    mockCacheGetJSON.mockResolvedValue(null);
+    mockCacheSetJSON.mockResolvedValue(true);
+});
+
+describe('resolveChannelId — /c/ vanity fallback (search.list)', () => {
+    it('retries the intermittent search 403 and succeeds', async () => {
+        global.fetch = jest.fn()
+            .mockResolvedValueOnce(forbidden())
+            .mockResolvedValueOnce(forbidden())
+            .mockResolvedValueOnce(ok({ items: [{ id: { channelId: 'UCresolved' } }] })) as jest.Mock;
+
+        const id = await resolveChannelId('https://www.youtube.com/c/CityOfAthens');
+
+        expect(id).toBe('UCresolved');
+        expect(global.fetch).toHaveBeenCalledTimes(3);
+        expect(mockCacheSetJSON).toHaveBeenCalledWith('oc:youtube:channel-id:https://www.youtube.com/c/CityOfAthens', 'UCresolved', expect.any(Number));
+    });
+
+    it('gives up after the retry cap when search keeps 403ing', async () => {
+        global.fetch = jest.fn().mockResolvedValue(forbidden()) as jest.Mock;
+
+        await expect(resolveChannelId('https://www.youtube.com/c/CityOfAthens')).rejects.toThrow('403');
+        expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+});
+
+describe('resolveChannelId — non-vanity paths are unaffected', () => {
+    it('resolves a handle via channels.list without retry', async () => {
+        global.fetch = jest.fn().mockResolvedValue(ok({ items: [{ id: 'UChandle' }] })) as jest.Mock;
+
+        const id = await resolveChannelId('https://www.youtube.com/@cityofathens.youtube');
+
+        expect(id).toBe('UChandle');
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns a canonical /channel/UC… id with no API call', async () => {
+        global.fetch = jest.fn() as jest.Mock;
+
+        const id = await resolveChannelId('https://www.youtube.com/channel/UCX5CxaBSCrAJxQawnE1sKHw');
+
+        expect(id).toBe('UCX5CxaBSCrAJxQawnE1sKHw');
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -64,6 +64,27 @@ interface SearchListResponse {
 }
 
 /**
+ * search.list intermittently returns 403 ("cannot act on behalf of the specified
+ * Google account") on our key — a known, transient YouTube quirk (~40% of calls in
+ * practice). Retry that specific failure a few times before surfacing it, so
+ * channel-id resolution for /c/ vanity URLs (the only remaining search.list caller)
+ * doesn't fail on a flaky response. Other errors are terminal and rethrow at once.
+ */
+const SEARCH_MAX_ATTEMPTS = 3;
+async function searchListWithRetry(params: Record<string, string>): Promise<SearchListResponse> {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= SEARCH_MAX_ATTEMPTS; attempt++) {
+        try {
+            return await ytFetch<SearchListResponse>('search', params);
+        } catch (error) {
+            lastError = error;
+            if (!(error instanceof Error && error.message.includes('search failed: 403'))) throw error;
+        }
+    }
+    throw lastError;
+}
+
+/**
  * Resolves a stored channel URL (handle, /channel/UC…, /user, or /c vanity) to a
  * canonical channel id. Cached in Valkey keyed by the input URL. Returns null when
  * the channel can't be resolved.
@@ -95,7 +116,8 @@ export async function resolveChannelId(channelUrl: string): Promise<string | nul
         channelId = data.items?.[0]?.id ?? null;
     } else {
         // Vanity /c/ URLs aren't directly resolvable — fall back to channel search.
-        const data = await ytFetch<SearchListResponse>('search', {
+        // search.list is flaky (intermittent 403), so retry that failure.
+        const data = await searchListWithRetry({
             part: 'id',
             type: 'channel',
             q: ref.value,


### PR DESCRIPTION
Related to #523 (the `search.list` → uploads-playlist switch).

## Why

While diagnosing the livestream-poll misses, we measured that `search.list` intermittently returns `403 "cannot act on behalf of the specified Google account"` on our key — **~40% of calls (9/15 succeeded)**, whereas `channels.list` / `playlistItems.list` / `videos.list` were 100% reliable.

#523 removes `search.list` from the video-listing hot path. But `resolveChannelId` still uses it for **one** case: resolving `/c/` **vanity** channel URLs (handles and `/channel/UC…` URLs use the reliable `channels.list` path or need no call). So if any administrative body's `youtubeChannelUrl` is a `/c/` vanity URL, a single flaky 403 fails channel-id resolution — and with it the entire poll for that body's meetings.

## What

Wrap that one vanity-fallback `search.list` call in a small retry (up to 3 attempts) that retries **only** the transient 403; any other error stays terminal. No change to the handle / `/channel/UC…` paths.

This is a targeted follow-up and is independent of #523 — it touches only `resolveChannelId`, not `listRecentChannelVideos`, so the two can merge in either order.

## Tests

New `src/lib/__tests__/resolveChannelId.test.ts` (separate file, no overlap with #523):
- vanity URL: 403 → 403 → 200 resolves and caches (3 calls)
- vanity URL: persistent 403 gives up after the cap and throws
- handle resolves via `channels.list` with a single call (no retry)
- `/channel/UC…` returns with no API call

All passing; existing suites unaffected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wraps the one remaining `search.list` call in `resolveChannelId` — used only for `/c/` vanity channel URLs — in a small retry loop (up to 3 attempts) that retries transient `403` responses while re-throwing all other errors immediately. The retry detection is correct and the test coverage is solid, though a couple of hardening opportunities remain.

- **`searchListWithRetry` in `youtube.ts`**: the 403-detection relies on a substring match against `ytFetch`'s error message format; if that format changes the retry silently degrades to zero retries. The loop also has no delay between attempts, so all three requests can fire within milliseconds of each other.
- **New test file**: covers the intended retry scenarios and non-vanity paths well, but is missing a case asserting that a non-403 error (e.g. 500) on the vanity path is rethrown immediately on the first attempt.

<h3>Confidence Score: 4/5</h3>

Change is narrow and well-contained; the retry logic is correct for the happy paths covered by tests, with minor hardening gaps that don't affect current behaviour.

The retry logic works correctly for every path the tests exercise. The main concerns are the missing inter-attempt delay and the substring-match coupling to ytFetch's error format, neither of which represents a current defect.

Both changed files warrant a second look: youtube.ts for the delay and error-format coupling, and the test file for the missing non-403 terminal-error case.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/youtube.ts | Adds `searchListWithRetry` wrapping the vanity-URL `search.list` call with up to 3 attempts; retry detection is correct but coupled to `ytFetch`'s error message format, and there is no delay between attempts. |
| src/lib/__tests__/resolveChannelId.test.ts | New test file covering 403-retry-then-success, exhausted-403-gives-up, handle via channels.list, and canonical /channel/UC… no-call paths; missing a case for non-403 terminal errors being immediately rethrown. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Flib%2Fyoutube.ts%3A76-83%0A**No%20delay%20between%20retry%20attempts**%0A%0AThe%20retry%20loop%20fires%20all%20three%20attempts%20back-to-back%20with%20no%20sleep.%20If%20the%20403%20is%20caused%20by%20momentary%20server-side%20state%20on%20YouTube's%20side%2C%20an%20instant%20re-request%20hits%20the%20same%20condition.%20Adding%20even%20a%20small%20fixed%20or%20linear%20delay%20%28e.g.%20%60attempt%20*%20500ms%60%29%20between%20attempts%20would%20give%20the%20upstream%20a%20brief%20window%20to%20clear%2C%20making%20the%20retry%20materially%20more%20effective%20than%20hammering%20the%20same%20endpoint%20three%20times%20in%20quick%20succession.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Flib%2Fyoutube.ts%3A81%0A**Retry%20detection%20coupled%20to%20%60ytFetch%60%20error%20message%20format**%0A%0AThe%20check%20%60error.message.includes%28'search%20failed%3A%20403'%29%60%20depends%20on%20the%20exact%20string%20produced%20by%20%60ytFetch%60%3A%20%60YouTube%20API%20%24%7Bpath%7D%20failed%3A%20%24%7Bstatus%7D%20%E2%80%A6%60.%20If%20that%20template%20ever%20changes%20%28e.g.%20a%20different%20verb%2C%20different%20ordering%29%2C%20the%20condition%20silently%20evaluates%20to%20%60false%60%20for%20all%20errors%20%E2%80%94%20every%20403%20becomes%20terminal%20and%20retries%20stop%20working%20entirely.%20Consider%20a%20typed%20%60YouTubeApiError%60%20class%20%28with%20a%20numeric%20%60status%60%20field%29%20in%20%60ytFetch%60%20and%20checking%20%60error%20instanceof%20YouTubeApiError%20%26%26%20error.status%20%3D%3D%3D%20403%60%20instead.%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Flib%2F__tests__%2FresolveChannelId.test.ts%3A25-44%0A**Missing%20test%20for%20non-403%20terminal%20errors%20on%20the%20vanity%20path**%0A%0AThe%20suite%20covers%20403-retries-then-success%20and%20exhausted-403s%2C%20but%20doesn't%20test%20that%20a%20non-403%20error%20%28e.g.%20a%20500%20or%20network%20error%29%20from%20%60search.list%60%20on%20a%20%60%2Fc%2F%60%20vanity%20URL%20is%20rethrown%20immediately%20on%20the%20first%20attempt%20rather%20than%20being%20silently%20swallowed%20or%20retried.%20Without%20this%20test%2C%20a%20future%20change%20to%20the%20%60if%20%28!%E2%80%A6includes%28'search%20failed%3A%20403'%29%29%60%20branch%20could%20start%20retrying%20all%20error%20kinds%20without%20any%20test%20catching%20the%20regression.%0A%0A&repo=schemalabz%2Fopencouncil&pr=525&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/lib/youtube.ts:76-83
**No delay between retry attempts**

The retry loop fires all three attempts back-to-back with no sleep. If the 403 is caused by momentary server-side state on YouTube's side, an instant re-request hits the same condition. Adding even a small fixed or linear delay (e.g. `attempt * 500ms`) between attempts would give the upstream a brief window to clear, making the retry materially more effective than hammering the same endpoint three times in quick succession.

### Issue 2 of 3
src/lib/youtube.ts:81
**Retry detection coupled to `ytFetch` error message format**

The check `error.message.includes('search failed: 403')` depends on the exact string produced by `ytFetch`: `YouTube API ${path} failed: ${status} …`. If that template ever changes (e.g. a different verb, different ordering), the condition silently evaluates to `false` for all errors — every 403 becomes terminal and retries stop working entirely. Consider a typed `YouTubeApiError` class (with a numeric `status` field) in `ytFetch` and checking `error instanceof YouTubeApiError && error.status === 403` instead.

### Issue 3 of 3
src/lib/__tests__/resolveChannelId.test.ts:25-44
**Missing test for non-403 terminal errors on the vanity path**

The suite covers 403-retries-then-success and exhausted-403s, but doesn't test that a non-403 error (e.g. a 500 or network error) from `search.list` on a `/c/` vanity URL is rethrown immediately on the first attempt rather than being silently swallowed or retried. Without this test, a future change to the `if (!…includes('search failed: 403'))` branch could start retrying all error kinds without any test catching the regression.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tasks): retry flaky search.list in c..."](https://github.com/schemalabz/opencouncil/commit/c647e7a4ce22b253a9e7e253a558a9726a47bf51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41637212)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->