### PR TITLE
feat(mcp): speaker roles and vote tallies on subject records

### DIFF
--- a/src/components/persons/RoleDisplay.tsx
+++ b/src/components/persons/RoleDisplay.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/routing';
 import { Badge } from '../ui/badge';
-import { cn, sortRolesByPriority, getPrimaryRole } from '@/lib/utils';
+import { cn, sortRolesByPriority, getPrimaryRole, getRoleText } from '@/lib/utils';
 import { Star, Building, Users } from 'lucide-react';
 import { RoleWithRelations } from '@/lib/db/types';
 const BADGE_MAX_CHARS_SMALL = 40;
@@ -39,38 +39,6 @@ const getRoleIconColor = (role: RoleWithRelations) => {
     if (role.cityId) return "text-[#a4c0e1]";
     if (role.administrativeBodyId) return "text-muted-foreground/70";
     return "text-muted-foreground/70";
-};
-
-const getRoleText = (role: RoleWithRelations, t: ReturnType<typeof useTranslations>) => {
-    // Party roles (has partyId)
-    if (role.partyId && role.party) {
-        const text = role.party.name;
-        if (role.isHead) return `${text} (${t('partyLeader')})`;
-        if (role.name) return `${text} - ${role.name}`;
-        return text;
-    }
-
-    // Administrative body roles (has administrativeBodyId)
-    if (role.administrativeBodyId && role.administrativeBody) {
-        // For administrative body roles, show role name first (e.g., "President"), then body name
-        if (role.name) {
-            return `${role.name} - ${role.administrativeBody.name}`;
-        }
-        // If no role name but is head, use the localized "president" label
-        if (role.isHead) {
-            return `${t('president')} - ${role.administrativeBody.name}`;
-        }
-        // Otherwise just show the administrative body name
-        return role.administrativeBody.name;
-    }
-
-    // City-level roles (has cityId but no partyId or administrativeBodyId, e.g., mayor)
-    if (role.cityId && !role.partyId && !role.administrativeBodyId) {
-        if (role.isHead) return t('mayor');
-        return role.name || t('member');
-    }
-
-    return role.name || t('member');
 };
 
 const getRoleVariant = (role: RoleWithRelations) => {

--- a/src/lib/mcp/__tests__/gate.test.ts
+++ b/src/lib/mcp/__tests__/gate.test.ts
@@ -28,31 +28,32 @@ describe('requireVisibleMeeting', () => {
     });
 
     it('passes released meetings for everyone', async () => {
-        mockMeetingFindFirst.mockResolvedValue({ released: true });
-        await expect(requireVisibleMeeting('athens', 'm1', null)).resolves.toEqual({ released: true });
-        await expect(requireVisibleMeeting('athens', 'm1', USER)).resolves.toEqual({ released: true });
-        await expect(requireVisibleMeeting('athens', 'm1', SERVICE)).resolves.toEqual({ released: true });
+        const meeting = { released: true, dateTime: new Date('2026-05-12T18:00:00Z') };
+        mockMeetingFindFirst.mockResolvedValue(meeting);
+        await expect(requireVisibleMeeting('athens', 'm1', null)).resolves.toEqual(meeting);
+        await expect(requireVisibleMeeting('athens', 'm1', USER)).resolves.toEqual(meeting);
+        await expect(requireVisibleMeeting('athens', 'm1', SERVICE)).resolves.toEqual(meeting);
     });
 
     it('hides unreleased meetings from anonymous and unrelated users', async () => {
-        mockMeetingFindFirst.mockResolvedValue({ released: false });
+        mockMeetingFindFirst.mockResolvedValue({ released: false, dateTime: new Date('2026-05-12T18:00:00Z') });
         await expect(requireVisibleMeeting('athens', 'm1', null)).rejects.toThrow(NotFoundError);
         await expect(requireVisibleMeeting('athens', 'm1', USER)).rejects.toThrow(NotFoundError);
     });
 
     it('shows unreleased meetings to service identities and city editors', async () => {
-        mockMeetingFindFirst.mockResolvedValue({ released: false });
-        await expect(requireVisibleMeeting('athens', 'm1', SERVICE)).resolves.toEqual({ released: false });
+        mockMeetingFindFirst.mockResolvedValue({ released: false, dateTime: new Date('2026-05-12T18:00:00Z') });
+        await expect(requireVisibleMeeting('athens', 'm1', SERVICE)).resolves.toEqual({ released: false, dateTime: new Date('2026-05-12T18:00:00Z') });
 
         mockUserFindUnique.mockResolvedValue({ isSuperAdmin: false, administers: [{ cityId: 'athens' }] });
-        await expect(requireVisibleMeeting('athens', 'm1', USER)).resolves.toEqual({ released: false });
+        await expect(requireVisibleMeeting('athens', 'm1', USER)).resolves.toEqual({ released: false, dateTime: new Date('2026-05-12T18:00:00Z') });
 
         mockUserFindUnique.mockResolvedValue({ isSuperAdmin: true, administers: [] });
-        await expect(requireVisibleMeeting('athens', 'm1', USER)).resolves.toEqual({ released: false });
+        await expect(requireVisibleMeeting('athens', 'm1', USER)).resolves.toEqual({ released: false, dateTime: new Date('2026-05-12T18:00:00Z') });
     });
 
     it('hides unreleased meetings from editors of other cities', async () => {
-        mockMeetingFindFirst.mockResolvedValue({ released: false });
+        mockMeetingFindFirst.mockResolvedValue({ released: false, dateTime: new Date('2026-05-12T18:00:00Z') });
         mockUserFindUnique.mockResolvedValue({ isSuperAdmin: false, administers: [{ cityId: 'argos' }] });
         await expect(requireVisibleMeeting('athens', 'm1', USER)).rejects.toThrow(NotFoundError);
     });

--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -12,6 +12,7 @@ import { upsertHighlightCore, canUserEditCity, canActorManageHighlight } from '@
 import { requestGenerateHighlightCore } from '@/lib/tasks/generateHighlight-core';
 import { NotFoundError, UnauthorizedError, BadRequestError, ForbiddenError } from '@/lib/api/errors';
 import { canSeeUnreleased, requireVisibleMeeting } from './gate';
+import { calculateVoteResult } from '@/lib/utils/votes';
 import {
     renderOptionsFromRequestBody,
     resolveRenderOptions,
@@ -294,6 +295,10 @@ export async function mcpGetSubject(subjectId: string, identity: McpIdentity) {
             }
             : null,
         votes: subject.votes.map(vote => ({ person: vote.person.name, vote: vote.voteType })),
+        // Precomputed tally so consumers (humans and agents alike) never have
+        // to count the array themselves — and with the same rules the site
+        // uses: PRESENT and DID_NOT_VOTE are declarations, not votes.
+        voteSummary: subject.votes.length > 0 ? calculateVoteResult(subject.votes) : null,
         url: urls.subject(subject.cityId, subject.councilMeetingId, subject.id),
     };
 }

