### PR TITLE
feat(embed): JSON pre-flight endpoint for the subjects widget

### DIFF
--- a/src/app/api/embed/subjects/route.ts
+++ b/src/app/api/embed/subjects/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { env } from '@/env.mjs';
+import { getCityCached, getCityIdForGeohashCached } from '@/lib/cache';
+import { parseEmbedConfig } from '@/lib/utils/embedParams';
+import { getRecentHotSubjects, getHotSubjectsNearGeohash, type HotSubject } from '@/lib/hotSubjects';
+import { getLocationDistancesFromPoint } from '@/lib/db/location';
+import { isValidGeohash, decodeGeohashToCenter } from '@/lib/geo';
+
+/**
+ * Public pre-flight endpoint for the subjects embed widget. Returns the same
+ * ranked subjects the widget at /embed/subjects renders, as JSON — so an
+ * embedding site can decide whether to render the iframe at all (e.g. collapse
+ * the container when `count` is 0).
+ *
+ * Accepts the widget's data params: cityId, geohash, limit, bodies, bodyIds.
+ * One of cityId/geohash is required; with only a geohash, the municipality is
+ * resolved server-side (point-in-polygon on the cell center).
+ */
+
+const CACHE_HEADERS = {
+    // Same CDN policy as the widget page (revalidate 300, SWR 1h), and CORS
+    // open: embedders call this from their own site's JavaScript.
+    'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=3600',
+    'Access-Control-Allow-Origin': '*',
+};
+
+function json(body: unknown, status = 200) {
+    return NextResponse.json(body, { status, headers: CACHE_HEADERS });
+}
+
+export async function GET(req: NextRequest) {
+    const params = Object.fromEntries(req.nextUrl.searchParams.entries());
+
+    const geohash = params.geohash && isValidGeohash(params.geohash)
+        ? params.geohash.toLowerCase()
+        : null;
+    if (params.geohash && !geohash) {
+        return json({ error: 'Invalid geohash: expected 6 base-32 characters' }, 400);
+    }
+    if (!params.cityId && !geohash) {
+        return json({ error: 'Provide cityId and/or geohash' }, 400);
+    }
+
+    // Same municipality resolution as the widget page.
+    const geohashCityId = geohash ? await getCityIdForGeohashCached(geohash) : null;
+    const cityId = params.cityId ?? geohashCityId;
+    const inSupportedMunicipality = geohash ? geohashCityId !== null : null;
+
+    const city = cityId ? await getCityCached(cityId) : null;
+    if (params.cityId && !city) {
+        return json({ error: `Unknown cityId: ${params.cityId}` }, 404);
+    }
+
+    const { limit, administrativeBodyTypes, administrativeBodyIds } = parseEmbedConfig(params);
+    const baseUrl = env.NEXTAUTH_URL.replace(/\/$/, '');
+
+    const top: HotSubject[] = city
+        ? geohash
+            ? await getHotSubjectsNearGeohash(city.id, geohash, { limit, administrativeBodyTypes, administrativeBodyIds })
+            : await getRecentHotSubjects(city.id, { limit, administrativeBodyTypes, administrativeBodyIds })
+        : [];
+
+    // Distance (m) from the geohash cell center to each located subject.
+    const distances = geohash
+        ? await getLocationDistancesFromPoint(
+            top.map(t => t.subject.locationId).filter((id): id is string => id != null),
+            decodeGeohashToCenter(geohash),
+        )
+        : new Map<string, number>();
+
+    const subjects = top.map(({ subject, meeting }) => ({
+        id: subject.id,
+        name: subject.name,
+        url: `${baseUrl}/${meeting.cityId}/${meeting.id}/subjects/${subject.id}`,
+        meetingDate: meeting.dateTime,
+        topic: subject.topic ? { name: subject.topic.name, colorHex: subject.topic.colorHex } : null,
+        /** Meters from the geohash cell center; null for municipality-wide (no-location) subjects. */
+        distanceMeters: (subject.locationId && distances.get(subject.locationId)) ?? null,
+    }));
+
+    const located = subjects.map(s => s.distanceMeters).filter((d): d is number => d !== null);
+
+    return json({
+        cityId: city?.id ?? null,
+        /** Whether the geohash cell center falls inside a covered municipality; null when no geohash was given. */
+        inSupportedMunicipality,
+        count: subjects.length,
+        closestSubjectDistanceMeters: located.length > 0 ? Math.min(...located) : null,
+        subjects,
+    });
+}

