### PR TITLE
fix(analytics): never identify against the cookieless sentinel

### DIFF
--- a/src/components/analytics/__tests__/identifyUser.test.ts
+++ b/src/components/analytics/__tests__/identifyUser.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment jsdom
+ *
+ * identifyPostHogUser reads localStorage, so it needs jsdom despite the
+ * .test.ts → node split in jest.config.js.
+ */
+import posthog from 'posthog-js';
+import type { Session } from 'next-auth';
+import { identifyPostHogUser } from '../identifyUser';
+import { INTERNAL_PERSON_KEY, INTERNAL_USER_KEY } from '@/lib/utils/analyticsConsent';
+
+jest.mock('posthog-js', () => ({
+  __esModule: true,
+  default: {
+    __loaded: true,
+    get_explicit_consent_status: jest.fn(),
+    get_distinct_id: jest.fn(),
+    identify: jest.fn(),
+    register: jest.fn(),
+    setPersonProperties: jest.fn(),
+  },
+}));
+
+const mocked = posthog as jest.Mocked<typeof posthog>;
+
+function session(user: Partial<Session['user']>): Session {
+  return { user, expires: '' } as Session;
+}
+
+const visitor = session({ id: 'user-1', email: 'someone@example.com' });
+const teamMember = session({ id: 'team-1', email: 'someone@opencouncil.gr' });
+
+describe('identifyPostHogUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mocked.__loaded = true;
+    mocked.get_explicit_consent_status.mockReturnValue('granted');
+    mocked.get_distinct_id.mockReturnValue('0197-anon-device-uuid');
+  });
+
+  it('identifies a consenting signed-in user on their user id', () => {
+    identifyPostHogUser(visitor);
+
+    expect(mocked.identify).toHaveBeenCalledWith('user-1');
+  });
+
+  it('does nothing when posthog is not initialized', () => {
+    mocked.__loaded = false;
+
+    identifyPostHogUser(teamMember);
+
+    expect(mocked.register).not.toHaveBeenCalled();
+    expect(mocked.identify).not.toHaveBeenCalled();
+    expect(mocked.setPersonProperties).not.toHaveBeenCalled();
+    expect(localStorage.getItem(INTERNAL_USER_KEY)).toBeNull();
+  });
+
+  it.each(['pending', 'denied'] as const)('does not identify while consent is %s', (status) => {
+    mocked.get_explicit_consent_status.mockReturnValue(status);
+
+    identifyPostHogUser(visitor);
+
+    expect(mocked.identify).not.toHaveBeenCalled();
+    expect(mocked.setPersonProperties).not.toHaveBeenCalled();
+  });
+
+  it('still marks the team device while consent is pending', () => {
+    // The device stamp must not sit behind the consent gate: it exists
+    // precisely so logged-out and cookieless visits from a team device are
+    // filtered too.
+    mocked.get_explicit_consent_status.mockReturnValue('pending');
+
+    identifyPostHogUser(teamMember);
+
+    expect(mocked.register).toHaveBeenCalledWith({ internal_user: true });
+    expect(localStorage.getItem(INTERNAL_USER_KEY)).toBe('1');
+    expect(mocked.identify).not.toHaveBeenCalled();
+    expect(mocked.setPersonProperties).not.toHaveBeenCalled();
+  });
+
+  it('does not identify while the tab still runs cookieless', () => {
+    // The cookieless sentinel is shared by every visitor: identifying
+    // against it would merge all such users into one PostHog person.
+    mocked.get_distinct_id.mockReturnValue('$posthog_cookieless');
+
+    identifyPostHogUser(visitor);
+
+    expect(mocked.identify).not.toHaveBeenCalled();
+    expect(mocked.setPersonProperties).not.toHaveBeenCalled();
+  });
+
+  it('marks a team device even while cookieless', () => {
+    mocked.get_distinct_id.mockReturnValue('$posthog_cookieless');
+
+    identifyPostHogUser(teamMember);
+
+    expect(localStorage.getItem(INTERNAL_USER_KEY)).toBe('1');
+    expect(mocked.register).toHaveBeenCalledWith({ internal_user: true });
+    expect(mocked.identify).not.toHaveBeenCalled();
+    // Writing the person property onto the shared sentinel person would flag
+    // every anonymous visitor as internal — the same class of bug as the
+    // sentinel identify.
+    expect(mocked.setPersonProperties).not.toHaveBeenCalled();
+  });
+
+  it('treats superadmins on external emails as team members', () => {
+    const superAdmin = session({ id: 'admin-1', email: 'someone@example.com', isSuperAdmin: true });
+
+    identifyPostHogUser(superAdmin);
+
+    expect(mocked.register).toHaveBeenCalledWith({ internal_user: true });
+    expect(mocked.setPersonProperties).toHaveBeenCalledWith({ $internal_or_test_user: true });
+  });
+
+  it('sends the internal person property once per account for team members', () => {
+    identifyPostHogUser(teamMember);
+    identifyPostHogUser(teamMember);
+
+    expect(mocked.setPersonProperties).toHaveBeenCalledTimes(1);
+    expect(mocked.setPersonProperties).toHaveBeenCalledWith({ $internal_or_test_user: true });
+    expect(localStorage.getItem(INTERNAL_PERSON_KEY)).toBe('team-1');
+  });
+
+  it('re-sends the person property when a different team member uses the same device', () => {
+    const secondTeamMember = session({ id: 'team-2', email: 'other@opencouncil.gr' });
+
+    identifyPostHogUser(teamMember);
+    identifyPostHogUser(secondTeamMember);
+
+    expect(mocked.setPersonProperties).toHaveBeenCalledTimes(2);
+    expect(localStorage.getItem(INTERNAL_PERSON_KEY)).toBe('team-2');
+  });
+
+  it('does not mark regular users as internal in any way', () => {
+    identifyPostHogUser(visitor);
+
+    expect(mocked.setPersonProperties).not.toHaveBeenCalled();
+    expect(mocked.register).not.toHaveBeenCalled();
+    expect(localStorage.getItem(INTERNAL_USER_KEY)).toBeNull();
+    expect(localStorage.getItem(INTERNAL_PERSON_KEY)).toBeNull();
+  });
+});

