### PR TITLE
Feat/explain coverage and new code callout

### DIFF
--- a/src/app/[locale]/(other)/explain/ExplainFeatures.tsx
+++ b/src/app/[locale]/(other)/explain/ExplainFeatures.tsx
@@ -1,18 +1,46 @@
 "use client";
 
 import type { Realm } from "@prisma/client";
+import { ArrowRight, Phone } from "lucide-react";
+import { Link } from "@/i18n/routing";
 import HowItWorks from "@/components/about/HowItWorks";
 import { FeatureBlock } from "@/components/about/OpennessFeatures";
 import { OPENNESS_FEATURES } from "@/components/about/config";
+import { HeadingAnchor } from "@/components/explain/HeadingAnchor";
+import { CityCoverageTable } from "@/components/explain/CityCoverageTable";
+import type { CoverageRow } from "@/lib/db/coverage";
+
+/** Pricing figures for the "Ποιος πληρώνει" section, derived from the pricing config. */
+export interface ExplainPricing {
+    /** Combined processing price per meeting hour (digitization + human review). */
+    perHour: number;
+    /** Cheapest platform tier monthly price (0 ⇒ free) and its population ceiling. */
+    cheapestMonthly: number;
+    cheapestUpTo: number | null;
+    /** Priciest platform tier monthly price and the population it kicks in above. */
+    topMonthly: number;
+    topFrom: number | null;
+}
+
+const fmt = (n: number) => n.toLocaleString("el-GR");
 
 /**
  * Product showcase reused from the /about page, rendered inside the
  * "Πως δουλεύει το OpenCouncil;" section of /explain (so it matches that
  * section's width): the "how it works" diagram followed by each openness
  * feature (Θέματα & Περιλήψεις, Αναζήτηση, Ειδοποιήσεις, Χάρτης θεμάτων) with
- * its interactive demo stacked below the text (rather than inline as on /about).
+ * its interactive demo stacked below the text (rather than inline as on /about),
+ * then the per-city coverage table, pricing and the closing call to action.
  */
