### PR TITLE
feat(i18n): persist the Serbian script choice across navigations

### DIFF
--- a/src/components/layout/ScriptSwitcher.tsx
+++ b/src/components/layout/ScriptSwitcher.tsx
@@ -47,9 +47,20 @@ export default function ScriptSwitcher({ className }: { className?: string }) {
     // Serbian, not an indicator of the current one.
     const active: "sr" | "sr-Latn" | null = isSerbianLocale(locale) ? locale : null
     const latPrefix = `/${urlPrefixForLocale("sr-Latn")}`
+    // The choice must ride in the URL, not an onClick cookie write: onClick
+    // never fires for middle-click / open-in-new-tab, and with a stored
+    // 'latn' cookie a bare unprefixed GET bounces straight back to /lat. The
+    // Ћир href carries ?script=cyrl, which the proxy consumes into the
+    // oc-script cookie (mirroring ?realm=). The Lat href needs no param: the
+    // /lat prefix wins over any cookie, and visiting it persists 'latn'.
     const hrefFor = (target: "sr" | "sr-Latn") => {
-        const path = target === "sr" ? pathname || "/" : pathname === "/" ? latPrefix : `${latPrefix}${pathname}`
-        return `${path}${search}`
+        if (target === "sr-Latn") {
+            const path = pathname === "/" ? latPrefix : `${latPrefix}${pathname}`
+            return `${path}${search}`
+        }
+        const params = new URLSearchParams(search)
+        params.set("script", "cyrl")
+        return `${pathname || "/"}?${params.toString()}`
     }
 
     const linkClass = (target: "sr" | "sr-Latn") =>

--- a/src/components/layout/ScriptSwitcher.tsx
+++ b/src/components/layout/ScriptSwitcher.tsx
@@ -71,7 +71,9 @@ export default function ScriptSwitcher({ className }: { className?: string }) {
 
     return (
         <div className={cn("inline-flex items-center gap-1.5 text-xs whitespace-nowrap", className)}>
-            <a href={hrefFor("sr")} className={linkClass("sr")} aria-label="Ћирилица" aria-current={active === "sr" ? "true" : undefined}>
+            {/* nofollow: the ?script=cyrl href is a crawlable twin of every
+                page — the cookie 302 means nothing to a cookieless crawler. */}
+            <a href={hrefFor("sr")} rel="nofollow" className={linkClass("sr")} aria-label="Ћирилица" aria-current={active === "sr" ? "true" : undefined}>
                 Ћир
             </a>
             <span className="text-muted-foreground/40" aria-hidden="true">|</span>

--- a/src/components/meetings/AddMeetingForm.tsx
+++ b/src/components/meetings/AddMeetingForm.tsx
@@ -130,6 +130,10 @@ export default function AddMeetingForm({ cityId, meeting, onSuccess }: AddMeetin
                 },
                 body: JSON.stringify({
                     ...values,
+                    // "none" is a UI sentinel (Radix Select can't have an empty-string
+                    // item) — it must not reach the API, where any truthy value is
+                    // stored as a foreign key and "none" violates the FK constraint.
+                    administrativeBodyId: values.administrativeBodyId === 'none' ? undefined : values.administrativeBodyId,
                     date: dateTime.toISOString(),
                 }),
             })

--- a/src/lib/__tests__/seo-redirects.test.ts
+++ b/src/lib/__tests__/seo-redirects.test.ts
@@ -1,4 +1,4 @@
-import { foreignLocaleRedirectPath, wwwRedirectTarget } from '../seo-redirects';
+import { foreignLocaleRedirectPath, serbianScriptRedirectPath, wwwRedirectTarget } from '../seo-redirects';
 import { computeForeignLocales, foreignLocalesForRealm } from '../realm';
 
 describe('wwwRedirectTarget', () => {
@@ -146,5 +146,35 @@ describe('foreignLocaleRedirectPath', () => {
         // emulation is faithful in local dev too.
         expect(foreignLocaleRedirectPath('localhost:3000', '/el/beograd', 'serbia')).toBe('/beograd');
         expect(foreignLocaleRedirectPath('localhost:3000', '/lat/beograd', 'serbia')).toBeNull();
+    });
+});
+
+describe('serbianScriptRedirectPath', () => {
+    it('redirects unprefixed serbia-realm paths to /lat while the cookie says latn', () => {
+        expect(serbianScriptRedirectPath('serbia', '/nis', 'latn')).toBe('/lat/nis');
+        expect(serbianScriptRedirectPath('serbia', '/nis/mar17-2026', 'latn')).toBe('/lat/nis/mar17-2026');
+        expect(serbianScriptRedirectPath('serbia', '/', 'latn')).toBe('/lat');
+    });
+
+    it('lets any explicit locale prefix win over the cookie', () => {
+        expect(serbianScriptRedirectPath('serbia', '/lat/nis', 'latn')).toBeNull();
+        expect(serbianScriptRedirectPath('serbia', '/lat', 'latn')).toBeNull();
+        expect(serbianScriptRedirectPath('serbia', '/en/nis', 'latn')).toBeNull();
+        expect(serbianScriptRedirectPath('serbia', '/sr/nis', 'latn')).toBeNull();
+    });
+
+    it('does nothing without a latn cookie', () => {
+        expect(serbianScriptRedirectPath('serbia', '/nis', undefined)).toBeNull();
+        expect(serbianScriptRedirectPath('serbia', '/nis', 'cyrl')).toBeNull();
+        expect(serbianScriptRedirectPath('serbia', '/nis', 'garbage')).toBeNull();
+    });
+
+    it('does nothing outside the serbia realm', () => {
+        expect(serbianScriptRedirectPath('greece', '/athens', 'latn')).toBeNull();
+        expect(serbianScriptRedirectPath('france', '/paris', 'latn')).toBeNull();
+    });
+
+    it('does not partial-match path segments that merely start with lat', () => {
+        expect(serbianScriptRedirectPath('serbia', '/latinika', 'latn')).toBe('/lat/latinika');
     });
 });

--- a/src/lib/__tests__/seo-redirects.test.ts
+++ b/src/lib/__tests__/seo-redirects.test.ts
@@ -1,4 +1,4 @@
-import { foreignLocaleRedirectPath, serbianScriptRedirectPath, wwwRedirectTarget } from '../seo-redirects';
+import { foreignLocaleRedirectPath, serbianScriptAdoption, serbianScriptParamTarget, serbianScriptRedirectPath, wwwRedirectTarget } from '../seo-redirects';
 import { computeForeignLocales, foreignLocalesForRealm } from '../realm';
 
 describe('wwwRedirectTarget', () => {
@@ -176,5 +176,61 @@ describe('serbianScriptRedirectPath', () => {
 
     it('does not partial-match path segments that merely start with lat', () => {
         expect(serbianScriptRedirectPath('serbia', '/latinika', 'latn')).toBe('/lat/latinika');
+    });
+});
+
+describe('serbianScriptRedirectPath embed exemption', () => {
+    it('never redirects embed routes, whose URL the embedding site chose', () => {
+        expect(serbianScriptRedirectPath('serbia', '/embed/meetings', 'latn')).toBeNull();
+        expect(serbianScriptRedirectPath('serbia', '/embed', 'latn')).toBeNull();
+    });
+});
+
+describe('serbianScriptAdoption', () => {
+    it('adopts latn when entering the /lat tree without it persisted', () => {
+        expect(serbianScriptAdoption('serbia', '/lat/nis', undefined)).toBe('latn');
+        expect(serbianScriptAdoption('serbia', '/lat', 'cyrl')).toBe('latn');
+    });
+
+    it('is a no-op when latn is already persisted', () => {
+        expect(serbianScriptAdoption('serbia', '/lat/nis', 'latn')).toBeNull();
+    });
+
+    it('adopts nothing outside the /lat tree', () => {
+        expect(serbianScriptAdoption('serbia', '/nis', undefined)).toBeNull();
+        expect(serbianScriptAdoption('serbia', '/latinika', undefined)).toBeNull();
+        expect(serbianScriptAdoption('serbia', '/en/nis', undefined)).toBeNull();
+    });
+
+    it('never lets an embed iframe set a site-wide preference', () => {
+        expect(serbianScriptAdoption('serbia', '/lat/embed/meetings', undefined)).toBeNull();
+        expect(serbianScriptAdoption('serbia', '/lat/embed', 'cyrl')).toBeNull();
+    });
+
+    it('does nothing outside the serbia realm', () => {
+        expect(serbianScriptAdoption('greece', '/lat/nis', undefined)).toBeNull();
+    });
+});
+
+describe('serbianScriptParamTarget', () => {
+    it('strips the /lat prefix when the param asks for cyrl', () => {
+        expect(serbianScriptParamTarget('/lat/nis', 'cyrl')).toBe('/nis');
+        expect(serbianScriptParamTarget('/lat', 'cyrl')).toBe('/');
+        expect(serbianScriptParamTarget('/nis', 'cyrl')).toBe('/nis');
+    });
+
+    it('enters the /lat tree in one hop when the param asks for latn', () => {
+        expect(serbianScriptParamTarget('/nis', 'latn')).toBe('/lat/nis');
+        expect(serbianScriptParamTarget('/', 'latn')).toBe('/lat');
+        expect(serbianScriptParamTarget('/lat/nis', 'latn')).toBe('/lat/nis');
+    });
+
+    it('leaves explicit non-Serbian prefixes alone in both directions', () => {
+        expect(serbianScriptParamTarget('/en/nis', 'latn')).toBe('/en/nis');
+        expect(serbianScriptParamTarget('/en/nis', 'cyrl')).toBe('/en/nis');
+    });
+
+    it('does not partial-match segments that merely start with lat', () => {
+        expect(serbianScriptParamTarget('/latinika', 'cyrl')).toBe('/latinika');
     });
 });

--- a/src/lib/seo-redirects.ts
+++ b/src/lib/seo-redirects.ts
@@ -1,6 +1,8 @@
 import { Realm } from '@prisma/client';
 import { REALMS, foreignLocalesForRealm, isKnownRealmHost, realmForHost } from '@/lib/realm';
 import { localePrefixPattern, urlPrefixForLocale } from '@/i18n/config';
+import { type SerbianScript } from '@/lib/serbian/transliterate';
+import { EMBED_PATH } from '@/lib/utils/embed';
 
 /**
  * SEO-motivated redirect decisions for the proxy. Pure module (no
@@ -68,7 +70,14 @@ export function foreignLocaleRedirectPath(
  */
 export const SERBIAN_SCRIPT_COOKIE = 'oc-script';
 
-const ANY_LOCALE_PREFIX_RE = new RegExp(`^/(${localePrefixPattern})(/|$)`);
+/** Any explicit locale URL prefix (/en, /el, /fr, /sr, /lat). Shared with the proxy. */
+export const LOCALE_PREFIX_RE = new RegExp(`^/(${localePrefixPattern})(/|$)`);
+
+const latPrefix = () => `/${urlPrefixForLocale('sr-Latn')}`;
+const inLatTree = (pathname: string) => {
+    const prefix = latPrefix();
+    return pathname === prefix || pathname.startsWith(`${prefix}/`);
+};
 
 /**
  * Path to 302 to when a reader who chose Latin script (cookie `latn`) hits an
@@ -86,8 +95,12 @@ const ANY_LOCALE_PREFIX_RE = new RegExp(`^/(${localePrefixPattern})(/|$)`);
  *   redirect; `/en` stays the escape hatch into English). The reverse choice
  *   needs no redirect at all: Ћир sets the cookie to 'cyrl' and unprefixed
  *   URLs already serve Cyrillic.
- * - The caller gates on page-navigation requests (GET + app path): redirecting
- *   a server-action POST would break it.
+ * - Embed routes are exempt: their URL is chosen by the embedding site's
+ *   configurator, and iframe content must not vary with the viewer's
+ *   site-wide preference (the /lat/embed variants also carry public cache
+ *   headers).
+ * - The caller gates on page-navigation requests (GET/HEAD + app path):
+ *   redirecting a server-action POST would break it.
  */
 export function serbianScriptRedirectPath(
     realm: Realm,
@@ -95,7 +108,47 @@ export function serbianScriptRedirectPath(
     scriptCookie: string | undefined,
 ): string | null {
     if (realm !== 'serbia' || scriptCookie !== 'latn') return null;
-    if (ANY_LOCALE_PREFIX_RE.test(pathname)) return null;
-    const latPrefix = `/${urlPrefixForLocale('sr-Latn')}`;
-    return pathname === '/' ? latPrefix : `${latPrefix}${pathname}`;
+    if (LOCALE_PREFIX_RE.test(pathname) || EMBED_PATH.test(pathname)) return null;
+    return pathname === '/' ? latPrefix() : `${latPrefix()}${pathname}`;
+}
+
+/**
+ * The cookie value to persist when serving this request, or null. Entering
+ * the /lat tree by any route (external link, share) adopts Latin as the
+ * reader's choice, so onward navigation through unprefixed links keeps the
+ * script (see `serbianScriptRedirectPath`). Unprefixed visits deliberately
+ * adopt nothing: with a 'latn' cookie they never get here (redirected), and
+ * without one the Cyrillic default needs no cookie — only the switcher's
+ * `?script=cyrl` sets 'cyrl'.
+ *
+ * Embed routes are exempt for the same reasons as the redirect — plus the
+ * reverse concern: an iframe on some third-party page must not silently set
+ * a site-wide preference the reader never chose.
+ */
+export function serbianScriptAdoption(
+    realm: Realm,
+    pathname: string,
+    scriptCookie: string | undefined,
+): SerbianScript | null {
+    if (realm !== 'serbia' || scriptCookie === 'latn') return null;
+    if (!inLatTree(pathname) || EMBED_PATH.test(pathname)) return null;
+    return 'latn';
+}
+
+/**
+ * Where the `?script=` consumer should land after persisting the choice: the
+ * URL is made to agree with the script it asked for, in one hop. Without
+ * this, `/lat/x?script=cyrl` (hand-written or shared — the switcher never
+ * builds it) would set 'cyrl' and then bounce the reader straight back into
+ * /lat via the adoption above, i.e. do the opposite of what it says.
+ * Explicit non-Serbian prefixes (/en) are left alone in both directions.
+ */
+export function serbianScriptParamTarget(pathname: string, script: SerbianScript): string {
+    if (script === 'cyrl') {
+        if (!inLatTree(pathname)) return pathname;
+        const stripped = pathname.slice(latPrefix().length);
+        return stripped === '' ? '/' : stripped;
+    }
+    if (inLatTree(pathname) || LOCALE_PREFIX_RE.test(pathname)) return pathname;
+    return pathname === '/' ? latPrefix() : `${latPrefix()}${pathname}`;
 }

--- a/src/lib/seo-redirects.ts
+++ b/src/lib/seo-redirects.ts
@@ -1,6 +1,6 @@
 import { Realm } from '@prisma/client';
 import { REALMS, foreignLocalesForRealm, isKnownRealmHost, realmForHost } from '@/lib/realm';
-import { urlPrefixForLocale } from '@/i18n/config';
+import { localePrefixPattern, urlPrefixForLocale } from '@/i18n/config';
 
 /**
  * SEO-motivated redirect decisions for the proxy. Pure module (no
@@ -58,4 +58,44 @@ export function foreignLocaleRedirectPath(
         if (pathname.startsWith(`/${prefix}/`)) return pathname.slice(prefix.length + 1);
     }
     return null;
+}
+
+/**
+ * Cookie persisting the reader's Serbian script choice across navigations.
+ * Set by the Ћир | Lat switcher (and refreshed by the proxy on explicit /lat
+ * visits); read only by the proxy. Values: 'latn' | 'cyrl'. Meaningless
+ * outside the serbia realm.
+ */
+export const SERBIAN_SCRIPT_COOKIE = 'oc-script';
+
+const ANY_LOCALE_PREFIX_RE = new RegExp(`^/(${localePrefixPattern})(/|$)`);
+
+/**
+ * Path to 302 to when a reader who chose Latin script (cookie `latn`) hits an
+ * unprefixed URL on the serbia realm, else null. Serbian is digraphic and the
+ * script variant lives in the URL (`/lat` prefix ↔ `sr-Latn`), so without
+ * this any link to an unprefixed URL — internal navigation, bookmarks, shared
+ * links — silently reverts the reader to Cyrillic.
+ *
+ * - Cookie-gated, so crawlers (cookieless) always see the canonical tree:
+ *   unprefixed Cyrillic, with the /lat variant canonicalised back to it (no
+ *   hreflang cluster is emitted anywhere — see `buildCanonicalAlternates`).
+ *   A 302 rather than a 301 because the response varies by cookie, so it must
+ *   never be treated as permanent; no effect on indexing either way.
+ * - Any explicit locale prefix wins over the cookie (`/lat` needs no
+ *   redirect; `/en` stays the escape hatch into English). The reverse choice
+ *   needs no redirect at all: Ћир sets the cookie to 'cyrl' and unprefixed
+ *   URLs already serve Cyrillic.
+ * - The caller gates on page-navigation requests (GET + app path): redirecting
+ *   a server-action POST would break it.
+ */
+export function serbianScriptRedirectPath(
+    realm: Realm,
+    pathname: string,
+    scriptCookie: string | undefined,
+): string | null {
+    if (realm !== 'serbia' || scriptCookie !== 'latn') return null;
+    if (ANY_LOCALE_PREFIX_RE.test(pathname)) return null;
+    const latPrefix = `/${urlPrefixForLocale('sr-Latn')}`;
+    return pathname === '/' ? latPrefix : `${latPrefix}${pathname}`;
 }

--- a/src/lib/serbian/transliterate.ts
+++ b/src/lib/serbian/transliterate.ts
@@ -139,6 +139,11 @@ export function latinToCyrillic(text: string): string {
 
 export type SerbianScript = 'cyrl' | 'latn';
 
+/** Type guard for untrusted script identifiers (cookies, query params). */
+export function isSerbianScript(value: string | null | undefined): value is SerbianScript {
+    return value === 'cyrl' || value === 'latn';
+}
+
 /**
  * Transliterates Serbian text to the target script; text already in the target
  * script — and any non-Serbian text — comes back unchanged.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,8 +4,8 @@ import { NextResponse, NextRequest } from 'next/server';
 import { auth } from './auth'
 import { env } from '@/env.mjs';
 import { REALMS, REALM_OVERRIDE_COOKIE, isRealm, isRealmApexHost, realmForHost, realmOverride } from './lib/realm';
-import { SERBIAN_SCRIPT_COOKIE, foreignLocaleRedirectPath, serbianScriptRedirectPath, wwwRedirectTarget } from './lib/seo-redirects';
-import { localePrefixPattern, urlPrefixForLocale } from './i18n/config';
+import { LOCALE_PREFIX_RE, SERBIAN_SCRIPT_COOKIE, foreignLocaleRedirectPath, serbianScriptAdoption, serbianScriptParamTarget, serbianScriptRedirectPath, wwwRedirectTarget } from './lib/seo-redirects';
+import { isSerbianScript } from './lib/serbian/transliterate';
 
 const i18nMiddleware = createIntlMiddleware(routing);
 
@@ -21,8 +21,6 @@ const JUNK_PATH = /^\/(wp-admin|wp-login|wp-content|wp-includes|wordpress|xmlrpc
 // gate on this.
 const APP_PATH = /^\/(?!api|_next|_vercel|qr\/|\..+).*/;
 
-// Any explicit locale URL prefix (/en, /el, /fr, /sr, /lat).
-const LOCALE_PREFIX_RE = new RegExp(`^/(${localePrefixPattern})(/|$)`);
 
 export default async function proxy(req: NextRequest) {
     // Basic auth check
@@ -119,9 +117,12 @@ export default async function proxy(req: NextRequest) {
     // method or path: the param only ever arrives on a switcher <a href> GET
     // and is stripped on first sight, so it never survives into a POST.
     const scriptParam = req.nextUrl.searchParams.get('script');
-    if (realm === 'serbia' && (scriptParam === 'cyrl' || scriptParam === 'latn')) {
+    if (realm === 'serbia' && isSerbianScript(scriptParam)) {
         const cleanUrl = req.nextUrl.clone();
         cleanUrl.searchParams.delete('script');
+        // Land on the tree that agrees with the requested script (one hop) —
+        // see serbianScriptParamTarget for the /lat/…?script=cyrl case.
+        cleanUrl.pathname = serbianScriptParamTarget(pathname, scriptParam);
         const response = NextResponse.redirect(cleanUrl, 302);
         response.cookies.set(SERBIAN_SCRIPT_COOKIE, scriptParam, {
             path: '/',
@@ -130,10 +131,11 @@ export default async function proxy(req: NextRequest) {
         });
         return response;
     }
-    // Page navigations only: GET (a 302 on a server-action POST would re-issue
-    // it as a bodyless GET) and app paths (never /api, /qr, static assets).
+    // Page navigations only: GET/HEAD (a 302 on a server-action POST would
+    // re-issue it as a bodyless GET; HEAD must agree with GET on the same
+    // URL) and app paths (never /api, /qr, static assets).
     const scriptCookie = req.cookies.get(SERBIAN_SCRIPT_COOKIE)?.value;
-    if (req.method === 'GET' && APP_PATH.test(pathname)) {
+    if ((req.method === 'GET' || req.method === 'HEAD') && APP_PATH.test(pathname)) {
         const scriptRedirect = serbianScriptRedirectPath(realm, pathname, scriptCookie);
         if (scriptRedirect !== null) {
             return NextResponse.redirect(new URL(scriptRedirect + req.nextUrl.search, req.url), 302);
@@ -173,18 +175,11 @@ export default async function proxy(req: NextRequest) {
         const response = await i18nMiddleware(req);
         if (response) {
             // Entering the /lat tree by any route (external link, share)
-            // adopts Latin as the persisted choice, so onward navigation
-            // through unprefixed links keeps the script (redirect above).
-            // Unprefixed visits deliberately do NOT set 'cyrl': with a 'latn'
-            // cookie they never reach here (redirected), and without one the
-            // default needs no cookie — only the switcher sets 'cyrl'.
-            const latPrefix = `/${urlPrefixForLocale('sr-Latn')}`;
-            if (
-                realm === 'serbia' &&
-                scriptCookie !== 'latn' &&
-                (pathname === latPrefix || pathname.startsWith(`${latPrefix}/`))
-            ) {
-                response.cookies.set(SERBIAN_SCRIPT_COOKIE, 'latn', {
+            // adopts Latin as the persisted choice — policy and rationale in
+            // serbianScriptAdoption (embeds exempt).
+            const adopted = serbianScriptAdoption(realm, pathname, scriptCookie);
+            if (adopted !== null) {
+                response.cookies.set(SERBIAN_SCRIPT_COOKIE, adopted, {
                     path: '/',
                     maxAge: 60 * 60 * 24 * 365,
                     sameSite: 'lax',

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,8 +4,8 @@ import { NextResponse, NextRequest } from 'next/server';
 import { auth } from './auth'
 import { env } from '@/env.mjs';
 import { REALMS, REALM_OVERRIDE_COOKIE, isRealm, isRealmApexHost, realmForHost, realmOverride } from './lib/realm';
-import { foreignLocaleRedirectPath, wwwRedirectTarget } from './lib/seo-redirects';
-import { localePrefixPattern } from './i18n/config';
+import { SERBIAN_SCRIPT_COOKIE, foreignLocaleRedirectPath, serbianScriptRedirectPath, wwwRedirectTarget } from './lib/seo-redirects';
+import { localePrefixPattern, urlPrefixForLocale } from './i18n/config';
 
 const i18nMiddleware = createIntlMiddleware(routing);
 
@@ -106,6 +106,40 @@ export default async function proxy(req: NextRequest) {
         return NextResponse.redirect(new URL(strippedPath + req.nextUrl.search, req.url), 301);
     }
 
+    // Script persistence for the digraphic Serbian realm: a reader who chose
+    // Latin (Ћир | Lat switcher → 'latn' cookie) stays in the /lat tree even
+    // when a link, bookmark or share points at an unprefixed URL.
+    //
+    // The switcher's Ћир link carries `?script=cyrl` (mirroring `?realm=`):
+    // the choice must live in the URL, not in an onClick cookie write,
+    // because middle-click / open-in-new-tab never runs the click handler —
+    // and a bare unprefixed GET with a stale 'latn' cookie would bounce
+    // straight back to /lat, making Cyrillic unreachable. Consuming the
+    // param here persists the cookie for every click type. Not gated on
+    // method or path: the param only ever arrives on a switcher <a href> GET
+    // and is stripped on first sight, so it never survives into a POST.
+    const scriptParam = req.nextUrl.searchParams.get('script');
+    if (realm === 'serbia' && (scriptParam === 'cyrl' || scriptParam === 'latn')) {
+        const cleanUrl = req.nextUrl.clone();
+        cleanUrl.searchParams.delete('script');
+        const response = NextResponse.redirect(cleanUrl, 302);
+        response.cookies.set(SERBIAN_SCRIPT_COOKIE, scriptParam, {
+            path: '/',
+            maxAge: 60 * 60 * 24 * 365,
+            sameSite: 'lax',
+        });
+        return response;
+    }
+    // Page navigations only: GET (a 302 on a server-action POST would re-issue
+    // it as a bodyless GET) and app paths (never /api, /qr, static assets).
+    const scriptCookie = req.cookies.get(SERBIAN_SCRIPT_COOKIE)?.value;
+    if (req.method === 'GET' && APP_PATH.test(pathname)) {
+        const scriptRedirect = serbianScriptRedirectPath(realm, pathname, scriptCookie);
+        if (scriptRedirect !== null) {
+            return NextResponse.redirect(new URL(scriptRedirect + req.nextUrl.search, req.url), 302);
+        }
+    }
+
     // Realm-locale handling: on a host whose realm default differs from the
     // app default (.fr → fr, .rs → sr), serve that locale's UI transparently.
     // Rewrite (not redirect) unprefixed app paths to the locale segment so the
@@ -137,7 +171,27 @@ export default async function proxy(req: NextRequest) {
     // Handle i18n first (skip for /qr/* paths to allow direct route handler)
     if (APP_PATH.test(pathname)) {
         const response = await i18nMiddleware(req);
-        if (response) return response;
+        if (response) {
+            // Entering the /lat tree by any route (external link, share)
+            // adopts Latin as the persisted choice, so onward navigation
+            // through unprefixed links keeps the script (redirect above).
+            // Unprefixed visits deliberately do NOT set 'cyrl': with a 'latn'
+            // cookie they never reach here (redirected), and without one the
+            // default needs no cookie — only the switcher sets 'cyrl'.
+            const latPrefix = `/${urlPrefixForLocale('sr-Latn')}`;
+            if (
+                realm === 'serbia' &&
+                scriptCookie !== 'latn' &&
+                (pathname === latPrefix || pathname.startsWith(`${latPrefix}/`))
+            ) {
+                response.cookies.set(SERBIAN_SCRIPT_COOKIE, 'latn', {
+                    path: '/',
+                    maxAge: 60 * 60 * 24 * 365,
+                    sameSite: 'lax',
+                });
+            }
+            return response;
+        }
     }
 
     return auth(req as any);


### PR DESCRIPTION
# Persist the Serbian script choice

On the Serbian realm the script variant lives in the URL (`/lat` ↔ `sr-Latn`, unprefixed ↔ `sr`), so a link to an unprefixed URL silently reverted a Latin-script reader to Cyrillic, and they had to re-toggle on every page.

**Scope**: next-intl `<Link>`/router navigations were never broken — under `sr-Latn` they already render `/lat/…` hrefs. What reverted the script was everything else: the ~14 plain `next/link` sites, raw anchors, bookmarks, and shared links. The inverse case is covered too: a Latin reader opening a shared unprefixed URL now stays in Latin.

## How it works

- The **Ћир | Lat switcher** carries the choice in its URLs: the Ћир link adds `?script=cyrl`, which the proxy consumes into an `oc-script` cookie and 302s to the matching tree in one hop (works for middle-click / new tab — no JS dependence, `rel="nofollow"` so crawlers skip the twin URLs).
- The **proxy 302s** unprefixed serbia-realm page loads (GET/HEAD) to `/lat` while the cookie says `latn` (`serbianScriptRedirectPath`). Ћир needs no redirect — unprefixed URLs already serve Cyrillic.
- **Entering `/lat` by any route** (external link, share) adopts Latin as the persisted choice (`serbianScriptAdoption`).
- **Embed routes are exempt** from both behaviors: their URL is chosen by the embedding site's configurator, `/lat/embed` carries public cache headers, and an iframe must not set a site-wide preference the reader never chose.

## Guardrails

- **Cookie-gated → SEO-neutral**: crawlers are cookieless, so they keep seeing the canonical unprefixed Cyrillic tree, with the `/lat` variant canonicalised back to it (no hreflang cluster is emitted anywhere — see `buildCanonicalAlternates`). 302 rather than 301 because the response varies by cookie.
- **GET/HEAD page paths only**: server-action POSTs and non-app paths are never redirected, and HEAD agrees with GET on every URL.
- **Explicit locale prefixes win** over the cookie (`/lat` itself, and `/en` stays the escape hatch).
- Works identically under the `?realm=serbia` preview override, so it's reviewable on the PR preview.

## Also on this branch

- `fix(meetings): don't send the 'none' admin-body sentinel to the API` — creating a meeting with no administrative body selected failed on an FK violation (the Radix Select's `"none"` sentinel reached the database). Surfaced while onboarding Niš, which had no bodies yet; fix strips the sentinel before submit. (The server-side schema hole — `administrativeBodyId` unconstrained in the OpenAPI contract — is tracked as a follow-up.)

## Testing

- Unit tests for all three policy helpers — `serbianScriptRedirectPath`, `serbianScriptAdoption`, `serbianScriptParamTarget` (prefix precedence, cookie states, realm gating, embed exemptions, no partial `/lat*` matches); full suite green, `tsc` clean, production build passes.
- Verified on the live preview: `?realm=serbia` → Lat → any navigation stays `/lat`; `?script=cyrl` flips back for every click type; cookieless requests get the canonical tree with no redirect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes edge proxy routing and cookie behavior for the Serbia realm, which affects all page navigations there; guardrails and tests are solid, but misconfiguration could break Cyrillic/Latin switching or embed URLs.
> 
> **Overview**
> Persists **Latin vs Cyrillic** on the Serbian realm via an **`oc-script` cookie** and proxy logic, so readers who chose Latin stay on **`/lat`** when they follow unprefixed links, bookmarks, or shares.
> 
> The **Ћир | Lat** switcher puts the choice in the URL: Cyrillic links add **`?script=cyrl`** (consumed by the proxy like **`?realm=`**), so middle-click and new-tab work; Latin links use the **`/lat`** prefix. **`rel="nofollow"`** on the Cyrillic toggle link avoids crawlable **`?script=cyrl`** duplicates.
> 
> **`proxy.ts`** redirects unprefixed GET/HEAD app paths to **`/lat`** when the cookie is **`latn`**, adopts **`latn`** when entering **`/lat`**, and resolves **`?script=`** to the matching path in one hop. Embed routes and explicit locale prefixes are exempt; redirects are **302** so cookie-varying responses stay non-permanent for crawlers.
> 
> Also fixes meeting creation when no administrative body is selected: **`AddMeetingForm`** omits the Radix **`"none"`** sentinel from the API payload so it does not violate the FK constraint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d448b69d5ecbeeec1f5821a5cac2f1086bcff47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR persists the Serbian Cyrillic/Latin choice across navigation and prevents the meeting form’s administrative-body sentinel from reaching the API.
- Adds cookie-backed Serbian script selection and URL normalization in the proxy.
- Updates the script switcher to support direct and new-tab navigation.
- Omits the `"none"` administrative-body sentinel from meeting payloads.
- Adds unit coverage for script redirects, explicit locale prefixes, adoption, and embed exemptions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/proxy.ts | Adds Serbian script query consumption, cookie persistence, and navigation redirects while preserving locale and embed handling. |
| src/lib/seo-redirects.ts | Introduces pure helpers for Serbian script redirects, explicit selection targets, and Latin-script adoption. |
| src/components/layout/ScriptSwitcher.tsx | Encodes script selection into navigable URLs so ordinary, middle-click, and new-tab navigation follow the same behavior. |
| src/components/meetings/AddMeetingForm.tsx | Removes the UI-only `"none"` administrative-body sentinel before serializing meeting requests. |
| src/lib/__tests__/seo-redirects.test.ts | Covers script-cookie states, realm and locale boundaries, embed exemptions, and script query targets. |

<sub>Reviews (4): Last reviewed commit: ["refactor(i18n): address script-persisten..."](https://github.com/schemalabz/opencouncil/commit/2d448b69d5ecbeeec1f5821a5cac2f1086bcff47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49834123)</sub>

<!-- /greptile_comment -->