### PR TITLE
fix(combobox): make search accent-insensitive

### DIFF
--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -6,7 +6,7 @@ import { ChevronsUpDown, Search, X } from "lucide-react"
 import { Command, CommandEmpty, CommandInput, CommandItem, CommandList, CommandGroup } from "@/components/ui/command"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { cn } from "@/lib/utils";
+import { cn, relevanceScore } from "@/lib/utils";
 
 type ComboboxGroup<T> = {
     key: string;
@@ -146,7 +146,11 @@ export default function Combobox<T>({
 
 
     const renderContent = () => (
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command
+            filter={(value, search, keywords) =>
+                relevanceScore(keywords?.length ? `${value} ${keywords.join(" ")}` : value, search)
+            }
+            className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
             <div className="flex items-center px-3 border-b">
                 <CommandInput
                     placeholder={searchPlaceholder || placeholder}
@@ -173,6 +177,7 @@ export default function Combobox<T>({
                                 <CommandItem
                                     key={itemValue}
                                     value={itemValue}
+                                    keywords={[getItemLabel(item)]}
                                     onSelect={() => {
                                         onChange(item === value ? null : item);
                                         setOpen(false);

--- a/src/components/__tests__/Combobox.test.tsx
+++ b/src/components/__tests__/Combobox.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { defaultFilter } from 'cmdk';
+import Combobox from '../Combobox';
+
+// Regression guard for #402: the shared Combobox must match Greek queries
+// accent-insensitively. Before this fix, cmdk's default (accent-sensitive)
+// filter was used, so typing the un-accented "αγιοι αναργυροι" found nothing.
+
+// jsdom lacks the layout/pointer APIs Radix Popover + cmdk reach for.
+beforeAll(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+    Element.prototype.hasPointerCapture = jest.fn(() => false);
+    Element.prototype.setPointerCapture = jest.fn();
+    Element.prototype.releasePointerCapture = jest.fn();
+    global.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    };
+    window.innerWidth = 1024; // desktop -> Popover path (not the mobile Dialog)
+});
+
+type City = { name: string; muni: string };
+
+// Municipality-selector wiring (see MunicipalitySelector.tsx):
+// value = "name name_municipality", label = name.
+const cities: City[] = [
+    { name: 'Άγιοι Ανάργυροι', muni: 'Δήμος Αγίων Αναργύρων-Καματερού' },
+    { name: 'Θεσσαλονίκη', muni: 'Δήμος Θεσσαλονίκης' }, // decoy: must be filtered out
+];
+
+const ACCENTED = 'Άγιοι Ανάργυροι';
+const DEACCENTED_QUERY = 'αγιοι αναργυροι';
+
+function renderCombobox() {
+    return render(
+        <Combobox<City>
+            items={cities}
+            value={null}
+            onChange={() => {}}
+            placeholder="Επιλέξτε δήμο"
+            searchPlaceholder="Αναζήτηση δήμου"
+            getItemLabel={(c) => c.name}
+            getItemValue={(c) => `${c.name} ${c.muni}`}
+        />,
+    );
+}
+
+function openAndSearch(query: string) {
+    renderCombobox();
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.change(screen.getByPlaceholderText('Αναζήτηση δήμου'), {
+        target: { value: query },
+    });
+}
+
+describe('Combobox accent-insensitive search (#402)', () => {
+    // Documents *why* the query below is a valid guard: on the previous
+    // implementation (cmdk default filter, no keywords) it scored 0 -> hidden.
+    // If someone later swaps in a query the old filter would have matched,
+    // this assertion fails and the guard below stops proving anything.
+    it('the chosen query genuinely failed under the old (default) filter', () => {
+        const value = `${ACCENTED} ${cities[0].muni}`;
+        expect(defaultFilter!(value, DEACCENTED_QUERY, undefined)).toBe(0);
+    });
+
+    it('finds an accented item when typing the un-accented query', () => {
+        openAndSearch(DEACCENTED_QUERY);
+        const list = screen.getByRole('listbox');
+        expect(within(list).getByText(ACCENTED)).toBeInTheDocument();
+        expect(within(list).queryByText('Θεσσαλονίκη')).not.toBeInTheDocument();
+    });
+
+    it('shows the empty state when nothing matches', () => {
+        openAndSearch('ζζζζζ');
+        expect(screen.queryByText(ACCENTED)).not.toBeInTheDocument();
+        expect(screen.queryByText('Θεσσαλονίκη')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary

The shared `Combobox` wrapped cmdk's `<Command>` with its default filter, which is accent-sensitive for Greek — typing `αγιοι αναργυροι` found nothing until the user typed the accented form. Since `Combobox` backs every selector (municipality, location, metadata filters, …), this was a hard dead end for the most common way people type Greek.

The repo already had the right tool: `relevanceScore()` in `src/lib/utils.ts` normalizes accents via `normalizeText()` and its doc comment says it was *designed* as a cmdk `<Command filter>` callback — it was just never wired into `Combobox`. This PR:

- passes `relevanceScore` as the `filter` on the `<Command>` in `src/components/Combobox.tsx`
- passes each item's label as cmdk `keywords`, so items whose `value` is an opaque id (e.g. subject ids in `HighlightDialog`) are also searchable by their visible label

No new matching logic — `normalizeText`/`relevanceScore` are already covered by Greek-accent test cases in `src/lib/__tests__/utils.test.ts`.

Closes #402

## Test plan

- `npx tsc --noEmit` passes
- `npm test`: 77 suites, 1092 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vk3qdnQUgyj7nYokvXqpTw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vk3qdnQUgyj7nYokvXqpTw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Combobox filtering behavior using existing tested utilities; no auth, data, or API changes.
> 
> **Overview**
> Fixes **accent-sensitive Greek search** across every selector that uses the shared `Combobox` by replacing cmdk’s default filter with the existing **`relevanceScore`** helper (accent normalization via `normalizeText`).
> 
> Each `CommandItem` now passes **`keywords={[getItemLabel(item)]}`** so filtering matches visible labels when `value` is an opaque id, not only the raw value string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fc01abb469b291573bc262fde8d2d3bcc3fbcae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the shared Combobox search behavior.
- Uses the existing accent-normalizing relevance score for cmdk filtering.
- Includes visible item labels as search keywords.
- Adds regression coverage for accent-insensitive Greek queries and empty results.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/Combobox.tsx | Wires accent-insensitive relevance scoring and visible labels into the shared command filter. |
| src/components/__tests__/Combobox.test.tsx | Adds focused regression tests for unaccented Greek searches and unmatched queries. |

<sub>Reviews (2): Last reviewed commit: ["test(combobox): guard accent-insensitive..."](https://github.com/schemalabz/opencouncil/commit/df71782b6e63c34f3e4407af7993a69dd6dceb27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47558868)</sub>

<!-- /greptile_comment -->