### PR TITLE
fix(transcript): keep the viewport still when an utterance edit is saved

### DIFF
--- a/src/components/meetings/transcript/Transcript.tsx
+++ b/src/components/meetings/transcript/Transcript.tsx
@@ -11,6 +11,7 @@ import { useHighlight } from "../HighlightContext";
 import { useTranslations } from 'next-intl';
 import { UnverifiedTranscriptBanner, BANNER_HEIGHT_FULL } from "./UnverifiedTranscriptBanner";
 import { UtteranceContextMenu } from "./UtteranceContextMenu";
+import { getScrollContainer } from "@/lib/utils/scrollAnchor";
 
 // Helper functions for speaker segment identification and parsing
 const SPEAKER_SEGMENT_PREFIX = 'speaker-segment-';
@@ -49,7 +50,7 @@ export default function Transcript() {
 
     // Track scroll state for banner minimization via scroll container
     useEffect(() => {
-        const container = containerRef.current?.closest('[data-scroll-container]');
+        const container = getScrollContainer(containerRef.current);
         if (!container) return;
 
         const handleScroll = () => {

--- a/src/components/meetings/transcript/Utterance.tsx
+++ b/src/components/meetings/transcript/Utterance.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { Utterance } from "@prisma/client";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { useTranslations } from 'next-intl';
 import { useVideoActions } from "../VideoProvider";
 import { useTranscriptOptions } from "../options/OptionsContext";
@@ -19,6 +20,7 @@ import { cn } from "@/lib/utils";
 import { useEditing } from "../EditingContext";
 import { formatTimestamp } from "@/lib/formatters/time";
 import { useLocalizeText } from "@/hooks/useLocalizeText";
+import { captureScrollAnchor, restoreScrollAnchor } from "@/lib/utils/scrollAnchor";
 
 /**
  * Resolve the character offset of a click within a text span.
@@ -61,6 +63,11 @@ const UtteranceC: React.FC<{
 
     const clickOffsetRef = useRef<number | null>(null);
     const [isEditing, setIsEditing] = useState(false);
+    // Whichever node currently stands for this utterance — the read-only span
+    // or the editor box. Closing the editor swaps one for the other, which is
+    // exactly the moment the browser loses its own scroll anchor (#367).
+    const rootRef = useRef<HTMLElement | null>(null);
+    const setRootRef = useCallback((el: HTMLElement | null) => { rootRef.current = el; }, []);
     const [localUtterance, setLocalUtterance] = useState(utterance);
     const [editedText, setEditedText] = useState(utterance.text);
     const [editedStartTime, setEditedStartTime] = useState(utterance.startTimestamp);
@@ -79,6 +86,19 @@ const UtteranceC: React.FC<{
         setEditedStartTime(utterance.startTimestamp);
         setEditedEndTime(utterance.endTimestamp);
     }, [utterance]);
+
+    // Stable identity, so React runs this when the editor actually mounts. An
+    // inline callback is re-attached on every render, which re-ran `focus()` on
+    // every keystroke — and each call asks the browser to scroll the textarea
+    // into view.
+    const focusEditor = useCallback((el: HTMLTextAreaElement | null) => {
+        if (!el) return;
+        el.focus();
+        if (clickOffsetRef.current !== null) {
+            el.selectionStart = el.selectionEnd = clickOffsetRef.current;
+            clickOffsetRef.current = null;
+        }
+    }, []);
 
     // Check if this utterance is highlighted in the current editing highlight
     const isHighlighted = editingHighlight?.highlightedUtterances.some(hu => hu.utteranceId === localUtterance.id) || false;
@@ -141,6 +161,21 @@ const UtteranceC: React.FC<{
         }
     };
 
+    /**
+     * Closing the editor collapses a block-level box back into the running text
+     * of the segment. Commit that synchronously, between two measurements, so
+     * the reader keeps their place through the reflow (#367). `commit` carries
+     * any state the caller wants applied in the same pass.
+     */
+    const closeEditor = (commit?: () => void) => {
+        const anchor = captureScrollAnchor(rootRef.current);
+        flushSync(() => {
+            commit?.();
+            setIsEditing(false);
+        });
+        restoreScrollAnchor(anchor, rootRef.current);
+    };
+
     const handleEdit = async (e: React.FormEvent | React.MouseEvent) => {
         e.preventDefault();
         const originalText = localUtterance.text;
@@ -153,19 +188,18 @@ const UtteranceC: React.FC<{
 
         // Nothing changed - just close the editor
         if (!textChanged && !timestampsChanged) {
-            setIsEditing(false);
+            closeEditor();
             return;
         }
 
         // Optimistic update - immediate
-        setLocalUtterance({ 
-            ...localUtterance, 
+        closeEditor(() => setLocalUtterance({
+            ...localUtterance,
             text: editedText,
             startTimestamp: editedStartTime,
             endTimestamp: editedEndTime
-        });
-        setIsEditing(false);
-        
+        }));
+
         // Background save
         try {
             // Update text first
@@ -221,10 +255,11 @@ const UtteranceC: React.FC<{
     };
 
     const handleCancel = () => {
-        setIsEditing(false);
-        setEditedText(localUtterance.text);
-        setEditedStartTime(localUtterance.startTimestamp);
-        setEditedEndTime(localUtterance.endTimestamp);
+        closeEditor(() => {
+            setEditedText(localUtterance.text);
+            setEditedStartTime(localUtterance.startTimestamp);
+            setEditedEndTime(localUtterance.endTimestamp);
+        });
     };
 
     const setStartTimeToCurrentVideo = () => {
@@ -259,7 +294,7 @@ const UtteranceC: React.FC<{
 
     if (isEditing) {
         return (
-            <div className="relative w-full py-1 border border-blue-300 rounded-md p-2 bg-blue-50/30">
+            <div ref={setRootRef} className="relative w-full py-1 border border-blue-300 rounded-md p-2 bg-blue-50/30">
                 {/* Text Editor */}
                 <form onSubmit={handleEdit} className="relative">
                     <textarea
@@ -292,15 +327,7 @@ const UtteranceC: React.FC<{
                             }
                         }}
                         className="w-full resize-none border border-gray-300 rounded px-2 py-1 pr-16 text-sm min-h-[2.5em] transcript-text"
-                        ref={(el) => {
-                            if (el) {
-                                el.focus();
-                                if (clickOffsetRef.current !== null) {
-                                    el.selectionStart = el.selectionEnd = clickOffsetRef.current;
-                                    clickOffsetRef.current = null;
-                                }
-                            }
-                        }}
+                        ref={focusEditor}
                         rows={Math.max(1, editedText.split('\n').length)}
                         style={{
                             height: 'auto',
@@ -417,6 +444,7 @@ const UtteranceC: React.FC<{
     // and renders one set of items instead of one Radix Menu per utterance.
     const utteranceSpan = (
         <span
+            ref={setRootRef}
             className={cn(className, emptyUtteranceClass)}
             id={localUtterance.id}
             data-utterance-id={localUtterance.id}

--- a/src/components/meetings/transcript/Utterance.tsx
+++ b/src/components/meetings/transcript/Utterance.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { Utterance } from "@prisma/client";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { useTranslations } from 'next-intl';
 import { useVideoActions } from "../VideoProvider";
 import { useTranscriptOptions } from "../options/OptionsContext";
@@ -19,6 +20,7 @@ import { cn } from "@/lib/utils";
 import { useEditing } from "../EditingContext";
 import { formatTimestamp } from "@/lib/formatters/time";
 import { useLocalizeText } from "@/hooks/useLocalizeText";
+import { captureScrollAnchor, restoreScrollAnchor } from "@/lib/utils/scrollAnchor";
 
 /**
  * Resolve the character offset of a click within a text span.
@@ -61,6 +63,11 @@ const UtteranceC: React.FC<{
 
     const clickOffsetRef = useRef<number | null>(null);
     const [isEditing, setIsEditing] = useState(false);
+    // Whichever node currently stands for this utterance — the read-only span
+    // or the editor box. Closing the editor swaps one for the other, which is
+    // exactly the moment the browser loses its own scroll anchor (#367).
+    const rootRef = useRef<HTMLElement | null>(null);
+    const setRootRef = useCallback((el: HTMLElement | null) => { rootRef.current = el; }, []);
     const [localUtterance, setLocalUtterance] = useState(utterance);
     const [editedText, setEditedText] = useState(utterance.text);
     const [editedStartTime, setEditedStartTime] = useState(utterance.startTimestamp);
@@ -141,6 +148,21 @@ const UtteranceC: React.FC<{
         }
     };
 
+    /**
+     * Closing the editor collapses a block-level box back into the running text
+     * of the segment. Commit that synchronously, between two measurements, so
+     * the reader keeps their place through the reflow (#367). `commit` carries
+     * any state the caller wants applied in the same pass.
+     */
+    const closeEditor = (commit?: () => void) => {
+        const anchor = captureScrollAnchor(rootRef.current);
+        flushSync(() => {
+            commit?.();
+            setIsEditing(false);
+        });
+        restoreScrollAnchor(anchor, rootRef.current);
+    };
+
     const handleEdit = async (e: React.FormEvent | React.MouseEvent) => {
         e.preventDefault();
         const originalText = localUtterance.text;
@@ -153,19 +175,18 @@ const UtteranceC: React.FC<{
 
         // Nothing changed - just close the editor
         if (!textChanged && !timestampsChanged) {
-            setIsEditing(false);
+            closeEditor();
             return;
         }
 
         // Optimistic update - immediate
-        setLocalUtterance({ 
-            ...localUtterance, 
+        closeEditor(() => setLocalUtterance({
+            ...localUtterance,
             text: editedText,
             startTimestamp: editedStartTime,
             endTimestamp: editedEndTime
-        });
-        setIsEditing(false);
-        
+        }));
+
         // Background save
         try {
             // Update text first
@@ -221,10 +242,11 @@ const UtteranceC: React.FC<{
     };
 
     const handleCancel = () => {
-        setIsEditing(false);
-        setEditedText(localUtterance.text);
-        setEditedStartTime(localUtterance.startTimestamp);
-        setEditedEndTime(localUtterance.endTimestamp);
+        closeEditor(() => {
+            setEditedText(localUtterance.text);
+            setEditedStartTime(localUtterance.startTimestamp);
+            setEditedEndTime(localUtterance.endTimestamp);
+        });
     };
 
     const setStartTimeToCurrentVideo = () => {
@@ -259,7 +281,7 @@ const UtteranceC: React.FC<{
 
     if (isEditing) {
         return (
-            <div className="relative w-full py-1 border border-blue-300 rounded-md p-2 bg-blue-50/30">
+            <div ref={setRootRef} className="relative w-full py-1 border border-blue-300 rounded-md p-2 bg-blue-50/30">
                 {/* Text Editor */}
                 <form onSubmit={handleEdit} className="relative">
                     <textarea
@@ -292,6 +314,13 @@ const UtteranceC: React.FC<{
                             }
                         }}
                         className="w-full resize-none border border-gray-300 rounded px-2 py-1 pr-16 text-sm min-h-[2.5em] transcript-text"
+                        // Deliberately inline: the changing identity makes React
+                        // re-attach this on every render, which re-focuses the
+                        // textarea. Every editor shortcut below hangs off its
+                        // onKeyDown, so anything that moves focus onto a control
+                        // in here — the timestamp buttons, the skip-interval
+                        // dropdown — would otherwise leave Enter and Escape dead
+                        // until the user clicked back into the text.
                         ref={(el) => {
                             if (el) {
                                 el.focus();
@@ -417,6 +446,7 @@ const UtteranceC: React.FC<{
     // and renders one set of items instead of one Radix Menu per utterance.
     const utteranceSpan = (
         <span
+            ref={setRootRef}
             className={cn(className, emptyUtteranceClass)}
             id={localUtterance.id}
             data-utterance-id={localUtterance.id}

--- a/src/lib/utils/__tests__/scrollAnchor.test.tsx
+++ b/src/lib/utils/__tests__/scrollAnchor.test.tsx
@@ -1,0 +1,102 @@
+import { captureScrollAnchor, getScrollContainer, restoreScrollAnchor } from '../scrollAnchor';
+
+// Regression guard for #367: saving an utterance mid-segment used to strand the
+// editor near the end of the segment. Named .test.tsx so jest runs it under
+// jsdom — these helpers are pure DOM, no React.
+
+// jsdom has no layout, so each element reports the top its `data-top` says.
+beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        value(this: HTMLElement) {
+            const top = Number(this.dataset.top ?? 0);
+            return { top, bottom: top, left: 0, right: 0, width: 0, height: 0, x: 0, y: top } as DOMRect;
+        },
+    });
+});
+
+/** jsdom's own scrollTop is inert, so back it with a plain value. */
+const trackScrollTop = (el: HTMLElement, initial: number) => {
+    let value = initial;
+    Object.defineProperty(el, 'scrollTop', {
+        configurable: true,
+        get: () => value,
+        set: (next: number) => { value = next; },
+    });
+    return () => value;
+};
+
+const build = (top: number) => {
+    document.body.innerHTML = `
+        <div data-scroll-container id="scroller">
+            <span id="utterance" data-top="${top}"></span>
+        </div>`;
+    return {
+        scroller: document.getElementById('scroller')!,
+        utterance: document.getElementById('utterance')!,
+    };
+};
+
+describe('scrollAnchor', () => {
+    it('scrolls the container to keep the replacement node where the old one was', () => {
+        const { scroller, utterance } = build(500);
+        const scrollTop = trackScrollTop(scroller, 4000);
+
+        const anchor = captureScrollAnchor(utterance);
+        // The surrounding layout collapses and drags the utterance 480px up.
+        utterance.dataset.top = '20';
+        restoreScrollAnchor(anchor, utterance);
+
+        expect(scrollTop()).toBe(3520);
+    });
+
+    it('anchors the replacement node, which need not be the one measured', () => {
+        const { scroller, utterance } = build(500);
+        const scrollTop = trackScrollTop(scroller, 4000);
+
+        const anchor = captureScrollAnchor(utterance);
+        // The editor box gives way to a fresh span, as React's swap does.
+        const replacement = document.createElement('span');
+        replacement.dataset.top = '620';
+        utterance.replaceWith(replacement);
+        restoreScrollAnchor(anchor, replacement);
+
+        expect(scrollTop()).toBe(4120);
+    });
+
+    it('ignores sub-pixel drift', () => {
+        const { scroller, utterance } = build(500);
+        const scrollTop = trackScrollTop(scroller, 4000);
+
+        const anchor = captureScrollAnchor(utterance);
+        utterance.dataset.top = '500.4';
+        restoreScrollAnchor(anchor, utterance);
+
+        expect(scrollTop()).toBe(4000);
+    });
+
+    it('captures nothing outside a scroll container', () => {
+        document.body.innerHTML = '<span id="orphan" data-top="500"></span>';
+        expect(captureScrollAnchor(document.getElementById('orphan'))).toBeNull();
+    });
+
+    it('finds the enclosing scroll container, or nothing', () => {
+        const { scroller, utterance } = build(500);
+        expect(getScrollContainer(utterance)).toBe(scroller);
+        expect(getScrollContainer(scroller)).toBe(scroller);
+        expect(getScrollContainer(document.body)).toBeNull();
+        expect(getScrollContainer(null)).toBeNull();
+    });
+
+    it('is a no-op without an anchor or a node to restore', () => {
+        const { scroller, utterance } = build(500);
+        const scrollTop = trackScrollTop(scroller, 4000);
+
+        const anchor = captureScrollAnchor(utterance);
+        utterance.dataset.top = '20';
+        restoreScrollAnchor(null, utterance);
+        restoreScrollAnchor(anchor, null);
+
+        expect(scrollTop()).toBe(4000);
+    });
+});

--- a/src/lib/utils/__tests__/scrollAnchor.test.tsx
+++ b/src/lib/utils/__tests__/scrollAnchor.test.tsx
@@ -1,0 +1,94 @@
+import { captureScrollAnchor, restoreScrollAnchor } from '../scrollAnchor';
+
+// Regression guard for #367: saving an utterance mid-segment used to strand the
+// editor near the end of the segment. Named .test.tsx so jest runs it under
+// jsdom — these helpers are pure DOM, no React.
+
+// jsdom has no layout, so each element reports the top its `data-top` says.
+beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        value(this: HTMLElement) {
+            const top = Number(this.dataset.top ?? 0);
+            return { top, bottom: top, left: 0, right: 0, width: 0, height: 0, x: 0, y: top } as DOMRect;
+        },
+    });
+});
+
+/** jsdom's own scrollTop is inert, so back it with a plain value. */
+const trackScrollTop = (el: HTMLElement, initial: number) => {
+    let value = initial;
+    Object.defineProperty(el, 'scrollTop', {
+        configurable: true,
+        get: () => value,
+        set: (next: number) => { value = next; },
+    });
+    return () => value;
+};
+
+const build = (top: number) => {
+    document.body.innerHTML = `
+        <div data-scroll-container id="scroller">
+            <span id="utterance" data-top="${top}"></span>
+        </div>`;
+    return {
+        scroller: document.getElementById('scroller')!,
+        utterance: document.getElementById('utterance')!,
+    };
+};
+
+describe('scrollAnchor', () => {
+    it('scrolls the container to keep the replacement node where the old one was', () => {
+        const { scroller, utterance } = build(500);
+        const scrollTop = trackScrollTop(scroller, 4000);
+
+        const anchor = captureScrollAnchor(utterance);
+        // The surrounding layout collapses and drags the utterance 480px up.
+        utterance.dataset.top = '20';
+        restoreScrollAnchor(anchor, utterance);
+
+        expect(scrollTop()).toBe(3520);
+    });
+
+    it('anchors the replacement node, which need not be the one measured', () => {
+        const { scroller, utterance } = build(500);
+        const scrollTop = trackScrollTop(scroller, 4000);
+
+        const anchor = captureScrollAnchor(utterance);
+        // The editor box gives way to a fresh span, as React's swap does.
+        const replacement = document.createElement('span');
+        replacement.dataset.top = '620';
+        utterance.replaceWith(replacement);
+        restoreScrollAnchor(anchor, replacement);
+
+        expect(scrollTop()).toBe(4120);
+    });
+
+    it('ignores sub-pixel drift', () => {
+        const { scroller, utterance } = build(500);
+        const scrollTop = trackScrollTop(scroller, 4000);
+
+        const anchor = captureScrollAnchor(utterance);
+        utterance.dataset.top = '500.4';
+        restoreScrollAnchor(anchor, utterance);
+
+        expect(scrollTop()).toBe(4000);
+    });
+
+    it('captures nothing outside a scroll container', () => {
+        document.body.innerHTML = '<span id="orphan" data-top="500"></span>';
+        expect(captureScrollAnchor(document.getElementById('orphan'))).toBeNull();
+    });
+
+    it('is a no-op without an anchor or a node to restore', () => {
+        const { scroller, utterance } = build(500);
+        const scrollTop = trackScrollTop(scroller, 4000);
+
+        const anchor = captureScrollAnchor(utterance);
+        utterance.dataset.top = '20';
+        restoreScrollAnchor(null, utterance);
+        restoreScrollAnchor(anchor, null);
+
+        expect(scrollTop()).toBe(4000);
+    });
+});

--- a/src/lib/utils/scrollAnchor.ts
+++ b/src/lib/utils/scrollAnchor.ts
@@ -1,0 +1,46 @@
+/**
+ * Hold an element still while the layout around it is rebuilt.
+ *
+ * Browsers do this themselves (scroll anchoring), but they anchor on the
+ * focused node and drop that anchor the moment it is unmounted. Swapping a
+ * focused editor back into read-only text does exactly that, and in a long
+ * transcript — where speaker segments are virtualised with
+ * `content-visibility: auto`, so the layout above the viewport keeps settling —
+ * losing the anchor for a single frame is enough to strand the reader far from
+ * where they were.
+ *
+ * Measure with `captureScrollAnchor`, commit the DOM change synchronously
+ * (`flushSync`), then hand the replacement node to `restoreScrollAnchor`.
+ */
+export interface ScrollAnchor {
+    container: HTMLElement;
+    top: number;
+}
+
+/**
+ * The scrolling element a page's content sits in, marked by the meeting layout.
+ * Everything that needs to reach it goes through here rather than repeating the
+ * selector.
+ */
+export function getScrollContainer(element: Element | null | undefined): HTMLElement | null {
+    return element?.closest<HTMLElement>('[data-scroll-container]') ?? null;
+}
+
+export function captureScrollAnchor(element: HTMLElement | null): ScrollAnchor | null {
+    const container = getScrollContainer(element);
+    if (!element || !container) return null;
+    return { container, top: element.getBoundingClientRect().top };
+}
+
+/**
+ * `element` is whatever now stands in for the node that was measured — it need
+ * not be the same node.
+ */
+export function restoreScrollAnchor(anchor: ScrollAnchor | null, element: HTMLElement | null): void {
+    if (!anchor || !element) return;
+    const drift = element.getBoundingClientRect().top - anchor.top;
+    // Sub-pixel drift is rounding, not movement.
+    if (Math.abs(drift) >= 1) {
+        anchor.container.scrollTop += drift;
+    }
+}

--- a/src/lib/utils/scrollAnchor.ts
+++ b/src/lib/utils/scrollAnchor.ts
@@ -1,0 +1,37 @@
+/**
+ * Hold an element still while the layout around it is rebuilt.
+ *
+ * Browsers do this themselves (scroll anchoring), but they anchor on the
+ * focused node and drop that anchor the moment it is unmounted. Swapping a
+ * focused editor back into read-only text does exactly that, and in a long
+ * transcript — where speaker segments are virtualised with
+ * `content-visibility: auto`, so the layout above the viewport keeps settling —
+ * losing the anchor for a single frame is enough to strand the reader far from
+ * where they were.
+ *
+ * Measure with `captureScrollAnchor`, commit the DOM change synchronously
+ * (`flushSync`), then hand the replacement node to `restoreScrollAnchor`.
+ */
+export interface ScrollAnchor {
+    container: HTMLElement;
+    top: number;
+}
+
+export function captureScrollAnchor(element: HTMLElement | null): ScrollAnchor | null {
+    const container = element?.closest<HTMLElement>('[data-scroll-container]');
+    if (!element || !container) return null;
+    return { container, top: element.getBoundingClientRect().top };
+}
+
+/**
+ * `element` is whatever now stands in for the node that was measured — it need
+ * not be the same node.
+ */
+export function restoreScrollAnchor(anchor: ScrollAnchor | null, element: HTMLElement | null): void {
+    if (!anchor || !element) return;
+    const drift = element.getBoundingClientRect().top - anchor.top;
+    // Sub-pixel drift is rounding, not movement.
+    if (Math.abs(drift) >= 1) {
+        anchor.container.scrollTop += drift;
+    }
+}


### PR DESCRIPTION
Closes #367

## The bug

Browsers keep your place through layout changes with a feature called **scroll anchoring**: when content resizes, the browser picks an element you're looking at and adjusts the scroll position so it stays put. Its preferred anchor is the **focused element**.

Editing an utterance replaces its inline `<span>` with a block-level editor box, so while you're typing, the focused textarea *is* the anchor. Pressing Enter does two things in the same frame:

1. destroys the textarea → the browser loses its anchor;
2. removes a block-shaped box from the middle of a paragraph → the text reflows.

The anchor is gone in exactly the frame it was needed. And the ground underneath isn't solid: speaker segments are virtualised with `content-visibility: auto` (`globals.css:226`), so off-screen segments aren't laid out and their heights are estimates that keep getting corrected. Scroll anchoring normally hides that; for one frame it can't, and the scroll lands wherever those estimates leave it — in a long segment, usually near its end. `VideoProvider.tsx:179` already re-scrolls three times after a deep link to work around the same instability.

That also explains the "doesn't happen every time" in the report: it depends on what the layout above the viewport happens to be doing at that moment.

### How this was pinned down

Frame-by-frame extraction of the screen recording in the issue shows the jump is a **single-frame** event at 30fps — 4.383s still has the open editor with the caret in it, 4.417s is already ~712px further down, and nothing moves for 0.27s before or 0.5s after. That rules out the app's own `scrollIntoView({behavior: 'smooth'})` calls, which animate over many frames, and places the jump exactly at the commit that closes the editor.

## The fix

Measure the edited node, commit the close synchronously, re-pin whatever node replaced it:

```ts
const closeEditor = (commit?: () => void) => {
    const anchor = captureScrollAnchor(rootRef.current);
    flushSync(() => {
        commit?.();
        setIsEditing(false);
    });
    restoreScrollAnchor(anchor, rootRef.current);
};
```

Both closing paths (save and cancel) go through it, passing whatever state should land in the same pass. Opening the editor is deliberately **not** anchored — the `EDIT_NEXT_UTTERANCE` shortcut relies on the browser scrolling to an off-screen utterance.

Keeping this in the two handlers rather than in a hook matters on this page: a hook would have added a ref and a layout effect to all ~9,000 utterances to serve the one being edited, on a component that is explicitly tuned for that scale.

`flushSync` is a deliberate deopt — it's React's documented escape hatch for measuring the DOM right after a state update, and it's called from event handlers here, so it's a sanctioned use. It forces a synchronous render of one memoized component.

### Also: the textarea's ref callback

It was written inline, so React re-attached it on every render and re-ran `focus()` on **every keystroke** — each call asking the browser to scroll the element into view. Wrapping the same callback in `useCallback([])` makes React invoke it only when the editor actually mounts, which is what "focus once" wants.

## Changes

| File | |
|---|---|
| `src/lib/utils/scrollAnchor.ts` | new — `captureScrollAnchor` / `restoreScrollAnchor`, pure DOM. Restore takes the replacement node explicitly, since React swaps the editor `<div>` for a fresh `<span>`. |
| `src/components/meetings/transcript/Utterance.tsx` | route both closing paths through `closeEditor`; make the textarea ref stable |
| `src/lib/utils/__tests__/scrollAnchor.test.tsx` | new — 5 tests (replacement node, sub-pixel drift, no scroll container, null guards) |

## Verification

- Full suite: 1270 passing. `tsc --noEmit` and `eslint` clean. `npm run build` compiles and type-checks (it then fails collecting page data for `/api/chat` on missing Elasticsearch env in the sandbox — unrelated).
- Reproduced the transcript's DOM in Chromium via Playwright (`content-visibility` segments, sticky headers, the inline↔block editor swap) and ran the exact capture → swap → jump → restore sequence: **−818px stranding without the anchor, +1px with it.**

## Follow-up worth considering

This compensates rather than cures. The root cause is that edit mode swaps *inline* text for a *block* box; an inline-sized editor wouldn't reflow the paragraph and would need no anchoring at all. That's a real rewrite of the editing UI (timestamp row, save/cancel buttons, auto-growing rows), so it isn't folded into this fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7bs2JUZvryhquRy7tCRFU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized transcript UX fix with guarded DOM helpers and tests; `flushSync` is limited to single-utterance edit close handlers.
> 
> **Overview**
> Fixes **#367**: saving or canceling an utterance edit no longer jumps the transcript scroll position when the block editor collapses back into inline text.
> 
> A new **`scrollAnchor`** helper measures the utterance’s position in the meeting **`data-scroll-container`**, then **`restoreScrollAnchor`** nudges **`scrollTop`** after layout reflow. **`Utterance`** routes save, cancel, and no-op close through **`closeEditor`**, which uses **`flushSync`** so the DOM swap completes before the second measurement; **`rootRef`** tracks whichever node is active (editor **`div`** or read-only **`span`**). **`Transcript`** reuses **`getScrollContainer`** for banner scroll tracking instead of duplicating the selector.
> 
> jsdom tests cover replacement nodes, sub-pixel drift, and missing-container guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 607ba4d5fc74aae9d7ab29045631f394c2eb2841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds explicit scroll-position preservation when closing the utterance editor and centralizes transcript scroll-container lookup.
- Captures the edited utterance’s viewport position, synchronously commits save or cancel state, and restores any resulting scroll drift.
- Adds focused DOM-helper tests for replacement nodes, drift correction, container discovery, and null handling.
- Reuses the scroll-container helper in the transcript’s banner scroll listener.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/meetings/transcript/Utterance.tsx | Routes save, unchanged-submit, and cancel closures through synchronous anchor restoration while preserving the existing editor interaction behavior. |
| src/lib/utils/scrollAnchor.ts | Introduces small DOM utilities for locating the transcript scroller and correcting replacement-node position drift. |
| src/lib/utils/__tests__/scrollAnchor.test.tsx | Covers scroll correction, replacement nodes, sub-pixel drift, container discovery, and null guards in jsdom. |
| src/components/meetings/transcript/Transcript.tsx | Replaces a duplicated scroll-container lookup with the shared helper without changing listener behavior. |

<sub>Reviews (2): Last reviewed commit: ["fix(transcript): keep the viewport still..."](https://github.com/schemalabz/opencouncil/commit/607ba4d5fc74aae9d7ab29045631f394c2eb2841) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50798871)</sub>

<!-- /greptile_comment -->