### PR TITLE
feat(landing): make the popular-searches chips real

### DIFF
--- a/prisma/migrations/20260712160231_add_search_query_source_realm/migration.sql
+++ b/prisma/migrations/20260712160231_add_search_query_source_realm/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "SearchQuery" ADD COLUMN     "realm" "Realm" NOT NULL DEFAULT 'greece',
+ADD COLUMN     "source" TEXT NOT NULL DEFAULT 'search';
+
+-- CreateIndex
+CREATE INDEX "SearchQuery_realm_createdAt_idx" ON "SearchQuery"("realm", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1243,6 +1243,10 @@ model SearchQuery {
   id        String   @id @default(cuid())
   query     String
   createdAt DateTime @default(now())
+  // Which surface logged the query ("search" = the /search page, "landing" = the landing search box)
+  source    String   @default("search")
+  // Tenant the query belongs to — keeps popular-searches suggestions per-realm
+  realm     Realm    @default(greece)
 
   // Relations
   user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
@@ -1250,6 +1254,7 @@ model SearchQuery {
 
   @@index([createdAt])
   @@index([userId])
+  @@index([realm, createdAt])
 }
 
 // QR Campaigns for short redirects

--- a/src/app/api/landing/log-search/route.ts
+++ b/src/app/api/landing/log-search/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { logSearchQuery } from '@/lib/db/searchQueries';
+import { getRealm } from '@/lib/realm.server';
+import { getTopics } from '@/lib/db/topics';
+import { getListedCitiesCached } from '@/lib/db/cities';
+import { detectCategoryQuery, detectMunicipalityQuery } from '@/lib/landing/landingData';
+
+// Logs a landing search so the popular-searches chips reflect what people actually look
+// for. The caller's text and kind are untrusted: the query is re-resolved here against the
+// realm's actual topics/municipalities and the CANONICAL matched name is stored (the fuzzy
+// matchers accept e.g. "<topic name><arbitrary suffix>", so storing raw text would let a
+// crafted phrase reach the public chips). No match → dropped. Address queries never reach
+// this endpoint (people type their home address; the client doesn't send them and no
+// topic/municipality resolves for them anyway).
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({
+    query: z.string().trim().min(1).max(100),
+    kind: z.enum(['category', 'municipality']),
+});
+
+export async function POST(request: Request) {
+    const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
+        return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
+    }
+    const { query, kind } = parsed.data;
+    const realm = await getRealm();
+
+    let canonical: string | null = null;
+    if (kind === 'category') {
+        const topics = await getTopics(realm);
+        const topicId = detectCategoryQuery(query, topics);
+        canonical = topics.find((t) => t.id === topicId)?.name ?? null;
+    } else {
+        const cities = await getListedCitiesCached(realm);
+        const match = detectMunicipalityQuery(query, cities);
+        canonical = match?.kind === 'known' ? match.name : null;
+    }
+
+    if (canonical) {
+        await logSearchQuery(canonical, { source: 'landing' });
+    }
+    return NextResponse.json({ ok: true });
+}

--- a/src/app/api/landing/popular-searches/route.ts
+++ b/src/app/api/landing/popular-searches/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from 'next/server';
-import { getPopularSearchQueries } from '@/lib/db/searchQueries';
+import { getRealm } from '@/lib/realm.server';
+import { getPopularSearchQueriesCached } from '@/lib/db/searchQueries';
 
-// Most-repeated real search queries, for the landing's "Δημοφιλείς αναζητήσεις" chips.
-// The client falls back to a curated list when this returns too few (early on there
-// isn't enough search history to surface meaningful suggestions).
+// Most-repeated real search queries of the realm, for the landing's "Δημοφιλείς αναζητήσεις"
+// chips. The client blends these with a curated list (real ones first) while the search
+// history is still thin. Dynamic for the Host-header realm; the query itself is cached.
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-    const keywords = await getPopularSearchQueries();
+    const keywords = await getPopularSearchQueriesCached(await getRealm());
     return NextResponse.json({ keywords });
 }

--- a/src/components/landing/v2/SearchBody.tsx
+++ b/src/components/landing/v2/SearchBody.tsx
@@ -13,39 +13,51 @@ import { PetitionCta } from './MunicipalitiesList';
 import { BODY_TYPES, DURATION_FILTERS, EMPTY_FILTERS, toggleValue, type MapFilters } from '@/lib/landing/landingCore';
 import { CityAvatar } from './controls';
 import { useSearchMatches } from './hooks/useSearchMatches';
