### PR TITLE
feat(landing): pre-release hardening — no prefetch, analytics coverage, merged ranking

### DIFF
--- a/src/components/landing/v2/DesktopLayout.tsx
+++ b/src/components/landing/v2/DesktopLayout.tsx
@@ -173,7 +173,7 @@ export function DesktopLayout({
                                 queryKind={queryKind}
                                 results={searchResults}
                                 loading={loading}
-                                onPickResult={selectSubject}
+                                onPickResult={(id) => selectSubject(id, 'search')}
                                 onLocateAddress={onLocateAddress}
                             />
                         </div>

--- a/src/components/landing/v2/LandingV2.tsx
+++ b/src/components/landing/v2/LandingV2.tsx
@@ -365,6 +365,15 @@ export function LandingV2({ defaultView, initial }: LandingV2Props) {
         setMapView,
     });
 
+    // Selection funnel: every user-initiated selection fires subject_selected with where it came
+    // from. NOT inside selectSubject itself — the deep-link effect also calls that, and a page
+    // load must not count as the session's first action.
+    const trackedSelectSubject = (id: string, source: 'list' | 'search' | 'map_pin' | 'cluster' | 'city_hall') => {
+        const s = findSubject(id);
+        captureLandingAction('subject_selected', { subject_id: id, city_id: s?.cityId ?? null, source });
+        selectSubject(id);
+    };
+
     // Subject pins (+ "+N" co-located markers and donut clusters) for the current viewport.
     useSubjectMarkers({
         mapInstance,
@@ -372,7 +381,7 @@ export function LandingV2({ defaultView, initial }: LandingV2Props) {
         visibleSubjects,
         clusterCell,
         selectedId,
-        onSelect: selectSubject,
+        onSelect: (id) => trackedSelectSubject(id, 'map_pin'),
         onClearSelection: clearSelection,
         suppressViewCaptureRef,
         pendingCoLocatedRef,
@@ -400,7 +409,10 @@ export function LandingV2({ defaultView, initial }: LandingV2Props) {
         mapInstance,
         view,
         mapCities,
-        onOpenCity: (cityId) => router.push(`/${cityId}`),
+        onOpenCity: (cityId) => {
+            captureLandingAction('city_opened', { city_id: cityId, source: 'map_marker' });
+            router.push(`/${cityId}`);
+        },
     });
 
     // Map overlays: desktop subject tooltip, OpenCouncil badge + popup, and the clicked
@@ -484,6 +496,10 @@ export function LandingV2({ defaultView, initial }: LandingV2Props) {
         captureLandingAction('map_zoom', { direction: 'out', method: 'button' });
         zoomOut();
     };
+    const trackedToggleMapStyle = () => {
+        captureLandingAction('map_style_changed', { to: satellite ? 'map' : 'satellite' });
+        toggleMapStyle();
+    };
 
     const layoutProps: LayoutProps = {
         // desktop has no 'home' tab → render 'home' as its 'subjects' split; mobile keeps all three
@@ -507,7 +523,7 @@ export function LandingV2({ defaultView, initial }: LandingV2Props) {
         upcoming,
         loading,
         selectedId,
-        selectSubject,
+        selectSubject: (id: string, source: 'list' | 'search' = 'list') => trackedSelectSubject(id, source),
         clearSelection,
         selectedSubject,
         ordered: listSubjects,
@@ -516,18 +532,18 @@ export function LandingV2({ defaultView, initial }: LandingV2Props) {
         searchResults,
         coLocated,
         onCoLocatedSelect: (id: string) => {
-            selectSubject(id);
+            trackedSelectSubject(id, 'cluster');
             setCoLocated(null);
         },
         onCoLocatedClose: () => setCoLocated(null),
         generalBox,
         onGeneralSelect: (id: string) => {
-            selectSubject(id);
+            trackedSelectSubject(id, 'city_hall');
             setGeneralBox(null);
         },
         onGeneralBoxClose: () => setGeneralBox(null),
         satellite,
-        toggleMapStyle,
+        toggleMapStyle: trackedToggleMapStyle,
         locate,
         geoError,
         onDismissGeoError: dismissGeoError,

--- a/src/components/landing/v2/MobileLayout.tsx
+++ b/src/components/landing/v2/MobileLayout.tsx
@@ -91,8 +91,8 @@ export function MobileLayout({
         setListCollapsed(false);
     };
     // Selecting a subject (list tap / search) brings the user to the Home map to see it.
-    const selectOnMap = (id: string) => {
-        selectSubject(id);
+    const selectOnMap = (id: string, source?: 'list' | 'search') => {
+        selectSubject(id, source);
         setView('home');
     };
 
@@ -265,7 +265,7 @@ export function MobileLayout({
                     autoFocusInput={searchMode === 'search'}
                     scrollToActiveFilter={searchMode === 'filters'}
                     onPickResult={(id) => {
-                        selectOnMap(id);
+                        selectOnMap(id, 'search');
                         setSearchMode(null);
                     }}
                     onClose={() => setSearchMode(null)}

--- a/src/components/landing/v2/MunicipalitiesList.tsx
+++ b/src/components/landing/v2/MunicipalitiesList.tsx
@@ -46,11 +46,14 @@ function MuniPanelCard({
     next?: UpcomingMeeting;
 }) {
     const t = useTranslations('landingV2');
+    // The landing → municipality-page conversion; all three anchors of the card count.
+    const trackOpen = () => captureLandingAction('city_opened', { city_id: city.id, source: 'municipalities_list' });
     return (
         <div className="group flex shrink-0 flex-col gap-3 rounded-2xl border border-black/40 bg-card p-4 shadow-sm transition-colors hover:border-black/60">
             <div className="flex items-center gap-2.5">
                 <Link
                     href={`/${city.id}`}
+                    onClick={trackOpen}
                     className="flex min-w-0 items-center gap-2.5 no-underline hover:no-underline"
                 >
                     <CityAvatar city={city} />
@@ -75,12 +78,13 @@ function MuniPanelCard({
                 <Link
                     href={`/${city.id}`}
                     aria-label={city.name}
+                    onClick={trackOpen}
                     className="ml-auto shrink-0 no-underline hover:no-underline"
                 >
                     <ArrowRight className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
                 </Link>
             </div>
-            <Link href={`/${city.id}`} className="flex flex-col gap-3 no-underline hover:no-underline">
+            <Link href={`/${city.id}`} onClick={trackOpen} className="flex flex-col gap-3 no-underline hover:no-underline">
                 <div className="grid grid-cols-3 gap-2">
                     <MuniStat label={t('municipality.subjects')} value={subjectCount} />
                     <MuniStat label={t('municipality.meetings')} value={city._count.councilMeetings} />

--- a/src/components/landing/v2/SubjectCard.tsx
+++ b/src/components/landing/v2/SubjectCard.tsx
@@ -56,6 +56,9 @@ export function SubjectPageLink({
     return (
         <Link
             href={href!}
+            // Never prefetch: a subject page's RSC payload is multi-MB (full meeting transcript),
+            // and the list would prefetch one per card scrolled into view.
+            prefetch={false}
             onClick={(e) => {
                 e.stopPropagation();
                 track();

--- a/src/components/landing/v2/controls.tsx
+++ b/src/components/landing/v2/controls.tsx
@@ -30,6 +30,7 @@ import type { Topic } from '@prisma/client';
 import { Link } from '@/i18n/routing';
 import { cn } from '@/lib/utils';
 import { env } from '@/env.mjs';
+import { captureLandingAction } from '@/lib/landing/analytics';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -269,6 +270,7 @@ export function MunicipalityPageButton({
     return (
         <Link
             href={`/${cityId}`}
+            onClick={() => captureLandingAction('city_opened', { city_id: cityId, source: 'page_button' })}
             className={cn(
                 'inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-xl border-2 border-[hsl(var(--orange))] bg-white font-semibold text-foreground no-underline shadow-md transition-colors hover:bg-[hsl(24,100%,96%)] hover:no-underline',
                 large ? 'h-12 gap-2.5 px-4 text-[15px]' : 'h-10 px-3 text-[13px]',

--- a/src/components/landing/v2/hooks/useFilteredSubjects.ts
+++ b/src/components/landing/v2/hooks/useFilteredSubjects.ts
@@ -141,29 +141,37 @@ export function useFilteredSubjects({
 
     // Flattened general subjects — selection lookups fall back here after the located ones.
     const allGeneralSubjects = useMemo(() => generalCities.flatMap((c) => c.subjects), [generalCities]);
-    // Non-located subjects shown in the list when zoomed out, ranked like the located ones.
     const visibleGeneralSubjects = useMemo(
-        () => rankVisible(visibleGeneralCities.flatMap((c) => c.subjects)),
+        () => visibleGeneralCities.flatMap((c) => c.subjects),
         [visibleGeneralCities],
+    );
+    // Located + non-located ranked as ONE set, so a hot municipality-wide subject can outrank
+    // weak located ones. The ranker's z-scores adapt to the merged distribution, and its
+    // `location` weight is the deliberate located-over-unlocated tiebreaker.
+    const orderedMerged = useMemo(
+        () => rankVisible([...visibleSubjects, ...visibleGeneralSubjects]),
+        [visibleSubjects, visibleGeneralSubjects],
     );
     const findSubject = (id: string): LandingSubject | null =>
         allSubjects.find((s) => s.id === id) ?? allGeneralSubjects.find((s) => s.id === id) ?? null;
 
     // The list shows ONLY subjects whose pin is inside the current map view, so panning to an
-    // empty area empties it. Exception: the selected subject is always kept in the list.
+    // empty area empties it. Non-located subjects (anchored at their city centroid, empty
+    // `where`) join in rank order while zoomed out below NONLOCATED_MAX_ZOOM — zoomed in, a
+    // municipality-wide subject isn't "in this view". Exception: the selected subject is
+    // always kept in the list.
     const listSubjects = useMemo(() => {
         let list: LandingSubject[];
         if (addressPoint) {
-            // Address search: `ordered` is already radius-filtered; skip viewport + non-located.
-            list = ordered;
-        } else if (!mapView) {
+            // Address search: `ordered` is already radius-filtered; located-only by design
+            // (a city-wide subject isn't "near this address").
             list = ordered;
         } else {
-            list = ordered.filter((s) => subjectInViewport(s, mapView));
-            // Surface non-located subjects while zoomed out, but only for δήμοι whose centroid is in view.
-            if (mapZoom < NONLOCATED_MAX_ZOOM && visibleGeneralSubjects.length) {
-                list = [...list, ...visibleGeneralSubjects.filter((s) => subjectInViewport(s, mapView))];
-            }
+            const includeNonLocated = mapZoom < NONLOCATED_MAX_ZOOM;
+            list = orderedMerged.filter((s) => {
+                if (!s.where.trim() && !includeNonLocated) return false;
+                return !mapView || subjectInViewport(s, mapView);
+            });
         }
         if (selectedId && !list.some((s) => s.id === selectedId)) {
             const sel = findSubject(selectedId);
@@ -171,12 +179,16 @@ export function useFilteredSubjects({
         }
         return list;
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [ordered, mapView, mapZoom, visibleGeneralSubjects, selectedId, allSubjects, allGeneralSubjects, addressPoint]);
+    }, [ordered, orderedMerged, mapView, mapZoom, selectedId, allSubjects, allGeneralSubjects, addressPoint]);
 
-    // Free-text search-panel results, independent of the category filter / viewport.
+    // Free-text search-panel results, independent of the category filter / viewport. Searches
+    // located AND municipality-wide subjects (the latter would otherwise be invisible to search).
     const searchResults = useMemo(
-        () => (query.trim() ? filterSubjectsByQuery(allSubjects, query).slice(0, 20) : []),
-        [allSubjects, query],
+        () =>
+            query.trim()
+                ? filterSubjectsByQuery([...allSubjects, ...allGeneralSubjects], query).slice(0, 20)
+                : [],
+        [allSubjects, allGeneralSubjects, query],
     );
 
     const selectedSubject = useMemo(

--- a/src/components/landing/v2/hooks/useMapActions.ts
+++ b/src/components/landing/v2/hooks/useMapActions.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 import type { Map as MapboxMap } from 'mapbox-gl';
 import { DEFAULT_MAP_STYLE, SATELLITE_MAP_STYLE } from '@/components/map/map';
+import { captureLanding, captureLandingAction } from '@/lib/landing/analytics';
 import { EXPLAIN_LNGLAT, SUBJECT_FOCUS_ZOOM, type FlyTarget } from '@/lib/landing/landingCore';
 import { isValidLngLat } from '@/lib/landing/landingData';
 import type { LatLng } from '@/lib/google-maps';
@@ -53,16 +54,20 @@ export function useMapActions({ mapInstance, isMobile, defaultView }: Args) {
             setGeoError(true);
             return;
         }
+        captureLandingAction('locate', {});
         const reqId = ++locateReqRef.current;
         navigator.geolocation.getCurrentPosition(
             (pos) => {
                 if (reqId !== locateReqRef.current) return;
+                captureLanding('locate_result', { status: 'granted' });
                 const { latitude: lat, longitude: lng } = pos.coords;
                 setGeo({ lat, lng });
                 setFlyTo({ type: 'Point', coordinates: [lng, lat] });
             },
             (err) => {
                 if (reqId !== locateReqRef.current) return;
+                // PERMISSION_DENIED (1) is a distinct signal from timeouts/unavailability.
+                captureLanding('locate_result', { status: err.code === 1 ? 'denied' : 'error' });
                 console.warn('Geolocation failed:', err.code, err.message);
                 setGeoError(true);
             },

--- a/src/components/landing/v2/hooks/useMapMarkers.tsx
+++ b/src/components/landing/v2/hooks/useMapMarkers.tsx
@@ -17,6 +17,7 @@ import {
     type MapViewport,
 } from '@/lib/landing/landingData';
 import { buildSubjectPins, createGeneralCityMarker, createMunicipalityMarker } from '../mapMarkers';
+import { captureLandingAction } from '@/lib/landing/analytics';
 
 /**
  * Capture the map view on every moveend so the list + clustering react to it. Re-clusters
@@ -131,8 +132,35 @@ export function useMapViewCapture({
         };
         capture();
         mapInstance.on('moveend', capture);
+
+        // Analytics: one debounced map_moved per exploration burst (kind + zoom level only —
+        // no coordinates). User-initiated moves only: dragend is always a user gesture, and a
+        // zoomend carries originalEvent only for wheel/pinch/dblclick (programmatic easeTo/flyTo
+        // and the +/- buttons, which are tracked separately as map_zoom, don't).
+        let moveDebounce: ReturnType<typeof setTimeout> | null = null;
+        let movedKind: 'zoom' | 'pan' | null = null;
+        const queueMoveCapture = (kind: 'zoom' | 'pan') => {
+            movedKind = kind === 'zoom' ? 'zoom' : movedKind ?? 'pan'; // zoom wins over pan in a burst
+            if (moveDebounce) clearTimeout(moveDebounce);
+            moveDebounce = setTimeout(() => {
+                captureLandingAction('map_moved', { kind: movedKind, zoom: Math.round(mapInstance.getZoom()) });
+                movedKind = null;
+            }, 1000);
+        };
+        const onDragEnd = () => queueMoveCapture('pan');
+        // mapbox-gl's zoomend typing omits originalEvent, but the runtime event carries it
+        // for gesture zooms (wheel/pinch/dblclick) and omits it for programmatic ones.
+        const onZoomEnd = (e: object) => {
+            if ((e as { originalEvent?: unknown }).originalEvent) queueMoveCapture('zoom');
+        };
+        mapInstance.on('dragend', onDragEnd);
+        mapInstance.on('zoomend', onZoomEnd);
+
         return () => {
             mapInstance.off('moveend', capture);
+            mapInstance.off('dragend', onDragEnd);
+            mapInstance.off('zoomend', onZoomEnd);
+            if (moveDebounce) clearTimeout(moveDebounce);
         };
         // setters + refs are stable; re-subscribe only when the map instance changes
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -184,6 +212,7 @@ export function useSubjectMarkers({
         if (!mapInstance || !subjectsActive) return;
 
         const openCoLocated = (group: LandingSubject[]) => {
+            captureLandingAction('cluster_opened', { kind: 'co_located', size: group.length });
             // opening a "+N" box deselects any subject so its preview closes
             onClearSelectionRef.current();
             const lng = group[0].lng;
@@ -277,6 +306,7 @@ export function useGeneralCityMarkers({
         const markers: { marker: Marker; root: Root }[] = [];
         for (const city of visibleGeneralCities) {
             const { marker, root } = createGeneralCityMarker(mapInstance, city, () => {
+                captureLandingAction('cluster_opened', { kind: 'city_hall', size: city.subjects.length, city_id: city.cityId });
                 // opening the general box clears the other map previews
                 onClearSelectionRef.current();
                 closeExplainPopupRef.current?.();

--- a/src/components/landing/v2/mapMarkers.tsx
+++ b/src/components/landing/v2/mapMarkers.tsx
@@ -355,6 +355,7 @@ export function createDonutMarker(map: MapboxMap, members: LandingSubject[], t: 
     const centerLat = members.reduce((sum, m) => sum + m.lat, 0) / members.length;
     el.addEventListener('click', (e) => {
         e.stopPropagation();
+        captureLandingAction('cluster_opened', { kind: 'donut', size: members.length });
         // always zoom in toward the cluster (fitBounds couldn't zoom in on narrow viewports)
         map.easeTo({ center: [centerLng, centerLat], zoom: Math.min(map.getZoom() + 2, 18), duration: 400 });
     });

--- a/src/lib/landing/landingCore.ts
+++ b/src/lib/landing/landingCore.ts
@@ -268,7 +268,8 @@ export type LayoutProps = {
     upcoming: UpcomingMeeting[];
     loading: boolean;
     selectedId: string | null;
-    selectSubject: (id: string) => void;
+    /** `source` feeds the subject_selected analytics event; defaults to 'list' */
+    selectSubject: (id: string, source?: 'list' | 'search') => void;
     clearSelection: () => void;
     selectedSubject: LandingSubject | null;
     /** in-view subjects for the desktop panel (sorted), with nearest-N fallback */


### PR DESCRIPTION
Pre-release pass over the new landing page (#408), driven by a staging performance + analytics review. The popular-searches rework (which carries a schema migration) is split out into #535; this PR is migration-free.

## 1. Don't prefetch subject pages from the list
Each subject card's «Προβολή θέματος» link prefetched the full subject page — **~890 KB compressed / 5.6 MB decoded** of RSC (the meeting layout serializes the whole transcript) plus an uncached multi-MB transcript pull from Postgres, one per card scrolled into view. Two visible cards already outweighed the entire landing payload. `prefetch={false}`.

This was the capacity blocker for a launch spike (~500–1000 visitors / 2–3 min on 2× 4 GB dedicated instances): landing renders alone fit comfortably (~130 ms serialized server time each), but the prefetch amplification added 10–35 heavy renders/sec on top.

## 2. Fill the PostHog gaps
Confirmed untracked on staging and now covered (all through the existing `captureLanding*` wrappers, so `landing_first_action` and the device/view context come for free):

- `subject_selected` `{source: list | search | map_pin | cluster | city_hall}` — captured at call sites, not in `selectSubject`, so a deep-linked page load doesn't count as an interaction
- `city_opened` `{source: municipalities_list | map_marker | page_button}` — the landing → municipality-page conversion was invisible
- `map_moved` — one debounced event per exploration burst, kind (pan/zoom) + rounded zoom level only, no coordinates; wired to `dragend`/gesture `zoomend` so programmatic pans and the (already-tracked) zoom buttons don't fire it
- `map_style_changed`, `locate` + `locate_result` (granted/denied/error), `cluster_opened` `{co_located | donut | city_hall}`

(The `landing_search` `method` prop and `popular_search_picked` ride with #535, since they touch the same hunks as the search-logging changes.)

## 3. Rank non-located subjects together with located ones
Municipality-wide subjects were appended below every located subject as a separately-ranked group, so a hot city-wide subject could never outrank even the weakest located one — despite the ranker's `hasLocation` tiebreaker being designed for a merged set. The union is now ranked once. Kept as-is by design: the zoom-14 gate, centroid-in-viewport visibility, and located-only address mode. The search panel now also finds non-located subjects (it was blind to them).

**Expect the default list's top cards to shift** — non-located subjects are the majority of the dataset; worth eyeballing on the preview.

## Verification
`npx tsc --noEmit` clean, `eslint` clean, 63/63 Jest suites (957 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the new landing page before release. The main changes are:

- Disables prefetching for expensive subject pages.
- Adds analytics for subject, municipality, map, cluster, and location actions.
- Ranks located and municipality-wide subjects together.
- Includes municipality-wide subjects in search results.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The earlier search-logging concern is outside this PR after the feature split.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/landing/v2/LandingV2.tsx | Adds source-aware analytics for subject selection, municipality navigation, and map-style changes. |
| src/components/landing/v2/hooks/useFilteredSubjects.ts | Merges located and municipality-wide subjects for ranking and search. |
| src/components/landing/v2/hooks/useMapMarkers.tsx | Adds debounced map-movement tracking and cluster interaction events. |
| src/components/landing/v2/hooks/useMapActions.ts | Tracks location requests and their granted, denied, or error outcomes. |
| src/components/landing/v2/SubjectCard.tsx | Disables automatic prefetching for subject-page links. |

<sub>Reviews (3): Last reviewed commit: ["feat(landing): rank non-located subjects..."](https://github.com/schemalabz/opencouncil/commit/4331639394b3ed88739f638931f1c52479e3bd93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43646519)</sub>

**Context used:**

- Context used - .cursorrules ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=8f01574a-2b8a-490a-a6a8-5bb80f6f984c))
- Context used - CLAUDE.md ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=a3ddaa95-717d-48e6-81cd-93c42696bbed))

<!-- /greptile_comment -->