### PR TITLE
ci(preview): opt into fork-PR checkout under pull_request_target

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -62,6 +62,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          # Building/previewing a PR requires checking out its (possibly fork)
+          # head. checkout v6.1.0 blocks this under pull_request_target by
+          # default; the deploy job is gated behind the reviewer-approved
+          # 'preview' environment, so opt back in explicitly.
+          allow-unsafe-pr-checkout: true
 
       - name: Check for migration files
         id: check-migrations
@@ -169,6 +174,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # See note on the preflight checkout: opt back into fork-PR checkout
+          # under pull_request_target (blocked by default since checkout v6.1.0).
+          allow-unsafe-pr-checkout: true
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31


### PR DESCRIPTION
## Problem

Every fork PR's `Deploy PR Preview` check now fails at the `actions/checkout` step:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow… set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

### Root cause

`actions/checkout` published a security patch across **all** major versions on 2026-07-20 (v6.1.0, v7.0.1, v5.1.0, v4.4.0, …). The patch adds a guard that refuses to check out **fork** PR code under a `pull_request_target` trigger — the classic "pwn request" surface.

Our workflow pins the floating `@v6` tag. Nothing in this repo changed: the tag simply moved from v6.0.3 (no guard) to v6.1.0 (guard) under us, so runs started failing mid-day on the 20th with the same workflow file. A full-SHA pin would have been immune, but the guard is now on every major, so downgrading does not help.

## Fix

Set `allow-unsafe-pr-checkout: true` on both checkout steps in `preview-deploy.yml` (preflight + deploy), restoring the exact behavior we had before the upstream re-tag.

## Why this is acceptable

The dangerous part — executing untrusted fork **build** code (`nix build`) with deploy secrets (SSH key, Cachix token) — remains gated behind the reviewer-approved `preview` environment for untrusted authors, via the `gate` job added in `c8ac0994`. The `preflight` checkout only runs `git`/`jq` over the fork tree, no fork code execution.

## Alternatives considered

- **Full-SHA pin** — immune to future tag moves, but a larger change and orthogonal to unblocking previews now.
- **Split build/deploy** (`pull_request` build with no secrets + gated deploy) — the "proper" long-term hardening, but a real redesign; out of scope for restoring previews today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores fork-PR preview deployments that started failing on 2026-07-20 when `actions/checkout` v6.1.0 introduced a guard refusing to check out fork code under `pull_request_target`. The fix opts back in by adding `allow-unsafe-pr-checkout: true` to both checkout steps, explicitly accepting the tradeoff.

- The `deploy` job's execution of fork-supplied `nix build` code — which runs with secrets (`PREVIEW_DEPLOY_SSH_KEY`, `CACHIX_AUTH_TOKEN`) — remains gated behind the `preview` environment's reviewer-approval requirement for untrusted authors via the existing `gate` job.
- The `preflight` job (which only runs `git diff` and `jq` on the fork tree) has no environment gate and fires immediately for all PRs, but it accesses no secrets and executes no fork-supplied build code, so the exposure there is minimal.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the deploy gate for untrusted forks is intact and preflight is limited to git/jq operations with no secret access.

The core security model holds: nix build execution on fork code is still gated behind reviewer approval for untrusted PRs, and preflight only touches safe read-only git and jq operations without any secrets. The main residual concern is that the preflight job's ungated nature is not made explicit in comments, which could mislead future maintainers into adding sensitive steps to it. The floating @v6 tag also leaves the workflow vulnerable to future silent breaking changes from upstream.

.github/workflows/preview-deploy.yml — specifically the preflight job, which runs without environment protection for all fork PRs.

<details open><summary><h3>Security Review</h3></summary>