--- a/src/components/analytics/identifyUser.ts
+++ b/src/components/analytics/identifyUser.ts
@@ -1,6 +1,11 @@
 import posthog from "posthog-js";
 import type { Session } from "next-auth";
-import { INTERNAL_USER_KEY } from "@/lib/utils/analyticsConsent";
+import { INTERNAL_PERSON_KEY, INTERNAL_USER_KEY } from "@/lib/utils/analyticsConsent";
+
+// posthog-js's cookieless sentinel distinct id (not exported publicly).
+// While in cookieless mode, EVERY visitor shares this value as their
+// distinct id.
+const COOKIELESS_SENTINEL = "$posthog_cookieless";
 
 // Team traffic on production can't be excluded by host filters, and person
 // filters can't see logged-out or cookieless visits. Instead, any device
@@ -26,11 +31,29 @@ export function identifyPostHogUser(session: Session | null) {
         posthog.register({ internal_user: true });
     }
     if (posthog.get_explicit_consent_status() !== "granted") return;
+    // Consent status lives in localStorage and is shared across tabs, but
+    // cookieless mode is per-tab runtime state: a tab still running
+    // cookieless can observe "granted" (set by another tab, with this one
+    // re-triggered by a session refetch). identify() would then alias the
+    // account to the shared sentinel distinct id, merging every user who
+    // ever hits this path into one PostHog person. Skip instead: this tab
+    // keeps capturing anonymously, and identify happens on the next cookied
+    // page load.
+    if (posthog.get_distinct_id() === COOKIELESS_SENTINEL) return;
     if (session?.user?.id) {
         // Deliberately no person properties: the id alone is enough to link
         // events to the account, keeps direct PII (email) out of PostHog, and
         // avoids the billable $set that identify() emits on every page load
         // when properties are passed for an already-identified person.
         posthog.identify(session.user.id);
+        if (isTeamMember(session) && localStorage.getItem(INTERNAL_PERSON_KEY) !== session.user.id) {
+            localStorage.setItem(INTERNAL_PERSON_KEY, session.user.id);
+            // Person-level backstop to the device stamp above: events sent
+            // from a fresh device before the first team sign-in carry no
+            // `internal_user`, but this property puts the person in the
+            // internal-users cohort, whose project filter excludes all their
+            // events at query time — including those unstamped ones.
+            posthog.setPersonProperties({ $internal_or_test_user: true });
+        }
     }
 }