--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -12,7 +12,10 @@ import { upsertHighlightCore, canUserEditCity, canActorManageHighlight } from '@
 import { requestGenerateHighlightCore } from '@/lib/tasks/generateHighlight-core';
 import { NotFoundError, UnauthorizedError, BadRequestError, ForbiddenError } from '@/lib/api/errors';
 import { canSeeUnreleased, requireVisibleMeeting } from './gate';
+import { getRoleLabelAt, RoleTextTranslator } from '@/lib/utils/roles';
 import { calculateVoteResult } from '@/lib/utils/votes';
+import { roleWithRelationsInclude } from '@/lib/db/types';
+import { getTranslations } from 'next-intl/server';
 import {
     renderOptionsFromRequestBody,
     resolveRenderOptions,
@@ -43,6 +46,16 @@ const urls = {
     moment: (cityId: string, meetingId: string, seconds: number) =>
         `${currentBaseUrl()}/${cityId}/${meetingId}?t=${Math.floor(seconds)}`,
 };
+
+
+/**
+ * Speaker role labels ride along with quoted speech so consumers copy titles
+ * instead of guessing them. The label is the site's own (getRoleLabelAt),
+ * resolved as of the meeting date; MCP serves the Greek public record, so it
+ * is always rendered from the Greek messages.
+ */
+const getRoleTranslations = (): Promise<RoleTextTranslator> =>
+    getTranslations({ locale: 'el', namespace: 'Person' });
 
 /** Turn contribution markdown ("[text](REF:UTTERANCE:id)") into plain text. */
 function stripRefLinks(text: string): string {
@@ -268,7 +281,12 @@ export async function mcpGetMeeting(cityId: string, meetingId: string, identity:
 export async function mcpGetSubject(subjectId: string, identity: McpIdentity) {
     const subject = await getSubject(subjectId);
     if (!subject) throw new NotFoundError('Subject not found');
-    await requireVisibleMeeting(subject.cityId, subject.councilMeetingId, identity);
+    const { dateTime: meetingDate } = await requireVisibleMeeting(
+        subject.cityId,
+        subject.councilMeetingId,
+        identity
+    );
+    const t = await getRoleTranslations();
 
     return {
         id: subject.id,
@@ -280,10 +298,15 @@ export async function mcpGetSubject(subjectId: string, identity: McpIdentity) {
         topic: subject.topic?.name ?? null,
         location: subject.location?.text ?? null,
         introducedBy: subject.introducedBy
-            ? { id: subject.introducedBy.id, name: subject.introducedBy.name }
+            ? {
+                id: subject.introducedBy.id,
+                name: subject.introducedBy.name,
+                role: getRoleLabelAt(subject.introducedBy.roles, t, meetingDate),
+            }
             : null,
         contributions: subject.contributions.map(contribution => ({
             speaker: contribution.speaker?.name ?? contribution.speakerName ?? 'Unknown',
+            role: getRoleLabelAt(contribution.speaker?.roles, t, meetingDate),
             text: stripRefLinks(contribution.text),
         })),
         decision: subject.decision
@@ -311,7 +334,12 @@ export async function mcpGetSubjectTranscript(subjectId: string, page: number, i
         select: { id: true, name: true, cityId: true, councilMeetingId: true },
     });
     if (!subject) throw new NotFoundError('Subject not found');
-    await requireVisibleMeeting(subject.cityId, subject.councilMeetingId, identity);
+    const { dateTime: meetingDate } = await requireVisibleMeeting(
+        subject.cityId,
+        subject.councilMeetingId,
+        identity
+    );
+    const t = await getRoleTranslations();
 
     const where: Prisma.UtteranceWhereInput = {
         discussionSubjectId: subjectId,
@@ -333,7 +361,16 @@ export async function mcpGetSubjectTranscript(subjectId: string, page: number, i
                 speakerSegment: {
                     select: {
                         speakerTag: {
-                            select: { label: true, person: { select: { id: true, name: true } } },
+                            select: {
+                                label: true,
+                                person: {
+                                    select: {
+                                        id: true,
+                                        name: true,
+                                        roles: roleWithRelationsInclude,
+                                    },
+                                },
+                            },
                         },
                     },
                 },
@@ -352,6 +389,7 @@ export async function mcpGetSubjectTranscript(subjectId: string, page: number, i
             utteranceId: utterance.id,
             speaker: utterance.speakerSegment.speakerTag.person?.name
                 ?? utterance.speakerSegment.speakerTag.label,
+            role: getRoleLabelAt(utterance.speakerSegment.speakerTag.person?.roles, t, meetingDate),
             startSec: utterance.startTimestamp,
             endSec: utterance.endTimestamp,
             text: utterance.text,
@@ -370,7 +408,8 @@ export async function mcpGetTranscript(
     options: { page: number; segmentsPerPage: number; includeUtteranceIds: boolean; personId?: string },
     identity: McpIdentity
 ) {
-    await requireVisibleMeeting(cityId, meetingId, identity);
+    const { dateTime: meetingDate } = await requireVisibleMeeting(cityId, meetingId, identity);
+    const t = await getRoleTranslations();
 
     const allSegments = await getTranscript(meetingId, cityId);
 
@@ -401,9 +440,10 @@ export async function mcpGetTranscript(
     const personIds = [...new Set(pageSegments.map(s => s.speakerTag.personId).filter((id): id is string => !!id))];
     const persons = await prisma.person.findMany({
         where: { id: { in: personIds } },
-        select: { id: true, name: true },
+        select: { id: true, name: true, roles: roleWithRelationsInclude },
     });
     const personNames = new Map(persons.map(person => [person.id, person.name]));
+    const personRoles = new Map(persons.map(person => [person.id, getRoleLabelAt(person.roles, t, meetingDate)]));
 
     return {
         cityId,
@@ -414,6 +454,7 @@ export async function mcpGetTranscript(
         segments: pageSegments.map(segment => ({
             speaker: (segment.speakerTag.personId && personNames.get(segment.speakerTag.personId))
                 || segment.speakerTag.label,
+            role: (segment.speakerTag.personId && personRoles.get(segment.speakerTag.personId)) || null,
             startSec: segment.startTimestamp,
             endSec: segment.endTimestamp,
             summary: segment.summary?.text ?? null,

--- a/src/lib/mcp/gate.ts
+++ b/src/lib/mcp/gate.ts
@@ -29,18 +29,19 @@ export async function requireVisibleMeeting(
     cityId: string,
     meetingId: string,
     identity: McpIdentity
-): Promise<{ released: boolean }> {
+): Promise<{ released: boolean; dateTime: Date }> {
     const meeting = await prisma.councilMeeting.findFirst({
         // Realm-scoped: a connector added on one domain must not reach another
         // realm's councils. Covers meetings, subjects and transcripts, which
         // all pass through here.
         where: { cityId, id: meetingId, city: { realm: currentRealm() } },
-        select: { released: true },
+        select: { released: true, dateTime: true },
     });
 
     if (!meeting || (!meeting.released && !(await canSeeUnreleased(identity, cityId)))) {
         throw new NotFoundError('Meeting not found');
     }
+
 
     return meeting;
 }

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -214,7 +214,10 @@ export function registerOpenCouncilServer(server: McpServer) {
             title: 'Get subject',
             description:
                 'Get a subject (agenda item) in detail: description, per-speaker contribution summaries, ' +
-                'decision, votes. For the verbatim discussion use get_subject_transcript.',
+                'decision, votes. Speaker `role` labels are resolved as of the meeting date (get_person ' +
+                'lists roles across all time). Vote semantics: ABSTAIN is ΛΕΥΚΟ (a blank ballot, counted ' +
+                'in totalVotes); DID_NOT_VOTE is ΑΠΟΧΗ (a declaration of non-participation, not a vote). ' +
+                'For the verbatim discussion use get_subject_transcript.',
             inputSchema: z.object({ subjectId: z.string().min(1) }),
         },
         (args, ctx: ServerContext) => run(() => mcpGetSubject(args.subjectId, identityFromContext(ctx)))
@@ -226,7 +229,8 @@ export function registerOpenCouncilServer(server: McpServer) {
             title: 'Get subject transcript',
             description:
                 'The verbatim transcript of everything said about one subject, as utterances with ids, ' +
-                'speaker names and timestamps. Utterance ids from here are what create_highlight needs.',
+                'speaker names, roles (resolved as of the meeting date) and timestamps. Utterance ids ' +
+                'from here are what create_highlight needs.',
             inputSchema: z.object({
                 subjectId: z.string().min(1),
                 ...paginationShape,
@@ -241,7 +245,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         {
             title: 'Get meeting transcript',
             description:
-                'The full transcript of a meeting as speaker segments, paginated. Long — prefer ' +
+                'The full transcript of a meeting as speaker segments, paginated. Speaker roles are ' +
+                'resolved as of the meeting date. Long — prefer ' +
                 'get_subject_transcript when you care about one subject. Pass personId for ' +
                 'everything one councillor said in the meeting (the way to gather their own ' +
                 'moments). Set includeUtteranceIds to get utterance ids for highlight creation.',

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -37,7 +37,9 @@ export {
   getSpeakerDisplayInfo,
   sortRolesByPriority,
   getRoleTypePriority,
-  getPrimaryRole
+  getPrimaryRole,
+  getRoleText,
+  getRoleLabelAt
 } from './utils/roles';
 
 export const IS_DEV = process.env.NODE_ENV === 'development';

--- a/src/lib/utils/__tests__/roles.test.ts
+++ b/src/lib/utils/__tests__/roles.test.ts
@@ -1,5 +1,6 @@
 import { Role, Party } from '@prisma/client';
-import { getSpeakerDisplayInfo, getPartyFromRoles, isRoleActiveAt, sortRolesByPriority, getPrimaryRole, simplifyRoleName } from '../roles';
+import { getSpeakerDisplayInfo, getPartyFromRoles, isRoleActiveAt, sortRolesByPriority, getPrimaryRole, simplifyRoleName, getRoleText, getRoleLabelAt } from '../roles';
+import { RoleWithRelations } from '@/lib/db/types';
 
 function makeRole(overrides: Partial<Role> & { party?: Party | null } = {}): Role & { party?: Party | null; cityId?: string | null } {
   return {
@@ -546,5 +547,95 @@ describe('simplifyRoleName', () => {
   it('passes through unrelated role names unchanged', () => {
     expect(simplifyRoleName('Δήμαρχος')).toBe('Δήμαρχος');
     expect(simplifyRoleName('Πρόεδρος')).toBe('Πρόεδρος');
+  });
+});
+
+// --- getRoleText / getRoleLabelAt (the label MCP and the badges share) ---
+
+const roleT = (key: 'mayor' | 'president' | 'partyLeader' | 'member') =>
+  ({ mayor: 'Δήμαρχος', president: 'Πρόεδρος', partyLeader: 'Επικεφαλής', member: 'Μέλος' }[key]);
+
+function makeAdminBody(name: string) {
+  return {
+    id: 'body-1',
+    cityId: 'city-1',
+    name,
+    name_en: name,
+    type: 'community' as const,
+    notificationBehavior: 'NOTIFICATIONS_DISABLED' as const,
+    showUnreviewedTranscript: false,
+    youtubeChannelUrl: null,
+    contactEmails: [],
+    diavgeiaUnitIds: [],
+    createdAt: new Date('2020-01-01'),
+    updatedAt: new Date('2020-01-01'),
+  };
+}
+
+function makeFullRole(overrides: Partial<RoleWithRelations> = {}): RoleWithRelations {
+  return { ...makeRole(), party: null, administrativeBody: null, city: null, ...overrides } as RoleWithRelations;
+}
+
+describe('getRoleText', () => {
+  it('labels a city head as mayor', () => {
+    const role = makeFullRole({ cityId: 'city-1', isHead: true });
+    expect(getRoleText(role, roleT)).toBe('Δήμαρχος');
+  });
+
+  it('never labels a non-city head as mayor (admin-body chair with null name)', () => {
+    const role = makeFullRole({
+      administrativeBodyId: 'body-1',
+      administrativeBody: makeAdminBody('6η Δημοτική Κοινότητα'),
+      isHead: true,
+    });
+    expect(getRoleText(role, roleT)).toBe('Πρόεδρος - 6η Δημοτική Κοινότητα');
+  });
+
+  it('labels a party head with the party name and leader suffix', () => {
+    const party = makeParty({ name: 'Αθήνα Ψηλά' });
+    const role = makeFullRole({ partyId: party.id, party, isHead: true });
+    expect(getRoleText(role, roleT)).toBe('Αθήνα Ψηλά (Επικεφαλής)');
+  });
+
+  it('labels a plain party member with the party name', () => {
+    const party = makeParty({ name: 'Αθήνα Τώρα' });
+    const role = makeFullRole({ partyId: party.id, party });
+    expect(getRoleText(role, roleT)).toBe('Αθήνα Τώρα');
+  });
+
+  it('prefers the stored role name on a named admin-body role', () => {
+    const role = makeFullRole({
+      name: 'Αντιπρόεδρος',
+      administrativeBodyId: 'body-1',
+      administrativeBody: makeAdminBody('Δημοτική Επιτροπή'),
+      isHead: true,
+    });
+    expect(getRoleText(role, roleT)).toBe('Αντιπρόεδρος - Δημοτική Επιτροπή');
+  });
+});
+
+describe('getRoleLabelAt', () => {
+  it('picks the most prominent role active at the date', () => {
+    const party = makeParty({ name: 'Αθήνα Ψηλά' });
+    const roles = [
+      makeFullRole({ id: 'party-role', partyId: party.id, party, isHead: true }),
+      makeFullRole({ id: 'chair', administrativeBodyId: 'body-1', administrativeBody: makeAdminBody('6η Δημοτική Κοινότητα'), isHead: true }),
+    ];
+    // admin-body head (priority 2) outranks party head (priority 3)
+    expect(getRoleLabelAt(roles, roleT, meetingDate)).toBe('Πρόεδρος - 6η Δημοτική Κοινότητα');
+  });
+
+  it('ignores roles that ended before the meeting date', () => {
+    const party = makeParty({ name: 'Αθήνα Τώρα' });
+    const roles = [
+      makeFullRole({ id: 'old-mayor', cityId: 'city-1', isHead: true, endDate: new Date('2023-12-31') }),
+      makeFullRole({ id: 'party-role', partyId: party.id, party }),
+    ];
+    expect(getRoleLabelAt(roles, roleT, meetingDate)).toBe('Αθήνα Τώρα');
+  });
+
+  it('returns null when no role is active', () => {
+    expect(getRoleLabelAt(undefined, roleT, meetingDate)).toBeNull();
+    expect(getRoleLabelAt([makeFullRole({ endDate: new Date('2020-06-01') })], roleT, meetingDate)).toBeNull();
   });
 });

--- a/src/lib/utils/roles.ts
+++ b/src/lib/utils/roles.ts
@@ -1,4 +1,5 @@
 import { Party, Role } from "@prisma/client";
+import { RoleWithRelations } from "@/lib/db/types";
 
 /**
  * Validation error type for role validation
@@ -131,10 +132,11 @@ export function isRoleActive(role: { startDate: Date | null, endDate: Date | nul
 /**
  * Filters roles to only include active ones.
  * @param roles Array of roles with startDate and endDate fields
+ * @param at Date to check against (defaults to now)
  * @returns Array of active roles
  */
-export function filterActiveRoles<T extends { startDate: Date | null, endDate: Date | null }>(roles: T[]): T[] {
-  return roles.filter(isRoleActive);
+export function filterActiveRoles<T extends { startDate: Date | null, endDate: Date | null }>(roles: T[], at?: Date): T[] {
+  return roles.filter(role => at ? isRoleActiveAt(role, at) : isRoleActive(role));
 }
 
 /**
@@ -480,3 +482,58 @@ export function getRoleNameForPerson(
   return '';
 }
 
+
+/**
+ * The translation keys getRoleText needs. Satisfied by useTranslations('Person')
+ * on the client and getTranslations({ namespace: 'Person' }) on the server.
+ */
+export type RoleTextTranslator = (key: 'mayor' | 'president' | 'partyLeader' | 'member') => string;
+
+/**
+ * Human-readable text for a single role — the label the site's badges render.
+ */
+export function getRoleText(role: RoleWithRelations, t: RoleTextTranslator): string {
+  // Party roles (has partyId)
+  if (role.partyId && role.party) {
+    const text = role.party.name;
+    if (role.isHead) return `${text} (${t('partyLeader')})`;
+    if (role.name) return `${text} - ${role.name}`;
+    return text;
+  }
+
+  // Administrative body roles (has administrativeBodyId)
+  if (role.administrativeBodyId && role.administrativeBody) {
+    // For administrative body roles, show role name first (e.g., "President"), then body name
+    if (role.name) {
+      return `${role.name} - ${role.administrativeBody.name}`;
+    }
+    // If no role name but is head, use the localized "president" label
+    if (role.isHead) {
+      return `${t('president')} - ${role.administrativeBody.name}`;
+    }
+    // Otherwise just show the administrative body name
+    return role.administrativeBody.name;
+  }
+
+  // City-level roles (has cityId but no partyId or administrativeBodyId, e.g., mayor)
+  if (role.cityId && !role.partyId && !role.administrativeBodyId) {
+    if (role.isHead) return t('mayor');
+    return role.name || t('member');
+  }
+
+  return role.name || t('member');
+}
+
+/**
+ * The label for a person's most prominent role active at a date — the same
+ * text the site's badges render (getPrimaryRole + getRoleText). Null when no
+ * role is active at that date.
+ */
+export function getRoleLabelAt(
+  roles: RoleWithRelations[] | undefined,
+  t: RoleTextTranslator,
+  at: Date
+): string | null {
+  const primary = getPrimaryRole(filterActiveRoles(roles ?? [], at));
+  return primary ? getRoleText(primary, t) : null;
+}


### PR DESCRIPTION
Two data enrichments to the public MCP server, both motivated by agent testing on #598 but independently useful to every MCP consumer (ChatGPT, Claude, and later Notis):

## Speaker roles on quoted speech

`get_subject` (contributions, `introducedBy`), `get_subject_transcript` (utterances) and `get_transcript` (segments) now attach each speaker's most senior role **active on the meeting date**:

```json
{ "speaker": "Χάρης Δούκας", "role": "Δήμαρχος", "text": "…" }
```

Before this, records carried only names, so model consumers guessed offices from context — in testing, the mayor of Argos got labeled «δημοτικός σύμβουλος». Labels prefer the stored role name («Αντιδήμαρχος Παιδείας & Διαγενεακής Αλληλεγγύης»), fall back to «Δήμαρχος» for a city-head role, and otherwise state party membership («παράταξη «Αθήνα Ψηλά»») — a fact, never an invented title. Uses the existing `isRoleActiveAt` / `getRoleTypePriority` helpers.

Cost: zero extra queries on the subject path (roles were already fetched), one widened batch select on transcripts. `requireVisibleMeeting` now also returns the meeting date it already looks up.

## Precomputed vote tally

`get_subject` adds `voteSummary` (`{"FOR": 15, "AGAINST": 6}`) next to the `votes` array. Two test wakes miscounted the same subject's votes two different ways (12–6 and 13–6); consumers should copy a tally, not count an array.

## Testing

`npx tsc --noEmit` and the MCP test suite (20 tests) pass; verified end-to-end against the local MCP: Δούκας → «Δήμαρχος», Λιμνιωτάκη → «Πρόεδρος», deputy-mayor role name verbatim, party fallback for plain councillors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive MCP fields and shared UI labeling with tests; visibility/auth behavior unchanged aside from returning meeting date from the existing gate query.
> 
> **Overview**
> **MCP responses now include meeting-date speaker roles and a precomputed vote tally**, so agents and other consumers stop inferring offices from names alone.
> 
> Role badge text is centralized: `getRoleText` and `getRoleLabelAt` move from `RoleDisplay` into `src/lib/utils/roles`, with `filterActiveRoles` accepting an optional `at` date. `RoleDisplay` imports the shared helpers. MCP loads Greek `Person` translations and attaches a `role` field on `get_subject` (`introducedBy`, contributions), `get_subject_transcript` utterances, and `get_transcript` segments, using each person’s top active role on the meeting date. `requireVisibleMeeting` now returns `dateTime` (no extra query) for that resolution; transcript paths widen person selects to include roles where needed.
> 
> `get_subject` also adds **`voteSummary`** via `calculateVoteResult`, matching site rules (e.g. `PRESENT` / `DID_NOT_VOTE` are not counted as votes). MCP tool descriptions document role timing and vote semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a9d6b3ba9216c6aa20a2e1aac5641ee7d82e803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR enriches public MCP subject and transcript responses with meeting-date speaker roles and adds a precomputed subject vote tally.
- Moves shared role-label rendering into `src/lib/utils/roles.ts`.
- Loads role relations on transcript speaker records and resolves labels against the meeting date.
- Returns `voteSummary` alongside individual subject votes.
- Extends meeting visibility lookup results with the meeting date and updates MCP descriptions and tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/mcp/data.ts | Adds role labels and vote summaries to MCP responses; the previously flagged role-helper import now uses the required source alias. |
| src/lib/utils/roles.ts | Introduces shared role-text and date-sensitive primary-role labeling helpers. |
| src/lib/mcp/gate.ts | Returns the selected meeting date with the existing visibility result for role resolution. |
| src/components/persons/RoleDisplay.tsx | Reuses the extracted shared role-text helper without changing badge behavior. |
| src/lib/mcp/server.ts | Documents the newly exposed speaker-role fields and vote semantics. |

<sub>Reviews (4): Last reviewed commit: ["feat(mcp): speaker roles on subjects and..."](https://github.com/schemalabz/opencouncil/commit/3a9d6b3ba9216c6aa20a2e1aac5641ee7d82e803) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51572313)</sub>

<!-- /greptile_comment -->