### PR TITLE
fix(nix): repack @posthog/cli so offline builds resolve it

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,19 +72,22 @@
       mkNpmDeps = pkgs:
         let
           origLock = pkgs.lib.importJSON ./package-lock.json;
+          cliPath = "node_modules/@posthog/cli";
+          cliEntry = origLock.packages.${cliPath};
           # the repacked tarball has a different hash and no install script, so drop the pinned
           # integrity and the now-meaningless shrinkwrap / install-script flags for this package.
           patchedLock = origLock // {
             packages = origLock.packages // {
-              "node_modules/@posthog/cli" = builtins.removeAttrs
-                origLock.packages."node_modules/@posthog/cli"
+              ${cliPath} = builtins.removeAttrs cliEntry
                 [ "integrity" "hasShrinkwrap" "hasInstallScript" ];
             };
           };
-          posthogCliPatched = pkgs.runCommand "posthog-cli-0.7.34-patched.tgz" {
+          # url + integrity come straight from the lockfile, so a dependabot bump of
+          # @posthog/cli is picked up automatically (no hardcoded version/hash to sync).
+          posthogCliPatched = pkgs.runCommand "posthog-cli-${cliEntry.version}-patched.tgz" {
             src = pkgs.fetchurl {
-              url = "https://registry.npmjs.org/@posthog/cli/-/cli-0.7.34.tgz";
-              hash = "sha512-wrRwj0FhbypW01TLpFRo1HkPBrwZHKP2tFE9xI4NTb84yMKZnXy49ibBdbImktJ5NbW7ndeWidOCZx+2Lkk7/Q==";
+              url = cliEntry.resolved;
+              hash = cliEntry.integrity;
             };
             nativeBuildInputs = [ pkgs.jq ];
           } ''
@@ -101,7 +104,7 @@
         in pkgs.importNpmLock {
           npmRoot = ./.;
           packageLock = patchedLock;
-          packageSourceOverrides."node_modules/@posthog/cli" = posthogCliPatched;
+          packageSourceOverrides.${cliPath} = posthogCliPatched;
         };
 
       mkNpmBuildInputs = pkgs: with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,48 @@
       # in package-lock.json, so there is no aggregate npmDepsHash to keep in
       # sync when the lockfile changes (e.g. dependabot bumps). Consumers must
       # pair this with importNpmLock.npmConfigHook.
-      mkNpmDeps = pkgs: pkgs.importNpmLock { npmRoot = ./.; };
+      # @posthog/cli ships a bundled npm-shrinkwrap.json ("hasShrinkwrap": true). In the
+      # no-network Nix sandbox npm honours that bundled shrinkwrap and requests @posthog/cli's
+      # own deps (detect-libc) by their registry URL — but importNpmLock only rewrote the
+      # TOP-LEVEL lock to local file:// paths, so the offline (only-if-cached) request misses the
+      # cache → ENOTCACHED. Dropping the lockfile flag isn't enough (npm reads the shrinkwrap FILE
+      # inside the extracted tarball), so swap in a repacked tarball with npm-shrinkwrap.json
+      # removed via importNpmLock's packageSourceOverrides; npm then resolves @posthog/cli's deps
+      # from the top-level lock, which is already offline.
+      mkNpmDeps = pkgs:
+        let
+          origLock = pkgs.lib.importJSON ./package-lock.json;
+          # the repacked tarball has a different hash and no install script, so drop the pinned
+          # integrity and the now-meaningless shrinkwrap / install-script flags for this package.
+          patchedLock = origLock // {
+            packages = origLock.packages // {
+              "node_modules/@posthog/cli" = builtins.removeAttrs
+                origLock.packages."node_modules/@posthog/cli"
+                [ "integrity" "hasShrinkwrap" "hasInstallScript" ];
+            };
+          };
+          posthogCliPatched = pkgs.runCommand "posthog-cli-0.7.34-patched.tgz" {
+            src = pkgs.fetchurl {
+              url = "https://registry.npmjs.org/@posthog/cli/-/cli-0.7.34.tgz";
+              hash = "sha512-wrRwj0FhbypW01TLpFRo1HkPBrwZHKP2tFE9xI4NTb84yMKZnXy49ibBdbImktJ5NbW7ndeWidOCZx+2Lkk7/Q==";
+            };
+            nativeBuildInputs = [ pkgs.jq ];
+          } ''
+            mkdir unpack && tar -xzf "$src" -C unpack
+            # (1) remove the bundled shrinkwrap that breaks offline resolution, and
+            # (2) drop the postinstall that downloads a prebuilt binary from GitHub — there's no
+            #     network in the sandbox, and the binary is only needed to actually run the CLI
+            #     (source-map upload), which is env-gated off in Nix builds anyway.
+            rm -f unpack/package/npm-shrinkwrap.json
+            jq 'del(.scripts.postinstall)' unpack/package/package.json > unpack/package/package.json.tmp
+            mv unpack/package/package.json.tmp unpack/package/package.json
+            tar -czf "$out" -C unpack package
+          '';
+        in pkgs.importNpmLock {
+          npmRoot = ./.;
+          packageLock = patchedLock;
+          packageSourceOverrides."node_modules/@posthog/cli" = posthogCliPatched;
+        };
 
       mkNpmBuildInputs = pkgs: with pkgs; [
         cairo pango libjpeg giflib pixman libpng glib librsvg

--- a/flake.nix
+++ b/flake.nix
@@ -74,8 +74,10 @@
           origLock = pkgs.lib.importJSON ./package-lock.json;
           cliPath = "node_modules/@posthog/cli";
           cliEntry = origLock.packages.${cliPath};
-          # the repacked tarball has a different hash and no install script, so drop the pinned
-          # integrity and the now-meaningless shrinkwrap / install-script flags for this package.
+          # the repacked tarball has different bytes than the lock's integrity, so npm ci would
+          # fail EINTEGRITY against it — drop the pinned integrity (this removal is required). The
+          # shrinkwrap / install-script flags then no longer describe the tarball, so drop them
+          # too for consistency (not required for the build, just keeps the lock honest).
           patchedLock = origLock // {
             packages = origLock.packages // {
               ${cliPath} = builtins.removeAttrs cliEntry
@@ -93,9 +95,12 @@
           } ''
             mkdir unpack && tar -xzf "$src" -C unpack
             # (1) remove the bundled shrinkwrap that breaks offline resolution, and
