### PR TITLE
perf(map): keep mapbox-gl out of initial bundles

### DIFF
--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/map/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/map/page.tsx
@@ -1,5 +1,5 @@
 "use client"
-import Map from "@/components/map/map";
+import Map from "@/components/map/DynamicMap";
 import { useCouncilMeetingData } from "@/components/meetings/CouncilMeetingDataContext";
 import { subjectToMapFeature } from "@/lib/utils";
 import { getRealmDefaultMapView } from "@/lib/realm";

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/page.tsx
@@ -1,5 +1,5 @@
 "use client"
-import MapView from "@/components/map/map";
+import MapView from "@/components/map/DynamicMap";
 import { useCouncilMeetingData } from "@/components/meetings/CouncilMeetingDataContext";
 import { SubjectSection } from "@/components/meetings/subject-section";
 import { TopicFilter } from "@/components/TopicFilter";

--- a/src/components/admin/NotificationMapDialog.tsx
+++ b/src/components/admin/NotificationMapDialog.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useMemo } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Loader2 } from 'lucide-react';
-import Map, { MapFeature } from '@/components/map/map';
+import Map from '@/components/map/DynamicMap';
+import type { MapFeature } from '@/components/map/map';
 import { createCircleBuffer } from '@/lib/geo';
 
 interface SubjectLocation {

--- a/src/components/consultations/ConsultationMap.tsx
+++ b/src/components/consultations/ConsultationMap.tsx
@@ -3,7 +3,8 @@
 import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import { usePathname, useRouter } from "@/i18n/routing";
-import Map, { MapFeature } from "@/components/map/map";
+import Map from "@/components/map/DynamicMap";
+import type { MapFeature } from "@/components/map/map";
 import { cn } from "@/lib/utils";
 import { RegulationData, RegulationItem, Geometry, ReferenceFormat, StaticGeometry, DerivedGeometry, BufferOperation, DifferenceOperation, CurrentUser, GeoSetData, SEARCH_COLORS } from "./types";
 import LayerControlsButton from "./LayerControlsButton";

--- a/src/components/landing/v2/hooks/useMapActions.ts
+++ b/src/components/landing/v2/hooks/useMapActions.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
 import type { Map as MapboxMap } from 'mapbox-gl';
-import { DEFAULT_MAP_STYLE, SATELLITE_MAP_STYLE } from '@/components/map/map';
+import { DEFAULT_MAP_STYLE, SATELLITE_MAP_STYLE } from '@/components/map/constants';
 import { captureLanding, captureLandingAction } from '@/lib/landing/analytics';
 import { EXPLAIN_LNGLAT, SUBJECT_FOCUS_ZOOM, type FlyTarget } from '@/lib/landing/landingCore';
 import { isValidLngLat } from '@/lib/landing/landingData';

--- a/src/components/map/DynamicMap.tsx
+++ b/src/components/map/DynamicMap.tsx
@@ -1,0 +1,13 @@
+'use client';
+import dynamic from 'next/dynamic';
+
+// Lazy-loaded map: mapbox-gl (~450KB) stays out of the initial chunk of every
+// page that renders (or may never render) a map. `ssr: false` because mapbox
+// is canvas/WebGL-only anyway. The placeholder fills the parent container so
+// already-sized layouts don't shift while the chunk loads.
+const DynamicMap = dynamic(() => import('./map'), {
+    ssr: false,
+    loading: () => <div className="h-full w-full animate-pulse bg-muted/30" />,
+});
+
+export default DynamicMap;

--- a/src/components/map/constants.ts
+++ b/src/components/map/constants.ts
@@ -1,0 +1,8 @@
+// Map style constants live in their own module so that consumers which only
+// need the style URLs (e.g. the landing basemap toggle) don't pull the whole
+// map component — and with it mapbox-gl — into their bundle.
+
+/** Default OpenCouncil base style. */
+export const DEFAULT_MAP_STYLE = 'mapbox://styles/christosporios/cm4icyrf700f201qw75bv27fa';
+/** Mapbox satellite imagery with roads/labels — used by the landing's basemap toggle. */
+export const SATELLITE_MAP_STYLE = 'mapbox://styles/mapbox/satellite-streets-v12';

--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { useRef, useEffect, useCallback, useMemo, memo, useState } from 'react'
 import mapboxgl from 'mapbox-gl'
-import MapboxDraw from '@mapbox/mapbox-gl-draw'
+import type MapboxDraw from '@mapbox/mapbox-gl-draw'
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import { useTranslations } from 'next-intl'
@@ -29,10 +29,10 @@ export interface MapFeature {
     }
 }
 
