### PR TITLE
feat(explain): better SEO for /explain, plus a "Learn more" footer link

### DIFF
--- a/messages/el.json
+++ b/messages/el.json
@@ -110,6 +110,7 @@
         "companyDescription": "Η OpenCouncil είναι εταιρεία της <link>Schema Labs</link>, μιας μη-κερδοσκοπικής εταιρείας που αναπτύσσει τεχνολογία για την ενίσχυση της δημοκρατίας.",
         "linksHeading": "Σύνδεσμοι",
         "linkHome": "Αρχική",
+        "linkLearnMore": "Μάθετε περισσότερα",
         "linkForMunicipalities": "Για δήμους",
         "linkSearch": "Αναζήτηση",
         "linkJobs": "Θέσεις Εργασίας",

--- a/messages/en.json
+++ b/messages/en.json
@@ -96,6 +96,7 @@
         "companyDescription": "OpenCouncil is a company of <link>Schema Labs</link>, a non-profit that builds technology to strengthen democracy.",
         "linksHeading": "Links",
         "linkHome": "Home",
+        "linkLearnMore": "Learn more",
         "linkForMunicipalities": "For municipalities",
         "linkSearch": "Search",
         "linkJobs": "Jobs",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -110,6 +110,7 @@
         "companyDescription": "OpenCouncil est une société de <link>Schema Labs</link>, une organisation à but non lucratif qui développe des technologies au service de la démocratie.",
         "linksHeading": "Liens",
         "linkHome": "Accueil",
+        "linkLearnMore": "En savoir plus",
         "linkForMunicipalities": "Pour les communes",
         "linkSearch": "Recherche",
         "linkJobs": "Emplois",

--- a/src/app/[locale]/(other)/explain/page.tsx
+++ b/src/app/[locale]/(other)/explain/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/pricing/config";
 import type { ExplainPricing } from "./ExplainFeatures";
 import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
+import { getRealmBaseUrl } from "@/lib/realm";
 import { getRealm } from "@/lib/realm.server";
 import { ARTICLES, SECTIONS } from "@/lib/explain/articles";
 import { OPENCOUNCIL_SUBSECTIONS } from "@/lib/explain/subsections";
@@ -54,6 +55,8 @@ const SECTION_PARENTS: Record<string, string> = {
 };
 
 const PAGE_TITLE = "Η τοπική αυτοδιοίκηση, απλά";
+/** Shown in the visible breadcrumb nav and mirrored in the BreadcrumbList JSON-LD. */
+const BREADCRUMB_LABEL = "Σχετικά με την τοπική αυτοδιοίκηση";
 const PAGE_DESCRIPTION =
     "Πώς λειτουργούν οι δήμοι στην Ελλάδα — έσοδα, όργανα, συνεδριάσεις και αποφάσεις — και πώς το OpenCouncil τα κάνει κατανοητά, αναζητήσιμα και προσβάσιμα.";
 