+import { captureLandingAction, logLandingSearch } from '@/lib/landing/analytics';
 
 /* Popular searches: most-repeated real queries (SearchQuery log), fetched once and shared
-   across dropdown/overlay. Falls back to the curated list until there's enough history. */
-let popularCache: string[] | null = null;
-let popularPromise: Promise<string[]> | null = null;
+   across dropdown/overlay. Real queries come first and the curated list fills the remaining
+   chips, so the feature degrades gracefully while the search history is still thin. Only the
+   fetched (locale-agnostic) keywords are cached module-wide; the blend happens per render
+   with the CURRENT locale's curated list, so a client-side locale switch re-fills correctly. */
+let realPopularCache: string[] | null = null;
+let realPopularPromise: Promise<string[]> | null = null;
+
+const POPULAR_CHIP_COUNT = 8;
+
+/** Real queries first, curated fill after (case/diacritics-insensitive dedup), capped. */
+function blendPopularSearches(real: string[], curated: string[]): string[] {
+    const seen = new Set(real.map((k) => normalizeText(k).trim()));
+    const fill = curated.filter((k) => !seen.has(normalizeText(k).trim()));
+    return [...real, ...fill].slice(0, POPULAR_CHIP_COUNT);
+}
 
 function usePopularSearches(): string[] {
     const t = useTranslations('landingV2');
     const fallback = t.raw('popularSearches') as string[];
-    const [keywords, setKeywords] = useState<string[]>(popularCache ?? fallback);
+    const [real, setReal] = useState<string[]>(realPopularCache ?? []);
     useEffect(() => {
-        if (popularCache) return;
-        if (!popularPromise) {
-            popularPromise = fetch('/api/landing/popular-searches')
+        if (realPopularCache) return;
+        if (!realPopularPromise) {
+            realPopularPromise = fetch('/api/landing/popular-searches')
                 .then((r) => (r.ok ? r.json() : { keywords: [] }))
                 .then((d: { keywords: string[] }) => {
-                    // Need a few to read as intentional; otherwise keep the curated list.
-                    popularCache = d.keywords.length >= 4 ? d.keywords : fallback;
-                    return popularCache;
+                    realPopularCache = Array.isArray(d.keywords) ? d.keywords : [];
+                    return realPopularCache;
                 })
                 .catch(() => {
-                    popularCache = fallback;
-                    return popularCache;
+                    realPopularCache = [];
+                    return realPopularCache;
                 });
         }
         let active = true;
-        void popularPromise.then((k) => active && setKeywords(k));
+        void realPopularPromise.then((k) => active && setReal(k));
         return () => {
             active = false;
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
-    return keywords;
+    // Cheap (≤ ~20 items) — computed per render so it always uses the active locale's fill.
+    return blendPopularSearches(real, fallback);
 }
 
 /* native date input with a Greek placeholder. Browsers localise the field from the UI
@@ -151,7 +163,15 @@ export function SearchBody({
                 {matchedTopic && (
                     <button
                         type="button"
-                        onClick={() => onToggleCat(matchedTopic.id)}
+                        onClick={() => {
+                            captureLandingAction('search', {
+                                query_length: query.trim().length,
+                                kind: 'category',
+                                method: 'suggestion',
+                            });
+                            logLandingSearch(query, 'category');
+                            onToggleCat(matchedTopic.id);
+                        }}
                         className="mb-3 flex w-full items-center gap-2 rounded-xl border border-border bg-background px-3 py-2.5 text-left text-sm transition-colors hover:border-foreground/30"
                     >
                         <span
@@ -169,7 +189,15 @@ export function SearchBody({
                 {knownMunicipality && (
                     <button
                         type="button"
-                        onClick={() => onFiltersChange({ ...filters, cityIds: [knownMunicipality.cityId] })}
+                        onClick={() => {
+                            captureLandingAction('search', {
+                                query_length: query.trim().length,
+                                kind: 'municipality',
+                                method: 'suggestion',
+                            });
+                            logLandingSearch(query, 'municipality');
+                            onFiltersChange({ ...filters, cityIds: [knownMunicipality.cityId] });
+                        }}
                         className="mb-3 flex w-full items-center gap-2 rounded-xl border border-border bg-background px-3 py-2.5 text-left text-sm transition-colors hover:border-foreground/30"
                     >
                         <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-foreground/70">
@@ -184,7 +212,14 @@ export function SearchBody({
                 {showAddress && (
                     <button
                         type="button"
-                        onClick={() => onLocateAddress(query)}
+                        onClick={() => {
+                            captureLandingAction('search', {
+                                query_length: query.trim().length,
+                                kind: 'address',
+                                method: 'suggestion',
+                            });
+                            onLocateAddress(query);
+                        }}
                         className="mb-3 flex w-full items-center gap-2 rounded-xl border border-border bg-background px-3 py-2.5 text-left text-sm transition-colors hover:border-foreground/30"
                     >
                         <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[hsl(var(--orange))]/10 text-[hsl(var(--orange))]">
@@ -256,7 +291,10 @@ export function SearchBody({
                     <button
                         key={k}
                         type="button"
-                        onClick={() => onPickKeyword(k)}
+                        onClick={() => {
+                            captureLandingAction('popular_search_picked', { keyword: k });
+                            onPickKeyword(k);
+                        }}
                         className="inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-3 py-2 text-[13px] text-muted-foreground transition-colors hover:border-foreground/30"
                     >
                         <Search className="h-3.5 w-3.5" /> {k}

--- a/src/components/landing/v2/SearchPanel.tsx
+++ b/src/components/landing/v2/SearchPanel.tsx
@@ -15,7 +15,7 @@ import {
 import { hasActiveFilters, SEARCH_FIELD_STYLE, type MapFilters } from '@/lib/landing/landingCore';
 import { FilterIconButton } from './controls';
 import { SearchBody } from './SearchBody';
-import { captureLandingAction } from '@/lib/landing/analytics';
+import { captureLandingAction, logLandingSearch } from '@/lib/landing/analytics';
 
 /* The search field (icon · input · clear), shared by dropdown and overlay. Enter applies a
    matched category/municipality filter (clearing the text) or geocodes an address, then calls
@@ -75,14 +75,18 @@ function SearchField({
                     captureLandingAction('search', {
                         query_length: query.trim().length,
                         kind: catId ? 'category' : municipality?.kind === 'known' ? 'municipality' : 'address',
+                        method: 'enter',
                     });
                     if (catId) {
+                        logLandingSearch(query, 'category');
                         if (!cats.includes(catId)) onToggleCat(catId);
                         onQueryChange('');
                     } else if (municipality?.kind === 'known') {
+                        logLandingSearch(query, 'municipality');
                         onFiltersChange({ ...filters, cityIds: [municipality.cityId] });
                         onQueryChange('');
                     } else {
+                        // address kind — deliberately not logged (see logLandingSearch)
                         onLocateAddress(query);
                     }
                     onAfterSubmit?.();

--- a/src/lib/db/searchQueries.ts
+++ b/src/lib/db/searchQueries.ts
@@ -1,26 +1,34 @@
+import { Realm } from "@prisma/client";
 import prisma from "./prisma";
 import { auth } from "@/auth";
+import { getRealm } from "@/lib/realm.server";
+import { createCache } from "@/lib/cache/index";
 
 // The API schema doesn't bound query length, so cap what we store.
 const MAX_LOGGED_QUERY_LENGTH = 500;
 
 // "Popular searches" tuning. We surface the most-repeated real queries from the last
-// POPULAR_WINDOW_DAYS, but only ones searched at least POPULAR_MIN_COUNT times (so a
-// single curious visitor can't seed a suggestion), keeping the top POPULAR_LIMIT.
+// POPULAR_WINDOW_DAYS, keeping the top POPULAR_LIMIT. The bar to appear is deliberately
+// high — at least POPULAR_MIN_COUNT searches spread over POPULAR_MIN_DAYS distinct days —
+// because the chips are public homepage content fed by unauthenticated endpoints: a
+// drive-by burst of identical requests must not be able to seed a suggestion.
 const POPULAR_WINDOW_DAYS = 90;
-const POPULAR_MIN_COUNT = 3;
+const POPULAR_MIN_COUNT = 10;
+const POPULAR_MIN_DAYS = 2;
 const POPULAR_LIMIT = 8;
 // Skip the messy tail: very short fragments and long pasted addresses make poor chips.
 const POPULAR_MIN_LENGTH = 3;
 const POPULAR_MAX_LENGTH = 40;
+// Popularity shifts slowly; no tag — the TTL alone keeps the chips fresh enough.
+const POPULAR_TTL = 900; // 15 min
 
 /**
- * Returns the most frequent real search queries from the recent window, suitable for the
- * landing's "Δημοφιλείς αναζητήσεις" suggestions. Grouped case-insensitively (the most
- * recent original casing wins for display). Returns `[]` when there isn't enough signal —
- * callers fall back to a curated list. Never throws.
+ * Returns the realm's most frequent real search queries from the recent window, suitable
+ * for the landing's "Δημοφιλείς αναζητήσεις" suggestions. Grouped case-insensitively (the
+ * most recent original casing wins for display). Returns `[]` when there isn't enough
+ * signal — callers blend with a curated list. Never throws.
  */
-export async function getPopularSearchQueries(): Promise<string[]> {
+export async function getPopularSearchQueries(realm: Realm): Promise<string[]> {
     try {
         const since = new Date(Date.now() - POPULAR_WINDOW_DAYS * 24 * 60 * 60 * 1000);
         const rows = await prisma.$queryRaw<Array<{ query: string; count: bigint }>>`
@@ -28,9 +36,11 @@ export async function getPopularSearchQueries(): Promise<string[]> {
                    COUNT(*) AS count
             FROM "SearchQuery"
             WHERE "createdAt" >= ${since}
+              AND "realm" = ${realm}::"Realm"
               AND CHAR_LENGTH(TRIM("query")) BETWEEN ${POPULAR_MIN_LENGTH} AND ${POPULAR_MAX_LENGTH}
             GROUP BY LOWER(TRIM("query"))
             HAVING COUNT(*) >= ${POPULAR_MIN_COUNT}
+               AND COUNT(DISTINCT DATE("createdAt")) >= ${POPULAR_MIN_DAYS}
             ORDER BY count DESC, query ASC
             LIMIT ${POPULAR_LIMIT}
         `;
@@ -41,12 +51,29 @@ export async function getPopularSearchQueries(): Promise<string[]> {
     }
 }
 
+/** Cached variant — the landing fetches this once per visitor, so don't run the GROUP BY each time. */
+export async function getPopularSearchQueriesCached(realm: Realm): Promise<string[]> {
+    return createCache(
+        () => getPopularSearchQueries(realm),
+        ["popular-searches", realm],
+        { revalidate: POPULAR_TTL },
+    )();
+}
+
 /**
  * Persists a search query for usage analytics, attributing it to the current
  * user when one is logged in. Never throws — logging must not break search.
+ *
+ * `source` says which surface logged it ('search' = the /search page pipeline,
+ * 'landing' = the landing search box). The realm comes from the request's Host
+ * header; outside a request scope (background jobs) it falls back to greece.
  */
-export async function logSearchQuery(query: string): Promise<void> {
+export async function logSearchQuery(
+    query: string,
+    opts?: { source?: "search" | "landing" },
+): Promise<void> {
     try {
+        const realm = await getRealm().catch(() => Realm.greece);
         const session = await auth();
         // Resolve only the user id: getCurrentUser() would join the full
         // administers relations, which is wasteful on the search hot path.
@@ -59,6 +86,8 @@ export async function logSearchQuery(query: string): Promise<void> {
         await prisma.searchQuery.create({
             data: {
                 query: query.slice(0, MAX_LOGGED_QUERY_LENGTH),
+                source: opts?.source ?? "search",
+                realm,
                 userId: user?.id ?? null,
             },
         });

--- a/src/lib/landing/analytics.ts
+++ b/src/lib/landing/analytics.ts
@@ -30,3 +30,20 @@ export function captureLandingAction(event: string, props: Record<string, unknow
     }
     captureLanding(event, props);
 }
+
+/**
+ * Persist a landing search into the SearchQuery log (feeds the popular-searches chips).
+ * Fire-and-forget; category/municipality kinds only — address queries are people typing
+ * their home address and must never enter a popularity feed, so callers don't send them
+ * and the endpoint rejects them.
+ */
+export function logLandingSearch(query: string, kind: 'category' | 'municipality'): void {
+    const q = query.trim();
+    if (!q) return;
+    void fetch('/api/landing/log-search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: q, kind }),
+        keepalive: true, // survives the filter applying / a navigation right after
+    }).catch(() => {});
+}


### PR DESCRIPTION
Companion to the landing pre-release PR — split out because this one carries a **schema migration** (`SearchQuery.source` + `SearchQuery.realm`, created with `--create-only`, **not applied anywhere yet**).

## Problem
The «Δημοφιλείς αναζητήσεις» chips read from `SearchQuery`, but only the `/search`-page pipeline wrote to it, and the client discarded real results unless there were ≥ 4. Prod history has exactly **one** qualifying query in 90 days («Πάρκινγκ»), so every visitor saw the curated i18n fallback — the feature ate from a table its own UI never fed.

## Changes
- **Log landing searches**: new `POST /api/landing/log-search` (`source='landing'`), called fire-and-forget from the search box (Enter) and the suggestion rows. Category/municipality kinds only — **address queries never enter the popularity feed** (people type their home address); the client doesn't send them and the endpoint rejects them.
- **Blend instead of all-or-nothing**: real queries first, curated fill up to 8 (case/diacritics-insensitive dedup), so the chips get progressively more real as history accumulates.
- **Realm scoping**: `SearchQuery` rows are realm-tagged (Host header, greece fallback outside request scope) and the popular query filters by realm — the `.fr` deployment would otherwise surface Greek chips (flagged by review on #408).
- **Caching**: the popular query was an uncached 90-day `GROUP BY` on every landing visit; now `createCache` with a 15-min TTL, keyed by realm.
- Analytics riders on the same surfaces: `landing_search` now carries `method: enter | suggestion` (the suggestion rows were previously untracked), and `landing_popular_search_picked` fires on chip clicks — so we can tell whether this feature earns its keep.

## Deploy notes
- Migration must be applied per environment (additive: two columns with defaults + one index — no backfill needed; existing rows become `source='search'`, `realm='greece'`, which is historically accurate).

## Verification
`npx tsc --noEmit` clean, `eslint` clean, 63/63 Jest suites (957 tests) pass on this branch standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public unauthenticated logging feeds homepage chips; mitigations include canonical re-resolution and stricter popularity thresholds, but abuse and migration rollout still warrant care.
> 
> **Overview**
> **Extends `SearchQuery` with `source` and `realm`** (migration + index) so analytics and popular chips can distinguish the `/search` page from the landing box and stay tenant-scoped via the Host header.
> 
> **Wires the landing search UI into that log**: fire-and-forget `POST /api/landing/log-search` re-resolves category/municipality text to canonical topic or municipality names before persisting (`source='landing'`); addresses are never logged. Enter and suggestion actions in `SearchPanel` / `SearchBody` call `logLandingSearch`; analytics gain `method: enter | suggestion` and `popular_search_picked`.
> 
> **Popular chips behavior**: `GET /api/landing/popular-searches` uses realm + a 15-minute cached aggregation; thresholds rise (10 hits over 2 distinct days). The client **blends** API keywords with the locale’s curated list (real first, up to 8) instead of replacing the whole list when history is thin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57032a57e1dbf4de5b21dd6af577e7aa75615177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes landing-page popular searches reflect real, realm-scoped usage. The main changes are:

- Logs canonical category and municipality searches from the landing page.
- Blends real popular queries with locale-specific curated terms.
- Scopes search history and caching by realm.
- Adds source and realm fields to the search-query schema.
- Tracks search methods and popular-chip clicks.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge once the documented migration is included in deployment.

- Canonical server-side resolution prevents arbitrary submitted text from entering the public chips.
- Locale-specific curated terms no longer enter the shared module cache.
- Realm filtering and cache keys are consistent across logging and retrieval.
- No blocking issue remains in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/api/landing/log-search/route.ts | Adds a validated endpoint that stores only canonical, realm-scoped category and municipality names. |
| src/components/landing/v2/SearchBody.tsx | Caches only real query results and blends them with the active locale's curated terms on each render. |
| src/components/landing/v2/SearchPanel.tsx | Logs category and municipality searches from Enter submissions while excluding addresses. |
| src/lib/db/searchQueries.ts | Adds realm-aware logging, aggregation thresholds, and a per-realm cache for popular searches. |
| prisma/migrations/20260712160231_add_search_query_source_realm/migration.sql | Adds source and realm columns with defaults and an index for realm-scoped recent-query aggregation. |

<sub>Reviews (2): Last reviewed commit: ["feat(landing): make the popular-searches..."](https://github.com/schemalabz/opencouncil/commit/57032a57e1dbf4de5b21dd6af577e7aa75615177) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43647171)</sub>

**Context used:**

- Context used - .cursorrules ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=8f01574a-2b8a-490a-a6a8-5bb80f6f984c))
- Context used - CLAUDE.md ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=a3ddaa95-717d-48e6-81cd-93c42696bbed))

<!-- /greptile_comment -->