### PR TITLE
feat(mcp): add UserMcpToken model and migration

### DIFF
--- a/prisma/migrations/20260803164326_add_user_mcp_token/migration.sql
+++ b/prisma/migrations/20260803164326_add_user_mcp_token/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "UserMcpToken" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL DEFAULT 'MCP token',
+    "hashedKey" TEXT NOT NULL,
+    "keyPrefix" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "UserMcpToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserMcpToken_hashedKey_key" ON "UserMcpToken"("hashedKey");
+
+-- AddForeignKey
+ALTER TABLE "UserMcpToken" ADD CONSTRAINT "UserMcpToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -832,6 +832,7 @@ model User {
   subjectVotes SubjectVote[]
   meetingAttendance MeetingAttendance[]
   serviceApiKeys ServiceApiKey[]
+  mcpTokens UserMcpToken[]
   searchQueries SearchQuery[]
 }
  
@@ -920,6 +921,22 @@ model ServiceApiKey {
 
   createdBy   User      @relation(fields: [createdById], references: [id])
   createdById String
+}
+
+// Personal access token for the MCP server. Unlike ServiceApiKey (superadmin,
+// service-level), an MCP token acts as the owning user: highlight creation is
+// attributed to them and limited by their per-city permissions.
+model UserMcpToken {
+  id         String    @id @default(cuid())
+  name       String    @default("MCP token")
+  hashedKey  String    @unique // SHA-256 hash of the raw token
+  keyPrefix  String    // First 10 chars for display (e.g. "mcp_a1b2c3")
+  createdAt  DateTime  @default(now())
+  lastUsedAt DateTime?
+  revokedAt  DateTime?
+
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String
 }
 
 model UtteranceEdit {


### PR DESCRIPTION
Adds the `UserMcpToken` table: personal access tokens for the MCP server (#587). User-scoped — unlike the superadmin-equivalent `ServiceApiKey` — SHA-256-hashed at rest with a display prefix, soft-revocable via `revokedAt`, and cascade-deleted with the owning user.

Split out as the bottom of the stack so the (purely additive) migration can be reviewed and applied ahead of the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive schema-only change with hashed secrets and standard FK constraints; no runtime auth or API behavior ships here.
> 
> **Overview**
> Introduces **user-scoped personal access tokens** for the upcoming MCP server, stored as the new `UserMcpToken` model and `User.mcpTokens` relation.
> 
> The schema mirrors `ServiceApiKey` (SHA-256 `hashedKey`, display `keyPrefix`, `lastUsedAt` / `revokedAt` lifecycle) but ties tokens to the **owning user** via `userId` with **cascade delete**, so MCP auth can act as that user rather than as a superadmin service key. The migration adds the table, unique index on `hashedKey`, and the user foreign key—no application logic in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11d6f5a6fdd199944755ed5621bab954bd9771c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds persistence for user-scoped MCP personal access tokens.
- Introduces the `UserMcpToken` Prisma model with hashed token storage, display prefixes, usage and revocation timestamps, and user ownership.
- Adds the corresponding additive migration, unique hash index, and cascade-delete foreign key.
- Adds the `User.mcpTokens` relation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| prisma/schema.prisma | Adds the user-token model and owning-user relation consistently with the migration. |
| prisma/migrations/20260803164326_add_user_mcp_token/migration.sql | Creates the additive token table, unique hashed-key index, and cascading user foreign key. |

<sub>Reviews (3): Last reviewed commit: ["feat(mcp): add UserMcpToken model and mi..."](https://github.com/schemalabz/opencouncil/commit/11d6f5a6fdd199944755ed5621bab954bd9771c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50051507)</sub>

<!-- /greptile_comment -->