### PR TITLE
fix(embed): make cityId optional for the subjects widget

### DIFF
--- a/src/app/[locale]/(embed)/embed/subjects/page.tsx
+++ b/src/app/[locale]/(embed)/embed/subjects/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 import { getTranslations } from 'next-intl/server';
-import { getCityCached } from '@/lib/cache';
+import { getCityCached, getCityIdForGeohashCached } from '@/lib/cache';
 import { EmbedSubjectCard } from '@/components/embed/EmbedSubjectCard';
 import { EmbedFooter } from '@/components/embed/EmbedFooter';
 import { parseEmbedConfig, type EmbedSearchParams } from '@/lib/utils/embedParams';
@@ -20,14 +20,6 @@ interface EmbedSubjectsPageProps {
 export default async function EmbedSubjectsPage(props: EmbedSubjectsPageProps) {
     const searchParams = await props.searchParams;
     const { locale } = await props.params;
-    const { cityId } = searchParams;
-
-    if (!cityId) notFound();
-
-    const city = await getCityCached(cityId);
-    if (!city) notFound();
-
-    const { limit, administrativeBodyTypes, administrativeBodyIds, themeVars, appThemeShim, baseUrl } = parseEmbedConfig(searchParams);
 
     // Optional location filter: a valid geohash-6 restricts to subjects within
     // 500m of the cell center (plus municipality-wide, no-location subjects).
@@ -35,9 +27,21 @@ export default async function EmbedSubjectsPage(props: EmbedSubjectsPageProps) {
         ? searchParams.geohash.toLowerCase()
         : null;
 
-    const cards = await getHotSubjectCards(cityId, {
-        limit, administrativeBodyTypes, administrativeBodyIds, geohash,
-    });
+    // cityId is optional when a geohash is given: resolve the municipality that
+    // contains the cell center. A geohash outside every covered municipality
+    // renders the empty state rather than a 404 inside the iframe.
+    if (!searchParams.cityId && !geohash) notFound();
+    const cityId = searchParams.cityId ?? (geohash ? await getCityIdForGeohashCached(geohash) : null);
+
+    const city = cityId ? await getCityCached(cityId) : null;
+    // An explicitly provided cityId must exist (unchanged behavior).
+    if (searchParams.cityId && !city) notFound();
+
+    const { limit, administrativeBodyTypes, administrativeBodyIds, themeVars, appThemeShim, baseUrl } = parseEmbedConfig(searchParams);
+
+    const cards = city
+        ? await getHotSubjectCards(city.id, { limit, administrativeBodyTypes, administrativeBodyIds, geohash })
+        : [];
 
     const t = await getTranslations('EmbedWidget');
 
@@ -64,14 +68,14 @@ export default async function EmbedSubjectsPage(props: EmbedSubjectsPageProps) {
                                 stats={stats}
                                 locale={locale}
                                 baseUrl={baseUrl}
-                                cityTimezone={city.timezone}
+                                cityTimezone={city?.timezone}
                             />
                         ))}
                     </div>
                 </div>
             )}
 
-            <EmbedFooter baseUrl={baseUrl} cityId={cityId} />
+            <EmbedFooter baseUrl={baseUrl} cityId={city?.id} />
         </div>
     );
 }

