### PR TITLE
perf(transcript): memoize hot paths in the meeting transcript UI

### DIFF
--- a/src/components/meetings/CouncilMeetingDataContext.tsx
+++ b/src/components/meetings/CouncilMeetingDataContext.tsx
@@ -8,6 +8,7 @@ import { Transcript } from '@/lib/db/transcript';
 import { MeetingData } from '@/lib/getMeetingData';
 import { PersonWithRelations } from '@/lib/db/people';
 import { getPartyFromRoles } from "@/lib/utils";
+import { getTimestampBounds } from '@/lib/utils/timestamps';
 import type { HighlightWithUtterances } from '@/lib/db/highlights';
 
 // Actions are mutations + getters that don't depend on transcript identity.
@@ -70,12 +71,7 @@ export function CouncilMeetingDataProvider({ children, data }: {
     const meetingId = data.meeting.id;
 
     const recalculateSegmentTimestamps = useCallback((utterances: Array<{ startTimestamp: number; endTimestamp: number }>) => {
-        if (utterances.length === 0) return null;
-        const allTimestamps = utterances.flatMap(u => [u.startTimestamp, u.endTimestamp]);
-        return {
-            startTimestamp: Math.min(...allTimestamps),
-            endTimestamp: Math.max(...allTimestamps)
-        };
+        return getTimestampBounds(utterances);
     }, []);
 
     const addHighlight = useCallback((highlight: HighlightWithUtterances) => {

--- a/src/components/meetings/TranscriptControls.tsx
+++ b/src/components/meetings/TranscriptControls.tsx
@@ -6,7 +6,7 @@ import { cn, formatTimestamp, getPartyFromRoles } from "@/lib/utils";
 import { useCouncilMeetingData } from "./CouncilMeetingDataContext";
 import { useTranscriptOptions } from "./options/OptionsContext";
 import { useHighlight } from "./HighlightContext";
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { Video } from "./Video";
 
 export default function TranscriptControls({ className }: { className?: string }) {
@@ -139,21 +139,22 @@ export default function TranscriptControls({ className }: { className?: string }
         setHoveredSpeaker(null);
     };
 
-    // Find current speaker
-    const currentSpeaker = (() => {
+    // Find current speaker. Memoized so unrelated re-renders (hover, touch,
+    // expand state) don't rescan all segments — only time/data changes do.
+    const currentSpeaker = useMemo(() => {
         for (const segment of speakerSegments) {
             if (currentTime >= segment.startTimestamp && currentTime <= segment.endTimestamp) {
                 const speakerTag = getSpeakerTag(segment.speakerTagId);
                 const person = speakerTag?.personId ? getPerson(speakerTag.personId) : undefined;
                 const party = person ? getPartyFromRoles(person.roles, meetingDate) : null;
-                let speakerColor = party?.colorHex || '#D3D3D3';
-                let speakerName = person ? person.name_short : speakerTag?.label || 'Unknown';
+                const speakerColor = party?.colorHex || '#D3D3D3';
+                const speakerName = person ? person.name_short : speakerTag?.label || 'Unknown';
 
                 return { name: speakerName, color: speakerColor };
             }
         }
         return null;
-    })();
+    }, [currentTime, speakerSegments, getSpeakerTag, getPerson, meetingDate]);
 
     // Calculate tooltip position
     const getTooltipPosition = () => {

--- a/src/components/meetings/TranscriptControls.tsx
+++ b/src/components/meetings/TranscriptControls.tsx
@@ -6,7 +6,7 @@ import { cn, formatTimestamp, getPartyFromRoles } from "@/lib/utils";
 import { useCouncilMeetingData } from "./CouncilMeetingDataContext";
 import { useTranscriptOptions } from "./options/OptionsContext";
 import { useHighlight } from "./HighlightContext";
-import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { Video } from "./Video";
 
 export default function TranscriptControls({ className }: { className?: string }) {
@@ -138,23 +138,6 @@ export default function TranscriptControls({ className }: { className?: string }
         setHoverTime(null);
         setHoveredSpeaker(null);
     };
-
-    // Find current speaker. Memoized so unrelated re-renders (hover, touch,
-    // expand state) don't rescan all segments — only time/data changes do.
-    const currentSpeaker = useMemo(() => {
-        for (const segment of speakerSegments) {
-            if (currentTime >= segment.startTimestamp && currentTime <= segment.endTimestamp) {
-                const speakerTag = getSpeakerTag(segment.speakerTagId);
-                const person = speakerTag?.personId ? getPerson(speakerTag.personId) : undefined;
-                const party = person ? getPartyFromRoles(person.roles, meetingDate) : null;
-                const speakerColor = party?.colorHex || '#D3D3D3';
-                const speakerName = person ? person.name_short : speakerTag?.label || 'Unknown';
-
-                return { name: speakerName, color: speakerColor };
-            }
-        }
-        return null;
-    }, [currentTime, speakerSegments, getSpeakerTag, getPerson, meetingDate]);
 
     // Calculate tooltip position
     const getTooltipPosition = () => {

--- a/src/lib/utils/__tests__/timestamps.test.ts
+++ b/src/lib/utils/__tests__/timestamps.test.ts
@@ -1,0 +1,43 @@
+import { getTimestampBounds } from '../timestamps';
+
+describe('getTimestampBounds', () => {
+    it('returns null for empty input', () => {
+        expect(getTimestampBounds([])).toBeNull();
+    });
+
+    it('returns bounds for a single utterance', () => {
+        expect(getTimestampBounds([{ startTimestamp: 5, endTimestamp: 10 }])).toEqual({
+            startTimestamp: 5,
+            endTimestamp: 10,
+        });
+    });
+
+    it('returns bounds across unsorted utterances', () => {
+        const utterances = [
+            { startTimestamp: 20, endTimestamp: 30 },
+            { startTimestamp: 5, endTimestamp: 12 },
+            { startTimestamp: 8, endTimestamp: 40 },
+        ];
+        expect(getTimestampBounds(utterances)).toEqual({ startTimestamp: 5, endTimestamp: 40 });
+    });
+
+    it('propagates NaN like Math.min/Math.max', () => {
+        const bounds = getTimestampBounds([
+            { startTimestamp: 1, endTimestamp: NaN },
+            { startTimestamp: 3, endTimestamp: 4 },
+        ]);
+        expect(bounds?.startTimestamp).toBeNaN();
+        expect(bounds?.endTimestamp).toBeNaN();
+    });
+
+    it('handles very large inputs without exceeding the argument limit', () => {
+        const utterances = Array.from({ length: 250_000 }, (_, i) => ({
+            startTimestamp: i + 1,
+            endTimestamp: i + 1.5,
+        }));
+        expect(getTimestampBounds(utterances)).toEqual({
+            startTimestamp: 1,
+            endTimestamp: 250_000.5,
+        });
+    });
+});

--- a/src/lib/utils/timestamps.ts
+++ b/src/lib/utils/timestamps.ts
@@ -1,0 +1,19 @@
+/**
+ * Compute the min start / max end timestamps across a set of utterances.
+ *
+ * Uses a single loop instead of `Math.min(...timestamps)` so that very large
+ * transcripts don't exceed the engine's argument-count limit (stack overflow).
+ */
+export function getTimestampBounds(
+    utterances: Array<{ startTimestamp: number; endTimestamp: number }>
+): { startTimestamp: number; endTimestamp: number } | null {
+    if (utterances.length === 0) return null;
+
+    let min = Infinity;
+    let max = -Infinity;
+    for (const u of utterances) {
+        min = Math.min(min, u.startTimestamp, u.endTimestamp);
+        max = Math.max(max, u.startTimestamp, u.endTimestamp);
+    }
+    return { startTimestamp: min, endTimestamp: max };
+}


### PR DESCRIPTION
Part of #242.

Two hot paths on the meeting transcript page.

`getTimestampBounds` used `Math.min(...timestamps)` / `Math.max(...)`. On a long meeting that spreads thousands of arguments onto the stack every time it runs, and past roughly 100k entries it throws instead of returning a number. It moved to `src/lib/utils/timestamps.ts` as a plain loop. Tests cover the empty array, a single utterance, unsorted input, NaN propagation (so it keeps matching `Math.min`/`Math.max` semantics), and a 250k-utterance array that the spread version could not handle.

`TranscriptControls` rescanned every speaker segment on each render to compute `currentSpeaker`. That value turned out to be dead: nothing renders it, and the hover tooltip reads `hoveredSpeaker`, which is maintained separately by the mouse and touch handlers. So it is deleted rather than memoized. Thanks to Greptile for catching that the first version of this PR memoized a computation that nobody consumed.

### Testing

`npm test` passes (1028 tests, 5 new). Typecheck clean.

Unrelated note: `utils.test.ts` has a flaky case, `klitiki > should handle mixed casing`, that failed once across my runs on both this branch and `main` and passes on re-run. It is untouched by this PR.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes an unused transcript speaker scan and adds a stack-safe timestamp bounds utility.
- Replaces timestamp array expansion with a single-pass bounds calculation.
- Adds timestamp utility tests for empty, unsorted, invalid, and large inputs.
- Removes the unused `currentSpeaker` calculation from `TranscriptControls`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/meetings/CouncilMeetingDataContext.tsx | Replaces the inline timestamp bounds calculation with the shared utility. |
| src/components/meetings/TranscriptControls.tsx | Removes the unused current-speaker calculation without affecting the separate hover and touch tooltip path. |
| src/lib/utils/timestamps.ts | Adds a single-pass timestamp bounds calculation that avoids argument-count limits. |
| src/lib/utils/__tests__/timestamps.test.ts | Tests the timestamp utility across empty, unsorted, invalid, and large inputs. |

<sub>Reviews (5): Last reviewed commit: ["refactor(transcript): drop unused curren..."](https://github.com/schemalabz/opencouncil/commit/aceff47b734f6c4a1574eaf6b0889db88cfb71f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46688183)</sub>

<!-- /greptile_comment -->