### PR TITLE
fix(meetings): always show the time on meeting cards

### DIFF
--- a/src/components/landing/city-overview.tsx
+++ b/src/components/landing/city-overview.tsx
@@ -95,6 +95,7 @@ export function CityOverview({ city, showPrivateLabel }: CityOverviewProps) {
                             }}
                             editable={false}
                             mostRecent={true}
+                            cityTimezone={city.timezone}
                             headingLevel="h3"
                         />
                     )}

--- a/src/components/meetings/MeetingCard.tsx
+++ b/src/components/meetings/MeetingCard.tsx
@@ -4,9 +4,9 @@ import { Card, CardContent } from "../ui/card";
 import { useLocale, useTranslations } from 'next-intl';
 import React, { useEffect, useState, useMemo } from 'react';
 import { format, formatDistanceToNow, isFuture } from 'date-fns';
-import { el, enUS } from 'date-fns/locale';
 import { CalendarIcon, Clock, Loader2, ChevronRight, Building } from 'lucide-react';
-import { sortSubjectsByImportance, formatDateTime, IS_DEV } from '@/lib/utils';
+import { sortSubjectsByImportance, IS_DEV } from '@/lib/utils';
+import { formatDateTime, getDateFnsLocale } from '@/lib/formatters/time';
 import SubjectBadge from '../subject-badge';
 import { cn } from '@/lib/utils';
 import { Link } from '@/i18n/routing';
@@ -25,7 +25,7 @@ interface MeetingCardProps {
     item: CouncilMeetingWithAdminBodyAndSubjects;
     editable: boolean;
     mostRecent?: boolean;
-    cityTimezone?: string;
+    cityTimezone: string;
     headingLevel?: 'h2' | 'h3';
 }
 