@@ -61,6 +64,8 @@ export async function generateMetadata(props: {
     params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
     const { locale } = await props.params;
+
+    const ogImageUrl = "/api/og?pageType=explain";
 
     return {
         title: `${PAGE_TITLE} | OpenCouncil`,
@@ -82,11 +87,20 @@ export async function generateMetadata(props: {
             type: "article",
             siteName: "OpenCouncil",
             locale: locale === "en" ? "en_US" : "el_GR",
+            images: [
+                {
+                    url: ogImageUrl,
+                    width: 1200,
+                    height: 630,
+                    alt: PAGE_TITLE,
+                },
+            ],
         },
         twitter: {
             card: "summary_large_image",
             title: PAGE_TITLE,
             description: PAGE_DESCRIPTION,
+            images: [ogImageUrl],
         },
         alternates: await buildCanonicalAlternates("/explain"),
     };
@@ -110,15 +124,43 @@ export default async function ExplainPage() {
         // the priciest (open-ended) tier kicks in above the previous tier's ceiling
         topFrom: PLATFORM_PRICING_TIERS[PLATFORM_PRICING_TIERS.length - 2]?.maxPopulation ?? null,
     };
+    // Canonical, realm-scoped URL — the JSON-LD must reference the same URL the
+    // page canonicalizes to, so search engines tie the structured data to the
+    // indexed document (fragments are never separate index entries).
+    const baseUrl = getRealmBaseUrl(realm);
+    const pageUrl = `${baseUrl}/explain`;
+    const organization = {
+        "@type": "Organization",
+        name: "OpenCouncil",
+        url: baseUrl,
+        logo: { "@type": "ImageObject", url: `${baseUrl}/logo.png` },
+    };
     const structuredData = {
         "@context": "https://schema.org",
-        "@type": "Article",
-        headline: PAGE_TITLE,
-        description: PAGE_DESCRIPTION,
-        about: "Τοπική αυτοδιοίκηση",
-        inLanguage: "el",
-        author: { "@type": "Organization", name: "OpenCouncil" },
-        publisher: { "@type": "Organization", name: "OpenCouncil" },
+        "@graph": [
+            {
+                "@type": "Article",
+                "@id": `${pageUrl}#article`,
+                mainEntityOfPage: pageUrl,
+                url: pageUrl,
+                headline: PAGE_TITLE,
+                description: PAGE_DESCRIPTION,
+                image: `${baseUrl}/api/og?pageType=explain`,
+                about: "Τοπική αυτοδιοίκηση",
+                inLanguage: "el",
+                author: organization,
+                publisher: organization,
+            },
+            // Mirrors the visual breadcrumb so results can show the site hierarchy.
+            {
+                "@type": "BreadcrumbList",
+                "@id": `${pageUrl}#breadcrumb`,
+                itemListElement: [
+                    { "@type": "ListItem", position: 1, name: "Αρχική", item: baseUrl },
+                    { "@type": "ListItem", position: 2, name: BREADCRUMB_LABEL, item: pageUrl },
+                ],
+            },
+        ],
     };
 
     return (
@@ -134,7 +176,7 @@ export default async function ExplainPage() {
                     Αρχική
                 </Link>
                 <span className="text-border">/</span>
-                <span>Σχετικά με την τοπική αυτοδιοίκηση</span>
+                <span>{BREADCRUMB_LABEL}</span>
             </nav>
 
             {/* title + description */}

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -12,7 +12,7 @@ import { getPartiesForCity } from '@/lib/db/parties';
 import { getPeopleForCity, getPerson } from '@/lib/db/people';
 import { getInitials } from '@/lib/formatters/name';
 import { sortSubjectsByImportance } from '@/lib/utils';
-import { Container, MeetingMetaRow, OgHeader, SubjectPills, formatCityDisplayName } from '@/components/og/shared-components';
+import { Container, DarkHeroOGImage, MeetingMetaRow, OgHeader, SubjectPills, formatCityDisplayName } from '@/components/og/shared-components';
 import { tryAcquireOgSlot, getOgConcurrencyStats } from '@/lib/og/concurrency';
 import { LOGO_BLACK_DATA_URI } from '@/lib/og/serverAssets';
 import SubjectOgImage from '@/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/opengraph-image';
@@ -717,169 +717,22 @@ const PeopleOGImage = async (cityId: string) => {
 };
 
 // About Page OG Image
-const AboutOGImage = () => {
-    return (
-        <div style={{
-            width: '1200px',
-            height: '630px',
-            display: 'flex',
-            flexDirection: 'column',
-            backgroundColor: '#0a0a0a',
-            padding: '60px 72px',
-        }}>
-            {/* Logo / wordmark top-left */}
-            <div style={{ display: 'flex', alignItems: 'center', marginBottom: '56px' }}>
-                <div style={{
-                    fontSize: '22px',
-                    fontWeight: '600',
-                    color: '#ffffff',
-                }}>
-                    OpenCouncil
-                </div>
-            </div>
-
-            {/* Main content */}
-            <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center', gap: '32px' }}>
-                {/* Headline — two lines to avoid flexWrap */}
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-                    <div style={{
-                        fontSize: '56px',
-                        fontWeight: '300',
-                        color: '#ffffff',
-                        lineHeight: 1.15,
-                        letterSpacing: '-0.02em',
-                    }}>
-                        Το λειτουργικό σύστημα
-                    </div>
-                    <div style={{
-                        fontSize: '56px',
-                        fontWeight: '500',
-                        color: '#f97316',
-                        lineHeight: 1.15,
-                        letterSpacing: '-0.02em',
-                    }}>
-                        των συλλογικών οργάνων
-                    </div>
-                </div>
-
-                {/* Stat pills */}
-                <div style={{ display: 'flex', gap: '16px', alignItems: 'center' }}>
-                    {['10 δήμοι', '5.000+ θέματα', '400+ ώρες συνεδριάσεων'].map((label) => (
-                        <div key={label} style={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            backgroundColor: 'rgba(255,255,255,0.07)',
-                            border: '1px solid rgba(255,255,255,0.12)',
-                            borderRadius: '100px',
-                            padding: '8px 20px',
-                            fontSize: '20px',
-                            color: 'rgba(255,255,255,0.75)',
-                        }}>
-                            {label}
-                        </div>
-                    ))}
-                </div>
-            </div>
-
-            {/* Feature tags bottom */}
-            <div style={{ display: 'flex', gap: '12px', marginTop: '40px' }}>
-                {['Απομαγνητοφωνήσεις', 'Πρακτικά', 'Ειδοποιήσεις δημοτών', 'Χάρτης θεμάτων'].map((tag) => (
-                    <div key={tag} style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        backgroundColor: 'rgba(249,115,22,0.12)',
-                        border: '1px solid rgba(249,115,22,0.3)',
-                        borderRadius: '6px',
-                        padding: '6px 14px',
-                        fontSize: '16px',
-                        color: '#f97316',
-                        fontWeight: '500',
-                    }}>
-                        {tag}
-                    </div>
-                ))}
-            </div>
-        </div>
-    );
-};
+const AboutOGImage = () => (
+    <DarkHeroOGImage
+        headline={['Το λειτουργικό σύστημα', 'των συλλογικών οργάνων']}
+        statPills={['10 δήμοι', '5.000+ θέματα', '400+ ώρες συνεδριάσεων']}
+        tags={['Απομαγνητοφωνήσεις', 'Πρακτικά', 'Ειδοποιήσεις δημοτών', 'Χάρτης θεμάτων']}
+    />
+);
 
 // Explain Page OG Image (/explain — "Η τοπική αυτοδιοίκηση, απλά")
-const ExplainOGImage = () => {
-    return (
-        <div style={{
-            width: '1200px',
-            height: '630px',
-            display: 'flex',
-            flexDirection: 'column',
-            backgroundColor: '#0a0a0a',
-            padding: '60px 72px',
-        }}>
-            {/* Logo / wordmark top-left */}
-            <div style={{ display: 'flex', alignItems: 'center', marginBottom: '56px' }}>
-                <div style={{
-                    fontSize: '22px',
-                    fontWeight: '600',
-                    color: '#ffffff',
-                }}>
-                    OpenCouncil
-                </div>
-            </div>
-
-            {/* Main content */}
-            <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center', gap: '32px' }}>
-                {/* Headline — two lines to avoid flexWrap */}
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-                    <div style={{
-                        fontSize: '56px',
-                        fontWeight: '300',
-                        color: '#ffffff',
-                        lineHeight: 1.15,
-                        letterSpacing: '-0.02em',
-                    }}>
-                        Η τοπική αυτοδιοίκηση,
-                    </div>
-                    <div style={{
-                        fontSize: '56px',
-                        fontWeight: '500',
-                        color: '#f97316',
-                        lineHeight: 1.15,
-                        letterSpacing: '-0.02em',
-                    }}>
-                        απλά
-                    </div>
-                </div>
-
-                <div style={{
-                    fontSize: '24px',
-                    color: 'rgba(255,255,255,0.75)',
-                    lineHeight: 1.4,
-                    maxWidth: '900px',
-                }}>
-                    Πώς λειτουργούν οι δήμοι στην Ελλάδα — και πώς το OpenCouncil τους κάνει κατανοητούς
-                </div>
-            </div>
-
-            {/* Section tags bottom */}
-            <div style={{ display: 'flex', gap: '12px', marginTop: '40px' }}>
-                {['Έσοδα των δήμων', 'Όργανα & συνεδριάσεις', 'Αποφάσεις', 'Πώς δουλεύει το OpenCouncil'].map((tag) => (
-                    <div key={tag} style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        backgroundColor: 'rgba(249,115,22,0.12)',
-                        border: '1px solid rgba(249,115,22,0.3)',
-                        borderRadius: '6px',
-                        padding: '6px 14px',
-                        fontSize: '16px',
-                        color: '#f97316',
-                        fontWeight: '500',
-                    }}>
-                        {tag}
-                    </div>
-                ))}
-            </div>
-        </div>
-    );
-};
+const ExplainOGImage = () => (
+    <DarkHeroOGImage
+        headline={['Η τοπική αυτοδιοίκηση,', 'απλά']}
+        subtitle="Πώς λειτουργούν οι δήμοι στην Ελλάδα — και πώς το OpenCouncil τους κάνει κατανοητούς"
+        tags={['Έσοδα των δήμων', 'Όργανα & συνεδριάσεις', 'Αποφάσεις', 'Πώς δουλεύει το OpenCouncil']}
+    />
+);
 
 // Search Page OG Image
 const SearchOGImage = () => {

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -803,6 +803,84 @@ const AboutOGImage = () => {
     );
 };
 
