### PR TITLE
feat(meetings): remove the Post (1:1) image export from the share menu

### DIFF
--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -114,94 +114,6 @@ const MeetingOGImage = async (cityId: string, meetingId: string, reqId: string) 
     );
 };
 
-// Meeting Feed OG Image (Square - 1080x1080)
-const MeetingFeedOGImage = async (cityId: string, meetingId: string, reqId: string) => {
-    const fetchT0 = Date.now();
-    console.log(`[og:${reqId}] fetching variant=feed city=${cityId} meeting=${meetingId}`);
-    const data = await getMeetingDataForOG(cityId, meetingId);
-    if (!data) {
-        console.log(`[og:${reqId}] not-found variant=feed city=${cityId} meeting=${meetingId}`);
-        return null;
-    }
-    logSubjectCounts(reqId, 'feed', data.subjects ?? [], Date.now() - fetchT0);
-
-    const meetingDate = new Date(data.dateTime);
-    const formattedDate = meetingDate.toLocaleDateString('el-GR', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-    });
-
-    const sortT0 = Date.now();
-    const sortedSubjects = sortSubjectsByImportance(data.subjects);
-    console.log(`[og:${reqId}] sorted variant=feed in ${Date.now() - sortT0}ms`);
-
-    const cityDisplayName = formatCityDisplayName(data.city.name_municipality, data.administrativeBody?.name);
-
-    return (
-        <Container watermarkLogoSrc={LOGO_BLACK_DATA_URI} watermarkProps={{ logoOnly: true, size: 120 }}>
-            <OgHeader
-                city={{
-                    name: cityDisplayName,
-                    logoImage: data.city.logoImage
-                }}
-            />
-
-            <div style={{
-                flex: 1,
-                display: 'flex',
-                flexDirection: 'column',
-                gap: '28px',
-                paddingTop: '8px',
-            }}>
-                <h1 style={{
-                    fontSize: 64,
-                    fontWeight: 800,
-                    color: '#111827',
-                    lineHeight: 1.25,
-                    margin: 0,
-                    maxWidth: '98%',
-                }}>
-                    {data.name}
-                </h1>
-
-                <MeetingMetaRow
-                    formattedDate={formattedDate}
-                    subjectsCount={data.subjects?.length || 0}
-                    fontSize={32}
-                    gap={24}
-                    iconGap={8}
-                />
-
-                {sortedSubjects.length > 0 && (
-                    <SubjectPills
-                        subjects={sortedSubjects}
-                        limit={6}
-                        styles={{
-                            containerGap: 14,
-                            containerMarginTop: 14,
-                            pillPadding: [16, 30],
-                            pillRadius: 9999,
-                            pillFontSize: 30,
-                            pillFontWeight: 800,
-                            pillBoxShadow: '0 3px 6px rgba(0, 0, 0, 0.08)',
-                            pillMaxWidth: '95%',
-                            remainingFontSize: 20,
-                            remainingMarginTop: 4,
-                            remainingColor: '#6b7280',
-                        }}
-                    />
-                )}
-            </div>
-        </Container>
-    );
-};
-
-// Meeting Story OG Image (1080×1920) is now rendered client-side via
-// src/lib/export/storyImage.tsx + ShareDropdown to avoid the satori/yoga
-// hang on Athens-scale data. The four templates are only invoked from the
-// browser — `?variant=story` is no longer handled by this route.
-
 // City OG Image
 const CityOGImage = async (cityId: string) => {
     // Fetch only the data we need in parallel
@@ -850,16 +762,15 @@ export async function GET(request: Request) {
     const personId = searchParams.get('personId');
     const subjectId = searchParams.get('subjectId');
     const pageType = searchParams.get('pageType'); // 'people', 'about', 'explain', 'search', 'chat'
-    const variant = searchParams.get('variant'); // 'feed' for 1:1, default is landscape (story is client-side now)
 
     // Short per-request id so concurrent requests' logs can be untangled by grepping a tag.
     const reqId = crypto.randomUUID().slice(0, 8);
-    console.log(`[og:${reqId}] enter variant=${variant ?? 'default'} city=${cityId ?? '-'} meeting=${meetingId ?? '-'} subject=${subjectId ?? '-'} pageType=${pageType ?? '-'}`);
+    console.log(`[og:${reqId}] enter city=${cityId ?? '-'} meeting=${meetingId ?? '-'} subject=${subjectId ?? '-'} pageType=${pageType ?? '-'}`);
 
     const slot = tryAcquireOgSlot();
     if (!slot) {
         const stats = getOgConcurrencyStats();
-        console.warn(`[og:${reqId}] 429 capacity ${stats.active}/${stats.max} variant=${variant ?? 'default'}`);
+        console.warn(`[og:${reqId}] 429 capacity ${stats.active}/${stats.max}`);
         return new Response('OG image generator at capacity — try again shortly.', {
             status: 429,
             headers: { 'Retry-After': '5' },
@@ -869,8 +780,8 @@ export async function GET(request: Request) {
     const t0 = Date.now();
     try {
         let element;
-        let width = 1200;
-        let height = 630;
+        const width = 1200;
+        const height = 630;
 
         if (consultationId && cityId) {
             element = await ConsultationOGImage(cityId, consultationId);
@@ -879,19 +790,13 @@ export async function GET(request: Request) {
             // Note: locale doesn't affect the image content, so we use 'el' as default
             return await SubjectOgImage({ params: Promise.resolve({ locale: 'el', cityId, meetingId, subjectId }) });
         } else if (meetingId && cityId) {
-            // Handle variant for meeting images. ?variant=story is no longer served here —
-            // story exports render client-side via src/lib/export/storyImage.tsx. A stray
-            // story request falls through to the default landscape, which is a reasonable
-            // fallback for any external caller still on the old URL shape.
-            if (variant === 'feed') {
-                // Square format for feed posts
-                element = await MeetingFeedOGImage(cityId, meetingId, reqId);
-                width = 1080;
-                height = 1080;
-            } else {
-                // Default landscape format
-                element = await MeetingOGImage(cityId, meetingId, reqId);
-            }
+            // ?variant=story and ?variant=feed are no longer served here — story exports
+            // render client-side via src/lib/export/storyImage.tsx (moved off the server
+            // to avoid the satori/yoga hang on Athens-scale data), and the square feed
+            // export was removed with the "Post" share option. A stray variant request
+            // falls through to the default landscape, which is a reasonable fallback for
+            // any external caller still on the old URL shape.
+            element = await MeetingOGImage(cityId, meetingId, reqId);
         } else if (personId && cityId) {
             element = await PersonOGImage(cityId, personId);
         } else if (pageType === 'people' && cityId) {
@@ -919,7 +824,7 @@ export async function GET(request: Request) {
         // when the body is consumed. Force it to complete here (inside the slot) by
         // awaiting arrayBuffer(), so the concurrency cap actually caps satori work
         // instead of just capping handler invocations.
-        console.log(`[og:${reqId}] image-construct variant=${variant ?? 'default'} dim=${width}x${height} t=${Date.now() - t0}ms`);
+        console.log(`[og:${reqId}] image-construct dim=${width}x${height} t=${Date.now() - t0}ms`);
         const satoriT0 = Date.now();
         const imageResponse = new ImageResponse(element, { width, height });
         // Heartbeat while waiting for satori. If these logs FIRE during a hang, the
@@ -935,7 +840,7 @@ export async function GET(request: Request) {
         } finally {
             clearInterval(heartbeat);
         }
-        console.log(`[og:${reqId}] rendered variant=${variant ?? 'default'} bytes=${buffer.byteLength} satori=${Date.now() - satoriT0}ms`);
+        console.log(`[og:${reqId}] rendered bytes=${buffer.byteLength} satori=${Date.now() - satoriT0}ms`);
         // Restore the Cache-Control that next/og's ImageResponse sets by default —
         // dropping it would make every crawler unfurl re-render, defeating the cap.
         // Matches next/og's exact defaults including the dev no-cache branch.
@@ -955,6 +860,6 @@ export async function GET(request: Request) {
         slot.release();
         const stats = getOgConcurrencyStats();
         // Now includes the satori render itself (we awaited arrayBuffer() above).
-        console.log(`[og:${reqId}] exit variant=${variant ?? 'default'} t=${Date.now() - t0}ms slots=${stats.active}/${stats.max}`);
+        console.log(`[og:${reqId}] exit t=${Date.now() - t0}ms slots=${stats.active}/${stats.max}`);
     }
 }

--- a/src/components/meetings/ShareDropdown.tsx
+++ b/src/components/meetings/ShareDropdown.tsx
@@ -11,14 +11,11 @@ import {
 } from "../ui/dropdown-menu";
 import { Input } from "../ui/input";
 import { Checkbox } from "../ui/checkbox";
-import { CheckCircle, CopyIcon, Share, FileDown, Loader2, Instagram } from "lucide-react";
+import { CheckCircle, CopyIcon, Share, Instagram } from "lucide-react";
 import { useVideo } from './VideoProvider';
 import { usePathname } from 'next/navigation';
-import { useTranslations } from 'next-intl';
 import { useShare } from '@/contexts/ShareContext';
 import { formatTimestamp } from '@/lib/utils';
-import { downloadFile } from '@/lib/export/meetings';
-import { useToast } from '@/hooks/use-toast';
 import StoryTemplatePickerDialog from './StoryTemplatePickerDialog';
 import posthog from 'posthog-js';
 
@@ -45,12 +42,9 @@ export default function ShareDropdown({ meetingId, cityId, className }: ShareDro
     const [url, setUrl] = useState('');
     const [includeTimestamp, setIncludeTimestamp] = useState(false);
     const [copySuccess, setCopySuccess] = useState(false);
-    const [downloading, setDownloading] = useState<string | null>(null);
     const { currentTime } = useVideo();
     const { isOpen, targetTimestamp, shouldTriggerCopy, closeShareDropdown, resetCopyTrigger } = useShare();
     const pathname = usePathname();
-    const t = useTranslations();
-    const { toast } = useToast();
     const [internalOpen, setInternalOpen] = useState(false);
     const [storyPickerOpen, setStoryPickerOpen] = useState(false);
 
@@ -102,14 +96,6 @@ export default function ShareDropdown({ meetingId, cityId, className }: ShareDro
         setTimeout(() => setCopySuccess(false), 3000);
     };
 
-    const errorToast = () => {
-        toast({
-            title: 'Αποτυχία λήψης',
-            description: 'Δεν ήταν δυνατή η δημιουργία της εικόνας. Δοκίμασε ξανά.',
-            variant: 'destructive',
-        });
-    };
-
     const openStoryPicker = () => {
         // Close the dropdown when opening the dialog so they don't stack.
         if (isOpen) {
@@ -118,33 +104,6 @@ export default function ShareDropdown({ meetingId, cityId, className }: ShareDro
             setInternalOpen(false);
         }
         setStoryPickerOpen(true);
-    };
-
-    const downloadFeed = async () => {
-        setDownloading('feed');
-        const imageUrl = `${window.location.origin}/api/og?cityId=${cityId}&meetingId=${meetingId}&variant=feed`;
-        try {
-            const response = await fetch(imageUrl);
-            if (!response.ok) {
-                if (response.status === 429) {
-                    toast({
-                        title: 'Αποτυχία δημιουργίας εικόνας',
-                        description: 'Δεν είναι διαθέσιμη αυτή τη στιγμή η δημιουργία εικόνων. Δοκίμασε ξανά αργότερα.',
-                        variant: 'destructive',
-                    });
-                } else {
-                    errorToast();
-                }
-                return;
-            }
-            const blob = await response.blob();
-            downloadFile(blob, `meeting-feed-${meetingId}.png`);
-        } catch (error) {
-            console.error('Error downloading feed image:', error);
-            errorToast();
-        } finally {
-            setDownloading(null);
-        }
     };
 
     // Determine what's being shared based on the current path
@@ -294,7 +253,6 @@ export default function ShareDropdown({ meetingId, cityId, className }: ShareDro
 
                             <Button
                                 onClick={openStoryPicker}
-                                disabled={downloading !== null}
                                 variant="outline"
                                 size="sm"
                                 className="w-full h-8 flex items-center gap-1.5"
@@ -302,22 +260,6 @@ export default function ShareDropdown({ meetingId, cityId, className }: ShareDro
                                 <Instagram className="w-3 h-3" />
                                 <span className="text-xs">Story</span>
                                 <span className="text-[10px] text-muted-foreground">(9:16)</span>
-                            </Button>
-
-                            <Button
-                                onClick={() => downloadFeed()}
-                                disabled={downloading !== null}
-                                variant="outline"
-                                size="sm"
-                                className="w-full h-8 flex items-center gap-1.5"
-                            >
-                                {downloading === 'feed' ? (
-                                    <Loader2 className="w-3 h-3 animate-spin" />
-                                ) : (
-                                    <FileDown className="w-3 h-3" />
-                                )}
-                                <span className="text-xs">Post</span>
-                                <span className="text-[10px] text-muted-foreground">(1:1)</span>
                             </Button>
                         </div>
                     </>


### PR DESCRIPTION
## Summary

Removes the barely-used "Post" (1:1 square feed) image export from the meeting Share menu, keeping only the "Story" export (which can also be posted to a feed). Pure deletion, ~130 lines:

**`src/components/meetings/ShareDropdown.tsx`**
- Removed the "Post" button and its `downloadFeed` handler
- Removed now-unused supporting code: the `downloading` state (Story goes through its own dialog and never used it meaningfully), the `errorToast` helper, the `useToast` hook, the `downloadFile` import, and the `FileDown`/`Loader2` icons

**`src/app/api/og/route.tsx`**
- Removed the `variant === 'feed'` branch and the `MeetingFeedOGImage` renderer (~85 lines) — repo-wide grep confirms `downloadFeed` was their only consumer
- Removed the now-unused `variant` search param and its mentions in the request logs
- A stray `?variant=feed` request falls through to the default landscape image — the same graceful fallback the earlier client-side story migration established for `?variant=story` (comment updated to cover both)
- Shared helpers (`logSubjectCounts`, `sortSubjectsByImportance`, `MeetingMetaRow`, `SubjectPills`) are still used by the default meeting image and untouched

Closes #540

## Test plan

- `npx tsc --noEmit` passes
- `npm test`: 77 suites, 1092 tests pass
- `grep -rn "variant=feed\|MeetingFeedOGImage\|downloadFeed" src/` returns only the explanatory comment
- Full `npm run build` isn't runnable in this environment (no service secrets; `/api/chat` fails page-data collection for that reason on main too) — relying on CI for the build check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vk3qdnQUgyj7nYokvXqpTw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vk3qdnQUgyj7nYokvXqpTw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only UI and OG route cleanup with a safe landscape fallback for legacy variant URLs; no auth or data-path changes.
> 
> **Overview**
> Removes the **Post (1:1 square)** image export from the meeting share menu, leaving **Story (9:16)** as the only image export path.
> 
> In **`ShareDropdown`**, the Post button, `downloadFeed`, download/toast/loading state, and related imports are deleted. In **`/api/og`**, the `MeetingFeedOGImage` renderer and `variant=feed` handling are removed; meeting requests always use the default landscape template. Old `?variant=feed` (and `story`) URLs fall back to that landscape image, matching the earlier client-side story migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7030a6ede13c30a908d97c4981a9c0beaa773b2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the square meeting-image export path.
- Removes the “Post” export control and its unused download, loading, and toast logic from the share menu.
- Removes server-side `variant=feed` rendering and makes obsolete variant requests use the default landscape meeting image.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/api/og/route.tsx | Removes the square feed renderer and variant-specific dimensions while retaining the default meeting-image fallback. |
| src/components/meetings/ShareDropdown.tsx | Removes the Post export button, handler, state, and imports while leaving Story export unchanged. |

<sub>Reviews (2): Last reviewed commit: ["feat(meetings): remove the Post (1:1) im..."](https://github.com/schemalabz/opencouncil/commit/72600f277b7b2b62bf3eea1c5e4ef63415e40da4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47560984)</sub>

<!-- /greptile_comment -->