### PR TITLE
fix(offers): stop cost table overflowing on mobile

### DIFF
--- a/src/components/offer-letter/offer-letter.tsx
+++ b/src/components/offer-letter/offer-letter.tsx
@@ -363,37 +363,18 @@ function CostTable({ offer }: { offer: Offer }) {
                             amount={line.amount}
                         />
                     ))}
-                    {/* Subtotal */}
-                    <tr className="border-t border-neutral-200">
-                        <td className="px-5 py-3 text-right text-neutral-600" colSpan={3}>
-                            Μερικό σύνολο
-                        </td>
-                        <td className="px-5 py-3 text-right font-medium">
-                            {b.subtotal}
-                        </td>
-                    </tr>
-
-                    {b.discountAmount && (
-                        <tr>
-                            <td className="px-5 py-3 text-right text-orange" colSpan={3}>
-                                {b.discountLabel}
-                            </td>
-                            <td className="px-5 py-3 text-right font-medium text-orange">
-                                −{b.discountAmount}
-                            </td>
-                        </tr>
-                    )}
-
-                    {/* Total */}
-                    <tr className="border-t-2 border-neutral-900 bg-neutral-50">
-                        <td className="px-5 py-4 text-right font-semibold text-neutral-900" colSpan={3}>
-                            Σύνολο
-                        </td>
-                        <td className="px-5 py-4 text-right text-xl font-bold text-neutral-900">
-                            {b.total}
-                        </td>
-                    </tr>
                 </tbody>
+                <tfoot>
+                    <SummaryRow variant="subtotal" label="Μερικό σύνολο" amount={b.subtotal} />
+                    {b.discountAmount && (
+                        <SummaryRow
+                            variant="discount"
+                            label={b.discountLabel!}
+                            amount={`−${b.discountAmount}`}
+                        />
+                    )}
+                    <SummaryRow variant="total" label="Σύνολο" amount={b.total} />
+                </tfoot>
             </table>
             <p className="px-5 py-3 text-xs text-muted-foreground italic border-t border-neutral-200 text-right">
                 Οι τιμές δεν περιλαμβάνουν ΦΠΑ.
@@ -429,6 +410,54 @@ function CostRow({
             <td className={`px-3 py-3 text-right hidden sm:table-cell whitespace-nowrap ${txt}`}>{qty}</td>
             <td className={`px-3 py-3 text-right hidden sm:table-cell whitespace-nowrap ${txt}`}>{rate}</td>
             <td className={`px-5 py-3 text-right font-medium whitespace-nowrap ${muted ? "text-neutral-500" : "text-neutral-900"}`}>
+                {amount}
+            </td>
+        </tr>
+    );
+}
+
+function SummaryRow({
+    variant,
+    label,
+    amount,
+}: {
+    variant: "subtotal" | "discount" | "total";
+    label: string;
+    amount: string;
+}) {
+    const config: Record<typeof variant, { row?: string; cell: string; label: string; amount: string }> = {
+        subtotal: {
+            row: "border-t border-neutral-200",
+            cell: "py-3",
+            label: "text-neutral-600",
+            amount: "font-medium",
+        },
+        discount: {
+            cell: "py-3",
+            label: "text-orange",
+            amount: "font-medium text-orange",
+        },
+        total: {
+            row: "border-t-2 border-neutral-900 bg-neutral-50",
+            cell: "py-4",
+            label: "font-semibold text-neutral-900",
+            amount: "text-xl font-bold text-neutral-900",
+        },
+    };
+    const s = config[variant];
+    const labelCell = `px-5 ${s.cell} text-right ${s.label}`;
+    // The label cell spans the numeric columns on desktop, but those columns
+    // don't exist on mobile — a colSpan there would force phantom columns and
+    // push the amount off-screen, so we render a separate mobile label cell.
+    return (
+        <tr className={s.row}>
+            <td className={`${labelCell} hidden sm:table-cell`} colSpan={3}>
+                {label}
+            </td>
+            <td className={`${labelCell} sm:hidden`}>
+                {label}
+            </td>
+            <td className={`px-5 ${s.cell} text-right whitespace-nowrap ${s.amount}`}>
                 {amount}
             </td>
         </tr>


### PR DESCRIPTION
## Problem

The cost table on offer letter pages (e.g. `/offer-letter/<id>`) broke on mobile: the subtotal, discount and total amounts were pushed off the right edge of the screen (the total showed as a clipped "9.2…").

The line-item rows already adapt to small screens by hiding the Μονάδα/Τιμή columns (`hidden sm:table-cell`), leaving 2 visible columns. But the three summary rows used `colSpan={3}` unconditionally, which forced the table into 4 layout columns on mobile — landing the amounts in columns that extend past the viewport.

## Fix

The summary rows now go through a shared `SummaryRow` component that renders two label cells: a plain one shown only below `sm`, and a `colSpan={3}` one shown from `sm` up. The row therefore always matches the visible column count.

## Verification

- Reproduced the overflow on production at 375px, then confirmed the fix locally at 375px using an offer that also exercises the discount row: subtotal, discount and total all fit and right-align with the line-item amounts.
- Confirmed the desktop (1280px) 4-column layout is unchanged.
- `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in the offer letter cost table with no pricing, auth, or data logic touched.
> 
> **Overview**
> Fixes **mobile horizontal overflow** on the offer letter cost table where subtotal, discount, and total amounts were clipped off-screen.
> 
> Those three summary rows are refactored into a shared **`SummaryRow`** component. On viewports below `sm`, the label uses a normal cell (matching the two visible line-item columns); from `sm` up it keeps **`colSpan={3}`** over the hidden unit/price columns, mirroring how **`CostRow`** handles responsive columns. Desktop styling for subtotal, discount, and total is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d795df536c63e82aab320bb66000bc30b6fd73a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors the offer-letter cost summary rows into a shared responsive component.
- Uses separate mobile and desktop label cells so summary amounts remain within the visible table columns.
- Moves subtotal, discount, and total rows into the table footer while preserving their existing styling and values.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/offer-letter/offer-letter.tsx | The responsive summary-row implementation resolves the mobile column mismatch without changing offer calculations or alternate PDF and DOCX rendering paths. |

<sub>Reviews (2): Last reviewed commit: ["fix(offers): stop cost table overflowing..."](https://github.com/schemalabz/opencouncil/commit/e081afe98722fb3152d00e9fb3b075d348b55429) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48637334)</sub>

<!-- /greptile_comment -->