+// Explain Page OG Image (/explain — "Η τοπική αυτοδιοίκηση, απλά")
+const ExplainOGImage = () => {
+    return (
+        <div style={{
+            width: '1200px',
+            height: '630px',
+            display: 'flex',
+            flexDirection: 'column',
+            backgroundColor: '#0a0a0a',
+            padding: '60px 72px',
+        }}>
+            {/* Logo / wordmark top-left */}
+            <div style={{ display: 'flex', alignItems: 'center', marginBottom: '56px' }}>
+                <div style={{
+                    fontSize: '22px',
+                    fontWeight: '600',
+                    color: '#ffffff',
+                }}>
+                    OpenCouncil
+                </div>
+            </div>
+
+            {/* Main content */}
+            <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center', gap: '32px' }}>
+                {/* Headline — two lines to avoid flexWrap */}
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                    <div style={{
+                        fontSize: '56px',
+                        fontWeight: '300',
+                        color: '#ffffff',
+                        lineHeight: 1.15,
+                        letterSpacing: '-0.02em',
+                    }}>
+                        Η τοπική αυτοδιοίκηση,
+                    </div>
+                    <div style={{
+                        fontSize: '56px',
+                        fontWeight: '500',
+                        color: '#f97316',
+                        lineHeight: 1.15,
+                        letterSpacing: '-0.02em',
+                    }}>
+                        απλά
+                    </div>
+                </div>
+
+                <div style={{
+                    fontSize: '24px',
+                    color: 'rgba(255,255,255,0.75)',
+                    lineHeight: 1.4,
+                    maxWidth: '900px',
+                }}>
+                    Πώς λειτουργούν οι δήμοι στην Ελλάδα — και πώς το OpenCouncil τους κάνει κατανοητούς
+                </div>
+            </div>
+
+            {/* Section tags bottom */}
+            <div style={{ display: 'flex', gap: '12px', marginTop: '40px' }}>
+                {['Έσοδα των δήμων', 'Όργανα & συνεδριάσεις', 'Αποφάσεις', 'Πώς δουλεύει το OpenCouncil'].map((tag) => (
+                    <div key={tag} style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        backgroundColor: 'rgba(249,115,22,0.12)',
+                        border: '1px solid rgba(249,115,22,0.3)',
+                        borderRadius: '6px',
+                        padding: '6px 14px',
+                        fontSize: '16px',
+                        color: '#f97316',
+                        fontWeight: '500',
+                    }}>
+                        {tag}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
 // Search Page OG Image
 const SearchOGImage = () => {
     return (
@@ -918,7 +996,7 @@ export async function GET(request: Request) {
     const consultationId = searchParams.get('consultationId');
     const personId = searchParams.get('personId');
     const subjectId = searchParams.get('subjectId');
-    const pageType = searchParams.get('pageType'); // 'people', 'about', 'search', 'chat'
+    const pageType = searchParams.get('pageType'); // 'people', 'about', 'explain', 'search', 'chat'
     const variant = searchParams.get('variant'); // 'feed' for 1:1, default is landscape (story is client-side now)
 
     // Short per-request id so concurrent requests' logs can be untangled by grepping a tag.
@@ -967,6 +1045,8 @@ export async function GET(request: Request) {
             element = await PeopleOGImage(cityId);
         } else if (pageType === 'about') {
             element = AboutOGImage();
+        } else if (pageType === 'explain') {
+            element = ExplainOGImage();
         } else if (pageType === 'search') {
             element = SearchOGImage();
         } else if (pageType === 'chat') {

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Link } from "@/i18n/routing"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import Logo from "./Logo"
 import CountrySwitcher from "./CountrySwitcher"
 import { Phone, Mail, ExternalLink } from "lucide-react"
@@ -17,6 +17,7 @@ interface FooterProps {
 
 export default function Footer({ className }: FooterProps = {}) {
     const t = useTranslations("Footer")
+    const locale = useLocale()
     return (
         <footer className={cn("w-full bg-muted border-t print:hidden", className)}>
             <div className="container mx-auto px-4 py-12">
@@ -50,6 +51,8 @@ export default function Footer({ className }: FooterProps = {}) {
                         <nav className="flex flex-col items-center md:items-start space-y-2">
                             {[
                                 { href: "/", label: t("linkHome") },
+                                // /explain is written in Greek, about Greek municipalities — only link it on the Greek locale
+                                ...(locale === "el" ? [{ href: "/explain", label: t("linkLearnMore") }] : []),
                                 { href: "/about", label: t("linkForMunicipalities") },
                                 { href: "/search", label: t("linkSearch") },
                                 { href: "/chat", label: "OpenCouncil AI" },

--- a/src/components/og/shared-components.tsx
+++ b/src/components/og/shared-components.tsx
@@ -287,6 +287,110 @@ export const SubjectPills = ({
     );
 };
 
+// Dark 1200x630 hero scaffold shared by the marketing-page OG images
+// (about, explain): wordmark top-left, two-line headline with an orange accent
+// line, an optional middle band (stat pills and/or subtitle), and a row of
+// orange tags along the bottom.
+interface DarkHeroOGImageProps {
+    /** Headline as two pre-split lines (white, then orange) to avoid flexWrap. */
+    headline: [string, string];
+    /** Neutral stat pills under the headline, e.g. "10 δήμοι". */
+    statPills?: string[];
+    /** One-sentence subtitle under the headline. */
+    subtitle?: string;
+    /** Orange tags along the bottom edge. */
+    tags: string[];
+}
+
+const darkHeroHeadlineStyle = {
+    fontSize: "56px",
+    lineHeight: 1.15,
+    letterSpacing: "-0.02em",
+};
+
+export const DarkHeroOGImage = ({ headline, statPills, subtitle, tags }: DarkHeroOGImageProps) => (
+    <div
+        style={{
+            width: "1200px",
+            height: "630px",
+            display: "flex",
+            flexDirection: "column",
+            backgroundColor: "#0a0a0a",
+            padding: "60px 72px",
+        }}
+    >
+        {/* Logo / wordmark top-left */}
+        <div style={{ display: "flex", alignItems: "center", marginBottom: "56px" }}>
+            <div style={{ fontSize: "22px", fontWeight: "600", color: "#ffffff" }}>OpenCouncil</div>
+        </div>
+
+        {/* Main content */}
+        <div style={{ display: "flex", flexDirection: "column", flex: 1, justifyContent: "center", gap: "32px" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                <div style={{ ...darkHeroHeadlineStyle, fontWeight: "300", color: "#ffffff" }}>{headline[0]}</div>
+                <div style={{ ...darkHeroHeadlineStyle, fontWeight: "500", color: "#f97316" }}>{headline[1]}</div>
+            </div>
+
+            {statPills && (
+                <div style={{ display: "flex", gap: "16px", alignItems: "center" }}>
+                    {statPills.map((label) => (
+                        <div
+                            key={label}
+                            style={{
+                                display: "flex",
+                                alignItems: "center",
+                                backgroundColor: "rgba(255,255,255,0.07)",
+                                border: "1px solid rgba(255,255,255,0.12)",
+                                borderRadius: "100px",
+                                padding: "8px 20px",
+                                fontSize: "20px",
+                                color: "rgba(255,255,255,0.75)",
+                            }}
+                        >
+                            {label}
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {subtitle && (
+                <div
+                    style={{
+                        fontSize: "24px",
+                        color: "rgba(255,255,255,0.75)",
+                        lineHeight: 1.4,
+                        maxWidth: "900px",
+                    }}
+                >
+                    {subtitle}
+                </div>
+            )}
+        </div>
+
+        {/* Tags bottom */}
+        <div style={{ display: "flex", gap: "12px", marginTop: "40px" }}>
+            {tags.map((tag) => (
+                <div
+                    key={tag}
+                    style={{
+                        display: "flex",
+                        alignItems: "center",
+                        backgroundColor: "rgba(249,115,22,0.12)",
+                        border: "1px solid rgba(249,115,22,0.3)",
+                        borderRadius: "6px",
+                        padding: "6px 14px",
+                        fontSize: "16px",
+                        color: "#f97316",
+                        fontWeight: "500",
+                    }}
+                >
+                    {tag}
+                </div>
+            ))}
+        </div>
+    </div>
+);
+
 // Shared OG Header component
 interface OgHeaderProps {
     city: {


### PR DESCRIPTION
## What this does

Helps search engines find and show the /explain page and its sections, and links to the page from the footer.

### How search engines treat the hash sections

Google does not index `#section` links as separate pages — `/explain#oc-search` and `/explain` are one page to it. What we can get is **"Jump to" links**: Google shows links to sections under the search result. It does this on its own when a page has headings with stable ids and a table of contents that links to them. The page already has both. This PR fills in the rest.

### Changes

**Richer page data for search engines** (`explain/page.tsx`)
- The JSON-LD grows from a bare `Article` to a graph with:
  - a full `Article`: canonical URL, image, and publisher with logo
  - a `BreadcrumbList` that matches the breadcrumb shown on the page
- Both use the realm's own domain (opencouncil.gr or .fr), the same URL the page already points to as canonical.
- No made-up dates: there is no real publish date to draw from, so the markup leaves dates out rather than fake them.

**A share image for the page** (`api/og/route.tsx`)
- The page had no image for social shares, so links to it looked bare. A new `pageType=explain` image shows the page title in the same dark style as the /about image.

**Footer link** (`Footer.tsx` + messages)
- The links section now links to /explain, right after "Αρχική": **Μάθετε περισσότερα** / Learn more / En savoir plus.
- This also helps SEO: a link from every page tells Google the page matters. Before, only the sitemap pointed to it.

### What this PR does not do, on purpose
- No `#fragment` URLs in the sitemap — Google drops the fragment.
- No FAQ markup — since 2023 Google only shows FAQ results for government and health sites.

## Checks

- `npx tsc --noEmit` clean
- All 66 test suites pass (988 tests)
- `npm run build` fails in the work container on `/api/chat` for lack of env vars; the same build fails the same way on `main`, so it is not this diff

## After deploy
- Ask Search Console to reindex `/explain`
- Check the JSON-LD with the Rich Results Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTEVtRTjKzfbrwcVRxZcM6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTEVtRTjKzfbrwcVRxZcM6)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/SEO and footer navigation only; no auth, payments, or data-handling changes.
> 
> **Overview**
> Improves discoverability and sharing for the Greek-only **`/explain`** page.
> 
> **`/explain` metadata** expands JSON-LD from a minimal `Article` to an **`@graph`** with a realm-canonical **`Article`** (canonical URL, OG image, publisher logo) and a **`BreadcrumbList`** aligned with the on-page breadcrumb via **`getRealmBaseUrl`**. Open Graph and Twitter metadata now reference **`/api/og?pageType=explain`**.
> 
> **OG API** adds a dedicated **`ExplainOGImage`** and routes **`pageType=explain`** to it (dark layout matching other marketing pages).
> 
> **Footer** adds translated **`linkLearnMore`** strings and a **“Learn more”** link to **`/explain`** only when **`locale === "el"`**, so en/fr users are not sent to Greek-only content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 188d91c64bc3b5c402c4464afacee163c77ba6e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves discovery and sharing for the `/explain` page. The main changes are:

- Adds realm-aware Article and breadcrumb structured data.
- Adds a dedicated social preview image for `/explain`.
- Extracts a shared dark hero component for marketing-page images.
- Adds a Greek-only footer link to the Greek explain page.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The footer now hides the Greek-only page link for English and French locales.
- No blocking issues were found in the updated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/layout/Footer.tsx | Restricts the new explain link to the Greek locale. |
| src/app/[locale]/(other)/explain/page.tsx | Adds richer metadata, structured data, and social image references. |
| src/app/api/og/route.tsx | Adds the explain image variant and reuses the shared hero renderer. |
| src/components/og/shared-components.tsx | Adds the reusable dark hero layout for marketing-page images. |
| messages/el.json | Adds the Greek label for the footer link. |
| messages/en.json | Adds the English label for the footer link. |
| messages/fr.json | Adds the French label for the footer link. |

<sub>Reviews (3): Last reviewed commit: ["refactor(og): extract shared dark hero s..."](https://github.com/schemalabz/opencouncil/commit/389f9aeb3eb7e399ba1c96e67a2a7d4e480d0d05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45870846)</sub>

**Context used:**

- Context used - .cursorrules ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=8f01574a-2b8a-490a-a6a8-5bb80f6f984c))
- Context used - CLAUDE.md ([source](https://app.greptile.com/schema-labs/github/schemalabz/opencouncil/-/custom-context?memory=a3ddaa95-717d-48e6-81cd-93c42696bbed))

<!-- /greptile_comment -->