### PR TITLE
fix(mcp): resolve /mcp page locale from params, not the request default

### DIFF
--- a/src/app/[locale]/(other)/mcp/page.tsx
+++ b/src/app/[locale]/(other)/mcp/page.tsx
@@ -10,8 +10,15 @@ import { McpTokenManager } from "@/components/mcp/McpTokenManager";
 import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
 import { ArrowRight, ArrowUpRight } from "lucide-react";
 
-export async function generateMetadata(): Promise<Metadata> {
-    const t = await getTranslations("mcp.metadata");
+// Both entry points read the locale from params and pass it explicitly:
+// without it, getTranslations races the [locale] layout's setRequestLocale
+// (layouts and pages render in parallel) and falls back to the default
+// locale — opencouncil.rs/mcp rendered Greek.
+export async function generateMetadata(props: {
+    params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+    const { locale } = await props.params;
+    const t = await getTranslations({ locale, namespace: "mcp.metadata" });
     return {
         title: t("title"),
         description: t("description"),
@@ -36,8 +43,9 @@ function SectionHeading({ children }: { children: React.ReactNode }) {
     );
 }
 
-export default async function McpPage() {
-    const t = await getTranslations("mcp");
+export default async function McpPage(props: { params: Promise<{ locale: string }> }) {
+    const { locale } = await props.params;
+    const t = await getTranslations({ locale, namespace: "mcp" });
     const user = await getCurrentUser();
     const tokens = user ? await listUserMcpTokens(user.id) : [];
     const serverUrl = mcpBaseUrl();


### PR DESCRIPTION
opencouncil.rs/mcp (and .fr/mcp) rendered Greek content under a correct `<html lang>`.

The page is under the `[locale]` tree and fully translated (`sr/mcp.json` is complete) — but it called `getTranslations` without a locale and took no `params` at all. Layouts and pages render **in parallel** in the App Router, so the page's `getTranslations` raced the `[locale]` layout's `setRequestLocale` and fell back to the app default (`el`). Every other `(other)`-group page dodges this by awaiting `params` first, which happens to sequence it after the layout.

Fix: both `generateMetadata` and the page now read `locale` from `params` and pass it to `getTranslations` explicitly — race-proof rather than ordering-dependent.

## Testing

Verified against the dev server with spoofed Host headers — title, `<h1>` and `<html lang>` now agree on all three realms:

- `opencouncil.rs` → «Питајте свог AI асистента о својој општини» (was Greek)
- `opencouncil.gr` → «Ρωτήστε τον AI βοηθό σας για τον δήμο σας»
- `opencouncil.fr` → « Interrogez votre assistant IA sur votre commune »

`npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized copy/metadata only on one page; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes wrong-language copy on `/mcp` (e.g. Serbian host showing Greek) when `<html lang>` was already correct.
> 
> **`generateMetadata` and the page** now accept `params`, await `locale`, and call `getTranslations({ locale, namespace: ... })` instead of relying on implicit request locale. That avoids a race with the `[locale]` layout’s `setRequestLocale` under parallel App Router rendering, which previously fell back to the default locale (`el`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a61e4491c62479bc00da4c8859e2aab5db87c8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the MCP page’s translation race by resolving the locale directly from route parameters.
- Passes the explicit route locale to page translation lookup.
- Applies the same locale handling to generated metadata.
- Keeps authentication, token loading, and canonical alternate behavior unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with page content and metadata now deterministically using the locale selected by the route.

The parent locale layout validates supported locale values, the explicit next-intl lookup form is already established in the repository, and the change does not alter authentication or token access behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/(other)/mcp/page.tsx | Explicitly supplies the validated route locale to both translation lookups, consistently fixing localized metadata and page content without introducing an actionable defect. |

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): resolve /mcp page locale from ..."](https://github.com/schemalabz/opencouncil/commit/6a61e4491c62479bc00da4c8859e2aab5db87c8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51884800)</sub>

<!-- /greptile_comment -->