### PR TITLE
chore: upgrade Docker images to Node 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Base image
-FROM node:20-alpine AS base
+FROM node:24-alpine AS base
 
 # Set the working directory in the container
 WORKDIR /app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Stage 1: Base image
-FROM node:20-alpine AS base
+FROM node:24-alpine AS base
 
 # Set the working directory in the container
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "seed": "tsx prisma/seed.ts"
   },
   "engines": {
-    "node": ">=20.9.0 <25"
+    "node": ">=20.9.0 <23 || >=24.15.0 <25"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "seed": "tsx prisma/seed.ts"
   },
   "engines": {
-    "node": ">=20.9.0 <23"
+    "node": ">=20.9.0 <25"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",


### PR DESCRIPTION
## Why

Production has been emitting recurring `App Router render` error alerts:

```
TypeError: controller[kState].transformAlgorithm is not a function
    at transformStreamDefaultControllerPerformTransform (node:internal/webstreams/transformstream:527:37)
```

This is not an application bug — it's a known race condition inside Node's `TransformStream` implementation ([nodejs/node#62036](https://github.com/nodejs/node/issues/62036)), triggered when a client disconnects (or an LB times out) while Next.js is still streaming a server-rendered page. The stack trace contains no application frames; it also underlies [vercel/next.js#75994](https://github.com/vercel/next.js/issues/75994).

The upstream fix ([nodejs/node#62040](https://github.com/nodejs/node/pull/62040)) shipped in Node 24.15.0 (LTS) and 25.8.1. Node 20 — our current Docker base — went EOL in April 2026 and will never receive the backport, so these alerts recur for as long as we stay on it.

## Changes

- `Dockerfile` and `Dockerfile.dev`: `node:20-alpine` → `node:24-alpine` (active LTS, contains the fix)
- `package.json`: widen `engines.node` from `>=20.9.0 <23` to `>=20.9.0 <25` so a Node 24 runtime is allowed (Nix dev shells and preview deployments stay on the nixpkgs default, currently Node 22, and remain within range)

## Notes for review

- Production and staging deploy via DO App Platform from this Dockerfile, so the runtime bump takes effect on the next deploy of `main` (staging) — worth watching staging after merge before promoting to `production`.
- PR previews build with Nix, not Docker, so the preview for this PR does **not** exercise Node 24. If we want previews/dev shells on 24 too, that's a follow-up in `flake.nix` (`pkgs.nodejs` → `pkgs.nodejs_24`).
- Next.js 16 requires Node ≥ 20.9 and supports Node 24, so no framework constraint blocks this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgSfUQJo3ifvUQr8mNxsgj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgSfUQJo3ifvUQr8mNxsgj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes the production/staging container runtime on deploy with no application code changes; validate staging after merge before promoting to production.
> 
> **Overview**
> Moves **production and development Docker** bases from `node:20-alpine` to **`node:24-alpine`** so deployed runtimes pick up the Node **TransformStream** fix tied to recurring Next.js App Router streaming errors on client disconnect.
> 
> Updates **`package.json` `engines.node`** to keep **Node 20.9–22.x** while also allowing **`>=24.15.0 <25`**, so Node 24 is permitted only at patch levels that include that fix (and unfixed Node 23 / early Node 24 are not declared compatible).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 236831655611855679df2eedaeb6964e1d574446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the application’s supported Node.js runtimes.

- Moves production and development Docker images from Node 20 to Node 24.
- Allows Node 24.15.0 and newer while excluding earlier Node 24 releases.
- Keeps Node 20 through Node 22 compatible with existing Nix environments.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The updated engine range excludes the Node 24 versions that lack the required fix.
- No blocking issues remain in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Dockerfile | Updates the production container base image from Node 20 Alpine to Node 24 Alpine. |
| Dockerfile.dev | Updates the development container base image from Node 20 Alpine to Node 24 Alpine. |
| package.json | Allows Node 24.15.0 through Node 24 while retaining support for Node 20 through Node 22. |

<sub>Reviews (2): Last reviewed commit: ["Update package.json"](https://github.com/schemalabz/opencouncil/commit/236831655611855679df2eedaeb6964e1d574446) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44077152)</sub>

<!-- /greptile_comment -->