@@ -152,7 +152,7 @@ export default function MeetingCard({ item: meeting, editable, mostRecent, cityT
                                     <span className="relative z-10 flex items-center gap-1.5">
                                         <Clock className="w-3.5 h-3.5" />
                                         {isUpcoming ? (
-                                            <>{t('upcoming')}: {formatDistanceToNow(meeting.dateTime, { locale: locale === 'el' ? el : enUS })}</>
+                                            <>{t('upcoming')}: {formatDistanceToNow(meeting.dateTime, { locale: getDateFnsLocale(locale) })}</>
                                         ) : (
                                             t('today')
                                         )}
@@ -188,7 +188,7 @@ export default function MeetingCard({ item: meeting, editable, mostRecent, cityT
                             )}
                             <div className="flex items-center gap-1">
                                 <CalendarIcon className="w-3.5 h-3.5 text-muted-foreground/70" />
-                                <span>{formatDateTime(meeting.dateTime, cityTimezone)}</span>
+                                <span>{formatDateTime(meeting.dateTime, cityTimezone, 'long', locale)}</span>
                             </div>
                         </div>
 

--- a/src/components/meetings/MeetingCard.tsx
+++ b/src/components/meetings/MeetingCard.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useState, useMemo } from 'react';
 import { format, formatDistanceToNow, isFuture } from 'date-fns';
 import { el, enUS } from 'date-fns/locale';
 import { CalendarIcon, Clock, Loader2, ChevronRight, Building } from 'lucide-react';
-import { sortSubjectsByImportance, formatDateTime, formatDate, IS_DEV } from '@/lib/utils';
+import { sortSubjectsByImportance, formatDateTime, IS_DEV } from '@/lib/utils';
 import SubjectBadge from '../subject-badge';
 import { cn } from '@/lib/utils';
 import { Link } from '@/i18n/routing';
@@ -188,10 +188,7 @@ export default function MeetingCard({ item: meeting, editable, mostRecent, cityT
                             )}
                             <div className="flex items-center gap-1">
                                 <CalendarIcon className="w-3.5 h-3.5 text-muted-foreground/70" />
-                                <span>{(isUpcoming || isToday)
-                                    ? formatDateTime(meeting.dateTime, cityTimezone)
-                                    : formatDate(meeting.dateTime, cityTimezone)}
-                                </span>
+                                <span>{formatDateTime(meeting.dateTime, cityTimezone)}</span>
                             </div>
                         </div>
 

--- a/src/components/meetings/__tests__/MeetingCard.test.tsx
+++ b/src/components/meetings/__tests__/MeetingCard.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import MeetingCard from '../MeetingCard';
+import { CouncilMeetingWithAdminBodyAndSubjects } from '@/lib/db/meetings';
+
+// Regression guard for #514: a *past* meeting card must still show the scheduled
+// time, rendered in the city's timezone rather than the visitor's. Before the fix
+// the card fell back to a date-only format once the meeting was no longer
+// upcoming or same-day, so the time silently disappeared from the archive.
+
+let mockLocale = 'el';
+
+jest.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+    useLocale: () => mockLocale,
+}));
+
+jest.mock('@/i18n/routing', () => ({
+    useRouter: () => ({ push: jest.fn() }),
+    usePathname: () => '/athens',
+    Link: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+// subject-badge pulls in lucide-react's dynamic icon map, which ships untransformed
+// ESM; the subjects list isn't what these assertions are about.
+jest.mock('../../subject-badge', () => ({
+    __esModule: true,
+    default: () => <span data-testid="subject-badge" />,
+}));
+
+// Drop the motion-only props rather than spreading them onto a real <div>, which
+// React warns about as unknown event handlers.
+jest.mock('framer-motion', () => ({
+    motion: {
+        div: ({
+            children,
+            whileHover,
+            initial,
+            animate,
+            transition,
+            onHoverStart,
+            onHoverEnd,
+            ...props
+        }: React.PropsWithChildren<Record<string, unknown>>) => <div {...props}>{children}</div>,
+    },
+}));
+
+// 2024-01-15T14:30:00Z is 16:30 in Athens (EET, UTC+2 in January) and well in the
+// past, so the card takes the previously date-only branch.
+const PAST_UTC = new Date('2024-01-15T14:30:00Z');
+
+const makeMeeting = (
+    overrides: Partial<CouncilMeetingWithAdminBodyAndSubjects> = {},
+): CouncilMeetingWithAdminBodyAndSubjects =>
+    ({
+        id: 'meeting-1',
+        cityId: 'athens',
+        name: 'Δημοτικό Συμβούλιο',
+        name_en: 'City Council',
+        dateTime: PAST_UTC,
+        released: true,
+        videoUrl: null,
+        subjects: [],
+        administrativeBody: null,
+        ...overrides,
+    }) as unknown as CouncilMeetingWithAdminBodyAndSubjects;
+
+const renderCard = (meeting = makeMeeting()) =>
+    render(<MeetingCard item={meeting} editable={false} cityTimezone="Europe/Athens" />);
+
+describe('MeetingCard date line (#514)', () => {
+    beforeEach(() => {
+        mockLocale = 'el';
+    });
+
+    it('shows the time on a past meeting, in the city timezone', () => {
+        renderCard();
+        // 14:30Z -> 16:30 Athens. Greek formatting renders this as "4:30 μ.μ.".
+        expect(screen.getByText(/15 Ιανουαρίου 2024/)).toHaveTextContent(/4:30/);
+    });
+
+    it('does not fall back to a date-only render', () => {
+        renderCard();
+        expect(screen.queryByText(/^15 Ιανουαρίου 2024$/)).not.toBeInTheDocument();
+    });
+
+    it('renders the city time, not the runner-local time', () => {
+        // Guards the timezone argument itself with a zone no CI runner uses:
+        // 14:30Z is 09:30 in New York (EST), and the calendar day is unchanged.
+        render(
+            <MeetingCard item={makeMeeting()} editable={false} cityTimezone="America/New_York" />,
+        );
+        expect(screen.getByText(/15 Ιανουαρίου 2024/)).toHaveTextContent(/9:30/);
+    });
+
+    it('follows the active locale', () => {
+        mockLocale = 'en';
+        renderCard();
+        expect(screen.getByText(/January 15, 2024/)).toHaveTextContent(/4:30/);
+    });
+});

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -107,10 +107,17 @@ describe('formatDateTime', () => {
     expect(formatDateTime(date)).toMatch(/2:30|14:30/);
   });
 
-  it('should handle timezone parameter', () => {
+  it('should render the time in the given timezone', () => {
     const date = new Date('2024-01-15T14:30:00Z');
-    // Just testing that it doesn't throw when timezone is provided
-    expect(() => formatDateTime(date, 'Europe/Athens')).not.toThrow();
+    // January is EET (UTC+2), so Athens runs two hours ahead of the UTC baseline.
+    expect(formatDateTime(date, 'Europe/Athens')).toMatch(/4:30/);
+    expect(formatDateTime(date, 'UTC')).toMatch(/2:30/);
+  });
+
+  it('should follow the locale parameter', () => {
+    const date = new Date('2024-01-15T14:30:00Z');
+    expect(formatDateTime(date, 'Europe/Athens', 'long', 'en')).toMatch(/January 15, 2024/);
+    expect(formatDateTime(date, 'Europe/Athens', 'long', 'el')).toMatch(/Ιανουαρίου/);
   });
 
   it('should use a compact month with dateStyle medium', () => {

--- a/src/lib/db/cities.ts
+++ b/src/lib/db/cities.ts
@@ -23,7 +23,7 @@ type CityCounts = {
     councilMeetings: number;
 };
 
-export type CityMinimalWithCounts = Pick<City, 'id' | 'name' | 'name_en' | 'name_municipality' | 'name_municipality_en' | 'logoImage' | 'supportsNotifications' | 'status' | 'officialSupport' | 'authorityType'> & {
+export type CityMinimalWithCounts = Pick<City, 'id' | 'name' | 'name_en' | 'name_municipality' | 'name_municipality_en' | 'logoImage' | 'supportsNotifications' | 'status' | 'officialSupport' | 'authorityType' | 'timezone'> & {
     _count: CityCounts;
 };
 
@@ -312,6 +312,7 @@ export async function getAllCitiesMinimal(realm?: Realm): Promise<CityMinimalWit
                 status: true,
                 authorityType: true,
                 officialSupport: true,
+                timezone: true,
                 _count: CITY_COUNT_SELECT
             },
             orderBy: CITY_ORDER_BY

--- a/src/lib/formatters/time.ts
+++ b/src/lib/formatters/time.ts
@@ -10,6 +10,17 @@ export function getDateFnsLocale(locale: string): Locale {
 }
 
 /**
+ * Map a next-intl locale string to the BCP 47 tag passed to `Intl.DateTimeFormat`.
+ * Defaults to Greek to match the app's default locale.
+ *
+ * `formatNumericDateTime` deliberately does not use this — it pins `en-GB` so its
+ * numeric output stays day-first in every locale.
+ */
+export function getIntlLocale(locale: string): string {
+    return locale === 'en' ? 'en-US' : locale === 'fr' ? 'fr-FR' : 'el-GR';
+}
+
+/**
  * Formats time in seconds to a human-readable string
  * @param time - Time in seconds
  * @returns Formatted string like "5:30" or "1:23:45"
@@ -85,12 +96,9 @@ export function formatDurationMs(ms: number): string {
  * @returns Formatted relative time string in the specified locale
  */
 export function formatRelativeTime(date: Date, locale: string = 'el'): string {
-  // Map locale to date-fns locale
-  const dateFnsLocale = locale === 'en' ? undefined : el;
-  
   return formatDistanceToNow(date, {
     addSuffix: true,
-    locale: dateFnsLocale
+    locale: getDateFnsLocale(locale)
   });
 }
 
@@ -107,7 +115,7 @@ export function formatDate(date: Date, timezone?: string, locale: string = 'el')
     options.timeZone = timezone;
   }
 
-  const intlLocale = locale === 'en' ? 'en-US' : locale === 'fr' ? 'fr-FR' : 'el-GR';
+  const intlLocale = getIntlLocale(locale);
   if (date instanceof Date) {
     return new Intl.DateTimeFormat(intlLocale, options).format(date);
   } else if (typeof date === 'string') {
@@ -147,9 +155,10 @@ export function formatNumericDateTime(date: Date, timezone?: string, locale: str
  * @param date - The date to format
  * @param timezone - Optional timezone
  * @param dateStyle - Optional date style (defaults to 'long'; use 'medium'/'short' for compact contexts)
+ * @param locale - Optional locale (defaults to 'el' to match the app's default locale)
  * @returns Formatted date and time string
  */
-export function formatDateTime(date: Date, timezone?: string, dateStyle: 'long' | 'medium' | 'short' = 'long'): string {
+export function formatDateTime(date: Date, timezone?: string, dateStyle: 'long' | 'medium' | 'short' = 'long', locale: string = 'el'): string {
   const options: Intl.DateTimeFormatOptions = {
     dateStyle,
     timeStyle: 'short'
@@ -159,10 +168,11 @@ export function formatDateTime(date: Date, timezone?: string, dateStyle: 'long' 
     options.timeZone = timezone;
   }
 
+  const intlLocale = getIntlLocale(locale);
   if (date instanceof Date) {
-    return new Intl.DateTimeFormat('el-GR', options).format(date);
+    return new Intl.DateTimeFormat(intlLocale, options).format(date);
   } else if (typeof date === 'string') {
-    return new Intl.DateTimeFormat('el-GR', options).format(new Date(date));
+    return new Intl.DateTimeFormat(intlLocale, options).format(new Date(date));
   } else {
     throw new Error(`Invalid date: ${date}`);
   }


### PR DESCRIPTION
## Summary

In the sessions list, `MeetingCard` only rendered the meeting time for upcoming or same-day meetings (`(isUpcoming || isToday) ? formatDateTime(...) : formatDate(...)`), so past sessions showed a date with no time. The scheduled time is just as relevant after a meeting has taken place, so this renders it unconditionally via `formatDateTime`.

The now-unused `formatDate` import is removed. The embed meeting card (`EmbedMeetingCard`), which is date-only by design, is left unchanged.

Closes #514

## Test plan

- `npx tsc --noEmit` passes
- Verified `isUpcoming` / `isToday` are still used by the status badge logic, so no dead code remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vk3qdnQUgyj7nYokvXqpTw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vk3qdnQUgyj7nYokvXqpTw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only meeting metadata change with explicit timezone on the landing path; no auth or data-layer behavior changes.
> 
> **Overview**
> **Meeting cards** now always render the scheduled **date and time** via `formatDateTime`, instead of showing date-only for past meetings that weren’t upcoming or “today.” The unused `formatDate` import is dropped.
> 
> Because past cards now include a time, **landing city overview** passes `cityTimezone={city.timezone}` into `MeetingCard`, and **`getAllCitiesMinimal` / `CityMinimalWithCounts`** include `timezone` so that data is available for `LandingCity`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 188ec233a7d6b20f5d17afa44162e1c6668797cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR ensures meeting cards consistently display localized dates and scheduled times in each city’s timezone.
- Makes `cityTimezone` required for `MeetingCard` and supplies it from landing-page city data.
- Extends minimal city queries and types to include timezone data.
- Centralizes locale mapping in the time formatter and adds regression coverage for past meetings, timezone conversion, and localization.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported browser-timezone failure is fixed: the timezone is required by MeetingCard, selected by the landing city query, and supplied by every current production caller.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/landing/city-overview.tsx | Supplies the city’s required timezone to the landing-page meeting card, completing the previously missing data flow. |
| src/components/meetings/MeetingCard.tsx | Requires a city timezone and always renders the meeting’s localized date and time in that timezone. |
| src/components/meetings/__tests__/MeetingCard.test.tsx | Adds focused regression tests covering past meeting times, explicit timezone conversion, and active-locale formatting. |
| src/lib/__tests__/utils.test.ts | Strengthens formatter coverage with concrete timezone and locale assertions. |
| src/lib/db/cities.ts | Includes the required timezone field in the minimal city type and database selection. |
| src/lib/formatters/time.ts | Centralizes locale mapping and extends date-time formatting to honor the requested locale. |

<sub>Reviews (3): Last reviewed commit: ["test(meetings): guard the meeting card d..."](https://github.com/schemalabz/opencouncil/commit/fea39a31bf775a314efbf74991e4ea6e07aafe8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47557889)</sub>

<!-- /greptile_comment -->