### PR TITLE
feat(subject): show decision box above summary

### DIFF
--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -280,6 +280,99 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                     <GroupedDiscussionNotice primarySubject={discussedIn} />
                 )}
 
+                {/* Decision Section (skip for beforeAgenda and withdrawn subjects) */}
+                {subject.nonAgendaReason !== 'beforeAgenda' && !subject.withdrawn && (
+                    <CollapsibleCard
+                        id="decision"
+                        icon={<Landmark className="w-4 h-4" />}
+                        title={
+                            decision ? (
+                                <span className="flex items-center gap-2">
+                                    {t("decision")}
+                                    <Badge variant="secondary" className="text-xs">
+                                        {decision.ada ? `ΑΔΑ: ${decision.ada}` : t("decision")}
+                                    </Badge>
+                                </span>
+                            ) : (
+                                <span className="text-muted-foreground">{t("noDecision")}</span>
+                            )
+                        }
+                    >
+                        {decision ? (
+                            <div className="p-4 space-y-3">
+                                <table className="w-full text-sm">
+                                    <tbody>
+                                        {decision.title && (
+                                            <tr>
+                                                <td className="py-1.5 pr-4 text-muted-foreground font-medium whitespace-nowrap align-top">{t("decisionTitle")}</td>
+                                                <td className="py-1.5">{decision.title}</td>
+                                            </tr>
+                                        )}
+                                        {decision.ada && (
+                                            <tr>
+                                                <td className="py-1.5 pr-4 text-muted-foreground font-medium whitespace-nowrap">ΑΔΑ</td>
+                                                <td className="py-1.5">{decision.ada}</td>
+                                            </tr>
+                                        )}
+                                        {decision.protocolNumber && (
+                                            <tr>
+                                                <td className="py-1.5 pr-4 text-muted-foreground font-medium whitespace-nowrap">{t("protocolNumber")}</td>
+                                                <td className="py-1.5">{decision.protocolNumber}</td>
+                                            </tr>
+                                        )}
+                                        {decision.publishDate && (
+                                            <tr>
+                                                <td className="py-1.5 pr-4 text-muted-foreground font-medium whitespace-nowrap">{t("publishDate")}</td>
+                                                <td className="py-1.5">{formatDate(new Date(decision.publishDate))}</td>
+                                            </tr>
+                                        )}
+                                    </tbody>
+                                </table>
+                                <div className="flex items-center justify-between pt-2 border-t border-border">
+                                    <a
+                                        href={decision.pdfUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+                                    >
+                                        <ExternalLink className="w-3.5 h-3.5" />
+                                        {t("viewDecision")}
+                                    </a>
+                                    {decision.updatedAt && (
+                                        <span className="text-xs text-muted-foreground">
+                                            {t("lastUpdated", { time: formatRelativeTime(new Date(decision.updatedAt), locale) })}
+                                        </span>
+                                    )}
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="p-6 text-center space-y-3">
+                                <p className="text-sm text-muted-foreground">{t("noDecisionDescription")}</p>
+                                {isFetchingDecision ? (
+                                    <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+                                        <Loader2 className="w-4 h-4 animate-spin" />
+                                        {t("searchingDecision")}
+                                    </div>
+                                ) : (
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={handleFetchDecision}
+                                    >
+                                        <Landmark className="w-4 h-4 mr-2" />
+                                        {t("fetchDecision")}
+                                    </Button>
+                                )}
+                                {lastSearchedAt && !isFetchingDecision && (
+                                    <p className="text-xs text-muted-foreground">
+                                        {t("lastSearched", { time: formatRelativeTime(new Date(lastSearchedAt), locale) })}
+                                    </p>
+                                )}
+                            </div>
+                        )}
+                    </CollapsibleCard>
+                )}
+
                 {/* Summary Section (Collapsible - Open by default) */}
                 {description && (
                     <CollapsibleCard
@@ -444,99 +537,6 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                 >
                     <VotingSection subjectId={subject.id} votes={subject.votes} attendance={subject.attendance} />
                 </CollapsibleCard>}
-
-                {/* Decision Section (skip for beforeAgenda and withdrawn subjects) */}
-                {subject.nonAgendaReason !== 'beforeAgenda' && !subject.withdrawn && (
-                    <CollapsibleCard
-                        id="decision"
-                        icon={<Landmark className="w-4 h-4" />}
-                        title={
-                            decision ? (
-                                <span className="flex items-center gap-2">
-                                    {t("decision")}
-                                    <Badge variant="secondary" className="text-xs">
-                                        {decision.ada ? `ΑΔΑ: ${decision.ada}` : t("decision")}
-                                    </Badge>
-                                </span>
-                            ) : (
-                                <span className="text-muted-foreground">{t("noDecision")}</span>
-                            )
-                        }
-                    >
-                        {decision ? (
-                            <div className="p-4 space-y-3">
-                                <table className="w-full text-sm">
-                                    <tbody>
-                                        {decision.title && (
-                                            <tr>
-                                                <td className="py-1.5 pr-4 text-muted-foreground font-medium whitespace-nowrap align-top">{t("decisionTitle")}</td>
-                                                <td className="py-1.5">{decision.title}</td>
-                                            </tr>
-                                        )}
-                                        {decision.ada && (
-                                            <tr>
-                                                <td className="py-1.5 pr-4 text-muted-foreground font-medium whitespace-nowrap">ΑΔΑ</td>
-                                                <td className="py-1.5">{decision.ada}</td>
-                                            </tr>
-                                        )}
-                                        {decision.protocolNumber && (
-                                            <tr>
-                                                <td className="py-1.5 pr-4 text-muted-foreground font-medium whitespace-nowrap">{t("protocolNumber")}</td>
-                                                <td className="py-1.5">{decision.protocolNumber}</td>
-                                            </tr>
-                                        )}
-                                        {decision.publishDate && (
-                                            <tr>
-                                                <td className="py-1.5 pr-4 text-muted-foreground font-medium whitespace-nowrap">{t("publishDate")}</td>
-                                                <td className="py-1.5">{formatDate(new Date(decision.publishDate))}</td>
-                                            </tr>
-                                        )}
-                                    </tbody>
-                                </table>
-                                <div className="flex items-center justify-between pt-2 border-t border-border">
-                                    <a
-                                        href={decision.pdfUrl}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
-                                    >
-                                        <ExternalLink className="w-3.5 h-3.5" />
-                                        {t("viewDecision")}
-                                    </a>
-                                    {decision.updatedAt && (
-                                        <span className="text-xs text-muted-foreground">
-                                            {t("lastUpdated", { time: formatRelativeTime(new Date(decision.updatedAt), locale) })}
-                                        </span>
-                                    )}
-                                </div>
-                            </div>
-                        ) : (
-                            <div className="p-6 text-center space-y-3">
-                                <p className="text-sm text-muted-foreground">{t("noDecisionDescription")}</p>
-                                {isFetchingDecision ? (
-                                    <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-                                        <Loader2 className="w-4 h-4 animate-spin" />
-                                        {t("searchingDecision")}
-                                    </div>
-                                ) : (
-                                    <Button
-                                        variant="outline"
-                                        size="sm"
-                                        onClick={handleFetchDecision}
-                                    >
-                                        <Landmark className="w-4 h-4 mr-2" />
-                                        {t("fetchDecision")}
-                                    </Button>
-                                )}
-                                {lastSearchedAt && !isFetchingDecision && (
-                                    <p className="text-xs text-muted-foreground">
-                                        {t("lastSearched", { time: formatRelativeTime(new Date(lastSearchedAt), locale) })}
-                                    </p>
-                                )}
-                            </div>
-                        )}
-                    </CollapsibleCard>
-                )}
 
                 {/* Admin Section - internal signals, only for users authorized to edit */}
                 {options.editsAllowed && (topicImportance || proximityImportance) && (


### PR DESCRIPTION
Moves the decision (απόφαση) section above the summary (σύνοψη) section on the subject page, so the meeting's outcome is the first thing visitors see.

Pure reorder of the JSX blocks in `src/components/meetings/subject/subject.tsx` — no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7Hfs45YFwRXTmQa6iE2Xw

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7Hfs45YFwRXTmQa6iE2Xw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only reorder in a single UI component; no API, auth, or decision-fetch logic changes.
> 
> **Overview**
> On the meeting **subject** page, the **decision** (απόφαση) collapsible block is moved **above** the **summary** (σύνοψη) section so the official outcome appears before the AI summary.
> 
> This is a **pure JSX reorder** in `subject.tsx`: the same decision UI (metadata table, PDF link, fetch-decision flow, and guards for `beforeAgenda` / withdrawn subjects) is unchanged—only its position in the page layout shifts from below voting to immediately after the grouped-discussion notice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b64706144a201f675a9460d7e54e5ffd25d56e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the decision section higher on the subject page.

- Decision card now appears before the summary.
- The existing decision JSX and guards are otherwise unchanged.
- The old decision-card position after voting was removed.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/meetings/subject/subject.tsx | Reorders the existing decision card above the summary with no logic changes found. |

<sub>Reviews (1): Last reviewed commit: ["feat(subject): show decision box above s..."](https://github.com/schemalabz/opencouncil/commit/2b64706144a201f675a9460d7e54e5ffd25d56e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42320831)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Context used - .cursorrules ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=8f01574a-2b8a-490a-a6a8-5bb80f6f984c))
- Context used - CLAUDE.md ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=a3ddaa95-717d-48e6-81cd-93c42696bbed))
- Context used - .cursor/rules/auth.mdc ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=6a7ded42-d418-476c-bfad-dae6c4739471))
- Context used - .cursor/rules/general.mdc ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=dc2172bf-e821-4a8e-b26f-cd165ffe6599))
</details>

<!-- /greptile_comment -->