-export function ExplainFeatures({ realm }: { realm: Realm }) {
+export function ExplainFeatures({
+    realm,
+    coverage,
+    pricing,
+}: {
+    realm: Realm;
+    coverage: CoverageRow[];
+    pricing: ExplainPricing;
+}) {
     return (
         <div className="mt-8 space-y-14 md:space-y-16">
             {/* "Πώς δουλεύει" diagram. The desktop diagram is wider than the
@@ -36,6 +64,111 @@ export function ExplainFeatures({ realm }: { realm: Realm }) {
                     />
                 </div>
             ))}
+
+            {/* per-city × body-type coverage table */}
+            <div id="oc-coverage" className="scroll-mt-24">
+                <h3 className="!text-left text-xl font-normal !leading-none text-foreground sm:text-2xl">
+                    <HeadingAnchor id="oc-coverage">Κάλυψη</HeadingAnchor>
+                </h3>
+                <p className="mt-3 leading-relaxed text-muted-foreground">
+                    Το OpenCouncil καλύπτει τις δημόσιες συνεδριάσεις των δημοτικών συμβουλίων του κάθε δήμου όπου
+                    συνεργάζεται. Στη σελίδα του κάθε Δήμου μπορείτε να βρείτε αναλόγως από το πότε ξεκίνησε η
+                    συνεργασία μας, τα Δημοτικά Συμβούλια ή και σε συγκεκριμένους δήμους τις συνεδριάσεις των
+                    Δημοτικών Επιτροπών και των Δημοτικών Κοινοτήτων.
+                </p>
+                <p className="mt-3 leading-relaxed text-muted-foreground">Παρακάτω ο αναλυτικός πίνακας κάλυψης:</p>
+                <div className="mt-4">
+                    <CityCoverageTable rows={coverage} />
+                </div>
+            </div>
+
+            {/* pricing / who pays */}
+            <div id="oc-pricing" className="scroll-mt-24">
+                <h3 className="!text-left text-xl font-normal !leading-none text-foreground sm:text-2xl">
+                    <HeadingAnchor id="oc-pricing">Ποιος πληρώνει για το OpenCouncil;</HeadingAnchor>
+                </h3>
+                <p className="mt-3 leading-relaxed text-muted-foreground">
+                    Οι δήμοι που συμμετέχουν στο OpenCouncil είναι και εκείνοι που πληρώνουν για αυτό.
+                </p>
+                <p className="mt-3 leading-relaxed text-muted-foreground">
+                    Συγκεκριμένα, είναι {pricing.perHour}€ ανά ώρα συνεδρίασης για την ψηφιοποίηση και μια
+                    συνδρομή ανά μήνα που καλύπτει τη λειτουργία και την ανάπτυξη του OpenCouncil. Η συνδρομή ανά
+                    μήνα εξαρτάται από το μέγεθος του κάθε δήμου:{" "}
+                    {pricing.cheapestMonthly === 0
+                        ? `είναι δωρεάν για δήμους μέχρι ${fmt(pricing.cheapestUpTo ?? 0)} κατοίκους`
+                        : `ξεκινά από ${fmt(pricing.cheapestMonthly)}€ για δήμους μέχρι ${fmt(
+                              pricing.cheapestUpTo ?? 0,
+                          )} κατοίκους`}{" "}
+                    και έως {fmt(pricing.topMonthly)} ευρώ το μήνα για δήμους με πάνω από{" "}
+                    {fmt(pricing.topFrom ?? 0)} κατοίκους.
+                </p>
+                <p className="mt-3 leading-relaxed text-muted-foreground">
+                    Μπορείτε να αναζητήσετε τις ενεργές μας συμβάσεις ψάχνοντας στο ΚΗΜΔΗΣ για το ΑΦΜ μας{" "}
+                    <strong className="font-semibold text-foreground">802666391</strong>.
+                </p>
+                <p className="mt-3 leading-relaxed text-muted-foreground">
+                    Το OpenCouncil μπορεί να αντικαταστήσει τα έξοδα που κάνουν ήδη οι δήμοι για τα{" "}
+                    <strong className="font-semibold text-foreground">πρακτικά</strong> των συλλογικών οργάνων
+                    τους και να τους γλιτώσει χρήματα.
+                </p>
+                <p className="mt-4 text-sm italic leading-relaxed text-muted-foreground">
+                    Μπορείτε να δείτε περισσότερα σχετικά με τη διαφανή τιμολόγηση στο{" "}
+                    <a
+                        href="https://opencouncil.gr/about"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-orange underline underline-offset-2 hover:text-orange/80"
+                    >
+                        opencouncil.gr/about
+                    </a>
+                </p>
+            </div>
+
+            {/* CTA — bring OpenCouncil to your municipality */}
+            <div id="oc-cta" className="not-prose scroll-mt-24 rounded-2xl bg-[#14110D] p-6 text-white sm:p-8">
+                <h3 className="!text-left text-xl font-normal !leading-none sm:text-2xl">
+                    <HeadingAnchor id="oc-cta">Φέρτε το OpenCouncil στον δήμο σας</HeadingAnchor>
+                </h3>
+                <div className="mt-6 grid gap-4 sm:grid-cols-2">
+                    {/* citizens */}
+                    <div className="flex flex-col items-center justify-center gap-4 rounded-xl bg-white/5 p-5 text-center">
+                        <p className="text-base font-medium text-white sm:text-lg">Αν είστε δημότης</p>
+                        <Link
+                            href="/petition"
+                            className="unstyled group inline-flex items-center gap-2 rounded-full bg-orange px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-orange/90"
+                        >
+                            Καταχωρήστε αίτημα
+                            <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+                        </Link>
+                    </div>
+                    {/* municipality staff / elected officials */}
+                    <div className="flex flex-col items-center justify-center gap-4 rounded-xl bg-white/5 p-5 text-center">
+                        <p className="text-base font-medium text-white sm:text-lg">
+                            Αν δουλεύετε σε δήμο, ή είστε αιρετός / αυτοδιοικητικός
+                        </p>
+                        <div className="flex flex-col items-center gap-2">
+                            <a
+                                href="tel:+302111980212"
+                                className="unstyled group inline-flex items-center gap-3 rounded-full border border-white/25 px-5 py-2.5 transition-colors hover:bg-white/10"
+                            >
+                                <Phone className="h-5 w-5 shrink-0 text-orange" />
+                                <span className="text-left leading-tight">
+                                    <span className="block text-base font-semibold text-white">
+                                        +30 211 198 0212
+                                    </span>
+                                    <span className="block text-xs text-white/60">Καλέστε μας τώρα</span>
+                                </span>
+                            </a>
+                            <Link
+                                href="/about"
+                                className="unstyled text-sm text-white/70 underline underline-offset-2 transition-colors hover:text-white"
+                            >
+                                Μάθετε περισσότερα
+                            </Link>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     );
 }

--- a/src/app/[locale]/(other)/explain/ExplainReader.tsx
+++ b/src/app/[locale]/(other)/explain/ExplainReader.tsx
@@ -17,11 +17,21 @@ interface Section {
  *  - highlights the matching link in the sticky desktop table of contents;
  *  - renders the mobile prev/next navigator fixed to the bottom of the screen.
  */
-export function ExplainReader({ sections }: { sections: Section[] }) {
+export function ExplainReader({
+    sections,
+    sectionParents,
+    mainTitle,
+}: {
+    sections: Section[];
+    /** Section id → its top-level part title, shown above the sticky subtitle. */
+    sectionParents?: Record<string, string>;
+    /** Page main title — the fallback shown above top-level parts that have no parent. */
+    mainTitle?: string;
+}) {
     const [active, setActive] = useState(-1);
-    // Title of the section the reader has scrolled *past* — shown as a sticky bar
+    // Index of the section the reader has scrolled *past* — shown as a sticky bar
     // on mobile so the current subtitle stays visible while reading the content.
-    const [stickyTitle, setStickyTitle] = useState<string | null>(null);
+    const [stickyIdx, setStickyIdx] = useState(-1);
 
     // Track the section in view and pin the desktop table of contents.
     useEffect(() => {
@@ -49,7 +59,7 @@ export function ExplainReader({ sections }: { sections: Section[] }) {
             const passed = activeEl ? activeEl.getBoundingClientRect().top < 0 : false;
             // the Substack "further reading" section shouldn't pin its title
             const show = idx >= 0 && passed && sections[idx].id !== "substack";
-            setStickyTitle(show ? sections[idx].title : null);
+            setStickyIdx(show ? idx : -1);
 
             // pin the ToC: position: sticky is broken by an overflow-hidden
             // ancestor, so translate it to hold PIN_TOP while it's in range.
@@ -82,25 +92,19 @@ export function ExplainReader({ sections }: { sections: Section[] }) {
     // Reflect the active section in the ToC (aria-current) and the URL hash.
     useEffect(() => {
         const activeId = active >= 0 ? sections[active].id : null;
-        const isSub = activeId?.startsWith("oc-") ?? false;
 
         const links = document.querySelectorAll<HTMLAnchorElement>("[data-toc] a");
-        links.forEach((a) => {
-            const href = a.getAttribute("href");
-            // Highlight the active link; while a sub-section is active, also keep the
-            // parent "Πως δουλεύει το OpenCouncil;" entry highlighted.
-            const on =
-                (activeId != null && href === `#${activeId}`) || (isSub && href === "#opencouncil");
-            if (on) a.setAttribute("aria-current", "true");
-            else a.removeAttribute("aria-current");
-        });
+        links.forEach((a) => a.removeAttribute("aria-current"));
 
-        // Expand the nested OpenCouncil group once it (or one of its sub-sections)
-        // is in view; collapse it otherwise.
-        const group = document.querySelector("[data-toc-group]");
-        if (group) {
-            if (activeId === "opencouncil" || isSub) group.setAttribute("data-expanded", "true");
-            else group.removeAttribute("data-expanded");
+        if (activeId) {
+            const activeLink = document.querySelector<HTMLElement>(`[data-toc] a[href="#${activeId}"]`);
+            activeLink?.setAttribute("aria-current", "true");
+            // keep the parent top-level group ("Οι ελληνικοί δήμοι" / "Πώς δουλεύει…")
+            // highlighted while any of its sections is active
+            activeLink
+                ?.closest("[data-toc-group]")
+                ?.querySelector("[data-toc-grouphead]")
+                ?.setAttribute("aria-current", "true");
         }
 
         if (active >= 0) {
@@ -119,17 +123,24 @@ export function ExplainReader({ sections }: { sections: Section[] }) {
 
     const next = active >= 0 && active < sections.length - 1 ? sections[active + 1] : null;
 
+    const stickySection = stickyIdx >= 0 ? sections[stickyIdx] : null;
+    // the section's parent part, or the page's main title for top-level parts
+    const stickyParent = stickySection ? sectionParents?.[stickySection.id] ?? mainTitle : undefined;
+
     // Only surfaces once the reader is inside an article.
     if (active < 0) return null;
 
     return (
         <>
-            {stickyTitle && (
+            {stickySection && (
                 <div className="fixed inset-x-0 top-0 z-30 bg-background/95 backdrop-blur lg:hidden">
                     <div className="mx-auto max-w-6xl px-4 py-2.5">
-                        <span className="!text-left text-2xl !leading-none">
-                            {stickyTitle}
-                        </span>
+                        {stickyParent && (
+                            <div className="text-xs font-medium text-muted-foreground">{stickyParent}</div>
+                        )}
+                        <div className="!text-left text-xl font-normal !leading-none text-foreground sm:text-2xl">
+                            {stickySection.title}
+                        </div>
                     </div>
                 </div>
             )}

--- a/src/app/[locale]/(other)/explain/page.tsx
+++ b/src/app/[locale]/(other)/explain/page.tsx
@@ -1,9 +1,16 @@
 import { Metadata } from "next";
-import { ChevronRight } from "lucide-react";
 import { Link } from "@/i18n/routing";
 import { HeadingAnchor } from "@/components/explain/HeadingAnchor";
 import { NeighborhoodIllustration } from "@/components/explain/NeighborhoodIllustration";
 import { getNeighborhoodSubjects } from "@/lib/db/neighborhood";
+import { getCityCoverage } from "@/lib/db/coverage";
+import {
+    PLATFORM_PRICING_TIERS,
+    SESSION_PROCESSING,
+    getCorrectnessPricing,
+    CURRENT_OFFER_VERSION,
+} from "@/lib/pricing/config";
+import type { ExplainPricing } from "./ExplainFeatures";
 import { buildHreflangAlternates } from "@/lib/utils/hreflang";
 import { getRealm } from "@/lib/realm.server";
 import { ARTICLES, SECTIONS } from "@/lib/explain/articles";
@@ -13,14 +20,38 @@ import { ExplainFeatures } from "./ExplainFeatures";
 import { SubstackCarousel } from "@/components/embeds/SubstackCarousel";
 import { SUBSTACK_POSTS } from "@/lib/explain/substackPosts";
 
-/** Full scroll-spy / mobile-nav order: articles, the OpenCouncil sub-sections,
- *  then the Substack "further reading" carousel as the final stop. */
 const SUBSTACK_HEADING = "Διάβασε περισσότερα στο Substack";
+
+// Two high-level parts: the local-government articles nested under "Οι ελληνικοί
+// δήμοι", and the OpenCouncil product (with its sub-sections). The part titles
+// double as the top-level table-of-contents groups.
+const GREEK_MUNICIPALITIES_TITLE = "Οι ελληνικοί δήμοι";
+const OPENCOUNCIL_TITLE = "Πώς δουλεύει το OpenCouncil";
+
+const LOCAL_GOV_SECTIONS = SECTIONS.filter((s) => s.id !== "opencouncil");
+const LOCAL_GOV_ARTICLES = ARTICLES.filter((a) => a.id !== "opencouncil");
+const OpenCouncilBody = ARTICLES.find((a) => a.id === "opencouncil")?.Body;
+
+/** Top-level ToC groups, each with its nested sections. */
+const NAV_GROUPS = [
+    { id: "greek-municipalities", title: GREEK_MUNICIPALITIES_TITLE, items: LOCAL_GOV_SECTIONS },
+    { id: "opencouncil", title: OPENCOUNCIL_TITLE, items: OPENCOUNCIL_SUBSECTIONS },
+];
+
+/** Full scroll-spy / mobile-nav order (top → bottom of the page). */
 const NAV_SECTIONS = [
-    ...SECTIONS,
+    { id: "greek-municipalities", title: GREEK_MUNICIPALITIES_TITLE },
+    ...LOCAL_GOV_SECTIONS,
+    { id: "opencouncil", title: OPENCOUNCIL_TITLE },
     ...OPENCOUNCIL_SUBSECTIONS,
     { id: "substack", title: SUBSTACK_HEADING },
 ];
+
+/** Each nested section → its top-level part title (for the mobile sticky header). */
+const SECTION_PARENTS: Record<string, string> = {
+    ...Object.fromEntries(LOCAL_GOV_SECTIONS.map((s) => [s.id, GREEK_MUNICIPALITIES_TITLE])),
+    ...Object.fromEntries(OPENCOUNCIL_SUBSECTIONS.map((s) => [s.id, OPENCOUNCIL_TITLE])),
+};
 
 const PAGE_TITLE = "Η τοπική αυτοδιοίκηση, απλά";
 const PAGE_DESCRIPTION =
@@ -64,6 +95,21 @@ export async function generateMetadata(props: {
 export default async function ExplainPage() {
     const realm = await getRealm();
     const neighborhoodSubjects = await getNeighborhoodSubjects();
+    const cityCoverage = await getCityCoverage(realm);
+
+    // Pricing shown in "Ποιος πληρώνει" — derived from the pricing config so it
+    // stays in sync with offers. Per-hour = digitization + human review; the
+    // subscription spans the cheapest platform tier to the priciest.
+    const cheapestTier = PLATFORM_PRICING_TIERS[0];
+    const priciestTier = PLATFORM_PRICING_TIERS[PLATFORM_PRICING_TIERS.length - 1];
+    const pricing: ExplainPricing = {
+        perHour: SESSION_PROCESSING.pricePerHour + getCorrectnessPricing(CURRENT_OFFER_VERSION).pricePerUnit,
+        cheapestMonthly: cheapestTier.monthlyPrice,
+        cheapestUpTo: cheapestTier.maxPopulation,
+        topMonthly: priciestTier.monthlyPrice,
+        // the priciest (open-ended) tier kicks in above the previous tier's ceiling
+        topFrom: PLATFORM_PRICING_TIERS[PLATFORM_PRICING_TIERS.length - 2]?.maxPopulation ?? null,
+    };
     const structuredData = {
         "@context": "https://schema.org",
         "@type": "Article",
@@ -111,61 +157,73 @@ export default async function ExplainPage() {
                     <h2 className="mb-3.5 text-xs font-bold uppercase tracking-wider text-muted-foreground !text-left">
                         Περιεχόμενα
                     </h2>
-                    <ol className="space-y-0.5">
-                        {SECTIONS.map((s) => {
-                            const isOc = s.id === "opencouncil";
-                            return (
-                                <li key={s.id} className={isOc ? "group" : undefined} data-toc-group={isOc ? "" : undefined}>
-                                    <a
-                                        href={`#${s.id}`}
-                                        className="flex items-center justify-between gap-2 border-l-2 border-border py-1.5 pl-3.5 pr-1 text-sm leading-snug text-muted-foreground transition-colors hover:text-foreground aria-[current=true]:border-orange aria-[current=true]:font-semibold aria-[current=true]:text-orange"
-                                    >
-                                        <span>{s.title}</span>
-                                        {isOc && (
-                                            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60 transition-transform duration-200 group-data-[expanded=true]:rotate-90" />
-                                        )}
-                                    </a>
-                                    {/* nested sub-sections — revealed when the section is active */}
-                                    {isOc && (
-                                        <div
-                                            data-toc-nested
-                                            className="grid grid-rows-[0fr] overflow-hidden transition-[grid-template-rows] duration-300 ease-out group-data-[expanded=true]:grid-rows-[1fr]"
-                                        >
-                                            <ol className="mt-1 min-h-0 space-y-0.5 overflow-hidden pl-2">
-                                                {OPENCOUNCIL_SUBSECTIONS.map((sub) => (
-                                                    <li key={sub.id}>
-                                                        <a
-                                                            href={`#${sub.id}`}
-                                                            className="block border-l-2 border-border py-1 pl-3 text-[13px] leading-snug text-muted-foreground transition-colors hover:text-foreground aria-[current=true]:border-orange/50 aria-[current=true]:font-medium aria-[current=true]:text-orange/80"
-                                                        >
-                                                            {sub.title}
-                                                        </a>
-                                                    </li>
-                                                ))}
-                                            </ol>
-                                        </div>
-                                    )}
-                                </li>
-                            );
-                        })}
+                    <ol className="space-y-5">
+                        {NAV_GROUPS.map((g) => (
+                            <li key={g.id} data-toc-group={g.id}>
+                                <a
+                                    href={`#${g.id}`}
+                                    data-toc-grouphead
+                                    className="block py-1 text-sm font-bold text-foreground/80 transition-colors hover:text-orange aria-[current=true]:text-orange"
+                                >
+                                    {g.title}
+                                </a>
+                                <ol className="mt-1.5 space-y-0.5">
+                                    {g.items.map((it) => (
+                                        <li key={it.id}>
+                                            <a
+                                                href={`#${it.id}`}
+                                                className="block border-l-2 border-border py-1.5 pl-3.5 text-sm leading-snug text-muted-foreground transition-colors hover:text-foreground aria-[current=true]:border-orange aria-[current=true]:font-semibold aria-[current=true]:text-orange"
+                                            >
+                                                {it.title}
+                                            </a>
+                                        </li>
+                                    ))}
+                                </ol>
+                            </li>
+                        ))}
                     </ol>
                 </aside>
 
-                {/* articles */}
-                <div className="space-y-14">
-                    {ARTICLES.map(({ id, title, Body }) => (
-                        <section key={id} id={id} className="scroll-mt-24">
-                            <h2 className="!text-left text-2xl font-bold !leading-none sm:text-3xl">
-                                <HeadingAnchor id={id}>{title}</HeadingAnchor>
-                            </h2>
-                            <div className="prose prose-neutral mt-4 max-w-none prose-headings:font-bold prose-a:text-orange prose-blockquote:border-l-orange prose-blockquote:not-italic">
-                                <Body />
+                {/* two high-level parts */}
+                <div className="space-y-16">
+                    {/* Part 1 — Οι ελληνικοί δήμοι */}
+                    <section aria-labelledby="greek-municipalities">
+                        <h2
+                            id="greek-municipalities"
+                            className="!text-left scroll-mt-24 !text-3xl !font-bold tracking-tight sm:!text-4xl"
+                        >
+                            <HeadingAnchor id="greek-municipalities">{GREEK_MUNICIPALITIES_TITLE}</HeadingAnchor>
+                        </h2>
+                        <div className="mt-8 space-y-14">
+                            {LOCAL_GOV_ARTICLES.map(({ id, title, Body }) => (
+                                <section key={id} id={id} className="scroll-mt-24">
+                                    <h3 className="!text-left text-xl font-normal !leading-none sm:text-2xl">
+                                        <HeadingAnchor id={id}>{title}</HeadingAnchor>
+                                    </h3>
+                                    <div className="prose prose-neutral mt-4 max-w-none prose-headings:font-bold prose-a:text-orange prose-blockquote:border-l-orange prose-blockquote:not-italic">
+                                        <Body />
+                                    </div>
+                                </section>
+                            ))}
+                        </div>
+                    </section>
+
+                    {/* Part 2 — Πώς δουλεύει το OpenCouncil */}
+                    <section aria-labelledby="opencouncil">
+                        <h2
+                            id="opencouncil"
+                            className="!text-left scroll-mt-24 !text-3xl !font-bold tracking-tight sm:!text-4xl"
+                        >
+                            <HeadingAnchor id="opencouncil">{OPENCOUNCIL_TITLE}</HeadingAnchor>
+                        </h2>
+                        {OpenCouncilBody && (
+                            <div className="prose prose-neutral mt-8 max-w-none prose-headings:font-bold prose-a:text-orange prose-blockquote:border-l-orange prose-blockquote:not-italic">
+                                <OpenCouncilBody />
                             </div>
-                            {/* Product showcase (diagram + feature demos), reused from
-                                /about — part of the OpenCouncil section, matching its width */}
-                            {id === "opencouncil" && <ExplainFeatures realm={realm} />}
-                        </section>
-                    ))}
+                        )}
+                        {/* Product showcase (diagram + feature demos + coverage/pricing/CTA) */}
+                        <ExplainFeatures realm={realm} coverage={cityCoverage} pricing={pricing} />
+                    </section>
                 </div>
             </div>
 
@@ -173,7 +231,7 @@ export default async function ExplainPage() {
             <hr className="mt-16 border-t border-border" />
             <SubstackCarousel id="substack" posts={SUBSTACK_POSTS} heading={SUBSTACK_HEADING} />
 
-            <ExplainReader sections={NAV_SECTIONS} />
+            <ExplainReader sections={NAV_SECTIONS} sectionParents={SECTION_PARENTS} mainTitle={PAGE_TITLE} />
         </div>
     );
 }

--- a/src/app/[locale]/(other)/explain/page.tsx
+++ b/src/app/[locale]/(other)/explain/page.tsx
@@ -3,7 +3,7 @@ import { Link } from "@/i18n/routing";
 import { HeadingAnchor } from "@/components/explain/HeadingAnchor";
 import { NeighborhoodIllustration } from "@/components/explain/NeighborhoodIllustration";
 import { getNeighborhoodSubjects } from "@/lib/db/neighborhood";
-import { getCityCoverage } from "@/lib/db/coverage";
+import { getCityCoverageCached } from "@/lib/cache/queries";
 import {
     PLATFORM_PRICING_TIERS,
     SESSION_PROCESSING,
@@ -95,7 +95,7 @@ export async function generateMetadata(props: {
 export default async function ExplainPage() {
     const realm = await getRealm();
     const neighborhoodSubjects = await getNeighborhoodSubjects();
-    const cityCoverage = await getCityCoverage(realm);
+    const cityCoverage = await getCityCoverageCached(realm);
 
     // Pricing shown in "Ποιος πληρώνει" — derived from the pricing config so it
     // stays in sync with offers. Per-hour = digitization + human review; the

--- a/src/components/about/MapDemo.tsx
+++ b/src/components/about/MapDemo.tsx
@@ -27,7 +27,7 @@ export default function MapDemo({ realm }: { realm: Realm }) {
     const t = useTranslations('about.demos.map')
 
     return (
-        <BrowserFrame url={`${getRealmDomain(realm)}/map`} className="w-full">
+        <BrowserFrame url={getRealmDomain(realm)} className="w-full">
             {/* Map area */}
             <div className="relative aspect-[4/3] overflow-hidden bg-[#f2efe9]">
                 {/* Mapbox static tile background */}

--- a/src/components/about/OpennessFeatures.tsx
+++ b/src/components/about/OpennessFeatures.tsx
@@ -93,7 +93,7 @@ export function FeatureBlock({
             <h3
                 className={
                     stacked
-                        ? 'text-lg md:text-xl font-semibold tracking-tight'
+                        ? '!text-left text-xl font-normal !leading-none sm:text-2xl'
                         : 'text-2xl md:text-3xl font-medium tracking-tight'
                 }
             >

--- a/src/components/about/config.ts
+++ b/src/components/about/config.ts
@@ -63,8 +63,9 @@ export const OPENNESS_FEATURES: Feature[] = [
     {
         id: 'map',
         status: 'live',
-        demoUrl: '/map',
-        demoUrlByRealm: { france: '/map' },
+        // the map lives on the landing page now, not the standalone /map route
+        demoUrl: '/',
+        demoUrlByRealm: { france: '/' },
     },
 ]
 

--- a/src/components/explain/CityCoverageTable.tsx
+++ b/src/components/explain/CityCoverageTable.tsx
@@ -89,7 +89,7 @@ export function CityCoverageTable({ rows }: { rows: CoverageRow[] }) {
                                             {TYPE_LABEL[r.bodyType]}
                                         </td>
                                         <td className="whitespace-nowrap px-4 py-3 text-muted-foreground">
-                                            {formatDate(new Date(r.fromDate))}
+                                            {formatDate(new Date(r.fromDate), r.cityTimezone)}
                                         </td>
                                         <td className="whitespace-nowrap px-4 py-3">
                                             <NowBadge />
@@ -116,7 +116,7 @@ export function CityCoverageTable({ rows }: { rows: CoverageRow[] }) {
                                     <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-muted-foreground">
                                         <span>
                                             <span className="text-foreground">Από:</span>{" "}
-                                            {formatDate(new Date(r.fromDate))}
+                                            {formatDate(new Date(r.fromDate), r.cityTimezone)}
                                         </span>
                                         <span aria-hidden>·</span>
                                         <span>

--- a/src/components/explain/CityCoverageTable.tsx
+++ b/src/components/explain/CityCoverageTable.tsx
@@ -1,0 +1,134 @@
+import { Link } from "@/i18n/routing";
+import { formatDate } from "@/lib/formatters/time";
+import type { AdministrativeBodyType } from "@prisma/client";
+import type { CoverageRow } from "@/lib/db/coverage";
+
+const TYPE_LABEL: Record<AdministrativeBodyType, string> = {
+    council: "Δημοτικά Συμβούλια",
+    committee: "Δημοτικές Επιτροπές",
+    community: "Δημοτικές Κοινότητες",
+};
+
+/** "Έως" is always the present. */
+const NOW_LABEL = "Τώρα";
+
+interface CityGroup {
+    cityId: string;
+    cityName: string;
+    items: CoverageRow[];
+}
+
+/** Rows arrive sorted by city then body type — collapse them into per-city groups. */
+function groupByCity(rows: CoverageRow[]): CityGroup[] {
+    const groups: CityGroup[] = [];
+    for (const r of rows) {
+        const last = groups[groups.length - 1];
+        if (last && last.cityId === r.cityId) last.items.push(r);
+        else groups.push({ cityId: r.cityId, cityName: r.cityName, items: [r] });
+    }
+    return groups;
+}
+
+function CityLink({ cityId, cityName }: { cityId: string; cityName: string }) {
+    return (
+        <Link
+            href={`/${cityId}`}
+            className="unstyled font-medium text-foreground transition-colors hover:text-orange"
+        >
+            {cityName}
+        </Link>
+    );
+}
+
+const NowBadge = () => (
+    <span className="inline-flex items-center rounded-full border border-orange/30 bg-orange/5 px-2.5 py-1 text-xs font-medium text-orange">
+        {NOW_LABEL}
+    </span>
+);
+
+/**
+ * Coverage matrix for the /explain "Κάλυψη" subsection: municipalities grouped
+ * with a sub-row per administrative body type — the date public coverage started
+ * ("Από") through the present ("Έως" = Τώρα). A table on ≥sm (city spans its body
+ * rows), stacked per-city cards on mobile. Data comes from {@link getCityCoverage}.
+ */
+export function CityCoverageTable({ rows }: { rows: CoverageRow[] }) {
+    const groups = groupByCity(rows);
+
+    return (
+        <div className="not-prose">
+            {/* desktop / tablet: table with the city cell spanning its body rows */}
+            <div className="hidden overflow-x-auto rounded-2xl border border-border sm:block">
+                <table className="w-full border-collapse text-sm">
+                    <thead>
+                        <tr className="border-b border-border bg-muted/40 text-left">
+                            <th className="px-4 py-3 font-semibold text-foreground">Δήμος</th>
+                            <th className="px-4 py-3 font-semibold text-foreground">Όργανο</th>
+                            <th className="px-4 py-3 font-semibold text-foreground">Από</th>
+                            <th className="px-4 py-3 font-semibold text-foreground">Έως</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {groups.map((g) =>
+                            g.items.map((r, i) => {
+                                const isLast = i === g.items.length - 1;
+                                return (
+                                    <tr
+                                        key={`${r.cityId}-${r.bodyType}`}
+                                        className={isLast ? "border-b border-border last:border-0" : undefined}
+                                    >
+                                        {i === 0 && (
+                                            <td
+                                                rowSpan={g.items.length}
+                                                className="whitespace-nowrap border-r border-border px-4 py-3 align-top"
+                                            >
+                                                <CityLink cityId={g.cityId} cityName={g.cityName} />
+                                            </td>
+                                        )}
+                                        <td className="whitespace-nowrap px-4 py-3 text-muted-foreground">
+                                            {TYPE_LABEL[r.bodyType]}
+                                        </td>
+                                        <td className="whitespace-nowrap px-4 py-3 text-muted-foreground">
+                                            {formatDate(new Date(r.fromDate))}
+                                        </td>
+                                        <td className="whitespace-nowrap px-4 py-3">
+                                            <NowBadge />
+                                        </td>
+                                    </tr>
+                                );
+                            }),
+                        )}
+                    </tbody>
+                </table>
+            </div>
+
+            {/* mobile: one card per city, body types listed inside */}
+            <ul className="space-y-3 sm:hidden">
+                {groups.map((g) => (
+                    <li key={g.cityId} className="rounded-2xl border border-border p-4">
+                        <div className="text-base">
+                            <CityLink cityId={g.cityId} cityName={g.cityName} />
+                        </div>
+                        <ul className="mt-3 space-y-2.5">
+                            {g.items.map((r) => (
+                                <li key={r.bodyType} className="text-sm">
+                                    <div className="font-medium text-foreground">{TYPE_LABEL[r.bodyType]}</div>
+                                    <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-muted-foreground">
+                                        <span>
+                                            <span className="text-foreground">Από:</span>{" "}
+                                            {formatDate(new Date(r.fromDate))}
+                                        </span>
+                                        <span aria-hidden>·</span>
+                                        <span>
+                                            <span className="text-foreground">Έως:</span> {NOW_LABEL}
+                                        </span>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/src/components/explain/NeighborhoodIllustration.tsx
+++ b/src/components/explain/NeighborhoodIllustration.tsx
@@ -65,7 +65,7 @@ export function NeighborhoodIllustration({
                 onMouseLeave={() => setActive(null)}
             >
                 <svg
-                    viewBox="0 0 1320 588"
+                    viewBox="0 0 1320 668"
                     xmlns="http://www.w3.org/2000/svg"
                     role="img"
                     style={{ width: "100%", height: "auto", display: "block" }}
@@ -78,8 +78,8 @@ export function NeighborhoodIllustration({
 .ni-el--live:hover,.ni-el--live:focus-visible{transform:translateY(-9px) scale(1.035);outline:none;}
 @media (prefers-reduced-motion:reduce){.ni-el{transition:none;}}
 `}</style>
-                    <rect x="0" y="0" width="1320" height="588" fill="#F7F3EA" />
-                    <rect x="0" y="412" width="1320" height="176" fill="#ECE5D4" />
+                    <rect x="0" y="0" width="1320" height="668" fill="#F7F3EA" />
+                    <rect x="0" y="412" width="1320" height="256" fill="#ECE5D4" />
                     <line x1="0" y1="412" x2="1320" y2="412" stroke="#14110D" strokeWidth="3" />
 
                     {/* trees & bench → environment */}
@@ -154,11 +154,15 @@ export function NeighborhoodIllustration({
 
                 {/* extra ground on small screens so the info card clears the buildings —
                     only while a panel is shown, so there's no dead space otherwise */}
-                {showPanel && <div aria-hidden className="h-24 bg-[#ECE5D4] sm:hidden" />}
+                {showPanel && <div aria-hidden className="h-16 sm:h-2 bg-[#ECE5D4] sm:hidden" />}
+
+                {/* while nothing is selected, extend the ground so the hint sits well
+                    below the buildings with room to breathe */}
+                {!showPanel && <div aria-hidden className="h-2 bg-[#ECE5D4] sm:h-1" />}
 
                 {/* hint at the bottom of the ground — hidden once an element is selected */}
                 {!showPanel && (
-                    <div className="pointer-events-none absolute inset-x-0 bottom-0 px-3 pb-2 text-center text-[11px] text-muted-foreground sm:text-xs">
+                    <div className="pointer-events-none absolute inset-x-0 bottom-0 px-3 pb-5 text-center text-[11px] text-muted-foreground sm:text-xs">
                         Πατήστε πάνω στα εικονίδια για να δείτε σχετικά θέματα
                     </div>
                 )}

--- a/src/lib/cache/queries.ts
+++ b/src/lib/cache/queries.ts
@@ -13,6 +13,7 @@ import { getMeetingStatus } from "@/lib/meetingStatus";
 import { getBatchStatisticsForSubjects, Statistics } from "@/lib/statistics";
 import { createCache } from "./index";
 import { fetchLatestSubstackPost } from "@/lib/db/landing";
+import { getCityCoverage } from "@/lib/db/coverage";
 
 /**
  * Cached list of all city ids (single shared cache key, tag `cities:all`).
@@ -240,5 +241,19 @@ export async function getGitHubStatsCached() {
     () => getGitHubStats(),
     ['about', 'github'],
     { tags: ['github'], revalidate: 86400 } // refresh once per day
+  )();
+}
+
+/**
+ * Cached per-city coverage for the /explain "Κάλυψη" table. Scans every released
+ * meeting of every supported city, so it must not run per request — cache it and
+ * refresh every 15 minutes (also picks up newly-past meetings). Revalidated by
+ * city/meeting changes via the `cities:all` tag.
+ */
+export async function getCityCoverageCached(realm: Realm) {
+  return createCache(
+    () => getCityCoverage(realm),
+    ['explain', 'coverage', realm],
+    { tags: ['cities:all', `realm:${realm}:cities:all`], revalidate: 900 }
   )();
 }

--- a/src/lib/db/coverage.ts
+++ b/src/lib/db/coverage.ts
@@ -5,10 +5,14 @@ import type { Realm, AdministrativeBodyType } from '@prisma/client';
  * One coverage row per (cooperating municipality × administrative body type) for
  * the /explain "Κάλυψη" subsection: since when we publicly cover that body type
  * in that city ("από" = its first released meeting) up to now ("έως" = τώρα).
+ *
+ * Prefer the cached wrapper `getCityCoverageCached` in `@/lib/cache/queries` —
+ * this scans a city's released meetings, so it shouldn't run on every request.
  */
 export interface CoverageRow {
     cityId: string;
     cityName: string; // name_municipality, e.g. "Δήμος Αθηναίων"
+    cityTimezone: string; // format `fromDate` in the municipality's own timezone
     bodyType: AdministrativeBodyType; // 'council' | 'committee' | 'community'
     /** ISO date of the first released meeting for this city + body type. */
     fromDate: string;
@@ -21,18 +25,24 @@ const TYPE_ORDER: Record<AdministrativeBodyType, number> = {
 };
 
 export async function getCityCoverage(realm: Realm): Promise<CoverageRow[]> {
+    // Only meetings that have already taken place count towards coverage — a
+    // future, pre-published meeting must not set an early "Από" date.
+    const now = new Date();
+    const releasedPast = { released: true, administrativeBody: { isNot: null }, dateTime: { lte: now } };
+
     const cities = await prisma.city.findMany({
         where: {
             realm,
             status: 'listed',
             officialSupport: true,
-            councilMeetings: { some: { released: true, administrativeBody: { isNot: null } } },
+            councilMeetings: { some: releasedPast },
         },
         select: {
             id: true,
             name_municipality: true,
+            timezone: true,
             councilMeetings: {
-                where: { released: true, administrativeBody: { isNot: null } },
+                where: releasedPast,
                 select: {
                     dateTime: true,
                     administrativeBody: { select: { type: true } },
@@ -55,6 +65,7 @@ export async function getCityCoverage(realm: Realm): Promise<CoverageRow[]> {
             rows.push({
                 cityId: c.id,
                 cityName: c.name_municipality,
+                cityTimezone: c.timezone,
                 bodyType,
                 fromDate: from.toISOString(),
             });

--- a/src/lib/db/coverage.ts
+++ b/src/lib/db/coverage.ts
@@ -1,0 +1,69 @@
+import prisma from './prisma';
+import type { Realm, AdministrativeBodyType } from '@prisma/client';
+
+/**
+ * One coverage row per (cooperating municipality × administrative body type) for
+ * the /explain "Κάλυψη" subsection: since when we publicly cover that body type
+ * in that city ("από" = its first released meeting) up to now ("έως" = τώρα).
+ */
+export interface CoverageRow {
+    cityId: string;
+    cityName: string; // name_municipality, e.g. "Δήμος Αθηναίων"
+    bodyType: AdministrativeBodyType; // 'council' | 'committee' | 'community'
+    /** ISO date of the first released meeting for this city + body type. */
+    fromDate: string;
+}
+
+const TYPE_ORDER: Record<AdministrativeBodyType, number> = {
+    council: 0,
+    committee: 1,
+    community: 2,
+};
+
+export async function getCityCoverage(realm: Realm): Promise<CoverageRow[]> {
+    const cities = await prisma.city.findMany({
+        where: {
+            realm,
+            status: 'listed',
+            officialSupport: true,
+            councilMeetings: { some: { released: true, administrativeBody: { isNot: null } } },
+        },
+        select: {
+            id: true,
+            name_municipality: true,
+            councilMeetings: {
+                where: { released: true, administrativeBody: { isNot: null } },
+                select: {
+                    dateTime: true,
+                    administrativeBody: { select: { type: true } },
+                },
+            },
+        },
+    });
+
+    const rows: CoverageRow[] = [];
+    for (const c of cities) {
+        // earliest released meeting per body type
+        const firstByType = new Map<AdministrativeBodyType, Date>();
+        for (const m of c.councilMeetings) {
+            const type = m.administrativeBody?.type;
+            if (!type) continue;
+            const current = firstByType.get(type);
+            if (!current || m.dateTime < current) firstByType.set(type, m.dateTime);
+        }
+        for (const [bodyType, from] of firstByType) {
+            rows.push({
+                cityId: c.id,
+                cityName: c.name_municipality,
+                bodyType,
+                fromDate: from.toISOString(),
+            });
+        }
+    }
+
+    rows.sort(
+        (a, b) =>
+            a.cityName.localeCompare(b.cityName, 'el') || TYPE_ORDER[a.bodyType] - TYPE_ORDER[b.bodyType],
+    );
+    return rows;
+}

--- a/src/lib/explain/articles.tsx
+++ b/src/lib/explain/articles.tsx
@@ -128,6 +128,30 @@ function DioikisiDimouBody() {
                 αρμοδιότητες του Δημοτικού Συμβουλίου και της Δημοτικής Επιτροπής που μέχρι πρότινος δεν ήταν
                 χωρισμένες.
             </p>
+            <div className="not-prose my-6 flex items-start gap-3 rounded-2xl border border-orange/30 bg-orange/5 p-5">
+                <span className="text-2xl leading-none" aria-hidden="true">
+                    ⚖️
+                </span>
+                <div>
+                    <p className="text-base font-semibold leading-relaxed text-foreground">
+                        Τι είναι ο νέος κώδικας τοπικής αυτοδιοίκησης;
+                    </p>
+                    <p className="mt-2 text-base leading-relaxed text-foreground">
+                        Ο νέος κώδικας τοπικής αυτοδιοίκησης (ν. 5314/2026), ψηφίστηκε τον Ιούνιου του 2026 και
+                        μαζεύει σε ένα ενιαίο κείμενο όλους τους κανόνες για την λειτουργία των δήμων και των
+                        περιφερειών της χώρας. Μπορείτε να διαβάσετε{" "}
+                        <a
+                            href="https://schemalabs.substack.com/p/neos-kodikas"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-medium text-orange underline underline-offset-2 hover:text-orange/80"
+                        >
+                            εδώ
+                        </a>{" "}
+                        το άρθρο που γράψαμε σχετικά με μερικές από τις αλλαγές που έφερε ο νέος κώδικας.
+                    </p>
+                </div>
+            </div>
         </>
     );
 }

--- a/src/lib/explain/subsections.ts
+++ b/src/lib/explain/subsections.ts
@@ -18,4 +18,7 @@ export const OPENCOUNCIL_SUBSECTIONS: NavSection[] = [
     { id: "oc-search", title: "Αναζήτηση" },
     { id: "oc-notifications", title: "Ειδοποιήσεις" },
     { id: "oc-map", title: "Χάρτης θεμάτων" },
+    { id: "oc-coverage", title: "Κάλυψη" },
+    { id: "oc-pricing", title: "Ποιος πληρώνει για το OpenCouncil;" },
+    { id: "oc-cta", title: "Φέρτε το OpenCouncil στον δήμο σας" },
 ];


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands and reorganizes the `/explain` page. The main changes are:

- Grouped navigation and updated sticky section headings.
- Municipality coverage with local-timezone date formatting.
- Cached coverage queries that exclude future meetings.
- Pricing details and new calls to action.
- Updated map links and supporting explain-page content.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- Future meetings are excluded consistently from coverage results.
- Coverage dates use the municipality timezone on desktop and mobile.
- The full coverage query is cached instead of running on every page request.
- No blocking issue remains in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/db/coverage.ts | Adds realm-scoped coverage aggregation, excludes future meetings, and includes municipality timezones. |
| src/lib/cache/queries.ts | Adds a realm-specific cached wrapper for the coverage query. |
| src/components/explain/CityCoverageTable.tsx | Adds responsive coverage tables with municipality-local date formatting. |
| src/app/[locale]/(other)/explain/page.tsx | Reorganizes the page into grouped sections and supplies coverage and pricing data. |
| src/app/[locale]/(other)/explain/ExplainFeatures.tsx | Adds coverage, pricing, and municipality onboarding sections. |
| src/app/[locale]/(other)/explain/ExplainReader.tsx | Updates scroll tracking and sticky headings for the grouped page structure. |

<sub>Reviews (2): Last reviewed commit: ["fix(explain): address review on the cove..."](https://github.com/schemalabz/opencouncil/commit/04c514db8cd645883a582c3b687f4367fa5a8464) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44134119)</sub>

**Context used:**

- Context used - .cursorrules ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=8f01574a-2b8a-490a-a6a8-5bb80f6f984c))
- Context used - CLAUDE.md ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=a3ddaa95-717d-48e6-81cd-93c42696bbed))

<!-- /greptile_comment -->