--- a/src/lib/utils/analyticsConsent.ts
+++ b/src/lib/utils/analyticsConsent.ts
@@ -15,6 +15,12 @@ export const REOPEN_CONSENT_EVENT = "oc-reopen-cookie-consent";
 // internal and test users" setting excludes. Clearing site data unmarks.
 export const INTERNAL_USER_KEY = "oc-internal-user";
 
+// Holds the user id of the team member whose `$internal_or_test_user` person
+// property was last sent from this device, so the (billable) $set goes out
+// once per account instead of on every page load — and still fires when a
+// different team member signs in on the same browser — see identifyUser.ts.
+export const INTERNAL_PERSON_KEY = "oc-internal-person";
+
 // Re-applies the stored ConsentChip answer whenever PostHog's own consent
 // state is back to 'pending' — on initial load, and right after
 // posthog.reset() on sign-out. In on_reject mode 'pending' DROPS all events,


### PR DESCRIPTION
## Problem

PostHog production data shows at least **five different signed-up users merged into a single PostHog person** (`13452e1d-b5bf-5f8b-805e-5f47dc9fa755`, 2,470 events). Their `$identify` events all share `anon_distinct_id: "$posthog_cookieless"` — the sentinel distinct id every cookieless visitor shares.

The race: consent status lives in localStorage (cross-tab), but cookieless mode is per-tab runtime state. A tab still running cookieless can observe granted consent (set by another tab, with the sync effect re-triggered by a `useSession` refetch) and call `identify()` while its distinct id is still the sentinel. Each such identify aliases another account to the same shared value, and PostHog merges them all into one person. Merges are irreversible.

## Fix

- Guard `identify()` on `posthog.get_distinct_id() !== "$posthog_cookieless"`. The affected tab keeps capturing anonymously; identify happens on the next cookied page load.

## Also included

- Team members now get `$internal_or_test_user: true` set as a person property (once per device, localStorage-guarded to avoid a billable `$set` per page load). The per-device `internal_user` event stamp misses events sent from a fresh device before the first team sign-in (~1,900 events leaked past the project filters since June 12); the person property puts them in the *Internal / Test users* cohort (152880), which the project filter excludes retroactively at query time.
- Unit tests for `identifyPostHogUser` covering the sentinel guard, the consent gate, device marking, and the once-per-device person property.

## Verification

- `npx tsc --noEmit` clean, 12/12 tests pass.
- After deploy, the frankenperson can be deleted in PostHog so future events re-create clean per-user persons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes identity aliasing and internal-user filtering in production analytics; wrong guards could leave users unidentified or mis-tag cohorts, but scope is limited to client-side PostHog helpers with new tests.
> 
> **Overview**
> Fixes a cross-tab race where **PostHog `identify()`** could run while a tab still used the shared **`$posthog_cookieless`** distinct id, merging multiple real users into one person. **`identifyPostHogUser`** now bails out when `get_distinct_id()` is that sentinel so identification waits for a cookied load.
> 
> Team/internal traffic also gets a **person-level backstop**: after consent, team members (including superadmins) receive **`$internal_or_test_user: true`** via `setPersonProperties`, deduped per account with new **`INTERNAL_PERSON_KEY`** in localStorage (still one device stamp via `internal_user` even when consent is pending or cookieless). **`identifyUser.test.ts`** adds jsdom coverage for consent, sentinel, device marking, and per-account person properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 736daba9a05c3368795fb523d5863284ebf2b16c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents PostHog identification against the shared cookieless sentinel and improves internal-user attribution.
- Skips identification and person-property updates while the current distinct ID is `$posthog_cookieless`.
- Records the last team account stamped on each device so shared browsers stamp each distinct team member once.
- Adds tests for consent, cookieless mode, device marking, superadmins, and per-account person properties.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported shared-device attribution failure is fixed by storing and comparing the team user ID, and no blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/analytics/identifyUser.ts | Adds the cookieless sentinel guard and correctly changes internal-person deduplication from device-wide to per-account. |
| src/components/analytics/__tests__/identifyUser.test.ts | Covers identification gates and verifies that different team accounts sharing a device each receive the internal person property. |
| src/lib/utils/analyticsConsent.ts | Defines and documents the localStorage key that tracks the most recently stamped team account. |

<sub>Reviews (3): Last reviewed commit: ["fix(analytics): never identify against t..."](https://github.com/schemalabz/opencouncil/commit/736daba9a05c3368795fb523d5863284ebf2b16c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47935844)</sub>

<!-- /greptile_comment -->