### PR TITLE
perf(list): memoize filtering and add sizes to the CityCard image

### DIFF
--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect, useRef } from 'react';
+import React, { useCallback, useMemo, useState, useEffect, useRef } from 'react';
 import { useSearchParams } from 'next/navigation';
 import FormSheet from './FormSheet';
 import { Search, ChevronLeft, ChevronRight } from "lucide-react";
@@ -39,6 +39,10 @@ interface ListProps<T, P = {}, F = string | undefined> extends BaseListProps {
     renderAfterFilters?: React.ReactNode | ((selectedValues: F[]) => React.ReactNode);
 }
 
+// Stable default so an absent `filterAvailableValues` prop doesn't produce a
+// fresh array identity on every render (which would defeat memoization below).
+const EMPTY_FILTER_VALUES: never[] = [];
+
 export default function List<T extends { id: string }, P = {}, F = string | undefined>({
     items,
     editable,
@@ -47,7 +51,7 @@ export default function List<T extends { id: string }, P = {}, F = string | unde
     formProps,
     t,
     itemProps,
-    filterAvailableValues = [],
+    filterAvailableValues = EMPTY_FILTER_VALUES,
     filter,
     smColumns = 1,
     mdColumns = 2,
@@ -69,8 +73,7 @@ export default function List<T extends { id: string }, P = {}, F = string | unde
     // Get filter and search values from URL
     const searchQuery = searchParams.get('search') || '';
     const rawFilters = searchParams.get('filters');
-    const explicitlyAll = rawFilters === '*';
-    const selectedFilterLabels = explicitlyAll ? [] : (rawFilters?.split(',').filter(Boolean) || []);
+    const hasRenderFilter = !!renderFilter;
 
     // Local state for search input
     const [localSearchQuery, setLocalSearchQuery] = useState(searchQuery);
@@ -88,13 +91,17 @@ export default function List<T extends { id: string }, P = {}, F = string | unde
     // - URL has specific labels → use those
     // - URL has '*' → explicitly all (empty array = no filtering)
     // - URL has nothing → use defaultFilterValues if provided, otherwise all
-    const selectedFilters = selectedFilterLabels.length > 0
-        ? selectedFilterLabels.map(label =>
-            filterAvailableValues.find(f => f.label === label)?.value
-        ).filter((value): value is F => value !== undefined)
-        : explicitlyAll
-            ? [] as F[]
-            : (defaultFilterValues || (renderFilter ? [] as F[] : filterAvailableValues.map(f => f.value)));
+    const selectedFilters = useMemo(() => {
+        const explicitlyAll = rawFilters === '*';
+        const selectedFilterLabels = explicitlyAll ? [] : (rawFilters?.split(',').filter(Boolean) || []);
+        return selectedFilterLabels.length > 0
+            ? selectedFilterLabels.map(label =>
+                filterAvailableValues.find(f => f.label === label)?.value
+            ).filter((value): value is F => value !== undefined)
+            : explicitlyAll
+                ? [] as F[]
+                : (defaultFilterValues || (hasRenderFilter ? [] as F[] : filterAvailableValues.map(f => f.value)));
+    }, [rawFilters, filterAvailableValues, defaultFilterValues, hasRenderFilter]);
 
     const scrollCarouselLeft = useCallback(() => {
         if (carouselRef.current) {
@@ -126,7 +133,7 @@ export default function List<T extends { id: string }, P = {}, F = string | unde
         layout === 'carousel' && `w-[${carouselItemWidth}px]`
     );
 
-    const filteredItems = items.filter((item) => {
+    const filteredItems = useMemo(() => items.filter((item) => {
         // First check search query
         if (searchQuery && showSearch) {
             const normalizedQuery = normalizeText(searchQuery);
@@ -145,7 +152,7 @@ export default function List<T extends { id: string }, P = {}, F = string | unde
         }
 
         return true;
-    });
+    }), [items, searchQuery, showSearch, filter, selectedFilters]);
 
     // Client-side pagination — read current page from URL to avoid
     // depending on server component re-renders for page changes.

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect, useRef } from 'react';
+import React, { useCallback, useMemo, useState, useEffect, useRef } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import FormSheet from './FormSheet';
@@ -40,6 +40,10 @@ interface ListProps<T, P = {}, F = string | undefined> extends BaseListProps {
     renderAfterFilters?: React.ReactNode | ((selectedValues: F[]) => React.ReactNode);
 }
 
+// Stable default so an absent `filterAvailableValues` prop doesn't produce a
+// fresh array identity on every render (which would defeat memoization below).
+const EMPTY_FILTER_VALUES: never[] = [];
+
 export default function List<T extends { id: string }, P = {}, F = string | undefined>({
     items,
     editable,
@@ -48,7 +52,7 @@ export default function List<T extends { id: string }, P = {}, F = string | unde
     formProps,
     t,
     itemProps,
-    filterAvailableValues = [],
+    filterAvailableValues = EMPTY_FILTER_VALUES,
     filter,
     smColumns = 1,
     mdColumns = 2,
@@ -71,8 +75,7 @@ export default function List<T extends { id: string }, P = {}, F = string | unde
     // Get filter and search values from URL
     const searchQuery = searchParams.get('search') || '';
     const rawFilters = searchParams.get('filters');
-    const explicitlyAll = rawFilters === '*';
-    const selectedFilterLabels = explicitlyAll ? [] : (rawFilters?.split(',').filter(Boolean) || []);
+    const hasRenderFilter = !!renderFilter;
 
     // Local state for search input
     const [localSearchQuery, setLocalSearchQuery] = useState(searchQuery);
@@ -90,13 +93,17 @@ export default function List<T extends { id: string }, P = {}, F = string | unde
     // - URL has specific labels → use those
     // - URL has '*' → explicitly all (empty array = no filtering)
     // - URL has nothing → use defaultFilterValues if provided, otherwise all
-    const selectedFilters = selectedFilterLabels.length > 0
-        ? selectedFilterLabels.map(label =>
-            filterAvailableValues.find(f => f.label === label)?.value
-        ).filter((value): value is F => value !== undefined)
-        : explicitlyAll
-            ? [] as F[]
-            : (defaultFilterValues || (renderFilter ? [] as F[] : filterAvailableValues.map(f => f.value)));
+    const selectedFilters = useMemo(() => {
+        const explicitlyAll = rawFilters === '*';
+        const selectedFilterLabels = explicitlyAll ? [] : (rawFilters?.split(',').filter(Boolean) || []);
+        return selectedFilterLabels.length > 0
+            ? selectedFilterLabels.map(label =>
+                filterAvailableValues.find(f => f.label === label)?.value
+            ).filter((value): value is F => value !== undefined)
+            : explicitlyAll
+                ? [] as F[]
+                : (defaultFilterValues || (hasRenderFilter ? [] as F[] : filterAvailableValues.map(f => f.value)));
+    }, [rawFilters, filterAvailableValues, defaultFilterValues, hasRenderFilter]);
 
     const scrollCarouselLeft = useCallback(() => {
         if (carouselRef.current) {
@@ -128,7 +135,7 @@ export default function List<T extends { id: string }, P = {}, F = string | unde
         layout === 'carousel' && `w-[${carouselItemWidth}px]`
     );
 
-    const filteredItems = items.filter((item) => {
+    const filteredItems = useMemo(() => items.filter((item) => {
         // First check search query
         if (searchQuery && showSearch) {
             const normalizedQuery = normalizeText(searchQuery);
@@ -147,7 +154,7 @@ export default function List<T extends { id: string }, P = {}, F = string | unde
         }
 
         return true;
-    });
+    }), [items, searchQuery, showSearch, filter, selectedFilters]);
 
     // Client-side pagination — read current page from URL to avoid
     // depending on server component re-renders for page changes.

--- a/src/components/PilotPage.tsx
+++ b/src/components/PilotPage.tsx
@@ -37,7 +37,13 @@ export default function PilotPage({ cities }: { cities: (City & { councilMeeting
                     </div>
                     <div className="flex flex-1 flex-col">
                         {cities.map((city) => (
-                            <CityCard key={city.id} city={city} />
+                            <CityCard
+                                key={city.id}
+                                city={city}
+                                // Cards stack full-width inside max-w-6xl below lg,
+                                // then sit in one of two columns above it.
+                                logoSizes="(max-width: 1024px) 50vw, (max-width: 1152px) 25vw, 288px"
+                            />
                         ))}
                     </div>
                 </div >

--- a/src/components/cities/CityCard.tsx
+++ b/src/components/cities/CityCard.tsx
@@ -8,11 +8,20 @@ import { useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { OfficialSupportBadge } from '@/components/cities/OfficialSupportBadge';
 
+// Matches CitiesList: 1 column below md, 2 up to lg, 3 above. The logo
+// occupies half the card, so each entry is half the card's width.
+const DEFAULT_LOGO_SIZES = '(max-width: 768px) 50vw, (max-width: 1024px) 25vw, 17vw';
+
 interface CityCardProps {
     city: City & { councilMeetings: CouncilMeeting[] };
+    /**
+     * Width of the logo slot per breakpoint. Override when the card is not in
+     * the CitiesList grid, otherwise Next picks a source for the wrong layout.
+     */
+    logoSizes?: string;
 }
 
-export function CityCard({ city }: CityCardProps) {
+export function CityCard({ city, logoSizes = DEFAULT_LOGO_SIZES }: CityCardProps) {
     let locale = useLocale();
     let localizedName = locale === 'en' ? city.name_en : city.name;
     const router = useRouter();
@@ -39,7 +48,7 @@ export function CityCard({ city }: CityCardProps) {
                                     src={city.logoImage || '/default-city-logo.jpg'}
                                     alt={`${localizedName} logo`}
                                     fill
-                                    sizes="(max-width: 768px) 50vw, (max-width: 1024px) 25vw, 17vw"
+                                    sizes={logoSizes}
                                     className="opacity-20 object-contain"
                                 />
                                 <div className="absolute inset-0 bg-gradient-to-l from-transparent to-background"></div>

--- a/src/components/cities/CityCard.tsx
+++ b/src/components/cities/CityCard.tsx
@@ -39,6 +39,7 @@ export function CityCard({ city }: CityCardProps) {
                                     src={city.logoImage || '/default-city-logo.jpg'}
                                     alt={`${localizedName} logo`}
                                     fill
+                                    sizes="(max-width: 768px) 50vw, (max-width: 1024px) 25vw, 17vw"
                                     className="opacity-20 object-contain"
                                 />
                                 <div className="absolute inset-0 bg-gradient-to-l from-transparent to-background"></div>

--- a/src/components/cities/CityCard.tsx
+++ b/src/components/cities/CityCard.tsx
@@ -40,6 +40,7 @@ export function CityCard({ city }: CityCardProps) {
                                     src={city.logoImage || '/default-city-logo.jpg'}
                                     alt={`${localizedName} logo`}
                                     fill
+                                    sizes="(max-width: 768px) 50vw, (max-width: 1024px) 25vw, 17vw"
                                     className="opacity-20 object-contain"
                                 />
                                 <div className="absolute inset-0 bg-gradient-to-l from-transparent to-background"></div>

--- a/src/components/cities/CityCard.tsx
+++ b/src/components/cities/CityCard.tsx
@@ -9,11 +9,20 @@ import { Loader2 } from 'lucide-react';
 import { OfficialSupportBadge } from '@/components/cities/OfficialSupportBadge';
 import { getLocalizedName } from '@/lib/formatters/name';
 
+// Matches CitiesList: 1 column below md, 2 up to lg, 3 above. The logo
+// occupies half the card, so each entry is half the card's width.
+const DEFAULT_LOGO_SIZES = '(max-width: 768px) 50vw, (max-width: 1024px) 25vw, 17vw';
+
 interface CityCardProps {
     city: City & { councilMeetings: CouncilMeeting[] };
+    /**
+     * Width of the logo slot per breakpoint. Override when the card is not in
+     * the CitiesList grid, otherwise Next picks a source for the wrong layout.
+     */
+    logoSizes?: string;
 }
 
-export function CityCard({ city }: CityCardProps) {
+export function CityCard({ city, logoSizes = DEFAULT_LOGO_SIZES }: CityCardProps) {
     let locale = useLocale();
     let localizedName = getLocalizedName(city, locale);
     const router = useRouter();
@@ -40,7 +49,7 @@ export function CityCard({ city }: CityCardProps) {
                                     src={city.logoImage || '/default-city-logo.jpg'}
                                     alt={`${localizedName} logo`}
                                     fill
-                                    sizes="(max-width: 768px) 50vw, (max-width: 1024px) 25vw, 17vw"
+                                    sizes={logoSizes}
                                     className="opacity-20 object-contain"
                                 />
                                 <div className="absolute inset-0 bg-gradient-to-l from-transparent to-background"></div>

--- a/src/components/cities/CityMeetings.tsx
+++ b/src/components/cities/CityMeetings.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useTranslations } from 'next-intl';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { AdministrativeBodyType } from '@prisma/client';
 import List from '@/components/List';
@@ -65,6 +65,22 @@ export default function CityMeetings({
         return null;
     }, [searchParams, councilMeetings, typeOptions]);
 
+    // Stable identity, otherwise List's filteredItems memo is invalidated on
+    // every render of this component.
+    const filterMeeting = useCallback(
+        (selectedValues: AdministrativeBodyType[], meeting: CouncilMeetingWithAdminBodyAndSubjects) => {
+            if (!filterMeetingByAdminBodyTypes(meeting, selectedValues)) return false;
+            if (resolvedBodyId) {
+                const selectedType = selectedValues.length === 1 ? selectedValues[0] : null;
+                if (selectedType && selectedType !== 'council') {
+                    return meeting.administrativeBody?.id === resolvedBodyId;
+                }
+            }
+            return true;
+        },
+        [resolvedBodyId]
+    );
+
     return (
         <List<CouncilMeetingWithAdminBodyAndSubjects, { cityTimezone: string }, AdministrativeBodyType>
             items={councilMeetings}
@@ -75,16 +91,7 @@ export default function CityMeetings({
             formProps={{ cityId }}
             t={t}
             filterAvailableValues={typeOptions}
-            filter={(selectedValues, meeting) => {
-                if (!filterMeetingByAdminBodyTypes(meeting, selectedValues)) return false;
-                if (resolvedBodyId) {
-                    const selectedType = selectedValues.length === 1 ? selectedValues[0] : null;
-                    if (selectedType && selectedType !== 'council') {
-                        return meeting.administrativeBody?.id === resolvedBodyId;
-                    }
-                }
-                return true;
-            }}
+            filter={filterMeeting}
             defaultFilterValues={defaultFilterValues}
             renderFilter={({ selectedValues, onChange }) => {
                 const selectedType = selectedValues.length === 1 ? selectedValues[0] : null;

--- a/src/components/cities/CityPeople.tsx
+++ b/src/components/cities/CityPeople.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSearchParams } from 'next/navigation';
 import { AdministrativeBody, AdministrativeBodyType } from '@prisma/client'
@@ -67,6 +67,22 @@ export default function CityPeople({
         return null;
     }, [searchParams, allPeople, typeOptions]);
 
+    // Stable identity, otherwise List's filteredItems memo is invalidated on
+    // every render of this component.
+    const filterPerson = useCallback(
+        (selectedValues: AdministrativeBodyType[], person: PersonWithRelations) => {
+            if (!filterPersonByAdminBodyTypes(person, selectedValues)) return false;
+            if (resolvedBodyId) {
+                const selectedType = selectedValues.length === 1 ? selectedValues[0] : null;
+                if (selectedType && selectedType !== 'council') {
+                    return person.roles.some(r => r.administrativeBodyId === resolvedBodyId);
+                }
+            }
+            return true;
+        },
+        [resolvedBodyId]
+    );
+
     return (
         <List<PersonWithRelations, Record<string, never>, AdministrativeBodyType>
             items={orderedPersons}
@@ -76,16 +92,7 @@ export default function CityPeople({
             formProps={{ cityId, parties, administrativeBodies }}
             t={t}
             filterAvailableValues={typeOptions}
-            filter={(selectedValues, person) => {
-                if (!filterPersonByAdminBodyTypes(person, selectedValues)) return false;
-                if (resolvedBodyId) {
-                    const selectedType = selectedValues.length === 1 ? selectedValues[0] : null;
-                    if (selectedType && selectedType !== 'council') {
-                        return person.roles.some(r => r.administrativeBodyId === resolvedBodyId);
-                    }
-                }
-                return true;
-            }}
+            filter={filterPerson}
             defaultFilterValues={defaultFilterValues}
             renderFilter={({ selectedValues, onChange }) => {
                 if (typeOptions.length <= 1) return null;


### PR DESCRIPTION
Part of #242.

`List` recomputed `selectedFilters` and `filteredItems` on every render, including renders that had nothing to do with the filters. Both are memoized now. `filterAvailableValues` also gets a stable default object, otherwise the fresh `{}` literal on each render would invalidate the memo immediately.

That is only half of it: `CityPeople` and `CityMeetings` passed inline arrow functions as `List`'s `filter` prop, so the prop identity changed on every parent render and the new memo would have been invalidated anyway. Both callbacks are `useCallback`ed on `resolvedBodyId`, which is the only value they close over.

Separately, the `CityCard` image uses `fill` without a `sizes` prop, so Next.js assumes `100vw` and picks a source much wider than the card is ever rendered. `sizes` is now a prop that defaults to the `CitiesList` grid geometry. `PilotPage` passes its own, because cards stack to the full container width there below `lg` and the shared default would have understated the slot by half.

### Testing

`npm test` passes (1023 tests). Typecheck clean.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Memoizes list filtering and selected-filter derivation, stabilizes city meeting and people filter callbacks, and adds layout-aware responsive sizing metadata to city-card images.
- Uses `useMemo` to avoid unnecessary filter recomputation.
- Uses `useCallback` for stable meeting and person filter identities.
- Adds a configurable `logoSizes` prop with defaults for the cities grid and a PilotPage override.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/List.tsx | Memoizes selected filters and filtered items while providing a stable default filter-values array. |
| src/components/cities/CityMeetings.tsx | Stabilizes the existing meeting filter callback without changing its filtering behavior. |
| src/components/cities/CityPeople.tsx | Stabilizes the existing people filter callback without changing its filtering behavior. |
| src/components/cities/CityCard.tsx | Adds responsive image sizing metadata configurable by each card layout. |
| src/components/PilotPage.tsx | Supplies CityCard image sizing metadata tailored to the page’s responsive layout. |

<sub>Reviews (5): Last reviewed commit: ["perf(list): stabilize filter callbacks a..."](https://github.com/schemalabz/opencouncil/commit/db972e8ffacb2e0c94b965346d10ab392014a954) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46688201)</sub>

<!-- /greptile_comment -->