### PR TITLE
fix(seed): detect and refresh stale cached seed_data.json

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -356,37 +356,128 @@ async function main() {
 }
 
 /**
- * Get seed data from local file or download if needed
+ * Timestamp of the newest local Prisma migration (directories are named
+ * `YYYYMMDDHHMMSS_name`, stamped in UTC), or null if none can be determined.
+ * Resolved from the working directory rather than `__dirname`, which does not
+ * exist when the preview deployment runs the esbuild ESM bundle of this script;
+ * both `prisma db seed` and the preview runner execute from the project root.
+ */
+function latestMigrationDate(): Date | null {
+  const migrationsDir = path.resolve(process.cwd(), 'prisma', 'migrations')
+  if (!fs.existsSync(migrationsDir)) return null
+
+  const stamps = fs.readdirSync(migrationsDir)
+    .map(name => name.match(/^(\d{14})_/)?.[1])
+    .filter((stamp): stamp is string => !!stamp)
+    .sort()
+  if (stamps.length === 0) return null
+
+  const s = stamps[stamps.length - 1]
+  return new Date(`${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}T${s.slice(8, 10)}:${s.slice(10, 12)}:${s.slice(12, 14)}Z`)
+}
+
+/**
+ * Returns a human-readable reason the cached seed data should be re-downloaded,
+ * or null if it looks usable. Seed data extracted before the newest migration
+ * may reference fields that no longer exist in the schema (e.g. the old
+ * `isListed` column), which otherwise surfaces as a confusing Prisma error deep
+ * inside seeding. A cache that was *downloaded* after the newest migration is
+ * accepted even if its extraction predates it — it is the freshest published
+ * dump available, and re-fetching it again would loop on every seed run.
+ */
+function seedDataStaleness(data: any): string | null {
+  const extractedAt = data?.metadata?.extractedAt
+  if (!extractedAt || isNaN(Date.parse(extractedAt))) {
+    return 'it has no metadata.extractedAt timestamp'
+  }
+  const migration = latestMigrationDate()
+  if (!migration || Date.parse(extractedAt) >= migration.getTime()) {
+    return null
+  }
+  const downloadedAt = data?.metadata?.downloadedAt
+  if (downloadedAt && !isNaN(Date.parse(downloadedAt)) && Date.parse(downloadedAt) >= migration.getTime()) {
+    return null
+  }
+  return `it was extracted at ${extractedAt}, before the latest schema migration (${migration.toISOString()})`
+}
+
+/**
+ * Get seed data from local file or download if needed. A cached file that is
+ * unreadable or predates the latest schema migration is re-downloaded; if the
+ * download fails (e.g. offline), the stale file is used with a warning rather
+ * than failing outright.
  */
 async function getSeedData() {
-  // Check if local file exists
+  let localData: any = null
+  let staleness: string | null = null
+
   if (fs.existsSync(SEED_DATA_PATH)) {
-    console.log(`Using local seed data file: ${SEED_DATA_PATH}`)
-    const data = JSON.parse(fs.readFileSync(SEED_DATA_PATH, 'utf-8'))
-    return data
+    try {
+      localData = JSON.parse(fs.readFileSync(SEED_DATA_PATH, 'utf-8'))
+      staleness = seedDataStaleness(localData)
+    } catch (error) {
+      staleness = `it is not valid JSON (${(error as Error).message})`
+    }
+
+    if (localData && !staleness) {
+      console.log(`Using local seed data file: ${SEED_DATA_PATH}`)
+      return localData
+    }
+    console.warn(`Local seed data file ${SEED_DATA_PATH} looks stale: ${staleness}. Re-downloading...`)
   }
 
-  // If no local file, download from URL
-  // Dynamic import to avoid bundling axios in production builds
-  // (preview deployments pre-download the seed data with curl)
-  console.log(`Downloading seed data from: ${SEED_DATA_URL}`)
   try {
+    return await downloadSeedData()
+  } catch (error) {
+    if (localData) {
+      console.warn('Download failed; falling back to the stale local file. If seeding fails with schema errors (e.g. an unknown argument), delete the file and re-run with network access.')
+      return localData
+    }
+    throw error
+  }
+}
+
+/**
+ * Download seed data from SEED_DATA_URL and cache it at SEED_DATA_PATH.
+ */
+async function downloadSeedData() {
+  console.log(`Downloading seed data from: ${SEED_DATA_URL}`)
+  let data: any
+  try {
+    // Dynamic import to avoid bundling axios in production builds
+    // (preview deployments pre-download the seed data with curl)
     const axios = (await import('axios')).default
     const response = await axios.get(SEED_DATA_URL)
-    const data = response.data
+    data = response.data
+  } catch (error) {
+    console.error('Failed to download seed data:', error)
+    throw new Error('Could not obtain seed data. Please provide a local file or ensure the URL is accessible.')
+  }
 
-    // Save to local file for future use
+  const staleness = seedDataStaleness(data)
+  if (staleness) {
+    console.warn(`Downloaded seed data also looks stale: ${staleness}. Proceeding anyway — if seeding fails, the published dump needs regenerating (npm run generate-seed).`)
+  }
+
+  // Stamp the fetch time into the cached copy so a published dump that
+  // predates the newest migration is re-fetched once, not on every seed run.
+  if (data?.metadata) {
+    data.metadata.downloadedAt = new Date().toISOString()
+  }
+
+  // Save to local file for future use. A failed write is not fatal — the
+  // freshly downloaded data is still the best data we have.
+  try {
     const directory = path.dirname(SEED_DATA_PATH)
     if (!fs.existsSync(directory)) {
       fs.mkdirSync(directory, { recursive: true })
     }
     fs.writeFileSync(SEED_DATA_PATH, JSON.stringify(data, null, 2))
-
-    return data
   } catch (error) {
-    console.error('Failed to download seed data:', error)
-    throw new Error('Could not obtain seed data. Please provide a local file or ensure the URL is accessible.')
+    console.warn(`Could not cache seed data to ${SEED_DATA_PATH} (${(error as Error).message}). Continuing with the downloaded data.`)
   }
+
+  return data
 }
 
 /**


### PR DESCRIPTION
## Summary

`getSeedData()` used a cached `prisma/seed_data.json` blindly whenever it existed, so a cache downloaded before a schema migration failed deep inside seeding with a confusing Prisma error (e.g. `Unknown argument 'isListed'`) and no hint that deleting the file fixes it.

The staleness signal needs no hand-maintained version constant: the dump generator already stamps `metadata.extractedAt`, and Prisma migration directories are named `YYYYMMDDHHMMSS_*`. A cache is treated as stale when its extraction predates the newest local migration.

Behavior (all contained in `prisma/seed.ts`):
- **Stale or unreadable cache** (predates latest migration, missing/invalid `extractedAt`, or invalid JSON) → warn with the concrete reason and re-download
- **Download fails with a stale cache present** (offline workflow) → fall back to the stale file with a warning telling the user what to do if seeding then fails, instead of hard-failing
- **Published dump itself predates the latest migration** → warn that the dump needs regenerating (`npm run generate-seed`) but proceed. The fetch time is stamped into the cached copy as `metadata.downloadedAt`, so this re-fetch happens **once per new migration**, not on every seed run

Closes #335

## Test plan

- `npx tsc --noEmit` passes; `npm test`: 77 suites, 1092 tests pass
- Extracted the helpers into a harness and ran them against the real repo state: `latestMigrationDate()` correctly returns `2026-07-20T12:00:00Z` (from `20260720120000_add_cyprus_realm`); fresh/stale/missing-metadata/invalid-date inputs all classify correctly
- End-to-end flow test against the real published dump: round 1 detects the stale cache, re-downloads (and correctly warns that the currently published dump, extracted 2026-03-19, is itself behind the latest migration), stamps `downloadedAt`; round 2 uses the cache without re-downloading
- Also exercised the download-failure fallback path (falls back to the stale local file with a warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vk3qdnQUgyj7nYokvXqpTw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vk3qdnQUgyj7nYokvXqpTw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to `prisma/seed.ts` dev/preview seeding paths and do not affect production runtime; worst case is incorrect staleness if cwd lacks migrations, which only weakens the new guardrails.
> 
> **Overview**
> **Stale seed cache detection** — `getSeedData()` no longer trusts `seed_data.json` just because it exists. New helpers compare `metadata.extractedAt` to the newest local migration timestamp (from `prisma/migrations` names, resolved via `process.cwd()` for ESM preview bundles) and treat missing/invalid metadata or JSON as stale.
> 
> **Refresh and fallback** — Stale or bad cache triggers a warn + re-download via extracted `downloadSeedData()`. If download fails but a local file exists, seeding continues with that file and guidance instead of failing immediately. Fresh downloads get `metadata.downloadedAt` so a published dump older than the latest migration is only re-fetched once per migration, not every run; stale remote dumps still warn but proceed, and cache write failures are non-fatal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7363ef217cf3848a4bb134b963834a658f48c892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The seed cache now validates its extraction timestamp against the latest Prisma migration.
- Resolves migrations from the runtime working directory, supporting the preview deployment’s ESM seed bundle.
- Refreshes stale, malformed, or unreadable cached seed data.
- Falls back to usable stale local data when downloading fails.
- Stamps downloaded data to avoid repeatedly fetching an unchanged published dump.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the preview runner invokes the ESM seed bundle from a build root containing prisma/migrations, so the revised lookup fixes the previously reported issue.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| prisma/seed.ts | Adds migration-aware seed-cache validation and download fallback behavior; the working-directory lookup correctly fixes the previously reported ESM preview-seeding failure. |

<sub>Reviews (2): Last reviewed commit: ["fix(seed): detect and refresh stale cach..."](https://github.com/schemalabz/opencouncil/commit/7363ef217cf3848a4bb134b963834a658f48c892) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47562273)</sub>

<!-- /greptile_comment -->