### PR TITLE
SEO: deindex /en, fix redirects, canonicals and soft-404s (GSC audit)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -123,6 +123,16 @@ const nextConfig = {
         ];
     },
     skipTrailingSlashRedirect: true,
+    // Serve blocking (non-streamed) metadata to these crawlers, so notFound()
+    // thrown in generateMetadata produces a real HTTP 404 instead of a streamed
+    // 200 + noindex (GSC was reporting dead subject/meeting URLs as soft-404s).
+    // Overriding replaces Next's default HTML_LIMITED_BOT_UA_RE, so this is the
+    // default list copied wholesale with `Googlebot` prepended — plain Googlebot
+    // is deliberately absent from Next's default because it executes JS, but a
+    // streamed 404 still reaches it as HTTP 200.
+    // Copied from next@16.2.6 (next/dist/shared/lib/router/utils/html-bots.js);
+    // resync when upgrading Next in case upstream adds new crawlers.
+    htmlLimitedBots: /Googlebot|[\w-]+-Google|Google-[\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight/i,
 };
 
 export default withPostHogConfig(withNextIntl(nextConfig), {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -78,6 +78,32 @@ const nextConfig = {
                 destination: '/:locale',
                 permanent: true,
             },
+            // The sitemap wrongly emitted a phantom /meetings/ segment until
+            // 2026-05-29 (real routes are /{cityId}/{meetingId}, no /meetings/),
+            // leaving ~1.9K GSC 404s that Google keeps recrawling. 301 them to
+            // the real URLs. The (?!api/|en/|el/|fr/) lookahead keeps the real
+            // /api/meetings/* routes (redirects run before middleware and the
+            // filesystem) and defers prefixed variants to the locale rules.
+            {
+                source: '/:cityId((?!api/|en/|el/|fr/)[^/]+)/meetings/:meetingId/subjects/:subjectId',
+                destination: '/:cityId/:meetingId/subjects/:subjectId',
+                statusCode: 301,
+            },
+            {
+                source: '/:cityId((?!api/|en/|el/|fr/)[^/]+)/meetings/:meetingId',
+                destination: '/:cityId/:meetingId',
+                statusCode: 301,
+            },
+            {
+                source: '/:locale(en|el|fr)/:cityId/meetings/:meetingId/subjects/:subjectId',
+                destination: '/:locale/:cityId/:meetingId/subjects/:subjectId',
+                statusCode: 301,
+            },
+            {
+                source: '/:locale(en|el|fr)/:cityId/meetings/:meetingId',
+                destination: '/:locale/:cityId/:meetingId',
+                statusCode: 301,
+            },
         ];
     },
     async rewrites() {

--- a/src/app/[locale]/(admin)/admin/layout.tsx
+++ b/src/app/[locale]/(admin)/admin/layout.tsx
@@ -4,6 +4,12 @@ import Header from "@/components/layout/Header"
 import { getCurrentUser, withUserAuthorizedToEdit } from "@/lib/auth"
 import { redirect } from "next/navigation";
 import React from "react"
+import { Metadata } from "next"
+
+// Auth-gated admin tree — nothing to index; covers every /admin/* page.
+export const metadata: Metadata = {
+    robots: { index: false, follow: false },
+};
 
 export default async function Layout({ children }: { children: React.ReactNode }) {
     const user = await getCurrentUser();

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/admin/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/admin/page.tsx
@@ -1,4 +1,12 @@
 import Admin from "@/components/meetings/admin/Admin";
+import { Metadata } from "next";
+
+// Auth-gated meeting admin — noindex, and null out the canonical inherited
+// from the meeting layout so a noindexed page doesn't also emit one.
+export const metadata: Metadata = {
+    robots: { index: false, follow: false },
+    alternates: null,
+};
 
 export default async function AdminPage() {
     return (

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
@@ -23,7 +23,7 @@ import { HighlightCreationPermission } from '@prisma/client';
 import { SubjectHeaderProvider } from '@/contexts/SubjectHeaderContext';
 import { NotificationPreferenceProvider } from '@/contexts/NotificationPreferenceContext';
 import { getTranslations } from 'next-intl/server';
-import { buildHreflangAlternates } from '@/lib/utils/hreflang';
+import { buildCanonicalAlternates } from '@/lib/utils/hreflang';
 
 export async function generateImageMetadata(
     props: {
@@ -88,7 +88,7 @@ export async function generateMetadata(
     return {
         title: optimizedTitle,
         description,
-        alternates: await buildHreflangAlternates(`/${cityId}/${meetingId}`, locale),
+        alternates: await buildCanonicalAlternates(`/${cityId}/${meetingId}`),
         openGraph: {
             title: optimizedTitle,
             description,

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx
@@ -72,9 +72,9 @@ export async function generateMetadata(
     const data = await getMeetingDataCached(cityId, meetingId);
 
     if (!data || !data.city) {
-        return {
-            title: 'Not Found'
-        };
+        // Thrown here (not just in the body below) so crawlers, which get
+        // blocking metadata via htmlLimitedBots, receive a real HTTP 404.
+        notFound();
     }
 
     // Create an optimized title between 30-60 characters

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/settings/layout.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/settings/layout.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from "next";
+
+// The settings page is a client component, so its metadata lives here.
+// Auth-gated meeting settings — noindex, and null out the canonical inherited
+// from the meeting layout so a noindexed page doesn't also emit one.
+export const metadata: Metadata = {
+    robots: { index: false, follow: false },
+    alternates: null,
+};
+
+export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+    return <>{children}</>;
+}

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
@@ -15,7 +15,23 @@ export async function generateMetadata(
     const subject = await getSubjectFromMeetingCached(params.cityId, params.meetingId, params.subjectId);
 
     if (!subject) {
-        notFound();
+        // Dead subject IDs (subjects are regenerated when a meeting is
+        // reprocessed) can't produce a real 404: the page renders below the
+        // meeting loading.tsx Suspense boundary, so the 200 shell is already
+        // flushed when notFound() throws. Explicit noindex metadata is the
+        // reliable signal — htmlLimitedBots (next.config.mjs) puts it in the
+        // blocking <head> for crawlers. The page body still calls notFound()
+        // for the UI. The nulls clear the meeting layout's inherited
+        // canonical/OG/Twitter tags, which would otherwise describe the parent
+        // meeting on a noindex URL (and risk the noindex signal being applied
+        // to the canonical target).
+        return {
+            title: 'Not Found',
+            robots: { index: false, follow: false },
+            alternates: null,
+            openGraph: null,
+            twitter: null,
+        };
     }
 
     // Get the full meeting data for city information
@@ -56,6 +72,14 @@ export default async function SubjectPage(
     props: { params: Promise<{ cityId: string; meetingId: string; subjectId: string }> }
 ) {
     const params = await props.params;
+
+    // Also checked in generateMetadata, but the 404 must not depend on the
+    // metadata path alone (metadata streams for regular browsers).
+    const subject = await getSubjectFromMeetingCached(params.cityId, params.meetingId, params.subjectId);
+    if (!subject) {
+        notFound();
+    }
+
     return (
         <>
             <SubjectReadTracker

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
@@ -3,7 +3,7 @@ import Subject from "@/components/meetings/subject/subject";
 import SubjectReadTracker from "@/components/analytics/SubjectReadTracker";
 import { getMeetingDataCached, getSubjectFromMeetingCached } from "@/lib/getMeetingData";
 import { notFound } from "next/navigation";
-import { buildHreflangAlternates } from "@/lib/utils/hreflang";
+import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
 
 export async function generateMetadata(
     props: {
@@ -36,9 +36,8 @@ export async function generateMetadata(
     return {
         title,
         description,
-        alternates: await buildHreflangAlternates(
-            `/${params.cityId}/${params.meetingId}/subjects/${params.subjectId}`,
-            params.locale
+        alternates: await buildCanonicalAlternates(
+            `/${params.cityId}/${params.meetingId}/subjects/${params.subjectId}`
         ),
         openGraph: {
             title,

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/consultations/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/consultations/page.tsx
@@ -4,7 +4,7 @@ import { isUserAuthorizedToEdit } from "@/lib/auth";
 import CityConsultations from "@/components/cities/CityConsultations";
 import { getCityCached } from "@/lib/cache";
 import { getAllConsultationsForCity, isConsultationActive } from "@/lib/db/consultations";
-import { buildHreflangAlternates } from '@/lib/utils/hreflang';
+import { buildCanonicalAlternates } from '@/lib/utils/hreflang';
 
 interface PageProps {
     params: Promise<{ cityId: string; locale: string }>;
@@ -76,7 +76,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
             description,
             images: [ogImageUrl],
         },
-        alternates: await buildHreflangAlternates(`/${params.cityId}/consultations`, params.locale),
+        alternates: await buildCanonicalAlternates(`/${params.cityId}/consultations`),
         other: {
             'consultations:total': totalConsultationsCount.toString(),
             'consultations:active': activeConsultationsCount.toString(),

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "next";
 import { isUserAuthorizedToEdit } from "@/lib/auth";
 import CityMeetings from "@/components/cities/CityMeetings";
 import { getCityCached, getCouncilMeetingsForCityCached } from "@/lib/cache";
-import { buildHreflangAlternates } from "@/lib/utils/hreflang";
+import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
 
 export async function generateMetadata(
     props: {
@@ -23,7 +23,7 @@ export async function generateMetadata(
         return {
             title: "Δήμος δεν βρέθηκε | OpenCouncil",
             description: "Ο δήμος που αναζητάτε δεν είναι διαθέσιμος.",
-            alternates: await buildHreflangAlternates(`/${cityId}`, locale),
+            alternates: await buildCanonicalAlternates(`/${cityId}`),
         };
     }
 
@@ -62,7 +62,7 @@ export async function generateMetadata(
             description,
             images: [ogImageUrl],
         },
-        alternates: await buildHreflangAlternates(`/${cityId}`, locale),
+        alternates: await buildCanonicalAlternates(`/${cityId}`),
     };
 }
 

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/parties/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/parties/page.tsx
@@ -1,8 +1,26 @@
 import { notFound } from "next/navigation";
+import { Metadata } from "next";
 import { isUserAuthorizedToEdit } from "@/lib/auth";
 import CityParties from "@/components/cities/CityParties";
-import { getPartiesForCityCached } from "@/lib/cache";
+import { getPartiesForCityCached, getCityCached } from "@/lib/cache";
 import { getPeopleForCityCached } from "@/lib/cache";
+import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
+
+export async function generateMetadata(props: { params: Promise<{ cityId: string }> }): Promise<Metadata> {
+    const params = await props.params;
+    const city = await getCityCached(params.cityId);
+
+    if (!city) {
+        notFound();
+    }
+
+    return {
+        title: `Παρατάξεις | ${city.name} | OpenCouncil`,
+        description: `Οι δημοτικές παρατάξεις του δήμου ${city.name}, τα μέλη τους και η δραστηριότητά τους στο δημοτικό συμβούλιο.`,
+        alternates: await buildCanonicalAlternates(`/${params.cityId}/parties`),
+    };
+}
+
 export default async function PartiesPage(
     props: {
         params: Promise<{ cityId: string }>

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/people/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/people/page.tsx
@@ -3,7 +3,7 @@ import { isUserAuthorizedToEdit } from "@/lib/auth";
 import CityPeople from "@/components/cities/CityPeople";
 import { getPartiesForCityCached, getPeopleForCityCached, getAdministrativeBodiesForCityCached, getCityCached } from "@/lib/cache";
 import { Metadata } from "next";
-import { buildHreflangAlternates } from '@/lib/utils/hreflang';
+import { buildCanonicalAlternates } from '@/lib/utils/hreflang';
 
 export async function generateMetadata(props: { params: Promise<{ cityId: string; locale: string }> }): Promise<Metadata> {
     const params = await props.params;
@@ -66,7 +66,7 @@ export async function generateMetadata(props: { params: Promise<{ cityId: string
             description,
             images: [ogImageUrl],
         },
-        alternates: await buildHreflangAlternates(`/${params.cityId}/people`, params.locale),
+        alternates: await buildCanonicalAlternates(`/${params.cityId}/people`),
         other: {
             'people:count': peopleCount.toString(),
             'people:parties': partiesCount.toString(),

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/widget/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/widget/page.tsx
@@ -3,6 +3,12 @@ import { isUserAuthorizedToEdit } from '@/lib/auth';
 import { getCityCached, getAdministrativeBodiesWithPublicMeetingsCached } from '@/lib/cache';
 import { AdministrativeBodyType } from '@prisma/client';
 import { EmbedConfigurator, type EmbedBodyGroup } from '@/components/embed/EmbedConfigurator';
+import { Metadata } from 'next';
+
+// Embed configurator for city admins — nothing to index.
+export const metadata: Metadata = {
+    robots: { index: false, follow: false },
+};
 
 const ADMIN_BODY_TYPE_ORDER: AdministrativeBodyType[] = ['council', 'committee', 'community'];
 

--- a/src/app/[locale]/(city)/[cityId]/(other)/notifications/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/notifications/page.tsx
@@ -3,12 +3,24 @@ import { OnboardingPageContent } from "@/components/onboarding/OnboardingPageCon
 import { OnboardingStage } from '@/lib/types/onboarding';
 import { Suspense } from "react";
 import { getCity } from "@/lib/db/cities";
+import { getCityCached } from "@/lib/cache";
 import { notFound, redirect } from "next/navigation";
+import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
 
-export const metadata: Metadata = {
-    title: "Εγγραφή για ενημερώσεις | OpenCouncil",
-    description: "Εγγραφείτε για να λαμβάνετε ενημερώσεις για θέματα που συζητούνται στα δημοτικά συμβούλια",
-};
+export async function generateMetadata(props: { params: Promise<{ cityId: string }> }): Promise<Metadata> {
+    const params = await props.params;
+    const city = await getCityCached(params.cityId);
+
+    if (!city) {
+        notFound();
+    }
+
+    return {
+        title: "Εγγραφή για ενημερώσεις | OpenCouncil",
+        description: "Εγγραφείτε για να λαμβάνετε ενημερώσεις για θέματα που συζητούνται στα δημοτικά συμβούλια",
+        alternates: await buildCanonicalAlternates(`/${params.cityId}/notifications`),
+    };
+}
 
 interface PageProps {
     params: Promise<{ cityId: string }>;

--- a/src/app/[locale]/(city)/[cityId]/(other)/parties/[partyId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/parties/[partyId]/page.tsx
@@ -6,7 +6,7 @@ import { getParty } from "@/lib/db/parties";
 import { notFound } from "next/navigation";
 import { getAdministrativeBodiesForCity } from "@/lib/db/administrativeBodies";
 import { Metadata } from "next";
-import { buildHreflangAlternates } from "@/lib/utils/hreflang";
+import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
 
 // Request-scoped dedup so generateMetadata and PartyPage share a single fetch.
 const getPartyCached = cache(getParty);
@@ -66,9 +66,8 @@ export async function generateMetadata(
             description,
             images: [ogImageUrl],
         },
-        alternates: await buildHreflangAlternates(
+        alternates: await buildCanonicalAlternates(
             `/${params.cityId}/parties/${params.partyId}`,
-            params.locale,
         ),
         other: {
             "party:name": party.name,

--- a/src/app/[locale]/(city)/[cityId]/(other)/people/[personId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/people/[personId]/page.tsx
@@ -9,7 +9,7 @@ import { getCity } from "@/lib/db/cities";
 import { getStatisticsFor } from "@/lib/statistics";
 import { isUserAuthorizedToEdit } from "@/lib/auth";
 import { Metadata } from "next";
-import { buildHreflangAlternates } from '@/lib/utils/hreflang';
+import { buildCanonicalAlternates } from '@/lib/utils/hreflang';
 
 export async function generateMetadata(
     props: { params: Promise<{ locale: string, personId: string, cityId: string }> }
@@ -79,7 +79,7 @@ export async function generateMetadata(
             description,
             images: [ogImageUrl],
         },
-        alternates: await buildHreflangAlternates(`/${params.cityId}/people/${params.personId}`, params.locale),
+        alternates: await buildCanonicalAlternates(`/${params.cityId}/people/${params.personId}`),
         other: {
             'person:name': person.name,
             'person:city': city.name,

--- a/src/app/[locale]/(city)/[cityId]/(other)/petition/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/petition/page.tsx
@@ -5,12 +5,17 @@ import { Suspense } from "react";
 import { getCity } from "@/lib/db/cities";
 import { notFound, redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import { buildCanonicalAlternates } from '@/lib/utils/hreflang';
 
-export async function generateMetadata(): Promise<Metadata> {
+export async function generateMetadata(props: {
+    params: Promise<{ cityId: string }>;
+}): Promise<Metadata> {
+    const { cityId } = await props.params;
     const t = await getTranslations("Onboarding.petition");
     return {
         title: t("metaTitle"),
         description: t("metaDescription"),
+        alternates: await buildCanonicalAlternates(`/${cityId}/petition`),
     };
 }
 

--- a/src/app/[locale]/(city)/[cityId]/consultation/[id]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/consultation/[id]/page.tsx
@@ -5,7 +5,7 @@ import { notFound } from "next/navigation";
 import { ConsultationViewer } from "@/components/consultations";
 import { auth } from "@/auth";
 import { Suspense } from "react";
-import { buildHreflangAlternates } from '@/lib/utils/hreflang';
+import { buildCanonicalAlternates } from '@/lib/utils/hreflang';
 import { getRealmBaseUrlFromRequest } from '@/lib/realm.server';
 
 interface PageProps {
@@ -79,7 +79,7 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
             description,
             images: [ogImageUrl],
         },
-        alternates: await buildHreflangAlternates(`/${params.cityId}/consultation/${params.id}`, params.locale),
+        alternates: await buildCanonicalAlternates(`/${params.cityId}/consultation/${params.id}`),
         other: {
             'consultation:status': isActive ? 'active' : 'expired',
             'consultation:endDate': consultation.endDate.toISOString(),

--- a/src/app/[locale]/(embed)/layout.tsx
+++ b/src/app/[locale]/(embed)/layout.tsx
@@ -1,3 +1,10 @@
+import { Metadata } from "next";
+
+// Iframe content — indexed standalone it would be a duplicate fragment.
+export const metadata: Metadata = {
+    robots: { index: false, follow: false },
+};
+
 /**
  * Minimal layout for embed routes.
  * No navigation, no footer, no session provider overhead.

--- a/src/app/[locale]/(fullscreen)/present/[cityId]/[meetingId]/page.tsx
+++ b/src/app/[locale]/(fullscreen)/present/[cityId]/[meetingId]/page.tsx
@@ -7,6 +7,9 @@ import PresentationView from "@/components/presentation/PresentationView";
 
 export const metadata = {
     title: "Παρουσίαση συνεδρίασης | OpenCouncil",
+    // Fullscreen presentation of the meeting page's content — the meeting URL
+    // is the indexable version.
+    robots: { index: false, follow: false },
 };
 
 export default async function PresentationPage(

--- a/src/app/[locale]/(interfaces)/chat/page.tsx
+++ b/src/app/[locale]/(interfaces)/chat/page.tsx
@@ -3,17 +3,7 @@ import { Suspense } from "react";
 import { Metadata } from "next";
 import { buildCanonicalAlternates } from '@/lib/utils/hreflang';
 
-export async function generateMetadata(
-    props: {
-        params: Promise<{ locale: string }>
-    }
-): Promise<Metadata> {
-    const params = await props.params;
-
-    const {
-        locale
-    } = params;
-
+export async function generateMetadata(): Promise<Metadata> {
     return {
         title: "OpenCouncil AI | Συνομιλήστε για τα Δημοτικά Συμβούλια",
         description: "Συνομιλήστε με την τεχνητή νοημοσύνη του OpenCouncil για να μάθετε για δημοτικά συμβούλια, θέματα πολιτικής και την τοπική αυτοδιοίκηση. Κάντε ερωτήσεις και λάβετε εξατομικευμένες απαντήσεις.",

--- a/src/app/[locale]/(interfaces)/chat/page.tsx
+++ b/src/app/[locale]/(interfaces)/chat/page.tsx
@@ -1,7 +1,7 @@
 import { ChatInterface } from "@/components/chat/ChatInterface";
 import { Suspense } from "react";
 import { Metadata } from "next";
-import { buildHreflangAlternates } from '@/lib/utils/hreflang';
+import { buildCanonicalAlternates } from '@/lib/utils/hreflang';
 
 export async function generateMetadata(
     props: {
@@ -52,7 +52,7 @@ export async function generateMetadata(
             creator: '@opencouncil',
             site: '@opencouncil'
         },
-        alternates: await buildHreflangAlternates('/chat', locale),
+        alternates: await buildCanonicalAlternates('/chat'),
         other: {
             'chat:type': 'ai-assistant',
             'chat:domain': 'municipal-politics',

--- a/src/app/[locale]/(interfaces)/search/page.tsx
+++ b/src/app/[locale]/(interfaces)/search/page.tsx
@@ -4,17 +4,7 @@ import { Suspense } from "react";
 import { Metadata } from "next";
 import { buildCanonicalAlternates } from '@/lib/utils/hreflang';
 
-export async function generateMetadata(
-    props: {
-        params: Promise<{ locale: string }>
-    }
-): Promise<Metadata> {
-    const params = await props.params;
-
-    const {
-        locale
-    } = params;
-
+export async function generateMetadata(): Promise<Metadata> {
     const description = "Αναζητήστε στα δημοτικά συμβούλια του OpenCouncil. Βρείτε αναφορές σε θέματα, τοποθετήσεις συμβούλων, στατιστικά και πολλά άλλα χρησιμοποιώντας την έξυπνη αναζήτηση του OpenCouncil.";
 
     const ogImageUrl = `/api/og?pageType=search`;

--- a/src/app/[locale]/(interfaces)/search/page.tsx
+++ b/src/app/[locale]/(interfaces)/search/page.tsx
@@ -2,7 +2,7 @@
 import { default as SearchPageComponent } from "@/components/search/SearchPage";
 import { Suspense } from "react";
 import { Metadata } from "next";
-import { buildHreflangAlternates } from '@/lib/utils/hreflang';
+import { buildCanonicalAlternates } from '@/lib/utils/hreflang';
 
 export async function generateMetadata(
     props: {
@@ -57,7 +57,7 @@ export async function generateMetadata(
             creator: '@opencouncil',
             site: '@opencouncil'
         },
-        alternates: await buildHreflangAlternates('/search', locale),
+        alternates: await buildCanonicalAlternates('/search'),
         other: {
             'search:type': 'intelligent',
             'search:scope': 'municipal-councils',

--- a/src/app/[locale]/(landing-immersive)/page.tsx
+++ b/src/app/[locale]/(landing-immersive)/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { LandingV2 } from '@/components/landing/v2/LandingV2';
-import { buildHreflangAlternates } from '@/lib/utils/hreflang';
+import { buildCanonicalAlternates } from '@/lib/utils/hreflang';
 import { getRealm } from '@/lib/realm.server';
 import { getRealmDefaultMapView } from '@/lib/realm';
 import { getMapSubjectsCached, getGeneralSubjectsCached, getSubjectCountsByCityCached } from '@/lib/db/subject';
@@ -13,7 +13,7 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
     const { locale } = await props.params;
     return {
-        alternates: await buildHreflangAlternates('', locale),
+        alternates: await buildCanonicalAlternates(''),
     };
 }
 

--- a/src/app/[locale]/(landing-immersive)/page.tsx
+++ b/src/app/[locale]/(landing-immersive)/page.tsx
@@ -8,10 +8,7 @@ import { getListedCitiesCached, getMapCitiesCached } from '@/lib/db/cities';
 import { getUpcomingMeetingsCached } from '@/lib/db/meetings';
 import { DEFAULT_RANGE, rangeToSubjectFilters } from '@/lib/landing/landingCore';
 
-export async function generateMetadata(props: {
-    params: Promise<{ locale: string }>;
-}): Promise<Metadata> {
-    const { locale } = await props.params;
+export async function generateMetadata(): Promise<Metadata> {
     return {
         alternates: await buildCanonicalAlternates(''),
     };

--- a/src/app/[locale]/(other)/about/page.tsx
+++ b/src/app/[locale]/(other)/about/page.tsx
@@ -2,7 +2,7 @@ import About from "@/components/about/AboutPage"
 import { Metadata } from "next"
 import { getTranslations } from 'next-intl/server'
 import { getSupportedCitiesWithLogosCached, getAboutPageStatsCached, getGitHubStatsCached } from '@/lib/cache/queries'
-import { buildHreflangAlternates } from '@/lib/utils/hreflang'
+import { buildCanonicalAlternates } from '@/lib/utils/hreflang'
 import { getRealm } from '@/lib/realm.server'
 
 export async function generateMetadata(
@@ -51,7 +51,7 @@ export async function generateMetadata(
             creator: '@opencouncil',
             site: '@opencouncil'
         },
-        alternates: await buildHreflangAlternates('/about', locale),
+        alternates: await buildCanonicalAlternates('/about'),
         other: {
             'about:mission': 'transparency',
             'about:technology': 'artificial-intelligence',

--- a/src/app/[locale]/(other)/corrections/page.tsx
+++ b/src/app/[locale]/(other)/corrections/page.tsx
@@ -1,4 +1,13 @@
+import { Metadata } from "next";
 import DocumentViewer from "@/components/static/DocumentViewer";
+import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
+
+export async function generateMetadata(): Promise<Metadata> {
+    return {
+        title: "Διορθώσεις | OpenCouncil",
+        alternates: await buildCanonicalAlternates('/corrections'),
+    };
+}
 
 const sections = [
     {

--- a/src/app/[locale]/(other)/docs/page.tsx
+++ b/src/app/[locale]/(other)/docs/page.tsx
@@ -1,6 +1,15 @@
 import fs from 'fs';
 import yaml from 'js-yaml';
+import { Metadata } from 'next';
 import ReactSwagger from '@/components/ReactSwagger';
+import { buildCanonicalAlternates } from '@/lib/utils/hreflang';
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'API | OpenCouncil',
+    alternates: await buildCanonicalAlternates('/docs'),
+  };
+}
 
 async function getSpec() {
   const yamlString = fs.readFileSync('./swagger.yaml', 'utf8');

--- a/src/app/[locale]/(other)/explain/page.tsx
+++ b/src/app/[locale]/(other)/explain/page.tsx
@@ -11,7 +11,7 @@ import {
     CURRENT_OFFER_VERSION,
 } from "@/lib/pricing/config";
 import type { ExplainPricing } from "./ExplainFeatures";
-import { buildHreflangAlternates } from "@/lib/utils/hreflang";
+import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
 import { getRealm } from "@/lib/realm.server";
 import { ARTICLES, SECTIONS } from "@/lib/explain/articles";
 import { OPENCOUNCIL_SUBSECTIONS } from "@/lib/explain/subsections";
@@ -88,7 +88,7 @@ export async function generateMetadata(props: {
             title: PAGE_TITLE,
             description: PAGE_DESCRIPTION,
         },
-        alternates: await buildHreflangAlternates("/explain", locale),
+        alternates: await buildCanonicalAlternates("/explain"),
     };
 }
 

--- a/src/app/[locale]/(other)/notifications/[id]/page.tsx
+++ b/src/app/[locale]/(other)/notifications/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { MapPin, Calendar, Building2, ChevronRight, Bell, Mail, MessageSquare, Clock, Youtube } from 'lucide-react';
@@ -11,6 +12,12 @@ import { ColorPercentageRing } from '@/components/ui/color-percentage-ring';
 import { getNotificationForView } from '@/lib/db/notifications';
 import { stripMarkdown } from '@/lib/formatters/markdown';
 import NotificationOpenTracker from '@/components/analytics/NotificationOpenTracker';
+
+// Personalized notification view — keep it out of search indexes.
+export const metadata: Metadata = {
+    title: 'Ειδοποίηση | OpenCouncil',
+    robots: { index: false, follow: false },
+};
 
 export default async function NotificationPage(props: { params: Promise<{ id: string; locale: string }> }) {
     const params = await props.params;

--- a/src/app/[locale]/(other)/offer-letter/[offerId]/page.tsx
+++ b/src/app/[locale]/(other)/offer-letter/[offerId]/page.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { getOffer } from '@/lib/db/offers'
 import { formatCurrency } from '@/lib/utils'
@@ -9,6 +10,12 @@ interface Props {
         offerId: string
     }>
 }
+// Private offer letter — keep it out of search indexes.
+export const metadata: Metadata = {
+    title: 'Προσφορά | OpenCouncil',
+    robots: { index: false, follow: false },
+}
+
 export default async function OfferLetterPage(props: Props) {
     const params = await props.params;
     const offer = await getOffer(params.offerId)

--- a/src/app/[locale]/(other)/old-landing/page.tsx
+++ b/src/app/[locale]/(other)/old-landing/page.tsx
@@ -5,17 +5,7 @@ import { fetchLatestSubstackPostCached, getAllCitiesMinimalCached, getCouncilMee
 import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
 import { getRealm } from "@/lib/realm.server";
 
-export async function generateMetadata(
-    props: {
-        params: Promise<{ locale: string }>
-    }
-): Promise<Metadata> {
-    const params = await props.params;
-
-    const {
-        locale
-    } = params;
-
+export async function generateMetadata(): Promise<Metadata> {
     return {
         alternates: await buildCanonicalAlternates('/old-landing'),
     };

--- a/src/app/[locale]/(other)/old-landing/page.tsx
+++ b/src/app/[locale]/(other)/old-landing/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import { Landing } from "@/components/landing/landing";
 import { LandingCity } from "@/lib/db/landing";
 import { fetchLatestSubstackPostCached, getAllCitiesMinimalCached, getCouncilMeetingsForCityPublicCached } from "@/lib/cache/queries";
-import { buildHreflangAlternates } from "@/lib/utils/hreflang";
+import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
 import { getRealm } from "@/lib/realm.server";
 
 export async function generateMetadata(
@@ -17,7 +17,7 @@ export async function generateMetadata(
     } = params;
 
     return {
-        alternates: await buildHreflangAlternates('/old-landing', locale),
+        alternates: await buildCanonicalAlternates('/old-landing'),
     };
 }
 

--- a/src/app/[locale]/(other)/petition/page.tsx
+++ b/src/app/[locale]/(other)/petition/page.tsx
@@ -5,11 +5,15 @@ import { PetitionMunicipalitySelector } from "@/components/onboarding/selectors/
 import { OpenCouncilDescription } from "@/components/landing/OpenCouncilDescription";
 import { getAllCitiesMinimalCached } from "@/lib/cache/queries";
 import { getRealm } from "@/lib/realm.server";
+import { buildCanonicalAlternates } from '@/lib/utils/hreflang';
 
-export const metadata: Metadata = {
-    title: "Υποστήριξη Δήμου | OpenCouncil",
-    description: "Υποστηρίξτε την προσθήκη του δήμου σας στο OpenCouncil",
-};
+export async function generateMetadata(): Promise<Metadata> {
+    return {
+        title: "Υποστήριξη Δήμου | OpenCouncil",
+        description: "Υποστηρίξτε την προσθήκη του δήμου σας στο OpenCouncil",
+        alternates: await buildCanonicalAlternates('/petition'),
+    };
+}
 
 export default async function PetitionPage() {
     // Fetch all cities

--- a/src/app/[locale]/(other)/privacy/page.tsx
+++ b/src/app/[locale]/(other)/privacy/page.tsx
@@ -1,4 +1,13 @@
+import { Metadata } from "next";
 import DocumentViewer from "@/components/static/DocumentViewer";
+import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
+
+export async function generateMetadata(): Promise<Metadata> {
+    return {
+        title: "Ενημέρωση για την επεξεργασία δεδομένων προσωπικού χαρακτήρα | OpenCouncil",
+        alternates: await buildCanonicalAlternates('/privacy'),
+    };
+}
 
 const sections = [
     {

--- a/src/app/[locale]/(other)/profile/page.tsx
+++ b/src/app/[locale]/(other)/profile/page.tsx
@@ -4,6 +4,12 @@ import { UserInfoForm } from "@/components/profile/UserInfoForm";
 import { AdminSection } from "@/components/profile/AdminSection";
 import { DevelopmentSection } from "@/components/profile/DevelopmentSection";
 import { redirect } from "next/navigation";
+import { Metadata } from "next";
+
+// Personalized page behind sign-in — nothing to index.
+export const metadata: Metadata = {
+    robots: { index: false, follow: false },
+};
 
 export default async function ProfilePage() {
     const user = await getCurrentUser();

--- a/src/app/[locale]/(other)/sign-in/page.tsx
+++ b/src/app/[locale]/(other)/sign-in/page.tsx
@@ -2,6 +2,12 @@ import { SignIn } from "@/components/user/sign-in"
 import { auth } from "@/auth"
 import { redirect } from "next/navigation"
 import { safeRedirectPath } from "@/lib/safeRedirect"
+import { Metadata } from "next"
+
+// Auth entry point — nothing to index.
+export const metadata: Metadata = {
+    robots: { index: false, follow: false },
+};
 
 export default async function SignInPage(
     props: {

--- a/src/app/[locale]/(other)/terms/page.tsx
+++ b/src/app/[locale]/(other)/terms/page.tsx
@@ -1,4 +1,13 @@
+import { Metadata } from "next";
 import DocumentViewer from "@/components/static/DocumentViewer";
+import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
+
+export async function generateMetadata(): Promise<Metadata> {
+    return {
+        title: "Όροι Χρήσης | OpenCouncil",
+        alternates: await buildCanonicalAlternates('/terms'),
+    };
+}
 
 const sections = [
     {

--- a/src/app/[locale]/(other)/unsubscribe/page.tsx
+++ b/src/app/[locale]/(other)/unsubscribe/page.tsx
@@ -1,8 +1,15 @@
+import { Metadata } from 'next';
 import { verifyUnsubscribeToken } from '@/lib/notifications/tokens';
 import { UnsubscribeConfirm } from '@/components/unsubscribe/UnsubscribeConfirm';
 import { getUnsubscribeContext } from '@/lib/db/notifications';
 import { XCircle } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
+
+// Token-personalized page — keep it out of search indexes.
+export const metadata: Metadata = {
+    title: 'Απεγγραφή | OpenCouncil',
+    robots: { index: false, follow: false },
+};
 
 interface Props {
     searchParams: Promise<{ token?: string }>;

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,6 @@
 import { MetadataRoute } from 'next'
 import prisma from '@/lib/db/prisma'
 import { Realm } from '@prisma/client'
-import { REALMS } from '@/lib/realm'
 import { getRealm, getRealmBaseUrlFromRequest } from '@/lib/realm.server'
 
 // Resolves the realm from the request Host, so it must render per request rather
@@ -15,18 +14,6 @@ type SitemapCity = {
         id: string
         subjects: Array<{ id: string }>
     }>
-}
-
-// Each realm exposes its own default locale (unprefixed) plus English (`/en`).
-// Alternates stay within the realm's own domain — cities exist in exactly one
-// realm, so there is no cross-domain (`.gr`↔`.fr`) hreflang.
-function buildAlternates(baseUrl: string, defaultLocale: string, path: string) {
-    return {
-        languages: {
-            [defaultLocale]: `${baseUrl}${path}`,
-            en: `${baseUrl}/en${path}`
-        }
-    }
 }
 
 async function fetchSitemapData(realm: Realm): Promise<SitemapCity[]> {
@@ -50,6 +37,9 @@ async function fetchSitemapData(realm: Realm): Promise<SitemapCity[]> {
     })
 }
 
+// Only the default-locale (unprefixed) URLs are advertised: /en variants are
+// intentionally deindexed (they canonicalize to the default-locale URL), so no
+// hreflang alternates are emitted.
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     if (process.env.SKIP_FULL_SITEMAP === 'true') {
         return []
@@ -59,7 +49,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     // opencouncil.gr and opencouncil.fr each emit their own realm's URLs.
     const realm = await getRealm()
     const baseUrl = await getRealmBaseUrlFromRequest()
-    const defaultLocale = REALMS[realm].defaultLocale
 
     const cities = await fetchSitemapData(realm)
 
@@ -68,25 +57,21 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
             url: baseUrl,
             changeFrequency: 'daily',
             priority: 1,
-            alternates: buildAlternates(baseUrl, defaultLocale, '')
         },
         {
             url: `${baseUrl}/about`,
             changeFrequency: 'weekly',
             priority: 0.8,
-            alternates: buildAlternates(baseUrl, defaultLocale, '/about')
         },
         {
             url: `${baseUrl}/explain`,
             changeFrequency: 'weekly',
             priority: 0.8,
-            alternates: buildAlternates(baseUrl, defaultLocale, '/explain')
         },
         {
             url: `${baseUrl}/corrections`,
             changeFrequency: 'weekly',
             priority: 0.8,
-            alternates: buildAlternates(baseUrl, defaultLocale, '/corrections')
         }
     ]
 
@@ -94,7 +79,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         url: `${baseUrl}/${city.id}`,
         changeFrequency: 'daily',
         priority: 0.9,
-        alternates: buildAlternates(baseUrl, defaultLocale, `/${city.id}`)
     }))
 
     const meetingEntries: MetadataRoute.Sitemap = cities.flatMap(city =>
@@ -102,7 +86,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
             url: `${baseUrl}/${city.id}/${meeting.id}`,
             changeFrequency: 'weekly',
             priority: 0.7,
-            alternates: buildAlternates(baseUrl, defaultLocale, `/${city.id}/${meeting.id}`)
         }))
     )
 
@@ -112,7 +95,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
                 url: `${baseUrl}/${city.id}/${meeting.id}/subjects/${subject.id}`,
                 changeFrequency: 'weekly',
                 priority: 0.6,
-                alternates: buildAlternates(baseUrl, defaultLocale, `/${city.id}/${meeting.id}/subjects/${subject.id}`)
             }))
         )
     )

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -13,6 +13,12 @@ export const routing = defineRouting({
 
     // Disable automatic locale detection from Accept-Language header
     localeDetection: false,
+
+    // Don't emit the hreflang `Link` response header (on by default). It
+    // advertises every locale variant as a distinct indexable alternate, which
+    // contradicts the canonical-to-default-locale scheme (hreflang via HTTP
+    // header carries the same weight for Google as <link> tags or the sitemap).
+    alternateLinks: false,
 });
 
 // Request header used to pass an explicit locale from the proxy to the root

--- a/src/lib/__tests__/next-config-redirects.test.ts
+++ b/src/lib/__tests__/next-config-redirects.test.ts
@@ -1,0 +1,49 @@
+// Pins the matching semantics of the redirect `source` patterns in
+// next.config.mjs — in particular the negative lookahead that keeps the
+// phantom-/meetings/ redirects away from the real /api/meetings/* routes,
+// which is subtle enough that it has already been (wrongly) flagged in review.
+//
+// The config can't be imported here (ESM + env validation at load), so the
+// patterns are extracted from the file's text and compiled with Next's own
+// bundled path-to-regexp — the test always exercises whatever is actually in
+// next.config.mjs.
+import fs from 'fs';
+import path from 'path';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getPathMatch } = require('next/dist/shared/lib/router/utils/path-match');
+
+const configText = fs.readFileSync(path.join(__dirname, '../../../next.config.mjs'), 'utf8');
+const redirectsBlock = configText.slice(
+    configText.indexOf('async redirects()'),
+    configText.indexOf('async rewrites()'),
+);
+const sources = [...redirectsBlock.matchAll(/source:\s*'([^']+)'/g)].map((m) => m[1]);
+
+const matchesAnyRedirect = (pathname: string) =>
+    sources.some((source) => getPathMatch(source)(pathname) !== false);
+
+describe('next.config.mjs redirect sources', () => {
+    it('extracts the redirect patterns from the config', () => {
+        expect(sources).toEqual(expect.arrayContaining(['/map', '/petitions']));
+        expect(sources.filter((s) => s.includes('/meetings/'))).toHaveLength(4);
+    });
+
+    it('redirects the phantom /meetings/ urls from the old sitemap', () => {
+        expect(matchesAnyRedirect('/athens/meetings/jan15_2024')).toBe(true);
+        expect(matchesAnyRedirect('/athens/meetings/jan15_2024/subjects/abc')).toBe(true);
+        expect(matchesAnyRedirect('/en/athens/meetings/jan15_2024')).toBe(true);
+        expect(matchesAnyRedirect('/fr/athens/meetings/jan15_2024/subjects/abc')).toBe(true);
+    });
+
+    it('does not touch the real /api/meetings/* routes', () => {
+        // The (?!api/|...) lookahead evaluates against the raw remaining path
+        // at the param position — 'api/meetings/…' — not the isolated segment.
+        expect(matchesAnyRedirect('/api/meetings/upcoming')).toBe(false);
+    });
+
+    it('does not touch real app routes', () => {
+        expect(matchesAnyRedirect('/athens')).toBe(false);
+        expect(matchesAnyRedirect('/athens/jan15_2024')).toBe(false);
+        expect(matchesAnyRedirect('/athens/jan15_2024/subjects/abc')).toBe(false);
+    });
+});

--- a/src/lib/__tests__/seo-redirects.test.ts
+++ b/src/lib/__tests__/seo-redirects.test.ts
@@ -1,4 +1,5 @@
-import { wwwRedirectTarget } from '../seo-redirects';
+import { foreignLocaleRedirectPath, wwwRedirectTarget } from '../seo-redirects';
+import { foreignLocalesForRealm } from '../realm';
 
 describe('wwwRedirectTarget', () => {
     it('redirects www.opencouncil.gr to the apex, preserving path and query', () => {
@@ -36,5 +37,47 @@ describe('wwwRedirectTarget', () => {
         expect(wwwRedirectTarget('www.example.com', '/x', '')).toBeNull();
         expect(wwwRedirectTarget(null, '/x', '')).toBeNull();
         expect(wwwRedirectTarget(undefined, '/x', '')).toBeNull();
+    });
+});
+
+describe('foreignLocalesForRealm', () => {
+    it('returns the other realms\' default locales', () => {
+        expect(foreignLocalesForRealm('greece')).toEqual(['fr']);
+        expect(foreignLocalesForRealm('france')).toEqual(['el']);
+    });
+});
+
+describe('foreignLocaleRedirectPath', () => {
+    it('strips /fr on the greek host', () => {
+        expect(foreignLocaleRedirectPath('opencouncil.gr', '/fr/athens')).toBe('/athens');
+    });
+
+    it('redirects a bare foreign-locale path to the root', () => {
+        expect(foreignLocaleRedirectPath('opencouncil.gr', '/fr')).toBe('/');
+    });
+
+    it('strips /el on the french host', () => {
+        expect(foreignLocaleRedirectPath('opencouncil.fr', '/el/lyon')).toBe('/lyon');
+    });
+
+    it('leaves the realm\'s own default prefix to next-intl', () => {
+        expect(foreignLocaleRedirectPath('opencouncil.gr', '/el/athens')).toBeNull();
+    });
+
+    it('leaves /en alone on both realms', () => {
+        expect(foreignLocaleRedirectPath('opencouncil.gr', '/en/athens')).toBeNull();
+        expect(foreignLocaleRedirectPath('opencouncil.fr', '/en/lyon')).toBeNull();
+    });
+
+    it('does not touch unknown hosts, so localhost keeps all locales', () => {
+        expect(foreignLocaleRedirectPath('localhost:3000', '/fr/athens')).toBeNull();
+    });
+
+    it('does not partial-match path segments starting with a locale', () => {
+        expect(foreignLocaleRedirectPath('opencouncil.gr', '/france')).toBeNull();
+    });
+
+    it('applies on realm subdomains like preview hosts', () => {
+        expect(foreignLocaleRedirectPath('pr-7.preview.opencouncil.gr', '/fr/athens')).toBe('/athens');
     });
 });

--- a/src/lib/__tests__/seo-redirects.test.ts
+++ b/src/lib/__tests__/seo-redirects.test.ts
@@ -1,0 +1,40 @@
+import { wwwRedirectTarget } from '../seo-redirects';
+
+describe('wwwRedirectTarget', () => {
+    it('redirects www.opencouncil.gr to the apex, preserving path and query', () => {
+        expect(wwwRedirectTarget('www.opencouncil.gr', '/athens', '?x=1'))
+            .toBe('https://opencouncil.gr/athens?x=1');
+    });
+
+    it('redirects www.opencouncil.fr to the french apex', () => {
+        expect(wwwRedirectTarget('www.opencouncil.fr', '/', ''))
+            .toBe('https://opencouncil.fr/');
+    });
+
+    it('strips trailing slashes so the redirect is a single hop', () => {
+        expect(wwwRedirectTarget('www.opencouncil.gr', '/athens/', '?x=1'))
+            .toBe('https://opencouncil.gr/athens?x=1');
+        expect(wwwRedirectTarget('www.opencouncil.gr', '/', ''))
+            .toBe('https://opencouncil.gr/');
+    });
+
+    it('strips the port before matching', () => {
+        expect(wwwRedirectTarget('www.opencouncil.gr:443', '/x', ''))
+            .toBe('https://opencouncil.gr/x');
+    });
+
+    it('leaves the apex domains alone', () => {
+        expect(wwwRedirectTarget('opencouncil.gr', '/athens', '')).toBeNull();
+    });
+
+    it('leaves nested subdomains alone', () => {
+        expect(wwwRedirectTarget('www.pr-7.preview.opencouncil.fr', '/x', '')).toBeNull();
+        expect(wwwRedirectTarget('opencouncil.chania.gr', '/x', '')).toBeNull();
+    });
+
+    it('ignores unknown and missing hosts', () => {
+        expect(wwwRedirectTarget('www.example.com', '/x', '')).toBeNull();
+        expect(wwwRedirectTarget(null, '/x', '')).toBeNull();
+        expect(wwwRedirectTarget(undefined, '/x', '')).toBeNull();
+    });
+});

--- a/src/lib/__tests__/seo-redirects.test.ts
+++ b/src/lib/__tests__/seo-redirects.test.ts
@@ -24,6 +24,11 @@ describe('wwwRedirectTarget', () => {
             .toBe('https://opencouncil.gr/x');
     });
 
+    it('matches hosts case-insensitively', () => {
+        expect(wwwRedirectTarget('WWW.OPENCOUNCIL.GR', '/athens', ''))
+            .toBe('https://opencouncil.gr/athens');
+    });
+
     it('leaves the apex domains alone', () => {
         expect(wwwRedirectTarget('opencouncil.gr', '/athens', '')).toBeNull();
     });
@@ -75,6 +80,9 @@ describe('foreignLocaleRedirectPath', () => {
 
     it('does not partial-match path segments starting with a locale', () => {
         expect(foreignLocaleRedirectPath('opencouncil.gr', '/france')).toBeNull();
+        // /el is the foreign prefix on the french host; a city id starting
+        // with the same letters must not be mistaken for it.
+        expect(foreignLocaleRedirectPath('opencouncil.fr', '/elefsina')).toBeNull();
     });
 
     it('applies on realm subdomains like preview hosts', () => {

--- a/src/lib/realm.ts
+++ b/src/lib/realm.ts
@@ -59,6 +59,17 @@ export function isKnownRealmHost(host: string | null | undefined): boolean {
 }
 
 /**
+ * Default locales of every OTHER realm — "foreign" URL prefixes on this realm's
+ * host (e.g. `fr` on opencouncil.gr). The proxy 301s these to the unprefixed
+ * URL; `en` is shared by all realms and is never foreign.
+ */
+export function foreignLocalesForRealm(realm: Realm): string[] {
+    return Object.entries(REALMS)
+        .filter(([r]) => r !== realm)
+        .map(([, cfg]) => cfg.defaultLocale);
+}
+
+/**
  * Canonical absolute base URL for a realm (e.g. `https://opencouncil.fr`). Used
  * for SEO metadata, sitemaps, hreflang/canonical links and the footer switcher's
  * cross-domain redirect.

--- a/src/lib/seo-redirects.ts
+++ b/src/lib/seo-redirects.ts
@@ -1,0 +1,30 @@
+import { REALMS } from '@/lib/realm';
+
+/**
+ * SEO-motivated redirect decisions for the proxy. Pure module (no
+ * `next/headers`/server-only imports), safe for the edge/middleware bundle —
+ * same constraints as `realm.ts`.
+ */
+
+/**
+ * Absolute redirect target when the request arrived on `www.<realm-domain>`
+ * (exactly — nested subdomains like preview hosts are left alone), else null.
+ * The www hosts serve the full site as a duplicate of the apex, so the proxy
+ * 301s them to consolidate indexing on the apex domain.
+ *
+ * Trailing slashes are stripped here too, so `www.../athens/` reaches the
+ * apex in one hop instead of chaining into the proxy's trailing-slash 308.
+ *
+ * @param pathname request path, e.g. `/athens/`
+ * @param search query string including `?`, or `''`
+ */
+export function wwwRedirectTarget(host: string | null | undefined, pathname: string, search: string): string | null {
+    const normalized = (host ?? '').split(':')[0].toLowerCase();
+    for (const { domain } of Object.values(REALMS)) {
+        if (normalized === `www.${domain}`) {
+            const path = pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
+            return `https://${domain}${path}${search}`;
+        }
+    }
+    return null;
+}

--- a/src/lib/seo-redirects.ts
+++ b/src/lib/seo-redirects.ts
@@ -1,4 +1,4 @@
-import { REALMS } from '@/lib/realm';
+import { REALMS, foreignLocalesForRealm, isKnownRealmHost, realmForHost } from '@/lib/realm';
 
 /**
  * SEO-motivated redirect decisions for the proxy. Pure module (no
@@ -25,6 +25,28 @@ export function wwwRedirectTarget(host: string | null | undefined, pathname: str
             const path = pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
             return `https://${domain}${path}${search}`;
         }
+    }
+    return null;
+}
+
+/**
+ * Path to 301 to when the request carries a foreign locale prefix on a known
+ * realm host (`/fr/x` on `.gr` → `/x`, `/el/x` on `.fr` → `/x`), else null.
+ * Kills the orphaned duplicate tree the foreign locale creates (it has no
+ * hreflang entry and no UI entry point).
+ *
+ * - Only on known realm hosts, so localhost keeps serving all locale prefixes
+ *   for development.
+ * - The realm's own default prefix (`/el` on `.gr`) is next-intl's job — its
+ *   middleware already redirects it away. `/en` intentionally keeps serving
+ *   200 (it canonicalizes to the default-locale URL instead).
+ */
+export function foreignLocaleRedirectPath(host: string | null | undefined, pathname: string): string | null {
+    if (!isKnownRealmHost(host)) return null;
+    const realm = realmForHost(host);
+    for (const locale of foreignLocalesForRealm(realm)) {
+        if (pathname === `/${locale}`) return '/';
+        if (pathname.startsWith(`/${locale}/`)) return pathname.slice(locale.length + 1);
     }
     return null;
 }

--- a/src/lib/utils/__tests__/hreflang.test.ts
+++ b/src/lib/utils/__tests__/hreflang.test.ts
@@ -1,0 +1,44 @@
+import { buildCanonicalAlternates } from '../hreflang';
+
+let currentHost: string;
+
+jest.mock('next/headers', () => ({
+    headers: async () => new Headers({ host: currentHost }),
+}));
+
+describe('buildCanonicalAlternates', () => {
+    it('canonicalizes to the unprefixed greece URL on the .gr host', async () => {
+        currentHost = 'opencouncil.gr';
+        expect(await buildCanonicalAlternates('/athens')).toEqual({
+            canonical: 'https://opencouncil.gr/athens',
+        });
+    });
+
+    it('canonicalizes to the .fr base URL on the french host', async () => {
+        currentHost = 'opencouncil.fr';
+        expect(await buildCanonicalAlternates('/lyon')).toEqual({
+            canonical: 'https://opencouncil.fr/lyon',
+        });
+    });
+
+    it('returns the bare base URL for the homepage', async () => {
+        currentHost = 'opencouncil.gr';
+        expect(await buildCanonicalAlternates('')).toEqual({
+            canonical: 'https://opencouncil.gr',
+        });
+    });
+
+    it('defaults unknown hosts to the greece realm', async () => {
+        currentHost = 'localhost:3000';
+        expect(await buildCanonicalAlternates('/athens')).toEqual({
+            canonical: 'https://opencouncil.gr/athens',
+        });
+    });
+
+    it('resolves preview subdomains to their realm', async () => {
+        currentHost = 'pr-7.preview.opencouncil.fr';
+        expect(await buildCanonicalAlternates('/x')).toEqual({
+            canonical: 'https://opencouncil.fr/x',
+        });
+    });
+});

--- a/src/lib/utils/hreflang.ts
+++ b/src/lib/utils/hreflang.ts
@@ -1,37 +1,22 @@
 import { Metadata } from 'next';
-import { getRealmBaseUrl, REALMS } from '@/lib/realm';
+import { getRealmBaseUrl } from '@/lib/realm';
 import { getRealm } from '@/lib/realm.server';
 
 /**
- * Builds canonical + hreflang alternates for a page, scoped to the request's
- * realm (resolved from the Host header).
+ * Builds the canonical URL for a page, scoped to the request's realm (resolved
+ * from the Host header).
  *
- * Each realm self-references its own domain only — a city/meeting page exists in
- * exactly one realm, so there is no cross-domain (`.gr`↔`.fr`) hreflang cluster.
- * The realm's default locale is served unprefixed (`/path`); English lives at
- * `/en/path`. `x-default` points at the default-locale URL. Each locale
- * self-references its own canonical to avoid contradicting the hreflang cluster.
+ * Every locale variant of a page canonicalizes to the realm's default-locale
+ * (unprefixed) URL: `/en` pages are intentionally deindexed — Google was
+ * serving them to Greek searchers — so no hreflang cluster is emitted, only
+ * `canonical`.
  *
- * - greece → `el` (default, unprefixed) + `en`, on `https://opencouncil.gr`
- * - france → `fr` (default, unprefixed) + `en`, on `https://opencouncil.fr`
+ * - greece → `https://opencouncil.gr{path}`
+ * - france → `https://opencouncil.fr{path}`
  *
  * @param path locale-agnostic path beginning with `/`, or `''` for the homepage
- * @param locale current request locale (`'el'` | `'en'` | `'fr'`)
  */
-export async function buildHreflangAlternates(path: string, locale: string): Promise<Metadata['alternates']> {
+export async function buildCanonicalAlternates(path: string): Promise<Metadata['alternates']> {
     const realm = await getRealm();
-    const baseUrl = getRealmBaseUrl(realm);
-    const defaultLocale = REALMS[realm].defaultLocale;
-
-    const defaultUrl = `${baseUrl}${path}`;
-    const enUrl = `${baseUrl}/en${path}`;
-
-    return {
-        canonical: locale === 'en' ? enUrl : defaultUrl,
-        languages: {
-            [defaultLocale]: defaultUrl,
-            en: enUrl,
-            'x-default': defaultUrl,
-        },
-    };
+    return { canonical: `${getRealmBaseUrl(realm)}${path}` };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,7 +4,7 @@ import { NextResponse, NextRequest } from 'next/server';
 import { auth } from './auth'
 import { env } from '@/env.mjs';
 import { realmForHost } from './lib/realm';
-import { wwwRedirectTarget } from './lib/seo-redirects';
+import { foreignLocaleRedirectPath, wwwRedirectTarget } from './lib/seo-redirects';
 
 const i18nMiddleware = createIntlMiddleware(routing);
 
@@ -69,6 +69,14 @@ export default async function proxy(req: NextRequest) {
         const url = req.nextUrl.clone();
         url.pathname = '/qr/t-shirt';
         return NextResponse.rewrite(url);
+    }
+
+    // A foreign locale prefix on a realm host (/fr on .gr, /el on .fr) is an
+    // orphaned duplicate tree — 301 it to the unprefixed URL. Must run before
+    // the .fr rewrite and the i18n middleware below.
+    const strippedPath = foreignLocaleRedirectPath(req.headers.get('host'), pathname);
+    if (strippedPath !== null) {
+        return NextResponse.redirect(new URL(strippedPath + req.nextUrl.search, req.url), 301);
     }
 
     // French-domain handling: on a .fr host, serve the French UI transparently.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,6 +4,7 @@ import { NextResponse, NextRequest } from 'next/server';
 import { auth } from './auth'
 import { env } from '@/env.mjs';
 import { realmForHost } from './lib/realm';
+import { wwwRedirectTarget } from './lib/seo-redirects';
 
 const i18nMiddleware = createIntlMiddleware(routing);
 
@@ -29,6 +30,16 @@ export default async function proxy(req: NextRequest) {
 
     if (JUNK_PATH.test(req.nextUrl.pathname)) {
         return new NextResponse(null, { status: 404 });
+    }
+
+    // www hosts duplicate the apex domain in Google's index — 301 them away.
+    const wwwTarget = wwwRedirectTarget(
+        req.headers.get('host'),
+        req.nextUrl.pathname,
+        req.nextUrl.search,
+    );
+    if (wwwTarget) {
+        return NextResponse.redirect(wwwTarget, 301);
     }
 
     // Handle the specific case for opencouncil.chania.gr


### PR DESCRIPTION
## Context

A Google Search Console audit (2026-07-15) of `sc-domain:opencouncil.gr` found **12.8K not-indexed vs 2.17K indexed pages**, and — the headline problem — **Greek searchers being served `/en` pages**: 8.16K impressions on `/en/` URLs in 3 months, 4,812 of them from users in Greece (119 clicks).

Root causes found in the code, each fixed in its own commit:

## Changes

### 1. Deindex `/en` (`fix(seo): canonicalize all locale variants...` + sitemap commit)
Every `/en` page self-canonicalized and the sitemap advertised every `/en` URL as an hreflang alternate, so Google indexed the English tree and served it to Greek users while the Greek variants sat in the 6.5K "Discovered – currently not indexed" backlog. `buildHreflangAlternates(path, locale)` is now `buildCanonicalAlternates(path)`: every locale variant canonicalizes to the realm's default-locale (unprefixed) URL, no hreflang cluster is emitted, and the sitemap no longer lists `/en` alternates. `/en` stays fully usable for humans.

### 2. `www` → apex 301 (`feat(proxy)`)
`www.opencouncil.gr` served the whole site as a duplicate host. The proxy now 301s exact `www.<realm-domain>` hosts to the apex, preserving path and query.

### 3. Foreign locale prefix → 301 (`feat(proxy)`)
`/fr/...` rendered fine on the `.gr` host (and `/el/...` on `.fr`), creating an orphaned duplicate tree (e.g. `/fr/docs` in GSC). On known realm hosts, the other realm's default-locale prefix now 301s to the unprefixed URL. `/en` keeps serving 200; localhost keeps all locales for development.

### 4. Phantom `/meetings/` redirects (`fix(seo)`)
Until e686908e (2026-05-29) the sitemap emitted `/{cityId}/meetings/{id}` URLs — the real routes have no `/meetings/` segment — leaving ~1.9K GSC 404s that Google keeps recrawling. Those (and locale-prefixed variants) now 301 to the real URLs. A negative lookahead protects the real `/api/meetings/*` routes.

### 5. Soft-404s for dead meetings/subjects (`fix(seo): stop soft-404s...`)
Dead subject IDs (subjects are regenerated when a meeting is reprocessed) returned HTTP 200 + streamed 404 UI + JS-injected noindex → 518 "excluded by noindex" + soft-404s in GSC.
- **Dead meetings** now throw `notFound()` from the meeting layout's `generateMetadata` (above the `loading.tsx` Suspense boundary) → **real HTTP 404 for everyone** (verified with curl).
- **Dead subjects** render below that boundary, so a real 404 is impossible without dropping the loading state; they now return explicit `robots: noindex, nofollow` metadata, and `Googlebot` was added to `htmlLimitedBots` so crawlers get blocking (non-streamed) metadata — the noindex and every canonical tag land in the `<head>` instead of being streamed late in the body.

### 6. Missing canonicals (`feat(seo): add canonical metadata...`)
~1.2K pages were "duplicate without user-selected canonical" because they had no metadata at all: privacy, terms, corrections, docs, explain (its client component was extracted so the page can be a server component), the fullscreen map layout, the city parties tab and the city notification-signup page now emit canonicals.

### 7. noindex private pages (`feat(seo)`)
`/unsubscribe` (token link), `/notifications/[id]` (personalized) and `/offer-letter/[offerId]` (private) are now `noindex, nofollow`.

## Verification

All verified against a local dev server with spoofed `Host` headers:
- `/en/about` canonical → `https://opencouncil.gr/about`; zero `hreflang` links; sitemap has zero `xhtml:link` entries
- `/athens/meetings/abc[/subjects/def]` → 301 to real URL; `/api/meetings/upcoming` untouched (200)
- `Host: www.opencouncil.gr` `/athens?x=1` → 301 `https://opencouncil.gr/athens?x=1`
- `Host: opencouncil.gr` `/fr/athens` → 301 `/athens`; `/en/athens` stays 200; plain localhost `/fr/...` stays 200
- Dead meeting → HTTP 404 (all UAs); dead subject → `noindex, nofollow` in the blocking head for Googlebot UA and in the streamed head for browsers; real meeting/subject pages unaffected
- `npx tsc --noEmit` clean, `npx jest` 977 passed (21 new tests for the canonical helper and redirect logic), eslint clean on changed files

Note: `www` redirect in production also depends on DNS/TLS for the `www` subdomain resolving to the app (verified reachable today).

## After merging

- GSC will take weeks to re-crawl; the "Duplicate/noindex/404" report counts should start dropping, and `/en` impressions for searchers in Greece should trend to zero.
- Consider resubmitting the sitemap in GSC to accelerate re-crawling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Every request passes through new proxy redirect branches and site-wide canonical/hreflang behavior changes affect all indexed URLs; logic is well-tested and mostly metadata/redirect only, with no auth or data-model changes.
> 
> **Overview**
> Addresses a Google Search Console audit where Greek users were served `/en` URLs and thousands of pages sat in duplicate, 404, or noindex states.
> 
> **Canonical and sitemap:** `buildHreflangAlternates` is replaced by `buildCanonicalAlternates` across public pages so every locale variant points at the realm’s unprefixed default URL; hreflang clusters are removed and the sitemap lists only those default-locale URLs.
> 
> **Redirects:** `next.config.mjs` adds 301s from legacy `/{city}/meetings/{id}` paths to real meeting URLs. `proxy.ts` 301s exact `www.<realm>` hosts to the apex and strips foreign default-locale prefixes on the wrong host (`/fr` on `.gr`, `/el` on `.fr`).
> 
> **Crawlers and dead content:** `htmlLimitedBots` is extended with `Googlebot` so meeting `notFound()` in layout `generateMetadata` yields a real HTTP 404 for bots; dead subjects return blocking `noindex` metadata and clear inherited OG/canonical. Private or token pages (`unsubscribe`, notification view, offer letter) are `noindex`. Several static and city tab routes gain missing canonical metadata.
> 
> **Tests:** New unit tests cover canonical URL building and SEO redirect helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92a29b725f56b4014ecf4395b716b3cd59f69ff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves a Google Search Console audit showing 12.8K non-indexed pages and English (`/en`) URLs being served to Greek users. It makes site-wide SEO corrections across seven distinct areas: canonical consolidation, proxy-level redirects, dead-content 404s, noindex for private pages, sitemap cleanup, `alternateLinks` suppression, and missing canonical metadata.

- **Canonical/hreflang:** `buildHreflangAlternates` is replaced by `buildCanonicalAlternates` across all public pages; every locale variant now points its canonical at the realm's unprefixed default URL, hreflang clusters are removed, and both the sitemap and next-intl's `alternateLinks` header are suppressed.
- **Proxy redirects:** `proxy.ts` gains www→apex and foreign-locale-strip 301s; `next.config.mjs` adds 301s for ~1.9K phantom `/meetings/` URLs.
- **Dead content:** `notFound()` in the meeting layout's `generateMetadata` produces real HTTP 404s for crawlers; dead subjects return explicit `noindex` with inherited canonical/OG tags nulled out.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are metadata, redirect, and canonical-only with no auth or data-model mutations.

Every redirect path has dedicated tests pinned to the actual config and module logic. The notFound() in generateMetadata follows Next.js documented behavior verified with curl. The hreflang-to-canonical refactor is complete across all 43 files with no missed call sites. No data, auth, or API surface changes.

No files require special attention. The most complex file is src/proxy.ts where redirect ordering matters; the ordering is correct and commented.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/proxy.ts | Adds www→apex 301 and foreign-locale-prefix 301 as early-exit branches in the correct order before the .fr rewrite and i18n middleware. |
| src/lib/seo-redirects.ts | New pure edge-safe module with wwwRedirectTarget and foreignLocaleRedirectPath; fully covered by the new test file. |
| src/lib/utils/hreflang.ts | buildHreflangAlternates replaced by buildCanonicalAlternates; returns only { canonical } pointing at the realm's unprefixed base URL. |
| next.config.mjs | Adds phantom /meetings/ → real URL 301 redirects with a negative lookahead protecting /api/meetings/*; htmlLimitedBots documented against next@16.2.6. |
| src/app/sitemap.ts | Removes buildAlternates helper and all alternates fields; sitemap now lists only default-locale unprefixed URLs. |
| src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/layout.tsx | notFound() thrown from generateMetadata so htmlLimitedBots receive a real HTTP 404 for dead meeting URLs. |
| src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx | Dead subjects return robots:noindex with alternates/openGraph/twitter nulled; page body independently calls notFound() for the UI. |
| src/i18n/routing.ts | alternateLinks: false suppresses next-intl's automatic hreflang Link response header. |
| src/lib/realm.ts | Adds foreignLocalesForRealm helper; correctly excludes 'en' since it is shared across realms. |
| src/lib/__tests__/seo-redirects.test.ts | Comprehensive coverage of both redirect helpers including edge cases for trailing slash, port, case, bare locale, and partial segment matching. |
| src/lib/__tests__/next-config-redirects.test.ts | Pins next.config.mjs redirect patterns using Next's own path-to-regexp; guards the /api/meetings/* negative lookahead. |

<sub>Reviews (6): Last reviewed commit: ["feat(seo): cover the pages that had neit..."](https://github.com/schemalabz/opencouncil/commit/a8487fda54670c0f4670834e3caadb454a175f81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44509479)</sub>

<!-- /greptile_comment -->