### PR TITLE
feat(realm): add cyprus realm on opencouncil.cy

### DIFF
--- a/prisma/migrations/20260720120000_add_cyprus_realm/migration.sql
+++ b/prisma/migrations/20260720120000_add_cyprus_realm/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "Realm" ADD VALUE 'cyprus';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -74,6 +74,7 @@ enum CityLanguage {
 enum Realm {
   greece
   france
+  cyprus
 }
 
 enum CityStatus {

--- a/src/components/layout/CountrySwitcher.tsx
+++ b/src/components/layout/CountrySwitcher.tsx
@@ -13,10 +13,11 @@ import {
 
 // Country names shown in their own language (endonyms), matching the realm order
 // used elsewhere in the app.
-const REALM_ORDER: Realm[] = ["greece", "france"]
+const REALM_ORDER: Realm[] = ["greece", "france", "cyprus"]
 const COUNTRY_LABEL: Record<Realm, string> = {
     greece: "Ελλάδα",
     france: "France",
+    cyprus: "Κύπρος",
 }
 
 /**

--- a/src/lib/__tests__/realm.test.ts
+++ b/src/lib/__tests__/realm.test.ts
@@ -1,0 +1,17 @@
+import { realmForHost, isKnownRealmHost } from '../realm';
+
+describe('realmForHost', () => {
+    it('resolves the cypriot apex domain', () => {
+        expect(realmForHost('opencouncil.cy')).toBe('cyprus');
+    });
+
+    it('resolves cypriot subdomains, like preview hosts, to cyprus', () => {
+        expect(realmForHost('pr-7.preview.opencouncil.cy')).toBe('cyprus');
+    });
+});
+
+describe('isKnownRealmHost', () => {
+    it('accepts cypriot hosts', () => {
+        expect(isKnownRealmHost('opencouncil.cy')).toBe(true);
+    });
+});

--- a/src/lib/__tests__/seo-redirects.test.ts
+++ b/src/lib/__tests__/seo-redirects.test.ts
@@ -50,6 +50,12 @@ describe('foreignLocalesForRealm', () => {
         expect(foreignLocalesForRealm('greece')).toEqual(['fr']);
         expect(foreignLocalesForRealm('france')).toEqual(['el']);
     });
+
+    it('does not treat el as foreign on either el realm', () => {
+        // greece and cyprus share el as their default locale.
+        expect(foreignLocalesForRealm('cyprus')).toEqual(['fr']);
+        expect(foreignLocalesForRealm('greece')).not.toContain('el');
+    });
 });
 
 describe('computeForeignLocales', () => {
@@ -82,6 +88,11 @@ describe('foreignLocaleRedirectPath', () => {
 
     it('leaves the realm\'s own default prefix to next-intl', () => {
         expect(foreignLocaleRedirectPath('opencouncil.gr', '/el/athens')).toBeNull();
+        expect(foreignLocaleRedirectPath('opencouncil.cy', '/el/nicosia')).toBeNull();
+    });
+
+    it('strips /fr on the cypriot host', () => {
+        expect(foreignLocaleRedirectPath('opencouncil.cy', '/fr/nicosia')).toBe('/nicosia');
     });
 
     it('leaves /en alone on both realms', () => {

--- a/src/lib/__tests__/seo-redirects.test.ts
+++ b/src/lib/__tests__/seo-redirects.test.ts
@@ -1,5 +1,5 @@
 import { foreignLocaleRedirectPath, wwwRedirectTarget } from '../seo-redirects';
-import { foreignLocalesForRealm } from '../realm';
+import { computeForeignLocales, foreignLocalesForRealm } from '../realm';
 
 describe('wwwRedirectTarget', () => {
     it('redirects www.opencouncil.gr to the apex, preserving path and query', () => {
@@ -49,6 +49,21 @@ describe('foreignLocalesForRealm', () => {
     it('returns the other realms\' default locales', () => {
         expect(foreignLocalesForRealm('greece')).toEqual(['fr']);
         expect(foreignLocalesForRealm('france')).toEqual(['el']);
+    });
+});
+
+describe('computeForeignLocales', () => {
+    it('never treats a realm\'s own default locale as foreign when another realm shares it', () => {
+        const SHARED = {
+            a: { defaultLocale: 'el' },
+            b: { defaultLocale: 'fr' },
+            c: { defaultLocale: 'el' },
+        };
+        expect(computeForeignLocales(SHARED)).toEqual({
+            a: ['fr'],
+            b: ['el'],
+            c: ['fr'],
+        });
     });
 });
 

--- a/src/lib/realm.ts
+++ b/src/lib/realm.ts
@@ -13,6 +13,7 @@ import { Realm } from '@prisma/client';
 export const REALMS = {
     greece: { domain: 'opencouncil.gr', defaultLocale: 'el', country: 'gr' },
     france: { domain: 'opencouncil.fr', defaultLocale: 'fr', country: 'fr' },
+    cyprus: { domain: 'opencouncil.cy', defaultLocale: 'el', country: 'cy' },
 } as const satisfies Record<Realm, { domain: string; defaultLocale: 'el' | 'fr'; country: string }>;
 
 /**
@@ -23,6 +24,7 @@ export const REALMS = {
 const REALM_DEFAULT_MAP_VIEW: Record<Realm, { center: [number, number]; zoom: number }> = {
     greece: { center: [23.7275, 37.9838], zoom: 6 }, // Athens
     france: { center: [2.4, 46.6], zoom: 5 },        // metropolitan France
+    cyprus: { center: [33.2, 35.0], zoom: 8 },       // island of Cyprus
 };
 
 /**

--- a/src/lib/realm.ts
+++ b/src/lib/realm.ts
@@ -59,14 +59,36 @@ export function isKnownRealmHost(host: string | null | undefined): boolean {
 }
 
 /**
- * Default locales of every OTHER realm — "foreign" URL prefixes on this realm's
- * host (e.g. `fr` on opencouncil.gr). The proxy 301s these to the unprefixed
- * URL; `en` is shared by all realms and is never foreign.
+ * Derives each realm's foreign locale prefixes: default locales of other realms
+ * that differ from the realm's own default (e.g. `fr` on opencouncil.gr). The
+ * proxy 301s these to the unprefixed URL; `en` is shared by all realms and is
+ * never foreign.
+ *
+ * Filtered by locale rather than by realm: realms may share a default locale,
+ * and a realm's own default is never foreign on its host no matter which other
+ * realm also uses it. Parameterized so that property stays testable
+ * independent of the realms production defines; app code should use
+ * `foreignLocalesForRealm`, which reads the result precomputed from `REALMS`
+ * at module load — this runs in the proxy hot path, and the realm config being
+ * static is what keeps per-request work at zero.
  */
+export function computeForeignLocales<R extends string>(
+    realms: Record<R, { defaultLocale: string }>,
+): Record<R, string[]> {
+    const allLocales = Object.values<{ defaultLocale: string }>(realms)
+        .map(({ defaultLocale }) => defaultLocale);
+    const entries = (Object.keys(realms) as R[]).map((realm) => {
+        const own = realms[realm].defaultLocale;
+        return [realm, [...new Set(allLocales.filter((locale) => locale !== own))]];
+    });
+    return Object.fromEntries(entries) as Record<R, string[]>;
+}
+
+const FOREIGN_LOCALES = computeForeignLocales(REALMS);
+
+/** A realm's foreign locale prefixes, precomputed from `REALMS`. */
 export function foreignLocalesForRealm(realm: Realm): string[] {
-    return Object.entries(REALMS)
-        .filter(([r]) => r !== realm)
-        .map(([, cfg]) => cfg.defaultLocale);
+    return FOREIGN_LOCALES[realm];
 }
 
 /**


### PR DESCRIPTION
Adds Cyprus as a third realm, on its own apex domain `opencouncil.cy`. Cyprus uses Greek as its content language — `el` is already the app's default locale, so no new locale, message files, or proxy rewrite are needed (unlike the French expansion). The realm addition itself is the standard recipe: `Realm` enum value with an additive one-line migration, `REALMS` entry (locale `el`, geocoding country `cy`), and the compiler-forced map fallback view and footer switcher entry.

## Foreign-locale fix (first commit)

Adding a realm that shares its default locale with an existing one surfaced a latent 1:1 realm↔locale assumption in `foreignLocalesForRealm`: it collected every *other realm's* default locale, so with cyprus present, `el` became "foreign" on the Greek host and `/el/...` on opencouncil.gr would have been 301-stripped instead of left to next-intl. The first commit fixes the derivation to filter by **locale** (a realm's own default is never foreign, deduplicated) — behavior-neutral for the current realms — and, since it runs in the proxy hot path off static config, precomputes the per-realm lists once at module load via a parameterized `computeForeignLocales` that keeps the shared-locale property testable against synthetic realm maps.

## Out of scope

DNS, TLS and reverse-proxy routing for `opencouncil.cy`, and applying the migration.

## Note

Both this PR and #548 add `src/lib/__tests__/realm.test.ts` (this one a minimal version with the cyprus pins, #548 the fuller resolver-contract suite) — whichever merges second will union the two files on rebase.

## Verification

`npx tsc --noEmit` clean, 994 tests passing (7 new: cyprus resolution pins, shared-locale foreign-locale pins on both `el` hosts, synthetic `computeForeignLocales` property), production build passes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Cyprus as a third realm on `opencouncil.cy` (locale `el`, geocoding country `cy`) and fixes a latent shared-locale bug where `foreignLocalesForRealm` incorrectly treated `el` as foreign on the Greek host once Cyprus was present.

- Cyprus is wired into all required places: the `Realm` enum migration, `REALMS` config, `REALM_DEFAULT_MAP_VIEW`, and the `CountrySwitcher` footer control — completeness is compiler-enforced for the typed maps.
- `computeForeignLocales` is extracted and exported so the shared-locale correctness property is testable independent of production config; the precomputed `FOREIGN_LOCALES` constant keeps per-request cost at zero in the proxy hot path.
- Seven new tests cover Cyprus host resolution pins, the `el`-on-both-el-hosts invariant, and a synthetic realm map that exercises the shared-locale property directly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive, the fixed foreignLocalesForRealm logic is well-tested, and the migration is a non-destructive enum extension.

The Cyprus realm addition touches exactly the places it needs to and no others. The shared-locale fix in computeForeignLocales is straightforward and its correctness is verified both by the synthetic property test and the real-realm pins. The migration is a standard additive ALTER TYPE with no data movement. No pre-existing behavior is altered for Greece or France.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| prisma/migrations/20260720120000_add_cyprus_realm/migration.sql | Additive ALTER TYPE enum migration — safe, non-destructive, and follows the project's migration convention. |
| prisma/schema.prisma | Adds `cyprus` to the Realm enum; straightforward one-liner addition. |
| src/lib/realm.ts | Adds the Cyprus realm entry and fixes the shared-locale bug in foreignLocalesForRealm by extracting and exporting computeForeignLocales; logic is correct and deduplication via Set handles the el/el overlap properly. |
| src/components/layout/CountrySwitcher.tsx | Adds `cyprus` to REALM_ORDER and the endonym `Κύπρος` to COUNTRY_LABEL; compiler-enforced completeness via Record<Realm, string>. |
| src/lib/__tests__/realm.test.ts | New minimal test file covering Cyprus host resolution pins; intentionally lean with the expectation that PR #548 will add broader coverage. |
| src/lib/__tests__/seo-redirects.test.ts | Extends existing test suite with shared-locale foreign-locale pins for Cyprus and a synthetic computeForeignLocales property test; good coverage of the new behavior. |

<sub>Reviews (1): Last reviewed commit: ["feat(realm): add cyprus realm on opencou..."](https://github.com/schemalabz/opencouncil/commit/f3f711d74a34e7cc7ac622ab4da095f1d6e84d01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45630079)</sub>

<!-- /greptile_comment -->