### PR TITLE
Updated BIRD_API_KEY and CRON_SECRET validation from z.string().min(1).optional() to z.string().optional().

### DIFF
--- a/src/env.mjs
+++ b/src/env.mjs
@@ -49,7 +49,7 @@ export const env = createEnv({
     DISCORD_WEBHOOK_URL: z.string().url().optional(),
 
     // Bird API for WhatsApp/SMS notifications
-    BIRD_API_KEY: z.string().min(1).optional(),
+    BIRD_API_KEY: z.string().optional(),
     BIRD_WORKSPACE_ID: z.string().optional(),
     BIRD_WHATSAPP_CHANNEL_ID: z.string().optional(),
     BIRD_SMS_CHANNEL_ID: z.string().optional(),
@@ -66,7 +66,7 @@ export const env = createEnv({
     GOOGLE_CALENDAR_ENABLED: z.string().optional(),
 
     // Cron Jobs
-    CRON_SECRET: z.string().min(1).optional(),
+    CRON_SECRET: z.string().optional(),
 
     // Cache (Valkey/Redis)
     CACHE_URL: z.string().optional(),


### PR DESCRIPTION
During local testing, the min(1) constraint prevented the application from starting when these optional keys were left unset. Changing these to z.string().optional() ensures the application loads correctly in a local environment without requiring these specific credentials.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR allows two optional credentials to remain empty during local startup. The changes are:

- Accept an empty `BIRD_API_KEY` value.
- Accept an empty `CRON_SECRET` value.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Empty Bird credentials are handled as unconfigured.
- Empty cron secrets return HTTP 503 before authorization checks.
- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/env.mjs | Allows empty values for the optional Bird API key and cron secret; current consumers reject or skip these unconfigured integrations safely. |

<sub>Reviews (1): Last reviewed commit: ["removing requirement for BIRD\_API\_KEY &amp; ..."](https://github.com/schemalabz/opencouncil/commit/52bb39ef0fcff330d55aaae08aef38cb000b35b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43651018)</sub>

**Context used:**

- Context used - .cursorrules ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=8f01574a-2b8a-490a-a6a8-5bb80f6f984c))
- Context used - CLAUDE.md ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=a3ddaa95-717d-48e6-81cd-93c42696bbed))

<!-- /greptile_comment -->