### PR TITLE
fix(theme): declare `color-scheme: only light` to stop browsers force-darking the site

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,6 +38,11 @@ blue: 164, 192, 225
 
 @layer base {
     :root {
+      /* Pairs with `colorScheme: 'only light'` in the root layout. The meta tag opts out of the
+         browsers' auto-dark repaint; this pins UA-rendered surfaces (scrollbars, form controls,
+         date pickers), which otherwise follow the OS scheme regardless of our own colours. */
+      color-scheme: only light;
+
       --gradient-orange: 16 97% 52%;
       --gradient-blue: 213 49% 73%;
       --orange: 24 100% 50%;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -55,6 +55,11 @@ export const viewport = {
     initialScale: 1,
     maximumScale: 1,
     userScalable: false,
+    // The app has no dark theme — `darkMode: ["class"]` is configured but the class is never
+    // applied. Without a declared color scheme, Chrome's Auto Dark Theme (and Samsung Internet,
+    // and in-app WebViews) assume the page simply hasn't been updated and algorithmically invert
+    // it, which darkens some surfaces and not others. `only light` is the documented opt-out.
+    colorScheme: 'only light',
 }
 
 export default async function RootLayout(


### PR DESCRIPTION
## Problem

During user testing, a user viewing the site on their phone in dark mode saw most elements rendered dark. We have **no dark theme at all** — `tailwind.config.ts` sets `darkMode: ["class"]`, but nothing ever applies that class (no `next-themes`, no `ThemeProvider`, no `classList.add('dark')`). The `.dark` token block in `globals.css` and the ~31 `dark:` variants are dead code.

Because we declare **no color scheme**, Chrome's Auto Dark Theme (Android), Samsung Internet, and in-app WebViews assume the page simply hasn't been updated and algorithmically invert it. That algorithm is selective — it darkens light backgrounds and skips images/many computed colours — which is exactly why only *some* elements changed.

## Fix

Declare the scheme explicitly, in two places:

1. **`colorScheme: 'only light'`** on the `viewport` export in `src/app/layout.tsx` → renders `<meta name="color-scheme" content="only light">`, the documented opt-out from Chrome's Auto Dark Theme.
2. **`color-scheme: only light`** on `:root` in `src/app/globals.css` → covers UA-drawn surfaces the meta tag doesn't reach (scrollbars, `<select>` dropdowns, date pickers).

## Caveats

- This does **not** stop Android's system-level *Force dark* (the accessibility/developer override, distinct from the Chrome setting). Worth confirming with the reporting user which setting they had on.
- Older Samsung Internet versions honour `color-scheme` inconsistently.

## Open question

`only light` suppresses the browser's dark mode. The alternative is to actually **ship a dark theme** — the `.dark` token block is already complete and unused, so the work would be mostly wiring `next-themes` and letting those tokens activate. This PR takes the `only light` route so we stop shipping a browser-invented broken theme in the meantime.

Closes #557

## Verification

`npm run build` passes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an explicit light-only color scheme to prevent browsers from automatically darkening the site.
- Declares `colorScheme: 'only light'` through the root Next.js viewport export.
- Applies `color-scheme: only light` globally for browser-rendered controls and surfaces.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable regressions identified.

The root layout and global stylesheet consistently declare the intended light-only scheme, and the CSS declaration is globally imported without a competing override.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/layout.tsx | Adds the root viewport color-scheme declaration; no actionable issue identified. |
| src/app/globals.css | Adds a global light-only CSS color scheme that reaches all pages and is not overridden elsewhere. |

<sub>Reviews (1): Last reviewed commit: ["fix(theme): declare color-scheme only li..."](https://github.com/schemalabz/opencouncil/commit/dbe74b785f204b3af08685b28b1d5edf67088fd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46962128)</sub>

<!-- /greptile_comment -->