### PR TITLE
perf(subjects): map lookup instead of nested find when merging coordinates

### DIFF
--- a/src/lib/db/subject.ts
+++ b/src/lib/db/subject.ts
@@ -522,7 +522,7 @@ export async function getSubjectsForMeeting(cityId: string, councilMeetingId: st
         });
 
         // Then get the coordinates for locations that exist
-        const locationIds = subjects.filter(s => s.location).map(s => s.location!.id);
+        const locationIds = subjects.flatMap(s => s.location ? [s.location.id] : []);
 
         if (locationIds.length > 0) {
             const locationCoordinates = await prisma.$queryRaw<Array<{ id: string; x: number; y: number }>>`
@@ -531,6 +531,7 @@ export async function getSubjectsForMeeting(cityId: string, councilMeetingId: st
                 WHERE id = ANY(${locationIds}::text[])
                 AND type = 'point'
             `;
+            const coordinatesByLocationId = new Map(locationCoordinates.map(l => [l.id, l]));
 
             // Merge coordinates into the subjects
             return subjects.map(subject => ({
@@ -538,7 +539,7 @@ export async function getSubjectsForMeeting(cityId: string, councilMeetingId: st
                 location: subject.location
                     ? {
                         ...subject.location,
-                        coordinates: locationCoordinates.find(l => l.id === subject.location!.id),
+                        coordinates: coordinatesByLocationId.get(subject.location.id),
                     }
                     : null,
             }));

--- a/src/lib/db/subject.ts
+++ b/src/lib/db/subject.ts
@@ -514,7 +514,7 @@ export async function getSubjectsForMeeting(cityId: string, councilMeetingId: st
         });
 
         // Then get the coordinates for locations that exist
-        const locationIds = subjects.filter(s => s.location).map(s => s.location!.id);
+        const locationIds = subjects.flatMap(s => s.location ? [s.location.id] : []);
 
         if (locationIds.length > 0) {
             const locationCoordinates = await prisma.$queryRaw<Array<{ id: string; x: number; y: number }>>`
@@ -523,6 +523,7 @@ export async function getSubjectsForMeeting(cityId: string, councilMeetingId: st
                 WHERE id = ANY(${locationIds}::text[])
                 AND type = 'point'
             `;
+            const coordinatesByLocationId = new Map(locationCoordinates.map(l => [l.id, l]));
 
             // Merge coordinates into the subjects
             return subjects.map(subject => ({
@@ -530,7 +531,7 @@ export async function getSubjectsForMeeting(cityId: string, councilMeetingId: st
                 location: subject.location
                     ? {
                         ...subject.location,
-                        coordinates: locationCoordinates.find(l => l.id === subject.location!.id),
+                        coordinates: coordinatesByLocationId.get(subject.location.id),
                     }
                     : null,
             }));


### PR DESCRIPTION
Part of #242.

`getSubjectsForMeeting` merged location coordinates by calling `locationCoordinates.find()` inside `subjects.map()`, so the work grew with subjects times locations. It now builds a Map keyed by location id once and looks up from that, and it collects the location ids in a single pass instead of two.

Same output, same ordering. On a meeting with a lot of geolocated subjects this is the difference between a quadratic scan and a hash lookup.

### Testing

`npm test` passes (1023 tests). No new tests here, the existing subject queries cover the shape of the result.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Optimizes coordinate merging for meeting subjects while preserving result shape and ordering.
- Collects location IDs in one pass with `flatMap`.
- Builds a location-ID map for constant-time coordinate lookup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/db/subject.ts | Replaces nested coordinate scans with primary-key map lookups without changing observable behavior. |

<sub>Reviews (4): Last reviewed commit: ["perf: use Map lookup for coordinate merg..."](https://github.com/schemalabz/opencouncil/commit/53b5706c32019f1043e63830746695956e8839de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46688173)</sub>

<!-- /greptile_comment -->