### PR TITLE
Grace period and retry backoff for livestream auto-transcription

### DIFF
--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -45,6 +45,11 @@ export interface TranscribeRequest extends TaskRequest {
     youtubeUrl: string;
     voiceprints?: Voiceprint[];
     cityLanguage: CityLanguage;
+    // Expected recording length in seconds (livestream wall-clock). When set, the
+    // backend verifies the downloaded media is at least this long and fails if it
+    // captured a partial recording (VOD still processing). Set for auto-matched
+    // livestreams; omitted for manual transcribes of arbitrary URLs.
+    expectedDurationSeconds?: number;
 }
 
 export type TranscriptWithUtteranceDrifts = Transcript & {

--- a/src/lib/tasks/__tests__/pollLivestreams.test.ts
+++ b/src/lib/tasks/__tests__/pollLivestreams.test.ts
@@ -66,7 +66,14 @@ function meeting(overrides: Record<string, unknown> = {}) {
     };
 }
 
-const VIDEO = { videoId: 'v1', title: '21η Τακτική Συνεδρίαση 10/06/2026', publishedAt: '2026-06-10T20:00:00Z' };
+// A finished livestream: 2h long, ended well in the past (clears the grace period).
+const VIDEO = {
+    videoId: 'v1',
+    title: '21η Τακτική Συνεδρίαση 10/06/2026',
+    publishedAt: '2026-06-10T20:00:00Z',
+    actualStartTime: '2026-06-10T18:00:00Z',
+    actualEndTime: '2026-06-10T20:00:00Z',
+};
 
 function aiDecision(decision: Record<string, unknown>) {
     mockAiChat.mockResolvedValue({ result: decision, usage: {} });
@@ -123,12 +130,79 @@ describe('pollLivestreamsForRecentMeetings', () => {
 
         const summary = await pollLivestreamsForRecentMeetings();
 
+        // Expected duration = actualEndTime - actualStartTime = 2h = 7200s.
         expect(mockRequestTranscribeInternal).toHaveBeenCalledWith(
-            'https://www.youtube.com/watch?v=v1', 'm1', 'athens',
+            'https://www.youtube.com/watch?v=v1', 'm1', 'athens', { expectedDurationSeconds: 7200 },
         );
         expect(mockMatchedAlert).toHaveBeenCalledTimes(1);
         expect(summary.matched).toBe(1);
         expect(summary.results[0].action).toBe('transcribe_triggered');
+    });
+
+    it('skips a match still within the grace period (VOD may still be processing)', async () => {
+        const justEnded = {
+            ...VIDEO,
+            actualStartTime: new Date(Date.now() - 70 * 60 * 1000).toISOString(),
+            actualEndTime: new Date(Date.now() - 10 * 60 * 1000).toISOString(), // ended 10 min ago
+        };
+        mockListRecentChannelVideos.mockResolvedValue([justEnded]);
+        mockMeetingFindMany.mockResolvedValue([meeting()]);
+        mockTaskFindMany.mockResolvedValue(processAgendaDone());
+        aiDecision({ decision: 'match', videoId: 'v1', confidence: 0.95, reasoning: 'title+date align' });
+
+        const summary = await pollLivestreamsForRecentMeetings();
+
+        expect(mockRequestTranscribeInternal).not.toHaveBeenCalled();
+        expect(summary.matched).toBe(0);
+        expect(summary.skipped).toBe(1);
+        expect(summary.results[0].action).toBe('skipped');
+    });
+
+    it('does not retry a failed transcribe while still within the backoff window', async () => {
+        mockMeetingFindMany.mockResolvedValue([meeting()]);
+        mockTaskFindMany.mockResolvedValue([
+            ...processAgendaDone(),
+            { councilMeetingId: 'm1', cityId: 'athens', type: 'transcribe', status: 'failed', updatedAt: new Date(Date.now() - 5 * 60 * 1000) }, // failed 5 min ago
+        ]);
+
+        const summary = await pollLivestreamsForRecentMeetings();
+
+        expect(summary.candidates).toBe(0);
+        expect(mockAiChat).not.toHaveBeenCalled();
+        expect(mockRequestTranscribeInternal).not.toHaveBeenCalled();
+    });
+
+    it('retries a failed transcribe once the backoff window has passed', async () => {
+        mockMeetingFindMany.mockResolvedValue([meeting()]);
+        mockTaskFindMany.mockResolvedValue([
+            ...processAgendaDone(),
+            { councilMeetingId: 'm1', cityId: 'athens', type: 'transcribe', status: 'failed', updatedAt: new Date(Date.now() - 45 * 60 * 1000) }, // failed 45 min ago
+        ]);
+        aiDecision({ decision: 'match', videoId: 'v1', confidence: 0.95, reasoning: 'title+date align' });
+
+        const summary = await pollLivestreamsForRecentMeetings();
+
+        expect(mockRequestTranscribeInternal).toHaveBeenCalledTimes(1);
+        expect(summary.matched).toBe(1);
+    });
+
+    it('gives up after the attempt cap of failed transcribes', async () => {
+        const failedRows = Array.from({ length: 8 }, () => (
+            { councilMeetingId: 'm1', cityId: 'athens', type: 'transcribe', status: 'failed', updatedAt: new Date(Date.now() - 60 * 60 * 1000) }
+        ));
+        mockMeetingFindMany.mockResolvedValue([meeting()]);
+        mockTaskFindMany.mockResolvedValue([...processAgendaDone(), ...failedRows]);
+
+        const summary = await pollLivestreamsForRecentMeetings();
+
+        expect(summary.candidates).toBe(0);
+        expect(mockAiChat).not.toHaveBeenCalled();
+        expect(mockRequestTranscribeInternal).not.toHaveBeenCalled();
+        // Not silently dropped — surfaced in the summary so a persistent failure is visible.
+        expect(summary.skipped).toBe(1);
+        expect(summary.results).toHaveLength(1);
+        expect(summary.results[0].action).toBe('gave_up');
+        expect(summary.results[0].meetingId).toBe('m1');
     });
 
     it('does not transcribe when confidence is below threshold', async () => {

--- a/src/lib/tasks/__tests__/pollLivestreams.test.ts
+++ b/src/lib/tasks/__tests__/pollLivestreams.test.ts
@@ -162,7 +162,7 @@ describe('pollLivestreamsForRecentMeetings', () => {
         mockMeetingFindMany.mockResolvedValue([meeting()]);
         mockTaskFindMany.mockResolvedValue([
             ...processAgendaDone(),
-            { councilMeetingId: 'm1', cityId: 'athens', type: 'transcribe', status: 'failed', updatedAt: new Date(Date.now() - 5 * 60 * 1000) }, // failed 5 min ago
+            { councilMeetingId: 'm1', cityId: 'athens', type: 'transcribe', status: 'failed', responseBody: 'INCOMPLETE_RECORDING: downloaded 600s but expected ~7200s', updatedAt: new Date(Date.now() - 5 * 60 * 1000) }, // failed 5 min ago
         ]);
 
         const summary = await pollLivestreamsForRecentMeetings();
@@ -172,11 +172,27 @@ describe('pollLivestreamsForRecentMeetings', () => {
         expect(mockRequestTranscribeInternal).not.toHaveBeenCalled();
     });
 
+    it('does not back off a failure that is not an incomplete-recording (e.g. manual/transient)', async () => {
+        mockMeetingFindMany.mockResolvedValue([meeting()]);
+        mockTaskFindMany.mockResolvedValue([
+            ...processAgendaDone(),
+            // A non-VOD failure (no INCOMPLETE_RECORDING marker) 5 min ago must not consume
+            // the backoff/cap — the meeting stays eligible on the normal cadence.
+            { councilMeetingId: 'm1', cityId: 'athens', type: 'transcribe', status: 'failed', responseBody: 'pyannote diarization failed', updatedAt: new Date(Date.now() - 5 * 60 * 1000) },
+        ]);
+        aiDecision({ decision: 'match', videoId: 'v1', confidence: 0.95, reasoning: 'title+date align' });
+
+        const summary = await pollLivestreamsForRecentMeetings();
+
+        expect(mockRequestTranscribeInternal).toHaveBeenCalledTimes(1);
+        expect(summary.matched).toBe(1);
+    });
+
     it('retries a failed transcribe once the backoff window has passed', async () => {
         mockMeetingFindMany.mockResolvedValue([meeting()]);
         mockTaskFindMany.mockResolvedValue([
             ...processAgendaDone(),
-            { councilMeetingId: 'm1', cityId: 'athens', type: 'transcribe', status: 'failed', updatedAt: new Date(Date.now() - 45 * 60 * 1000) }, // failed 45 min ago
+            { councilMeetingId: 'm1', cityId: 'athens', type: 'transcribe', status: 'failed', responseBody: 'INCOMPLETE_RECORDING: downloaded 600s but expected ~7200s', updatedAt: new Date(Date.now() - 45 * 60 * 1000) }, // failed 45 min ago
         ]);
         aiDecision({ decision: 'match', videoId: 'v1', confidence: 0.95, reasoning: 'title+date align' });
 
@@ -188,7 +204,7 @@ describe('pollLivestreamsForRecentMeetings', () => {
 
     it('gives up after the attempt cap of failed transcribes', async () => {
         const failedRows = Array.from({ length: 8 }, () => (
-            { councilMeetingId: 'm1', cityId: 'athens', type: 'transcribe', status: 'failed', updatedAt: new Date(Date.now() - 60 * 60 * 1000) }
+            { councilMeetingId: 'm1', cityId: 'athens', type: 'transcribe', status: 'failed', responseBody: 'INCOMPLETE_RECORDING: downloaded 600s but expected ~7200s', updatedAt: new Date(Date.now() - 60 * 60 * 1000) }
         ));
         mockMeetingFindMany.mockResolvedValue([meeting()]);
         mockTaskFindMany.mockResolvedValue([...processAgendaDone(), ...failedRows]);

--- a/src/lib/tasks/pollLivestreams.ts
+++ b/src/lib/tasks/pollLivestreams.ts
@@ -16,6 +16,24 @@ const MAX_TRANSCRIBES_PER_RUN = 10;
 const MULTI_ALERT_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
 /** Transcribe statuses that mean "already handled" — anything but a failed attempt. */
 const TRANSCRIBE_ACTIVE_STATUSES = new Set(["pending", "processing", "running", "succeeded"]);
+/**
+ * Grace period after a livestream ends before we transcribe it. A just-ended stream's
+ * archived VOD is still being processed by YouTube for a while (roughly 30–60 min for a
+ * long council meeting) and can't be reliably downloaded yet, so we wait it out.
+ */
+const GRACE_MS = 35 * 60 * 1000;
+/**
+ * Minimum wait between transcribe retries for a meeting whose previous attempts failed.
+ * The backend fails a partial download (VOD still processing), and this backoff spaces the
+ * retries out instead of hammering every 10-min cron run.
+ */
+const RETRY_BACKOFF_MS = 30 * 60 * 1000;
+/**
+ * Give up auto-transcribing a meeting after this many failed attempts. With RETRY_BACKOFF_MS
+ * this covers several hours of retries — well past normal VOD processing — after which a
+ * persistent failure is a different problem (handled manually), not a still-processing VOD.
+ */
+const MAX_TRANSCRIBE_ATTEMPTS = 8;
 
 function meetingKey(cityId: string, meetingId: string): string {
     return `${cityId}:${meetingId}`;
@@ -102,7 +120,7 @@ export interface PollLivestreamsMeetingResult {
     decision: LivestreamMatchDecision['decision'] | 'error';
     videoId?: string;
     confidence?: number;
-    action: 'transcribe_triggered' | 'alerted_multiple' | 'alerted_multiple_skipped' | 'skipped' | 'dry_run' | 'error';
+    action: 'transcribe_triggered' | 'alerted_multiple' | 'alerted_multiple_skipped' | 'skipped' | 'gave_up' | 'dry_run' | 'error';
     error?: string;
 }
 
@@ -171,11 +189,14 @@ export async function pollLivestreamsForRecentMeetings(
             councilMeetingId: { in: meetingIds },
             type: { in: ['processAgenda', 'transcribe'] },
         },
-        select: { councilMeetingId: true, cityId: true, type: true, status: true },
+        select: { councilMeetingId: true, cityId: true, type: true, status: true, updatedAt: true },
     });
 
     const processAgendaSucceeded = new Set<string>();
     const transcribeActive = new Set<string>();
+    // Per meeting: how many transcribe attempts have failed and when the latest one failed.
+    // Drives retry backoff (space attempts out) and the give-up cap.
+    const failedTranscribe = new Map<string, { count: number; latestFailedAt: Date }>();
     for (const t of taskStatuses) {
         const key = meetingKey(t.cityId, t.councilMeetingId);
         if (t.type === 'processAgenda' && t.status === 'succeeded') {
@@ -184,17 +205,43 @@ export async function pollLivestreamsForRecentMeetings(
         if (t.type === 'transcribe' && TRANSCRIBE_ACTIVE_STATUSES.has(t.status)) {
             transcribeActive.add(key);
         }
+        if (t.type === 'transcribe' && t.status === 'failed') {
+            const cur = failedTranscribe.get(key);
+            if (!cur) {
+                failedTranscribe.set(key, { count: 1, latestFailedAt: t.updatedAt });
+            } else {
+                cur.count += 1;
+                if (t.updatedAt > cur.latestFailedAt) cur.latestFailedAt = t.updatedAt;
+            }
+        }
     }
 
     // Candidate = processAgenda succeeded AND no transcribe that is succeeded or in flight.
-    // A meeting whose only prior transcribe attempts failed is eligible again (auto-retry).
+    // A meeting whose only prior transcribe attempts failed is eligible again (auto-retry),
+    // but only after the backoff window and up to the attempt cap.
+    // Meetings that hit the cap are surfaced (not silently dropped) so a persistent failure
+    // is operator-visible in the poll summary rather than just a log line.
+    const gaveUp: PollLivestreamsMeetingResult[] = [];
     const candidates = meetings.filter(m => {
         const key = meetingKey(m.cityId, m.id);
-        return processAgendaSucceeded.has(key) && !transcribeActive.has(key);
+        if (!processAgendaSucceeded.has(key) || transcribeActive.has(key)) return false;
+
+        const failed = failedTranscribe.get(key);
+        if (failed) {
+            if (failed.count >= MAX_TRANSCRIBE_ATTEMPTS) {
+                console.warn(`[pollLivestreams] ${key}: ${failed.count} failed transcribe attempts, giving up (cap reached)`);
+                gaveUp.push({ cityId: m.cityId, meetingId: m.id, decision: 'no_match', action: 'gave_up', error: `gave up after ${failed.count} failed transcribe attempts` });
+                return false;
+            }
+            if (now.getTime() - failed.latestFailedAt.getTime() < RETRY_BACKOFF_MS) {
+                return false; // still within retry backoff
+            }
+        }
+        return true;
     });
 
     if (candidates.length === 0) {
-        return { ...empty, candidates: 0 };
+        return { ...empty, candidates: 0, skipped: gaveUp.length, results: gaveUp };
     }
 
     // Resolve + list videos once per distinct channel (quota-friendly).
@@ -216,10 +263,10 @@ export async function pollLivestreamsForRecentMeetings(
         }
     }
 
-    const results: PollLivestreamsMeetingResult[] = [];
+    const results: PollLivestreamsMeetingResult[] = [...gaveUp];
     let matched = 0;
     let multipleMeetings = 0;
-    let skipped = 0;
+    let skipped = gaveUp.length;
     let errors = 0;
     let transcribesTriggered = 0;
 
@@ -251,6 +298,18 @@ export async function pollLivestreamsForRecentMeetings(
                 matchedVideo &&
                 decision.confidence >= MATCH_CONFIDENCE_THRESHOLD
             ) {
+                // Grace period: a just-ended stream's VOD may still be processing and not
+                // yet downloadable. Wait until it's been ended a while before transcribing.
+                // (A normal upload has no actualEndTime and is never delayed.)
+                if (matchedVideo.actualEndTime) {
+                    const endedMsAgo = now.getTime() - new Date(matchedVideo.actualEndTime).getTime();
+                    if (endedMsAgo < GRACE_MS) {
+                        skipped++;
+                        results.push({ cityId, meetingId, decision: 'match', videoId: matchedVideo.videoId, confidence: decision.confidence, action: 'skipped', error: 'within grace period (VOD may still be processing)' });
+                        continue;
+                    }
+                }
+
                 if (transcribesTriggered >= MAX_TRANSCRIBES_PER_RUN) {
                     skipped++;
                     results.push({ cityId, meetingId, decision: 'match', videoId: matchedVideo.videoId, confidence: decision.confidence, action: 'skipped', error: 'per-run cap reached' });
@@ -263,8 +322,16 @@ export async function pollLivestreamsForRecentMeetings(
                     continue;
                 }
 
+                // Expected recording length from the livestream's wall-clock, so the backend
+                // can reject a partial download of a still-processing VOD. Undefined for a
+                // normal upload (no live timing) — then the backend skips the check.
+                const expectedDurationSeconds =
+                    matchedVideo.actualStartTime && matchedVideo.actualEndTime
+                        ? Math.max(0, (new Date(matchedVideo.actualEndTime).getTime() - new Date(matchedVideo.actualStartTime).getTime()) / 1000)
+                        : undefined;
+
                 const videoUrl = watchUrl(matchedVideo.videoId);
-                await requestTranscribeInternal(videoUrl, meetingId, cityId);
+                await requestTranscribeInternal(videoUrl, meetingId, cityId, { expectedDurationSeconds });
                 transcribesTriggered++;
                 matched++;
                 sendLivestreamMatchedAlert({

--- a/src/lib/tasks/pollLivestreams.ts
+++ b/src/lib/tasks/pollLivestreams.ts
@@ -34,6 +34,12 @@ const RETRY_BACKOFF_MS = 30 * 60 * 1000;
  * persistent failure is a different problem (handled manually), not a still-processing VOD.
  */
 const MAX_TRANSCRIBE_ATTEMPTS = 8;
+/**
+ * Prefix the backend puts on the error when it rejects a partial download of a
+ * still-processing VOD. Only these failures drive the backoff/cap — other failures
+ * retry on the normal cadence. Keep in sync with the backend (opencouncil-tasks pipeline).
+ */
+const INCOMPLETE_RECORDING_MARKER = 'INCOMPLETE_RECORDING';
 
 function meetingKey(cityId: string, meetingId: string): string {
     return `${cityId}:${meetingId}`;
@@ -189,13 +195,16 @@ export async function pollLivestreamsForRecentMeetings(
             councilMeetingId: { in: meetingIds },
             type: { in: ['processAgenda', 'transcribe'] },
         },
-        select: { councilMeetingId: true, cityId: true, type: true, status: true, updatedAt: true },
+        select: { councilMeetingId: true, cityId: true, type: true, status: true, updatedAt: true, responseBody: true },
     });
 
     const processAgendaSucceeded = new Set<string>();
     const transcribeActive = new Set<string>();
-    // Per meeting: how many transcribe attempts have failed and when the latest one failed.
-    // Drives retry backoff (space attempts out) and the give-up cap.
+    // Per meeting: how many transcribe attempts failed because the download was an
+    // incomplete recording (VOD still processing), and when the latest one failed.
+    // Drives the retry backoff and give-up cap. Only these failures count — a failure
+    // for any other reason (manual transcribe, transient backend/network error) neither
+    // consumes the cap nor triggers the backoff, so it retries on the normal poll cadence.
     const failedTranscribe = new Map<string, { count: number; latestFailedAt: Date }>();
     for (const t of taskStatuses) {
         const key = meetingKey(t.cityId, t.councilMeetingId);
@@ -205,7 +214,7 @@ export async function pollLivestreamsForRecentMeetings(
         if (t.type === 'transcribe' && TRANSCRIBE_ACTIVE_STATUSES.has(t.status)) {
             transcribeActive.add(key);
         }
-        if (t.type === 'transcribe' && t.status === 'failed') {
+        if (t.type === 'transcribe' && t.status === 'failed' && (t.responseBody ?? '').includes(INCOMPLETE_RECORDING_MARKER)) {
             const cur = failedTranscribe.get(key);
             if (!cur) {
                 failedTranscribe.set(key, { count: 1, latestFailedAt: t.updatedAt });
@@ -324,7 +333,9 @@ export async function pollLivestreamsForRecentMeetings(
 
                 // Expected recording length from the livestream's wall-clock, so the backend
                 // can reject a partial download of a still-processing VOD. Undefined for a
-                // normal upload (no live timing) — then the backend skips the check.
+                // normal upload (no live timing) — then the backend skips the check. In the
+                // rare case a finished stream reports actualEndTime but not actualStartTime,
+                // we can't compute a length; the 35-min grace period is the fallback guard.
                 const expectedDurationSeconds =
                     matchedVideo.actualStartTime && matchedVideo.actualEndTime
                         ? Math.max(0, (new Date(matchedVideo.actualEndTime).getTime() - new Date(matchedVideo.actualStartTime).getTime()) / 1000)

--- a/src/lib/tasks/transcribeInternal.ts
+++ b/src/lib/tasks/transcribeInternal.ts
@@ -47,9 +47,13 @@ export async function deleteExistingSpeakerData(
 }
 
 export async function requestTranscribeInternal(youtubeUrl: string, councilMeetingId: string, cityId: string, {
-    force = false
+    force = false,
+    expectedDurationSeconds,
 }: {
     force?: boolean;
+    /** Livestream wall-clock length (actualEndTime - actualStartTime), in seconds.
+     *  Passed to the backend so it can reject a partial download of a still-processing VOD. */
+    expectedDurationSeconds?: number;
 } = {}) {
     console.log(`Requesting transcription for ${youtubeUrl}`);
     const councilMeeting = await prisma.councilMeeting.findUnique({
@@ -130,6 +134,7 @@ export async function requestTranscribeInternal(youtubeUrl: string, councilMeeti
         youtubeUrl,
         voiceprints: voiceprints.length > 0 ? voiceprints : undefined,
         cityLanguage: city.language,
+        expectedDurationSeconds,
     }
 
     await prisma.councilMeeting.update({

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -27,6 +27,11 @@ export interface YouTubeVideo {
     title: string;
     publishedAt: string;
     description?: string;
+    // Present for finished livestreams (absent for normal uploads). Used to gate
+    // transcription behind a grace period and to compute the expected recording
+    // length so the backend can detect a partial download of a still-processing VOD.
+    actualStartTime?: string;
+    actualEndTime?: string;
 }
 
 function requireApiKey(): string {
@@ -220,6 +225,8 @@ export async function listRecentChannelVideos(channelId: string): Promise<YouTub
             title: v.snippet?.title ?? '',
             publishedAt: v.snippet?.publishedAt ?? '',
             description: v.snippet?.description,
+            actualStartTime: v.liveStreamingDetails?.actualStartTime,
+            actualEndTime: v.liveStreamingDetails?.actualEndTime,
         }));
 
     await cacheSetJSON(cacheKey, videos, CHANNEL_VIDEOS_TTL_SECONDS);


### PR DESCRIPTION
Follow-up to the livestream auto-transcription work. A livestream that just ended isn't downloadable right away because YouTube is still processing the VOD, so kicking off transcription the moment we spot the finished video tends to grab a partial recording, or fail and retry immediately on a loop.

Two things change:

Once a meeting is matched to its finished livestream, we now wait 35 minutes past the stream's `actualEndTime` before triggering. A normal upload has no end time, so it isn't delayed.

A failed transcribe used to be retried on every 10-minute poll. Failed attempts are now spaced 30 minutes apart and capped at 8. After the cap the meeting shows up in the poll summary as `gave_up` rather than retrying forever or vanishing without a trace.

It also stops throwing away the livestream's start and end times (they were fetched and then dropped) and passes `expectedDurationSeconds` to the backend so it can confirm the download is complete. That backend check is in schemalabz/opencouncil-tasks#71 and only takes effect once both sides are deployed. The grace period and backoff here work regardless.

Tests: expanded the pollLivestreams suite for the grace skip, the backoff window, the cap, the give-up visibility, and the duration being passed through.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves auto-transcription for livestream VODs. The main changes are:

- Adds a 35-minute grace period after livestream end time.
- Adds retry backoff, retry capping, and `gave_up` reporting.
- Preserves YouTube live start and end times.
- Sends expected livestream duration to the task backend.
- Expands poller tests for the new retry and duration behavior.

<h3>Confidence Score: 4/5</h3>

This is close, but these issues should be fixed before merging.

- A livestream with an end time but no start time can still be sent without duration validation.
- The new backend field is still sent on the normal livestream path without a compatibility gate.

src/lib/tasks/pollLivestreams.ts, src/lib/tasks/transcribeInternal.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/tasks/pollLivestreams.ts | Adds grace-period gating, incomplete-recording retry backoff, retry capping, give-up reporting, and duration propagation. |
| src/lib/tasks/transcribeInternal.ts | Adds optional expected duration to internal transcription requests and forwards it to the task backend. |
| src/lib/youtube.ts | Propagates YouTube livestream start and end timestamps into the video model. |
| src/lib/apiTypes.ts | Adds the optional `expectedDurationSeconds` field to transcription task requests. |
| src/lib/tasks/__tests__/pollLivestreams.test.ts | Adds coverage for grace skipping, retry backoff, retry limits, give-up reporting, and duration forwarding. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Flib%2Ftasks%2FpollLivestreams.ts%3A339-342%0A**Missing%20Duration%20Guard**%0A%0AWhen%20YouTube%20returns%20%60actualEndTime%60%20without%20%60actualStartTime%60%2C%20the%20grace%20check%20still%20lets%20the%20livestream%20proceed%20after%2035%20minutes%2C%20but%20this%20expression%20sets%20%60expectedDurationSeconds%60%20to%20%60undefined%60.%20That%20field%20is%20then%20omitted%20from%20the%20backend%20request%2C%20so%20the%20backend%20has%20no%20expected%20length%20to%20compare%20against%20and%20can%20accept%20a%20partial%20VOD%20as%20a%20complete%20transcription%20input.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Flib%2Ftasks%2FtranscribeInternal.ts%3A137%0A**Ungated%20Backend%20Field**%0A%0AFor%20finished%20livestreams%20with%20both%20live%20timestamps%2C%20%60expectedDurationSeconds%60%20is%20a%20number%20and%20is%20serialized%20into%20the%20%60%2Ftranscribe%60%20payload.%20There%20is%20no%20feature%20flag%20or%20backend-version%20gate%20around%20this%20new%20field%2C%20so%20a%20frontend%20deploy%20ahead%20of%20a%20strict%20task%20backend%20can%20reject%20these%20auto-matched%20livestream%20requests%20instead%20of%20processing%20them%20with%20the%20new%20grace%20and%20retry%20behavior.%0A%0A&repo=schemalabz%2Fopencouncil&pr=530&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/lib/tasks/pollLivestreams.ts:339-342
**Missing Duration Guard**

When YouTube returns `actualEndTime` without `actualStartTime`, the grace check still lets the livestream proceed after 35 minutes, but this expression sets `expectedDurationSeconds` to `undefined`. That field is then omitted from the backend request, so the backend has no expected length to compare against and can accept a partial VOD as a complete transcription input.

### Issue 2 of 2
src/lib/tasks/transcribeInternal.ts:137
**Ungated Backend Field**

For finished livestreams with both live timestamps, `expectedDurationSeconds` is a number and is serialized into the `/transcribe` payload. There is no feature flag or backend-version gate around this new field, so a frontend deploy ahead of a strict task backend can reject these auto-matched livestream requests instead of processing them with the new grace and retry behavior.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(livestream): only count incomplete-d..."](https://github.com/schemalabz/opencouncil/commit/b349dd4cc55bb84bc24f1ce2942bf8faf5bbf5c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42357661)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Context used - .cursorrules ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=8f01574a-2b8a-490a-a6a8-5bb80f6f984c))
- Context used - CLAUDE.md ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=a3ddaa95-717d-48e6-81cd-93c42696bbed))
- Context used - .cursor/rules/auth.mdc ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=6a7ded42-d418-476c-bfad-dae6c4739471))
- Context used - .cursor/rules/general.mdc ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=dc2172bf-e821-4a8e-b26f-cd165ffe6599))
</details>

<!-- /greptile_comment -->