### PR TITLE
feat(realm): resolve hosts to the most specific realm domain

### DIFF
--- a/src/lib/__tests__/realm.test.ts
+++ b/src/lib/__tests__/realm.test.ts
@@ -1,17 +1,74 @@
-import { realmForHost, isKnownRealmHost } from '../realm';
+import { realmForHost, createRealmResolver, isKnownRealmHost } from '../realm';
 
-describe('realmForHost', () => {
-    it('resolves the cypriot apex domain', () => {
-        expect(realmForHost('opencouncil.cy')).toBe('cyprus');
+describe('createRealmResolver', () => {
+    // Parent declared first so a naive first-match would wrongly return it for
+    // hosts on the child's domain — the ordering under test must not depend on
+    // declaration order.
+    const NESTED = {
+        parent: { domain: 'example.org' },
+        child: { domain: 'sub.example.org' },
+    };
+    const resolve = createRealmResolver(NESTED);
+
+    it('resolves a host on a subdomain realm to that realm, not its parent', () => {
+        expect(resolve('sub.example.org')).toBe('child');
     });
 
-    it('resolves cypriot subdomains, like preview hosts, to cyprus', () => {
-        expect(realmForHost('pr-7.preview.opencouncil.cy')).toBe('cyprus');
+    it('resolves subdomains of a subdomain realm to that realm', () => {
+        expect(resolve('pr-7.sub.example.org')).toBe('child');
+    });
+
+    it('resolves other subdomains of the parent domain to the parent realm', () => {
+        expect(resolve('pr-7.preview.example.org')).toBe('parent');
+    });
+
+    it('does not match a label that merely ends with a subdomain realm label', () => {
+        expect(resolve('notsub.example.org')).toBe('parent');
+    });
+
+    it('strips the port and lowercases the host', () => {
+        expect(resolve('SUB.Example.ORG:443')).toBe('child');
+    });
+
+    it('returns null when no realm domain matches', () => {
+        expect(resolve('unknown.com')).toBeNull();
+        expect(resolve(null)).toBeNull();
     });
 });
 
+describe('realmForHost', () => {
+    it('resolves the production apex domains', () => {
+        expect(realmForHost('opencouncil.gr')).toBe('greece');
+        expect(realmForHost('opencouncil.fr')).toBe('france');
+        expect(realmForHost('opencouncil.cy')).toBe('cyprus');
+    });
+
+    it('resolves preview subdomains of a realm domain to that realm', () => {
+        expect(realmForHost('pr-7.preview.opencouncil.gr')).toBe('greece');
+        expect(realmForHost('pr-7.preview.opencouncil.fr')).toBe('france');
+        expect(realmForHost('pr-7.preview.opencouncil.cy')).toBe('cyprus');
+    });
+
+    it.each([null, undefined, '', 'localhost:3000', 'example.com'])(
+        'defaults %p to greece',
+        (host) => {
+            expect(realmForHost(host)).toBe('greece');
+        },
+    );
+});
+
 describe('isKnownRealmHost', () => {
-    it('accepts cypriot hosts', () => {
+    it('accepts apex and subdomain hosts of any realm domain', () => {
+        expect(isKnownRealmHost('opencouncil.gr')).toBe(true);
+        expect(isKnownRealmHost('opencouncil.fr')).toBe(true);
         expect(isKnownRealmHost('opencouncil.cy')).toBe(true);
+        expect(isKnownRealmHost('pr-7.preview.opencouncil.fr')).toBe(true);
+    });
+
+    it('rejects unknown hosts', () => {
+        expect(isKnownRealmHost('evil.com')).toBe(false);
+        expect(isKnownRealmHost('localhost')).toBe(false);
+        expect(isKnownRealmHost('')).toBe(false);
+        expect(isKnownRealmHost(null)).toBe(false);
     });
 });

--- a/src/lib/realm.ts
+++ b/src/lib/realm.ts
@@ -1,10 +1,14 @@
 import { Realm } from '@prisma/client';
 
 /**
- * Realm (tenant) configuration. A single deployment serves both domains off one
+ * Realm (tenant) configuration. A single deployment serves all domains off one
  * database; the realm a request belongs to is resolved from its Host header (see
  * `realmForHost`). This is the single source of truth mapping each realm to its
  * canonical production domain and default UI locale.
+ *
+ * A realm's domain may be a subdomain of another realm's domain; `realmForHost`
+ * matches the most specific domain first, so the parent realm only claims hosts
+ * no child realm does.
  *
  * Pure module — no `next/headers`/server-only imports — so it is safe to use from
  * client components (the footer country-switcher) and the edge/middleware bundle
@@ -27,24 +31,49 @@ const REALM_DEFAULT_MAP_VIEW: Record<Realm, { center: [number, number]; zoom: nu
     cyprus: { center: [33.2, 35.0], zoom: 8 },       // island of Cyprus
 };
 
-/**
- * Resolves the realm for a Host header value. The port is stripped and the host
- * lowercased so `localhost:3000`-style hosts and a spoofed `Host: opencouncil.fr`
- * both work; each realm's domain matches as the apex or any subdomain (so preview
- * hosts like `pr-7.preview.opencouncil.fr` resolve correctly). Defaults to
- * `greece` for unknown hosts (localhost, the Greek production domain).
- */
 const hostMatchesDomain = (host: string, domain: string): boolean =>
     host === domain || host.endsWith(`.${domain}`);
 
-export function realmForHost(host: string | null | undefined): Realm {
-    const normalized = (host ?? '').split(':')[0].toLowerCase();
-    for (const [realm, { domain }] of Object.entries(REALMS)) {
-        if (hostMatchesDomain(normalized, domain)) {
-            return realm as Realm;
+/**
+ * Builds a resolver mapping a Host header value to a realm of `realms`, or null
+ * when none matches. The port is stripped and the host lowercased so
+ * `localhost:3000`-style hosts and a spoofed `Host: opencouncil.fr` both work;
+ * each realm's domain matches as the apex or any subdomain (so preview hosts
+ * like `pr-7.preview.opencouncil.fr` resolve correctly). Domains are checked
+ * most-specific (longest) first — a subdomain is always longer than its parent
+ * domain — so a realm hosted on a subdomain of another realm's domain wins over
+ * the parent regardless of declaration order.
+ *
+ * A factory so the specificity ordering is computed once per realm map, not per
+ * request — resolution stays free in the proxy hot path, which is the point of
+ * keeping realm config in code. Parameterized so the ordering contract stays
+ * testable independent of the realms in production; app code should use
+ * `realmForHost`.
+ */
+export function createRealmResolver<R extends string>(
+    realms: Record<R, { domain: string }>,
+): (host: string | null | undefined) => R | null {
+    const bySpecificity = (Object.entries(realms) as [R, { domain: string }][])
+        .sort(([, a], [, b]) => b.domain.length - a.domain.length);
+    return (host) => {
+        const normalized = (host ?? '').split(':')[0].toLowerCase();
+        for (const [realm, { domain }] of bySpecificity) {
+            if (hostMatchesDomain(normalized, domain)) {
+                return realm;
+            }
         }
-    }
-    return 'greece';
+        return null;
+    };
+}
+
+const resolveRealm = createRealmResolver(REALMS);
+
+/**
+ * The realm a Host header value belongs to, defaulting to `greece` for unknown
+ * hosts (localhost, direct-IP requests).
+ */
+export function realmForHost(host: string | null | undefined): Realm {
+    return resolveRealm(host) ?? 'greece';
 }
 
 /**


### PR DESCRIPTION
Realm resolution (#494) matches hosts against realm domains in declaration order, with each domain claiming its apex and all subdomains. That makes a realm hosted on a subdomain of another realm's domain unreachable — the parent's suffix match always wins, so e.g. a realm on `sub.opencouncil.gr` could never resolve. This PR resolves against domains **most-specific (longest) first**, so such a realm claims its own hosts while the parent realm keeps all others, including preview hosts like `pr-N.preview.opencouncil.gr`.

## What changed

- Resolution logic is built by `createRealmResolver(realms)`, which sorts the realm→domain map by domain length once (a subdomain is always longer than its parent, so length ordering is exactly specificity ordering) and returns the resolver; `realmForHost` binds it to `REALMS` with the existing greece fallback. The ordering is computed once at module load, not per request — resolution stays free in the proxy hot path, which is the point of keeping realm config in code.
- New `realm.test.ts` pins the contract against a synthetic nested domain pair — subdomain realm wins, parent keeps its other subdomains, a label that merely ends with the subdomain label doesn't false-match — plus the production apex/preview/fallback behavior and `isKnownRealmHost` trust boundaries.

The current realm domains don't nest, so production behavior is unchanged. Actually adding a subdomain realm later is the usual realm addition (enum value + `REALMS` entry + compiler-forced map entries) plus its DNS/TLS/routing.

## Verification

`npx tsc --noEmit` clean, `eslint .` clean, 1003 tests passing (15 new), production build passes. Also live-tested end-to-end with a spoofed-Host pass against a dev server with a temporarily nested realm config: robots/sitemap/metadata emit the nested realm's base URL on its host, the parent apex and preview hosts keep the parent realm's, and cross-realm data isolation holds.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in realm resolution where a realm hosted on a subdomain of another realm's domain was unreachable because the parent realm's suffix match always won. The fix sorts the realm→domain map by domain length (descending) once at module load inside the new `createRealmResolver` factory, so the most-specific domain always claims its hosts first.

- `createRealmResolver(realms)` replaces the previous inline loop in `realmForHost` with a factory that pre-sorts entries and returns a closure — zero per-request overhead.
- `realmForHost` becomes a thin wrapper around the pre-built resolver with the existing `greece` fallback.
- 15 new tests pin the nested-domain contract (child wins, dot-separator guard, port stripping, case folding) plus production apex/preview/fallback and `isKnownRealmHost` trust boundaries.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive, production behavior is unchanged (no current domain nesting), and the fix is gated behind a well-tested sort.

The sort-by-length approach correctly establishes specificity ordering because a proper subdomain always adds at least one label plus a dot, making it strictly longer than its parent. All edge cases (port stripping, case normalization, null/empty input) are handled correctly and covered by the new tests. No existing callers change behavior since current realm domains do not nest.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/realm.ts | Introduces `createRealmResolver` factory that sorts realms by domain length (descending) once at module load and returns a per-host lookup closure; `realmForHost` wraps it with the existing `greece` fallback. Logic is correct, hot path is free. |
| src/lib/__tests__/realm.test.ts | Adds 15 new tests covering nested-domain resolution (child wins over parent, dot-separator guard, port stripping, case normalization) and expands production-domain and isKnownRealmHost coverage; contract is well-pinned. |

<sub>Reviews (3): Last reviewed commit: ["feat(realm): resolve hosts to the most s..."](https://github.com/schemalabz/opencouncil/commit/e499ea446c40388bdb80f002c7e760953d193ba6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45604683)</sub>

<!-- /greptile_comment -->