### PR TITLE
fix(admin): broken combobox dropdown inside dialogs

### DIFF
--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button"
 import { ChevronsUpDown, Search, X } from "lucide-react"
 import { Command, CommandEmpty, CommandInput, CommandItem, CommandList, CommandGroup } from "@/components/ui/command"
@@ -192,12 +192,8 @@ export default function Combobox<T>({
         </Command>
     );
 
-    // Keep a ref to the trigger to discover the nearest dialog container for portalling
-    const triggerRef = useRef<HTMLDivElement | null>(null);
-
     const trigger = (
-        <div 
-            ref={triggerRef}
+        <div
             onClick={() => !disabled && !loading && setOpen(true)}
             className={disabled ? "pointer-events-none" : undefined}
         >
@@ -235,19 +231,13 @@ export default function Combobox<T>({
         );
     }
 
-    // Mount popover inside nearest dialog content to avoid modal aria-hidden/inert issues
-    const dialogContainer = triggerRef.current
-        ? (triggerRef.current.closest('[data-oc-dialog-content="true"]') as HTMLElement | null)
-        : null;
-
     return (
-        // Non-modal prevents the parent Dialog from making the popover subtree inert
-        <Popover open={open} onOpenChange={setOpen} modal={false}>
+        // Modal keeps the popover clickable when the trigger is inside a modal Dialog
+        <Popover open={open} onOpenChange={setOpen} modal={true}>
             <PopoverTrigger asChild>
                 {trigger}
             </PopoverTrigger>
-            {/* Portal inside the dialog so pointer events are not blocked by the modal overlay */}
-            <PopoverContent className={cn("p-0", className)} container={dialogContainer ?? undefined}>
+            <PopoverContent className={cn("w-[var(--radix-popover-trigger-width)] p-0", className)}>
                 {renderContent()}
             </PopoverContent>
         </Popover>

--- a/src/components/admin/users/user-dialog.tsx
+++ b/src/components/admin/users/user-dialog.tsx
@@ -249,7 +249,6 @@ export function UserDialog({ open, onOpenChange, user, onDelete }: UserDialogPro
                                     { key: 'people', label: 'People', items: groupedEntities.people },
                                 ]}
                                 disabled={loadingEntities}
-                                className="w-full"
                             />
                             <div className="flex flex-wrap gap-2 mt-2">
                                 {selectedEntities.map(entity => (

--- a/src/components/dev/MobilePreviewButton.tsx
+++ b/src/components/dev/MobilePreviewButton.tsx
@@ -28,7 +28,7 @@ interface ConnectedDevice {
   isOnline: boolean
 }
 
-export default function MobilePreviewButton({ barRef }: { barRef: React.RefObject<HTMLDivElement | null> }) {
+export default function MobilePreviewButton() {
   const [isOpen, setIsOpen] = useState(false)
   const [lanInfo, setLanInfo] = useState<LanInfo | null>(null)
   const [devices, setDevices] = useState<ConnectedDevice[]>([])
@@ -101,7 +101,6 @@ export default function MobilePreviewButton({ barRef }: { barRef: React.RefObjec
         align="end"
         sideOffset={12}
         className="w-72 p-3"
-        container={barRef.current ?? undefined}
       >
         {lanInfo === null && (
           <div className="text-xs text-muted-foreground text-center py-2">Loading...</div>

--- a/src/components/dev/QuickLogin.tsx
+++ b/src/components/dev/QuickLogin.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useRouter, usePathname } from 'next/navigation'
 import { useSession, signOut } from 'next-auth/react'
 import { 
@@ -40,7 +40,6 @@ export default function QuickLogin({ isPreview = false }: { isPreview?: boolean 
   const router = useRouter()
   const pathname = usePathname()
   const { isVisible, isLoaded, hide } = useQuickLoginVisibility()
-  const barRef = useRef<HTMLDivElement>(null)
 
   // Check if test users exist when dialog opens
   useEffect(() => {
@@ -181,9 +180,9 @@ export default function QuickLogin({ isPreview = false }: { isPreview?: boolean 
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <div ref={barRef} className="fixed bottom-4 right-4 z-50">
+      <div className="fixed bottom-4 right-4 z-50">
         <div className="relative flex items-stretch bg-red-600 text-white rounded-md shadow-lg text-sm">
-          <MobilePreviewButton barRef={barRef} />
+          <MobilePreviewButton />
           <div className="w-px bg-red-400/40 my-1.5" />
           <DialogTrigger asChild>
             <button className="flex items-center gap-2 px-3 py-1.5 hover:bg-red-700/50 transition-colors rounded-r-md">

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -44,8 +44,6 @@ const DialogContent = React.forwardRef<
         align === "center" ? "justify-items-center text-center" : "justify-items-start",
         className
       )}
-      // Marker used by components (e.g., Combobox) to portal overlays inside this dialog
-      data-oc-dialog-content="true"
       {...props}
     >
       {children}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -11,10 +11,9 @@ const PopoverTrigger = PopoverPrimitive.Trigger
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & { container?: HTMLElement }
->(({ className, align = "center", sideOffset = 4, container, ...props }, ref) => (
-  // Allow specifying a custom portal container (e.g., mount inside an open Dialog)
-  <PopoverPrimitive.Portal container={container}>
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}


### PR DESCRIPTION
## Problem

The entity picker in the Create/Edit User dialog on `/admin/users` rendered as a huge, misplaced panel covering the whole dialog instead of a dropdown:

The `Combobox` portalled its Radix `PopoverContent` **inside** the parent `DialogContent` (via a `data-oc-dialog-content` marker), a workaround from 2ba45ec6 for dropdown clicks not registering inside modal dialogs. But `DialogContent`'s `translate(-50%,-50%)` centering transform makes it the containing block for `position: fixed` descendants, so the popper's viewport-based coordinates landed the popover in the wrong place, clipped by the dialog's `overflow-y-auto` and stretched by `w-full`.

## Fix

- Portal the popover to `<body>` as normal and set `modal={true}` on the `Popover` — the standard Radix fix for the original click-blocking issue the portal hack was working around.
- Default the popover width to the trigger width via `--radix-popover-trigger-width` (callers can still override with an explicit width class).
- Cleanup of now-dead code: `container` prop on `PopoverContent`, the `data-oc-dialog-content` marker on `DialogContent`, redundant `w-full` in the user dialog, and `barRef` threading in the dev-only QuickLogin bar (same prop, unnecessary since the bar has no transform).

## Verification

- `/admin/users` Create User → entity picker opens anchored to the trigger, search filters, selecting adds the badge (in-dialog clicks work, covering the HighlightDialog case from 2ba45ec6 which uses the same code path).
- Non-dialog usage checked on `/profile?tab=notifications` city picker — positions and sizes correctly.
- `npx tsc --noEmit` clean, all Jest suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI overlay behavior only in shared Combobox/Popover/Dialog primitives; no auth or data changes, with a well-known Radix pattern for nested modals.
> 
> **Overview**
> Fixes **misplaced, oversized combobox panels** when the trigger sits inside a modal dialog (e.g. admin user entity picker) by dropping the old workaround that portalled the popover **into** `DialogContent`.
> 
> **`Combobox`** now uses a normal body portal with **`modal={true}`** on the Radix `Popover` so clicks still work inside parent dialogs, and sets popover width to **`--radix-popover-trigger-width`** (callers can override via `className`).
> 
> Removes related plumbing: **`PopoverContent` `container` prop**, **`data-oc-dialog-content`** on dialog content, redundant **`w-full`** on the user-dialog combobox, and **`barRef`** threading for dev **QuickLogin** / **MobilePreviewButton** popovers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ec816c2304a6a51ce53b7360f476bf34b9ef9ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects combobox positioning and interaction inside modal dialogs.
- Portals popover content to the document body and enables modal Radix behavior.
- Sizes combobox popovers to their trigger width by default.
- Removes the obsolete custom portal container, dialog marker, and associated refs.
- Cleans up redundant width and development-toolbar props.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete regressions identified in the changed paths.

The custom portal API and dialog marker are removed consistently across their callers, while the replacement modal popover behavior and trigger-width sizing preserve the intended dialog and standalone combobox flows.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/Combobox.tsx | Replaces dialog-local popover portalling with a modal body portal and trigger-width sizing; no actionable defect identified. |
| src/components/ui/popover.tsx | Removes the custom portal-container extension, with all repository callers updated. |
| src/components/ui/dialog.tsx | Removes the dialog-content marker that is no longer consumed. |
| src/components/admin/users/user-dialog.tsx | Removes a redundant popover width override now supplied by Combobox. |
| src/components/dev/MobilePreviewButton.tsx | Uses the default body portal and removes the unnecessary bar ref dependency. |
| src/components/dev/QuickLogin.tsx | Removes ref plumbing that was used only by the deleted custom portal target. |

<sub>Reviews (1): Last reviewed commit: ["fix(admin): broken combobox dropdown ins..."](https://github.com/schemalabz/opencouncil/commit/7ec816c2304a6a51ce53b7360f476bf34b9ef9ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47529168)</sub>

<!-- /greptile_comment -->