- **Fork code execution under `pull_request_target`**: `allow-unsafe-pr-checkout: true` bypasses `actions/checkout`'s new guard. The `deploy` job runs `nix build --impure` on fork-supplied code with deployment secrets present; this is mitigated by the `preview` environment's reviewer-approval gate for untrusted authors.
- **`preflight` runs unprotected for all fork PRs**: The job has no `needs: [gate]` and fires immediately for every fork PR. Current operations (`git diff`, `jq`) do not access secrets or execute fork code, but the structural pattern could become dangerous if future steps are added without recognising the job is ungated.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/preview-deploy.yml | Adds `allow-unsafe-pr-checkout: true` to both checkout steps (preflight and deploy) to restore fork-PR preview builds broken by actions/checkout v6.1.0's new guard; security relies on the gate→preview environment approval for untrusted forks. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `.github/workflows/preview-deploy.yml`, line 54-70 ([link](https://github.com/schemalabz/opencouncil/blob/8774559f4fdfd8fcfb4f61798e69c7980ca73320/.github/workflows/preview-deploy.yml#L54-L70)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **`preflight` runs without the environment gate**

   The comment on the `preflight` checkout says "the deploy job is gated behind the reviewer-approved `preview` environment" to justify `allow-unsafe-pr-checkout: true` — and that justification is correct for `deploy`. But `preflight` itself has no `needs: [gate]` and no environment protection: it fires immediately for every fork PR, including fully untrusted ones, before any reviewer can approve. Today this is safe because `preflight` only runs `git diff` and `jq`, never touching secrets or executing fork-supplied build code. However, the comment could mislead a future maintainer into thinking `preflight` is also behind the gate. Consider adding a one-liner like "Note: `preflight` itself is intentionally ungated — it does not run fork code or access secrets" to make the asymmetry explicit and guard against unsafe steps being added to this job in the future.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/preview-deploy.yml
   Line: 54-70

   Comment:
   **`preflight` runs without the environment gate**

   The comment on the `preflight` checkout says "the deploy job is gated behind the reviewer-approved `preview` environment" to justify `allow-unsafe-pr-checkout: true` — and that justification is correct for `deploy`. But `preflight` itself has no `needs: [gate]` and no environment protection: it fires immediately for every fork PR, including fully untrusted ones, before any reviewer can approve. Today this is safe because `preflight` only runs `git diff` and `jq`, never touching secrets or executing fork-supplied build code. However, the comment could mislead a future maintainer into thinking `preflight` is also behind the gate. Consider adding a one-liner like "Note: `preflight` itself is intentionally ungated — it does not run fork code or access secrets" to make the asymmetry explicit and guard against unsafe steps being added to this job in the future.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpreview-deploy.yml%0ALine%3A%2054-70%0A%0AComment%3A%0A**%60preflight%60%20runs%20without%20the%20environment%20gate**%0A%0AThe%20comment%20on%20the%20%60preflight%60%20checkout%20says%20%22the%20deploy%20job%20is%20gated%20behind%20the%20reviewer-approved%20%60preview%60%20environment%22%20to%20justify%20%60allow-unsafe-pr-checkout%3A%20true%60%20%E2%80%94%20and%20that%20justification%20is%20correct%20for%20%60deploy%60.%20But%20%60preflight%60%20itself%20has%20no%20%60needs%3A%20%5Bgate%5D%60%20and%20no%20environment%20protection%3A%20it%20fires%20immediately%20for%20every%20fork%20PR%2C%20including%20fully%20untrusted%20ones%2C%20before%20any%20reviewer%20can%20approve.%20Today%20this%20is%20safe%20because%20%60preflight%60%20only%20runs%20%60git%20diff%60%20and%20%60jq%60%2C%20never%20touching%20secrets%20or%20executing%20fork-supplied%20build%20code.%20However%2C%20the%20comment%20could%20mislead%20a%20future%20maintainer%20into%20thinking%20%60preflight%60%20is%20also%20behind%20the%20gate.%20Consider%20adding%20a%20one-liner%20like%20%22Note%3A%20%60preflight%60%20itself%20is%20intentionally%20ungated%20%E2%80%94%20it%20does%20not%20run%20fork%20code%20or%20access%20secrets%22%20to%20make%20the%20asymmetry%20explicit%20and%20guard%20against%20unsafe%20steps%20being%20added%20to%20this%20job%20in%20the%20future.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=schemalabz%2Fopencouncil&pr=552&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>