--- a/src/components/embed/EmbedFooter.tsx
+++ b/src/components/embed/EmbedFooter.tsx
@@ -1,13 +1,14 @@
 interface EmbedFooterProps {
     baseUrl: string;
-    cityId: string;
+    /** Links to the city page when known; falls back to the homepage. */
+    cityId?: string;
 }
 
 export function EmbedFooter({ baseUrl, cityId }: EmbedFooterProps) {
     return (
         <div className="embed-footer">
             <a
-                href={`${baseUrl}/${cityId}`}
+                href={cityId ? `${baseUrl}/${cityId}` : baseUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="embed-footer-link"

--- a/src/lib/cache/queries.ts
+++ b/src/lib/cache/queries.ts
@@ -1,6 +1,7 @@
 import { AdministrativeBodyType, Realm } from "@prisma/client";
 import { isUserAuthorizedToEdit } from "@/lib/auth";
-import { getCity, getAllCitiesMinimal, getAllCityIds, getSupportedCitiesWithLogos, getAboutPageStats } from "@/lib/db/cities";
+import { getCity, getAllCitiesMinimal, getAllCityIds, getSupportedCitiesWithLogos, getAboutPageStats, getCityIdContainingPoint } from "@/lib/db/cities";
+import { decodeGeohashToCenter } from "@/lib/geo";
 import { getGitHubStats } from "@/lib/github";
 import { getCityMessage } from "@/lib/db/cityMessages";
 import { getCouncilMeetingsForCity } from "@/lib/db/meetings";
@@ -24,6 +25,19 @@ export async function getAllCityIdsCached(realm: Realm) {
     () => getAllCityIds(realm),
     ['cities', 'ids', realm],
     { tags: ['cities:all', `realm:${realm}:cities:all`] }
+  )();
+}
+
+/**
+ * Cached geohash → listed-city resolution (point-in-polygon on the cell center).
+ * Keyed per geohash so every widget load of the same cell hits the cache.
+ * Tagged `city` so boundary/status changes revalidate it.
+ */
+export async function getCityIdForGeohashCached(geohash: string) {
+  return createCache(
+    () => getCityIdContainingPoint(decodeGeohashToCenter(geohash)),
+    ['embed', 'geohashCity', geohash],
+    { tags: ['city'] }
   )();
 }
 

--- a/src/lib/db/cities.ts
+++ b/src/lib/db/cities.ts
@@ -356,6 +356,28 @@ export async function attachGeometryToCities<T extends Pick<City, 'id'>>(
 }
 
 /**
+ * The publicly listed city whose boundary contains the given [lng, lat] point,
+ * or null when the point falls outside every covered municipality. Used by the
+ * embed widget to resolve a geohash to a city when no cityId is provided.
+ */
+export async function getCityIdContainingPoint([lng, lat]: [number, number]): Promise<string | null> {
+    try {
+        const rows = await prisma.$queryRaw<{ id: string }[]>`
+            SELECT id FROM "City"
+            WHERE status = 'listed'
+              AND geometry IS NOT NULL
+              AND ST_Covers(geometry::geometry, ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326))
+            ORDER BY id
+            LIMIT 1
+        `;
+        return rows[0]?.id ?? null;
+    } catch (error) {
+        console.error('Error resolving city for point:', error);
+        return null;
+    }
+}
+
+/**
  * Check if a city can use the city creator tool.
  * Returns true if the city exists and has no existing data, false otherwise.
  */


### PR DESCRIPTION
Hotfix for widget integrators: the subjects widget (`/embed/subjects`) no longer requires `cityId` when a `geohash` is provided.

- **Resolution**: the municipality is resolved server-side by point-in-polygon (`ST_Covers`) of the geohash-6 cell center against **listed** city boundaries, cached per geohash (`getCityIdForGeohashCached`).
- **Outside coverage**: a geohash that falls outside every covered municipality renders the widget's normal empty state (not a 404 inside the iframe).
- **Unchanged**: explicit `cityId` behavior (including 404 for unknown ids), and requests with neither param still 404. The meetings widget is untouched.

Verified: `tsc` clean; geo/ranking tests pass (34); resolution query checked against real data (Athens cell → `athens`, sea cell → no match).

Intended to ship to staging (`main`) and production immediately — integrators are blocked on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to public embed read path and a single spatial lookup; explicit cityId behavior is unchanged and failures return null/empty state rather than exposing data.
> 
> **Overview**
> The **subjects embed** (`/embed/subjects`) no longer requires `cityId` when a valid **`geohash`** is passed. The server resolves the municipality from the geohash-6 cell center via a new **point-in-polygon** lookup (`ST_Covers` on **listed** cities with geometry), wrapped in **`getCityIdForGeohashCached`** (per-geohash cache, `city` tag for revalidation).
> 
> If the geohash is outside every covered municipality, the iframe shows the **normal empty state** instead of 404. **Explicit `cityId`** still 404s when unknown; **neither param** still 404s. **`EmbedFooter`** accepts optional `cityId` and links to the homepage when city is unknown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 747268b7bc4c2b350df750132112722c53c935be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `cityId` optional for the `/embed/subjects` widget by resolving the municipality server-side via a PostGIS `ST_Covers` point-in-polygon query on the geohash-6 cell center, with the result cached per geohash under the `city` revalidation tag. When no city is found (geohash outside all listed municipalities), the widget renders its normal empty state rather than a 404 inside the iframe.

- The request/resolution logic in `page.tsx` is correct: explicit `cityId` still 404s on unknown IDs, neither param still 404s, and geohash-only requests gracefully degrade to empty state.
- `getCityIdContainingPoint` in `cities.ts` swallows all exceptions and returns `null`; because `createCache` caches successful `null` returns, a transient DB error on a geohash's first lookup will be persisted as \"no city\" until the `city` tag is manually revalidated.
- `EmbedFooter` gains a clean `cityId`-optional fallback to `baseUrl`.

<h3>Confidence Score: 4/5</h3>

Safe to merge for unblocking integrators; the geohash-to-city resolution logic is correct and the empty-state fallback is the intended behavior for out-of-coverage points.

The core logic is sound and verified against real data. The two concerns are both in the new PostGIS helper: the catch-all that silently returns null (which unstable_cache will store as a legitimate miss), and the undocumented SRID assumption that works today but could silently break if city boundaries are ever re-imported in a different projection.

src/lib/db/cities.ts — the new getCityIdContainingPoint function's error handling and SRID assumption are worth a second look before this pattern is reused elsewhere.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/(embed)/embed/subjects/page.tsx | Correctly restructures the cityId/geohash precedence logic; edge case where cityId is empty string bypasses geohash resolution yielding empty state instead of 404, but this is very unlikely in practice. |
| src/lib/db/cities.ts | New getCityIdContainingPoint silently catches all DB/PostGIS errors and returns null; that null propagates to the cache layer and gets stored as 'no city found,' turning transient errors into persistent empty-state cache entries. |
| src/lib/cache/queries.ts | Correctly follows the createCache()() pattern; tags the entry with 'city' for boundary-change revalidation; no issues. |
| src/components/embed/EmbedFooter.tsx | cityId made optional with a clean baseUrl fallback; straightforward and correct. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Fdb%2Fcities.ts%3A374-377%0A**Error-as-null%20gets%20permanently%20cached**%0A%0A%60getCityIdContainingPoint%60%20catches%20every%20exception%20%E2%80%94%20including%20transient%20connection%20errors%2C%20PostGIS%20failures%2C%20or%20a%20bad%20deployment%20window%20%E2%80%94%20and%20returns%20%60null%60.%20Because%20%60createCache%60%2F%60unstable_cache%60%20treats%20a%20successful%20%60null%60%20return%20and%20a%20legitimate%20%22no%20matching%20city%22%20as%20identical%2C%20a%20DB%20hiccup%20on%20the%20very%20first%20request%20for%20a%20geohash%20will%20permanently%20cache%20the%20empty%20state%20for%20that%20hash%20until%20something%20triggers%20%60revalidateTag%28'city'%29%60.%20Consider%20rethrowing%20%28or%20not%20catching%20at%20all%29%20so%20%60createCache%60%20surfaces%20the%20error%20%E2%80%94%20it%20already%20logs%20and%20rethrows%20via%20its%20own%20try%2Fcatch%20%E2%80%94%20rather%20than%20silently%20solidifying%20a%20transient%20failure%20into%20a%20long-lived%20cache%20entry.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Fdb%2Fcities.ts%3A365-371%0A**Implicit%20SRID%204326%20assumption%20in%20%60ST_Covers%60**%0A%0AThe%20query%20hardcodes%20SRID%204326%20for%20the%20probe%20point%20via%20%60ST_SetSRID%28ST_MakePoint%28...%29%2C%204326%29%60%20but%20does%20not%20assert%20or%20transform%20the%20SRID%20of%20the%20stored%20%60geometry%60%20column.%20If%20city%20boundaries%20were%20imported%20in%20a%20different%20projection%20%28e.g.%20SRID%200%20or%20a%20national%20grid%29%2C%20%60ST_Covers%60%20will%20silently%20return%20false%20for%20every%20point%20%E2%80%94%20no%20error%2C%20just%20an%20unexpected%20empty%20state.%20It%20is%20worth%20adding%20a%20comment%20confirming%20the%20expected%20SRID%20of%20the%20%60geometry%60%20column%2C%20or%20making%20the%20assumption%20explicit%20in%20the%20query%20with%20%60ST_Transform%28geometry%3A%3Ageometry%2C%204326%29%60.%0A%0A&repo=schemalabz%2Fopencouncil&pr=526&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/lib/db/cities.ts:374-377
**Error-as-null gets permanently cached**

`getCityIdContainingPoint` catches every exception — including transient connection errors, PostGIS failures, or a bad deployment window — and returns `null`. Because `createCache`/`unstable_cache` treats a successful `null` return and a legitimate "no matching city" as identical, a DB hiccup on the very first request for a geohash will permanently cache the empty state for that hash until something triggers `revalidateTag('city')`. Consider rethrowing (or not catching at all) so `createCache` surfaces the error — it already logs and rethrows via its own try/catch — rather than silently solidifying a transient failure into a long-lived cache entry.

### Issue 2 of 2
src/lib/db/cities.ts:365-371
**Implicit SRID 4326 assumption in `ST_Covers`**

The query hardcodes SRID 4326 for the probe point via `ST_SetSRID(ST_MakePoint(...), 4326)` but does not assert or transform the SRID of the stored `geometry` column. If city boundaries were imported in a different projection (e.g. SRID 0 or a national grid), `ST_Covers` will silently return false for every point — no error, just an unexpected empty state. It is worth adding a comment confirming the expected SRID of the `geometry` column, or making the assumption explicit in the query with `ST_Transform(geometry::geometry, 4326)`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(embed): make cityId optional for the..."](https://github.com/schemalabz/opencouncil/commit/747268b7bc4c2b350df750132112722c53c935be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42039183)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->