-            # (2) drop the postinstall that downloads a prebuilt binary from GitHub — there's no
-            #     network in the sandbox, and the binary is only needed to actually run the CLI
-            #     (source-map upload), which is env-gated off in Nix builds anyway.
+            # (2) drop the postinstall that downloads a prebuilt binary from GitHub. This is
+            #     load-bearing, not just tidiness: importNpmLock's npmConfigHook runs `npm rebuild`
+            #     after the `--ignore-scripts` install, and rebuild DOES execute the script — with
+            #     no network in the sandbox it fails (getaddrinfo EAI_AGAIN github.com). Dropping it
+            #     is also safe: the binary only backs the CLI's source-map upload, which is
+            #     env-gated off in Nix builds anyway.
             rm -f unpack/package/npm-shrinkwrap.json
             jq 'del(.scripts.postinstall)' unpack/package/package.json > unpack/package/package.json.tmp
             mv unpack/package/package.json.tmp unpack/package/package.json


### PR DESCRIPTION
## Problem

The `Nix Checks` CI job (`check-types` / `lint` / `tests`) fails on current `main` with `ENOTCACHED` for `detect-libc@2.1.2`. This is **base-infra — it affects every PR on current `main`, not one branch.**

**Root cause:** `0c4f0877` added `@posthog/nextjs-config`, which pulls in **`@posthog/cli`**. That package ships a bundled `npm-shrinkwrap.json` **and** a `postinstall` that downloads a prebuilt binary from GitHub. In the no-network Nix sandbox both fail: npm reifies the bundled shrinkwrap and requests `detect-libc` by its registry URL (a miss against `importNpmLock`'s `file://` offline cache → `ENOTCACHED`), and the postinstall can't reach the network.

## Fix

`flake.nix` (`mkNpmDeps`): repack the `@posthog/cli` tarball via `importNpmLock`'s `packageSourceOverrides` — strip the bundled shrinkwrap and the `postinstall` — so npm resolves the package's deps from the top-level lockfile and runs no install script. The prebuilt binary is only needed for actual source-map upload, which is env-gated off in Nix builds anyway. `package-lock.json` is untouched.

## Verification

Locally: `nix flake check` passes **lint + types + tests** (62 suites, 1850 passed). Platform-independent, so it should go green on CI's `x86_64-linux` too.

## Note

This is cherry-picked out of #408 (the landing redesign), where it was riding along even though it unblocks all PRs — splitting it here so it can land on its own. cc @christosporios

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the Nix npm dependency import handle `@posthog/cli` offline. The main changes are:

- Repack the `@posthog/cli` tarball during `mkNpmDeps`.
- Remove the bundled shrinkwrap from the repacked package.
- Remove the CLI postinstall script that downloads a binary.
- Read the CLI tarball URL, hash, and version from `package-lock.json`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| flake.nix | Adds a dynamic repack override for `@posthog/cli` so Nix builds can resolve it from the top-level lockfile without running its install script. |

<sub>Reviews (3): Last reviewed commit: ["docs(nix): clarify which @posthog/cli re..."](https://github.com/schemalabz/opencouncil/commit/5d8880045dff5c2b88616f7f9e483736e90a8304) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42377234)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Context used - .cursorrules ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=8f01574a-2b8a-490a-a6a8-5bb80f6f984c))
- Context used - CLAUDE.md ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=a3ddaa95-717d-48e6-81cd-93c42696bbed))
- Context used - .cursor/rules/auth.mdc ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=6a7ded42-d418-476c-bfad-dae6c4739471))
- Context used - .cursor/rules/general.mdc ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=dc2172bf-e821-4a8e-b26f-cd165ffe6599))
</details>

<!-- /greptile_comment -->