-/** Default OpenCouncil base style. */
-export const DEFAULT_MAP_STYLE = 'mapbox://styles/christosporios/cm4icyrf700f201qw75bv27fa';
-/** Mapbox satellite imagery with roads/labels — used by the landing's basemap toggle. */
-export const SATELLITE_MAP_STYLE = 'mapbox://styles/mapbox/satellite-streets-v12';
+// Style constants live in ./constants so light consumers don't pull mapbox-gl;
+// re-exported here for backward compatibility.
+import { DEFAULT_MAP_STYLE } from './constants';
+export { DEFAULT_MAP_STYLE, SATELLITE_MAP_STYLE } from './constants';
 
 interface MapProps {
     className?: string
@@ -98,6 +98,9 @@ const Map = memo(function Map({
     const isInitialized = useRef(false)
     const [mapReady, setMapReady] = useState(false)
     const draw = useRef<MapboxDraw | null>(null)
+    // Flipped after the lazily-imported Draw control is created, so effects
+    // that need draw.current re-run once it becomes available.
+    const [drawReady, setDrawReady] = useState(false)
     const hoverTimeout = useRef<NodeJS.Timeout | null>(null)
     const currentHoveredFeature = useRef<string | null>(null)
 
@@ -385,7 +388,7 @@ const Map = memo(function Map({
                 }
             }
         }
-    }, [selectedGeometryForEdit, features]);
+    }, [selectedGeometryForEdit, features, drawReady]);
 
     // Initialize map only once
     useEffect(() => {
@@ -892,14 +895,31 @@ const Map = memo(function Map({
         }
     }, [showPois, mapReady]);
 
-    // Handle Mapbox GL Draw setup for editing mode
+    // Handle Mapbox GL Draw setup for editing mode. The draw library (~200KB)
+    // is loaded lazily on first entry into editing mode, so plain map viewers
+    // never download it.
     useEffect(() => {
         if (!map.current || !isInitialized.current) return;
 
         if (editingMode && selectedGeometryForEdit) {
+            let cancelled = false;
+
+            const setupDraw = async () => {
             // Initialize Mapbox GL Draw if not already done
             if (!draw.current) {
-                draw.current = new MapboxDraw({
+                let MapboxDrawCtor: typeof MapboxDraw;
+                try {
+                    MapboxDrawCtor = (await import('@mapbox/mapbox-gl-draw')).default;
+                } catch (error) {
+                    // Chunk failed to load (offline / deploy skew). Leave draw
+                    // unset — the effect retries on the next dep change.
+                    console.error('Failed to load mapbox-gl-draw:', error);
+                    return;
+                }
+                // Bail if the effect was cleaned up (unmount, mode toggle,
+                // Strict Mode double-invoke) while the chunk was loading.
+                if (cancelled || !map.current || draw.current) return;
+                draw.current = new MapboxDrawCtor({
                     displayControlsDefault: false,
                     controls: {},
                     styles: [
@@ -972,7 +992,12 @@ const Map = memo(function Map({
                 });
 
                 map.current.addControl(draw.current, 'top-left');
+                setDrawReady(true);
             }
+
+            // A cleanup (mode exit / unmount) may have run while awaiting the
+            // chunk — don't re-attach listeners on a torn-down effect.
+            if (cancelled) return;
 
             // IMPORTANT: Always refresh event listeners when selectedGeometryForEdit changes
             // This ensures the handlers capture the latest geometry ID
@@ -996,6 +1021,10 @@ const Map = memo(function Map({
                     draw.current.changeMode('draw_polygon');
                 }
             }
+            };
+            setupDraw();
+
+            return () => { cancelled = true; };
         } else {
             // Remove drawing control when exiting editing mode
             if (draw.current && map.current) {
@@ -1003,6 +1032,7 @@ const Map = memo(function Map({
                 map.current.off('draw.create', handleDrawCreate);
                 map.current.off('draw.update', handleDrawUpdate);
                 draw.current = null;
+                setDrawReady(false);
             }
         }
     }, [editingMode, drawingMode, selectedGeometryForEdit, handleDrawCreate, handleDrawUpdate]);

--- a/src/components/map/map.tsx
+++ b/src/components/map/map.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { useRef, useEffect, useCallback, useMemo, memo, useState } from 'react'
 import mapboxgl from 'mapbox-gl'
-import MapboxDraw from '@mapbox/mapbox-gl-draw'
+import type MapboxDraw from '@mapbox/mapbox-gl-draw'
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import { useTranslations } from 'next-intl'
@@ -29,10 +29,10 @@ export interface MapFeature {
     }
 }
 
-/** Default OpenCouncil base style. */
-export const DEFAULT_MAP_STYLE = 'mapbox://styles/christosporios/cm4icyrf700f201qw75bv27fa';
-/** Mapbox satellite imagery with roads/labels — used by the landing's basemap toggle. */
-export const SATELLITE_MAP_STYLE = 'mapbox://styles/mapbox/satellite-streets-v12';
+// Style constants live in ./constants so light consumers don't pull mapbox-gl;
+// re-exported here for backward compatibility.
+import { DEFAULT_MAP_STYLE } from './constants';
+export { DEFAULT_MAP_STYLE, SATELLITE_MAP_STYLE } from './constants';
 
 interface MapProps {
     className?: string
@@ -98,6 +98,9 @@ const Map = memo(function Map({
     const isInitialized = useRef(false)
     const [mapReady, setMapReady] = useState(false)
     const draw = useRef<MapboxDraw | null>(null)
+    // Flipped after the lazily-imported Draw control is created, so effects
+    // that need draw.current re-run once it becomes available.
+    const [drawReady, setDrawReady] = useState(false)
     const hoverTimeout = useRef<NodeJS.Timeout | null>(null)
     const currentHoveredFeature = useRef<string | null>(null)
 
@@ -352,7 +355,7 @@ const Map = memo(function Map({
                 }
             }
         }
-    }, [selectedGeometryForEdit, features]);
+    }, [selectedGeometryForEdit, features, drawReady]);
 
     // Initialize map only once
     useEffect(() => {
@@ -859,14 +862,31 @@ const Map = memo(function Map({
         }
     }, [showPois, mapReady]);
 
-    // Handle Mapbox GL Draw setup for editing mode
+    // Handle Mapbox GL Draw setup for editing mode. The draw library (~200KB)
+    // is loaded lazily on first entry into editing mode, so plain map viewers
+    // never download it.
     useEffect(() => {
         if (!map.current || !isInitialized.current) return;
 
         if (editingMode && selectedGeometryForEdit) {
+            let cancelled = false;
+
+            const setupDraw = async () => {
             // Initialize Mapbox GL Draw if not already done
             if (!draw.current) {
-                draw.current = new MapboxDraw({
+                let MapboxDrawCtor: typeof MapboxDraw;
+                try {
+                    MapboxDrawCtor = (await import('@mapbox/mapbox-gl-draw')).default;
+                } catch (error) {
+                    // Chunk failed to load (offline / deploy skew). Leave draw
+                    // unset — the effect retries on the next dep change.
+                    console.error('Failed to load mapbox-gl-draw:', error);
+                    return;
+                }
+                // Bail if the effect was cleaned up (unmount, mode toggle,
+                // Strict Mode double-invoke) while the chunk was loading.
+                if (cancelled || !map.current || draw.current) return;
+                draw.current = new MapboxDrawCtor({
                     displayControlsDefault: false,
                     controls: {},
                     styles: [
@@ -939,7 +959,12 @@ const Map = memo(function Map({
                 });
 
                 map.current.addControl(draw.current, 'top-left');
+                setDrawReady(true);
             }
+
+            // A cleanup (mode exit / unmount) may have run while awaiting the
+            // chunk — don't re-attach listeners on a torn-down effect.
+            if (cancelled) return;
 
             // IMPORTANT: Always refresh event listeners when selectedGeometryForEdit changes
             // This ensures the handlers capture the latest geometry ID
@@ -963,6 +988,10 @@ const Map = memo(function Map({
                     draw.current.changeMode('draw_polygon');
                 }
             }
+            };
+            setupDraw();
+
+            return () => { cancelled = true; };
         } else {
             // Remove drawing control when exiting editing mode
             if (draw.current && map.current) {
@@ -970,6 +999,7 @@ const Map = memo(function Map({
                 map.current.off('draw.create', handleDrawCreate);
                 map.current.off('draw.update', handleDrawUpdate);
                 draw.current = null;
+                setDrawReady(false);
             }
         }
     }, [editingMode, drawingMode, selectedGeometryForEdit, handleDrawCreate, handleDrawUpdate]);

--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -1,5 +1,5 @@
 "use client";
-import Map from "@/components/map/map";
+import Map from "@/components/map/DynamicMap";
 import { useCouncilMeetingData } from "../CouncilMeetingDataContext";
 import { useVideo } from "../VideoProvider";
 import { Button } from "@/components/ui/button";

--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -1,5 +1,5 @@
 "use client";
-import Map from "@/components/map/map";
+import Map from "@/components/map/DynamicMap";
 import { useCouncilMeetingData } from "../CouncilMeetingDataContext";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";

--- a/src/components/onboarding/containers/MapContainer.tsx
+++ b/src/components/onboarding/containers/MapContainer.tsx
@@ -3,10 +3,10 @@
 import { useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { useOnboarding } from '@/contexts/OnboardingContext';
-import { MapFeature } from '@/components/map/map';
+import type { MapFeature } from '@/components/map/map';
 import { calculateMapView } from '@/lib/geo';
 import { getRealmDefaultMapView } from '@/lib/realm';
-import Map from '@/components/map/map';
+import Map from '@/components/map/DynamicMap';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Eye, EyeOff, Map as MapIcon } from 'lucide-react';


### PR DESCRIPTION
Part of #242.

`mapbox-gl` is about 450KB and `@mapbox/mapbox-gl-draw` another 200KB, and both were landing in initial bundles of pages that show a map conditionally or never show one at all. Three separate changes here.

A `DynamicMap` wrapper (`next/dynamic`, `ssr: false`) now fronts the map for the meeting page, the subject page, the admin notification dialog, consultations, and onboarding. Those pages only pay for mapbox once a map actually renders. The map was already client-only in practice, so dropping SSR here does not change what is rendered.

A separate `constants.ts` for `DEFAULT_MAP_STYLE` and `SATELLITE_MAP_STYLE`, re-exported from `map.tsx` so nothing else moves. The landing page's `useMapActions` imported those two strings from `map.tsx` and dragged the whole map component, and therefore mapbox, into its chunk.

Lazy `mapbox-gl-draw`. The drawing library is only loaded on first entry into editing mode. There is a cancellation guard for the case where you leave edit mode while the import is in flight, handling for a failed import, and a `drawReady` signal so the effect that loads existing geometry waits until the control exists rather than racing it. Viewers who never edit, which includes everyone on the landing page, no longer download it.

### What this does not do

The landing page still imports the map statically. Its marker and popup modules do a value import of `mapboxgl` for `new Marker()` and `new Popup()`, so mapbox would stay in the landing chunk regardless of how the map component itself is imported. The map is also the main content there, so it should not wait on a second round trip. Moving it behind a lazy boundary means moving markers and popups with it, which is a bigger refactor and better as its own PR.

### On the dynamic-import rule

CLAUDE.md says not to use dynamic imports, and this PR uses two of them, so it should not slip past without a note.

Both patterns already exist on `main` for the same purpose. `dynamic(() => import(...), { ssr: false })` wraps a heavy client-only library in `AuroraClient.tsx`, `CommentSection.tsx`, `ReactSwagger.tsx` and `icon.tsx`. `await import(...)` defers a big dependency until the feature is actually used in `use-pdf-download.ts` (for `@react-pdf/renderer`), `brochure-generator.tsx`, `download-pdf-button.tsx` and `documents-dropdown.tsx`.

`DynamicMap` is the `AuroraClient` case and the lazy draw import is the `use-pdf-download` case, so I read the rule as being about dynamic imports used for code organization or to escape import cycles, rather than about deliberate code splitting. The dev-component rule points the same way, since it treats keeping something out of the production bundle as a good reason to skip a static import.

One honest difference: the existing `await import(...)` call sites all sit in click handlers, while the draw import runs in an effect. That is what the cancellation guard and the `drawReady` flag are for. If you would rather I move it behind an explicit user action, or drop the lazy draw part and keep only the `DynamicMap` and `constants.ts` changes, say so and I will.

### Testing

`npm test` passes (1023 tests). Typecheck clean.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces initial map-related bundle costs.
- Adds a client-only `DynamicMap` wrapper for meeting, subject, admin notification, consultation, and onboarding views.
- Moves map style constants into a lightweight standalone module.
- Lazily loads Mapbox Draw when editing mode is entered and coordinates geometry initialization with control readiness.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure eligible for this follow-up review remains.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/map/map.tsx | Defers Mapbox Draw loading until editing mode and adds cancellation and readiness handling around its lifecycle. |
| src/components/map/DynamicMap.tsx | Adds a client-only dynamic wrapper that loads the existing map component with a full-size placeholder. |
| src/components/map/constants.ts | Extracts unchanged map style URLs into a lightweight module while retaining compatibility re-exports. |
| src/components/consultations/ConsultationMap.tsx | Switches consultation map rendering to the dynamic wrapper while preserving type-only map feature imports. |
| src/components/landing/v2/hooks/useMapActions.ts | Imports map style constants without loading the full map component module. |

<sub>Reviews (4): Last reviewed commit: ["perf: keep mapbox out of initial bundles..."](https://github.com/schemalabz/opencouncil/commit/4dc020a05d9dbc43e6c5bb39b175777081609548) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46688219)</sub>

<!-- /greptile_comment -->