2. `.github/workflows/preview-deploy.yml`, line 61 ([link](https://github.com/schemalabz/opencouncil/blob/8774559f4fdfd8fcfb4f61798e69c7980ca73320/.github/workflows/preview-deploy.yml#L61)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Floating `@v6` tag remains a risk vector**

   Both checkout steps still use the floating `actions/checkout@v6` tag. The root cause of this PR was that `@v6` silently moved from v6.0.3 to v6.1.0 with a breaking security change. The PR description notes a full-SHA pin as an alternative; while it is explicitly out of scope for this fix, it is worth tracking as a follow-up. Any future patch on the `v6` line — including ones that add new required inputs, change default behaviour, or introduce new guards — will again silently affect all runs until discovered.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/preview-deploy.yml
   Line: 61

   Comment:
   **Floating `@v6` tag remains a risk vector**

   Both checkout steps still use the floating `actions/checkout@v6` tag. The root cause of this PR was that `@v6` silently moved from v6.0.3 to v6.1.0 with a breaking security change. The PR description notes a full-SHA pin as an alternative; while it is explicitly out of scope for this fix, it is worth tracking as a follow-up. Any future patch on the `v6` line — including ones that add new required inputs, change default behaviour, or introduce new guards — will again silently affect all runs until discovered.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpreview-deploy.yml%0ALine%3A%2061%0A%0AComment%3A%0A**Floating%20%60%40v6%60%20tag%20remains%20a%20risk%20vector**%0A%0ABoth%20checkout%20steps%20still%20use%20the%20floating%20%60actions%2Fcheckout%40v6%60%20tag.%20The%20root%20cause%20of%20this%20PR%20was%20that%20%60%40v6%60%20silently%20moved%20from%20v6.0.3%20to%20v6.1.0%20with%20a%20breaking%20security%20change.%20The%20PR%20description%20notes%20a%20full-SHA%20pin%20as%20an%20alternative%3B%20while%20it%20is%20explicitly%20out%20of%20scope%20for%20this%20fix%2C%20it%20is%20worth%20tracking%20as%20a%20follow-up.%20Any%20future%20patch%20on%20the%20%60v6%60%20line%20%E2%80%94%20including%20ones%20that%20add%20new%20required%20inputs%2C%20change%20default%20behaviour%2C%20or%20introduce%20new%20guards%20%E2%80%94%20will%20again%20silently%20affect%20all%20runs%20until%20discovered.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=schemalabz%2Fopencouncil&pr=552&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fpreview-deploy.yml%3A54-70%0A**%60preflight%60%20runs%20without%20the%20environment%20gate**%0A%0AThe%20comment%20on%20the%20%60preflight%60%20checkout%20says%20%22the%20deploy%20job%20is%20gated%20behind%20the%20reviewer-approved%20%60preview%60%20environment%22%20to%20justify%20%60allow-unsafe-pr-checkout%3A%20true%60%20%E2%80%94%20and%20that%20justification%20is%20correct%20for%20%60deploy%60.%20But%20%60preflight%60%20itself%20has%20no%20%60needs%3A%20%5Bgate%5D%60%20and%20no%20environment%20protection%3A%20it%20fires%20immediately%20for%20every%20fork%20PR%2C%20including%20fully%20untrusted%20ones%2C%20before%20any%20reviewer%20can%20approve.%20Today%20this%20is%20safe%20because%20%60preflight%60%20only%20runs%20%60git%20diff%60%20and%20%60jq%60%2C%20never%20touching%20secrets%20or%20executing%20fork-supplied%20build%20code.%20However%2C%20the%20comment%20could%20mislead%20a%20future%20maintainer%20into%20thinking%20%60preflight%60%20is%20also%20behind%20the%20gate.%20Consider%20adding%20a%20one-liner%20like%20%22Note%3A%20%60preflight%60%20itself%20is%20intentionally%20ungated%20%E2%80%94%20it%20does%20not%20run%20fork%20code%20or%20access%20secrets%22%20to%20make%20the%20asymmetry%20explicit%20and%20guard%20against%20unsafe%20steps%20being%20added%20to%20this%20job%20in%20the%20future.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fpreview-deploy.yml%3A61%0A**Floating%20%60%40v6%60%20tag%20remains%20a%20risk%20vector**%0A%0ABoth%20checkout%20steps%20still%20use%20the%20floating%20%60actions%2Fcheckout%40v6%60%20tag.%20The%20root%20cause%20of%20this%20PR%20was%20that%20%60%40v6%60%20silently%20moved%20from%20v6.0.3%20to%20v6.1.0%20with%20a%20breaking%20security%20change.%20The%20PR%20description%20notes%20a%20full-SHA%20pin%20as%20an%20alternative%3B%20while%20it%20is%20explicitly%20out%20of%20scope%20for%20this%20fix%2C%20it%20is%20worth%20tracking%20as%20a%20follow-up.%20Any%20future%20patch%20on%20the%20%60v6%60%20line%20%E2%80%94%20including%20ones%20that%20add%20new%20required%20inputs%2C%20change%20default%20behaviour%2C%20or%20introduce%20new%20guards%20%E2%80%94%20will%20again%20silently%20affect%20all%20runs%20until%20discovered.%0A%0A&repo=schemalabz%2Fopencouncil&pr=552&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/preview-deploy.yml:54-70
**`preflight` runs without the environment gate**

The comment on the `preflight` checkout says "the deploy job is gated behind the reviewer-approved `preview` environment" to justify `allow-unsafe-pr-checkout: true` — and that justification is correct for `deploy`. But `preflight` itself has no `needs: [gate]` and no environment protection: it fires immediately for every fork PR, including fully untrusted ones, before any reviewer can approve. Today this is safe because `preflight` only runs `git diff` and `jq`, never touching secrets or executing fork-supplied build code. However, the comment could mislead a future maintainer into thinking `preflight` is also behind the gate. Consider adding a one-liner like "Note: `preflight` itself is intentionally ungated — it does not run fork code or access secrets" to make the asymmetry explicit and guard against unsafe steps being added to this job in the future.

### Issue 2 of 2
.github/workflows/preview-deploy.yml:61
**Floating `@v6` tag remains a risk vector**

Both checkout steps still use the floating `actions/checkout@v6` tag. The root cause of this PR was that `@v6` silently moved from v6.0.3 to v6.1.0 with a breaking security change. The PR description notes a full-SHA pin as an alternative; while it is explicitly out of scope for this fix, it is worth tracking as a follow-up. Any future patch on the `v6` line — including ones that add new required inputs, change default behaviour, or introduce new guards — will again silently affect all runs until discovered.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(preview): opt into fork-PR checkout u..."](https://github.com/schemalabz/opencouncil/commit/8774559f4fdfd8fcfb4f61798e69c7980ca73320) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45715828)</sub>

<!-- /greptile_comment -->