### PR TITLE
Filter meeting data to officially supported cities only

### DIFF
--- a/src/app/api/admin/reviews/volume-chart/route.ts
+++ b/src/app/api/admin/reviews/volume-chart/route.ts
@@ -24,7 +24,8 @@ export async function GET() {
       where: {
         dateTime: {
           gte: twelveWeeksAgo
-        }
+        },
+        city: { officialSupport: true }
       },
       include: {
         taskStatuses: {

--- a/src/components/admin/reviews/ReviewsOverviewWidget.tsx
+++ b/src/components/admin/reviews/ReviewsOverviewWidget.tsx
@@ -11,7 +11,7 @@ export async function ReviewsOverviewWidget() {
     <Card>
       <CardHeader>
         <CardTitle>Transcript Reviews</CardTitle>
-        <CardDescription>Track human review progress across all meetings</CardDescription>
+        <CardDescription>Track human review progress across officially supported cities</CardDescription>
       </CardHeader>
       <CardContent>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -359,6 +359,7 @@ export async function getMeetingUploadLists(last30Days: boolean = false): Promis
         prisma.councilMeeting.findMany({
             where: {
                 AND: [
+                    { city: { officialSupport: true } },
                     {
                         NOT: {
                             taskStatuses: {
@@ -377,7 +378,10 @@ export async function getMeetingUploadLists(last30Days: boolean = false): Promis
         }),
         // Scheduled: meetings with dateTime in the future (not affected by the 30-day filter)
         prisma.councilMeeting.findMany({
-            where: { dateTime: { gt: now } },
+            where: {
+                dateTime: { gt: now },
+                city: { officialSupport: true }
+            },
             select: meetingListItemSelect,
             orderBy: { dateTime: 'asc' }
         })

--- a/src/lib/db/reviews.ts
+++ b/src/lib/db/reviews.ts
@@ -915,6 +915,9 @@ export async function getMeetingsNeedingReview(filters: ReviewFilterOptions = {}
   // Build database filter conditions
   const conditions: Prisma.CouncilMeetingWhereInput[] = [];
 
+  // Only track reviews for officially supported cities
+  conditions.push({ city: { officialSupport: true } });
+
   // Add status filter
   conditions.push(buildStatusWhereConditions(show));
 
@@ -999,6 +1002,7 @@ export async function getReviewStats(): Promise<ReviewStats> {
     prisma.councilMeeting.count({
       where: {
         AND: [
+          { city: { officialSupport: true } },
           baseNeedsAttentionWhere,
           {
             NOT: {
@@ -1022,6 +1026,7 @@ export async function getReviewStats(): Promise<ReviewStats> {
     prisma.councilMeeting.count({
       where: {
         AND: [
+          { city: { officialSupport: true } },
           baseNeedsAttentionWhere,
           {
             speakerSegments: {
@@ -1052,6 +1057,7 @@ export async function getReviewStats(): Promise<ReviewStats> {
     where: {
       type: 'humanReview',
       status: 'succeeded',
+      councilMeeting: { city: { officialSupport: true } },
       createdAt: {
         gte: startOfWeek
       }


### PR DESCRIPTION
## Summary
This PR restricts meeting data queries to only include cities with official support enabled, ensuring that analytics, reviews, and upload lists only reflect data from officially supported municipalities.

## Changes
- **`src/lib/db/meetings.ts`**: Added `city: { officialSupport: true }` filter to both the "Needs Upload" and "Scheduled" queries in `getMeetingUploadLists()`
- **`src/app/api/admin/reviews/volume-chart/route.ts`**: Added `city: { officialSupport: true }` filter to the volume chart query to exclude unsupported cities from analytics
- **`src/lib/db/reviews.ts`**: Added `city: { officialSupport: true }` condition to `getMeetingsNeedingReview()` to ensure only officially supported cities are tracked for review workflows

## Implementation Details
All three query locations now consistently filter by the `officialSupport` flag on the related `city` relation, ensuring data consistency across:
- Meeting upload tracking
- Admin analytics dashboards
- Review queue management

This prevents data from pilot or unsupported municipalities from appearing in system-wide metrics and workflows.

https://claude.ai/code/session_0199tdLr1x1urTnZTB2d9CP6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrowing read-only list and analytics queries; behavior change is intentional scoping with no auth or data-mutation paths touched.
> 
> **Overview**
> **Admin and ops meeting views** now consistently require `city.officialSupport: true`, so pilot or unsupported municipalities no longer appear in shared workflows or metrics.
> 
> `getMeetingUploadLists` applies the filter to both **needs upload** and **scheduled** queries. `getMeetingsNeedingReview` adds it as a base condition alongside existing status, date, and reviewer filters. The **volume chart** API applies the same constraint when loading the last 12 weeks of meetings for reviewed vs needs-review duration totals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9346cabb7af3ce4c171bf75b7c4e3ca57768b051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consistently scopes four read-only query sites — meeting upload lists, the review queue, admin review statistics, and the volume-chart API — to cities where `officialSupport` is `true`, preventing pilot/unsupported municipalities from appearing in shared workflows and metrics.

- `getMeetingUploadLists` gains the filter on both the "needs upload" and "scheduled" sub-queries; `getMeetingsNeedingReview` and both count paths in `getReviewStats` (including the `taskStatus` join) all receive the same condition.
- The volume-chart route applies the filter at the top-level `councilMeeting` query, so all downstream categorization logic is unaffected.
- The `ReviewsOverviewWidget` description is updated to match the narrowed scope.

<h3>Confidence Score: 5/5</h3>

All changes are additive, read-only filter additions on an existing boolean field with a well-defined default; no data mutation or auth paths are touched.

The `officialSupport` field is already part of the Prisma schema and used throughout the codebase. Every affected query site received the filter consistently, and the changes are self-contained within list/count operations. No edge cases in the filtering logic were identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/db/reviews.ts | Added `city: { officialSupport: true }` filter to `getMeetingsNeedingReview`, and to both count queries and the `taskStatus` lookup in `getReviewStats` — all changed sites are consistent. |
| src/lib/db/meetings.ts | Added `officialSupport` filter to both the "needs upload" and "scheduled" queries in `getMeetingUploadLists`; changes are structurally correct. |
| src/app/api/admin/reviews/volume-chart/route.ts | Added `city: { officialSupport: true }` to the main meeting query powering the 12-week volume chart; no other logic changed. |
| src/components/admin/reviews/ReviewsOverviewWidget.tsx | Updated card description text to reflect the new scope ("officially supported cities"); purely cosmetic. |

<sub>Reviews (2): Last reviewed commit: ["feat(reviews): only count officially sup..."](https://github.com/schemalabz/opencouncil/commit/b0ba37995306e4b88c2ed1d15bdf1fa7b3b6cff4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45627963)</sub>

<!-- /greptile_comment -->