--- a/src/lib/db/location.ts
+++ b/src/lib/db/location.ts
@@ -119,6 +119,40 @@ export async function filterLocationIdsWithinRadius(
 }
 
 /**
+ * Distance in meters from `center` ([lng, lat]) to each of the given point
+ * locations. Same swapped-coordinate handling as filterLocationIdsWithinRadius;
+ * non-point locations are omitted from the result.
+ */
+export async function getLocationDistancesFromPoint(
+    locationIds: string[],
+    center: [number, number] // [longitude, latitude]
+): Promise<Map<string, number>> {
+    if (locationIds.length === 0) return new Map();
+    const [lng, lat] = center;
+
+    try {
+        const rows = await prisma.$queryRaw<Array<{ id: string; meters: number }>>`
+            SELECT id, ST_Distance(
+                CASE
+                  WHEN ST_X(coordinates::geometry) < 19.5 OR ST_X(coordinates::geometry) > 28.5
+                    OR ST_Y(coordinates::geometry) < 34.5 OR ST_Y(coordinates::geometry) > 41.5
+                  THEN ST_SetSRID(ST_MakePoint(ST_Y(coordinates::geometry), ST_X(coordinates::geometry)), 4326)::geography
+                  ELSE coordinates::geography
+                END,
+                ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326)::geography
+              ) AS meters
+            FROM "Location"
+            WHERE id = ANY(${locationIds}::text[])
+              AND type = 'point'
+        `;
+        return new Map(rows.map(r => [r.id, Math.round(r.meters)]));
+    } catch (error) {
+        console.error('Error measuring location distances:', error);
+        return new Map();
+    }
+}
+
+/**
  * Get location by ID
  */
 export async function getLocation(id: string): Promise<Location | null> {


### PR DESCRIPTION
Adds `GET /api/embed/subjects` — a public JSON endpoint returning the same ranked subjects the widget at `/embed/subjects` renders, so embedding sites can decide whether to render the iframe at all (their "blank when empty" requirement).

**Params** (same as the widget): `cityId`, `geohash`, `limit`, `bodies`, `bodyIds`. One of `cityId`/`geohash` required; with only a geohash the municipality is resolved server-side (reuses #526's cached point-in-polygon).

**Response**:
```json
{
  "cityId": "athens",
  "inSupportedMunicipality": true,
  "count": 5,
  "closestSubjectDistanceMeters": 132,
  "subjects": [
    { "id": "…", "name": "…", "url": "…", "meetingDate": "…", "topic": { "name": "…", "colorHex": "…" }, "distanceMeters": 132 }
  ]
}
```
- `inSupportedMunicipality`: geohash cell center inside a listed city's boundary (`null` when no geohash given)
- `distanceMeters` / `closestSubjectDistanceMeters`: meters from the cell center, inversion-aware `ST_Distance` (same swapped-coordinate handling as the radius filter); `null` for municipality-wide subjects
- Errors: 400 (neither param / malformed geohash), 404 (unknown explicit cityId)
- CORS `*` (embedders call it from their own site's JS); `Cache-Control: s-maxage=300, stale-while-revalidate=3600` matching the widget page

Reuses the existing cached queries (`getHotSubjectsNearGeohash` / `getRecentHotSubjects` / `getCityIdForGeohashCached`) — no new query paths besides the distance measurement.

Verified: `tsc` clean. Intended for staging + production immediately (integrators waiting); will verify against staging after merge, before promoting to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only public API reusing existing cached subject queries; new distance SQL follows the same coordinate-handling pattern as existing location filters.
> 
> **Overview**
> Adds **`GET /api/embed/subjects`**, a public JSON pre-flight that mirrors the subjects embed widget’s ranked list so partner sites can skip the iframe when **`count`** is 0 (or use **`inSupportedMunicipality`** / distances before showing UI).
> 
> The handler reuses the widget’s query params (`cityId`, `geohash`, `limit`, `bodies`, `bodyIds`), the same municipality resolution via cached geohash lookup, and existing hot-subject queries (`getRecentHotSubjects` / `getHotSubjectsNearGeohash`). Responses include subject links, topics, **`distanceMeters`** from the geohash cell center, and **`closestSubjectDistanceMeters`**, with **CORS `*`** and CDN cache headers aligned to the embed page. Validation returns **400** for missing/invalid params and **404** for unknown explicit **`cityId`**.
> 
> **`getLocationDistancesFromPoint`** in `location.ts` is new: PostGIS **`ST_Distance`** from a center point to point locations, using the same lat/lng swap workaround as the existing radius filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a90b03a6f8a00ee2b294252016c47bfdba757c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a public JSON pre-flight endpoint (`GET /api/embed/subjects`) that returns the same ranked subjects as the `/embed/subjects` widget, allowing embedding sites to decide whether to show the iframe before rendering it. The implementation reuses existing cached query paths and mirrors the coordinate/geohash handling from the widget page faithfully.

- **New route** (`src/app/api/embed/subjects/route.ts`): validates geohash and cityId params, resolves municipality from geohash via point-in-polygon, fetches hot subjects, and measures distances using the new DB helper. CORS wildcard and CDN cache headers match the widget page policy.
- **New DB helper** (`src/lib/db/location.ts`): `getLocationDistancesFromPoint` adds an `ST_Distance` query with the same swapped-coordinate workaround already used by `filterLocationIdsWithinRadius`, returning a `Map<id, meters>`.

<h3>Confidence Score: 4/5</h3>

Safe to merge with a minor fix recommended: error responses currently carry the same CDN cache headers as success responses.

The logic is sound and the implementation closely mirrors the existing widget page and location filtering code. The only notable issue is that the shared json() helper applies Cache-Control: public, s-maxage=300 to 400 and 404 error responses — Vercel's edge cache can store these, meaning a newly added city could serve a stale 404 for up to 5 minutes after being created.

src/app/api/embed/subjects/route.ts — specifically the shared json() helper and how cache headers are applied to error responses.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/api/embed/subjects/route.ts | New public JSON pre-flight endpoint; logic mirrors the widget page. Cache headers are applied uniformly to all responses including errors (400/404), which can cause stale error responses on Vercel's CDN edge cache. |
| src/lib/db/location.ts | Adds getLocationDistancesFromPoint — a clean ST_Distance query using the same swapped-coordinate workaround as the existing filterLocationIdsWithinRadius. Implementation is consistent and correct. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fapp%2Fapi%2Fembed%2Fsubjects%2Froute.ts%3A27-29%0A**Cache-Control%20applied%20to%20error%20responses**%0A%0AThe%20shared%20%60json%28%29%60%20helper%20sets%20%60Cache-Control%3A%20public%2C%20s-maxage%3D300%60%20on%20every%20response%2C%20including%20400%20and%20404%20errors.%20Vercel's%20edge%20network%20respects%20%60s-maxage%60%20regardless%20of%20HTTP%20status%20code%2C%20so%20a%20%60404%60%20for%20an%20unknown%20%60cityId%60%20would%20be%20cached%20for%205%20minutes.%20If%20a%20new%20city%20is%20added%20in%20that%20window%2C%20every%20request%20to%20that%20%60cityId%60%20continues%20receiving%20the%20stale%20404%20until%20the%20CDN%20cache%20expires.%20Consider%20applying%20the%20cache%20headers%20only%20on%20200%20responses%2C%20or%20using%20a%20separate%20no-store%20header%20for%20errors.%0A%0A&repo=schemalabz%2Fopencouncil&pr=528&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/app/api/embed/subjects/route.ts:27-29
**Cache-Control applied to error responses**

The shared `json()` helper sets `Cache-Control: public, s-maxage=300` on every response, including 400 and 404 errors. Vercel's edge network respects `s-maxage` regardless of HTTP status code, so a `404` for an unknown `cityId` would be cached for 5 minutes. If a new city is added in that window, every request to that `cityId` continues receiving the stale 404 until the CDN cache expires. Consider applying the cache headers only on 200 responses, or using a separate no-store header for errors.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(embed): add JSON pre-flight endpoin..."](https://github.com/schemalabz/opencouncil/commit/68a90b03a6f8a00ee2b294252016c47bfdba757c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42099301)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->