### PR TITLE
docs(claude): require Simplified Technical English and necessary-only comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,37 @@ Multi-channel delivery in `src/lib/notifications/`:
 Additional AI-specific rules:
 - Never add `Co-Authored-By` lines for AI in commit messages
 
+## Writing Style
+
+Write in Simplified Technical English (ASD-STE100).
+
+**In scope**:
+- Chat responses.
+- Commit messages.
+- Pull request descriptions.
+- Comments on GitHub: issue comments, review comments, and replies.
+- Documentation under `docs/`.
+
+**Out of scope**:
+- Release announcements. `.claude/skills/release/templates/discord.md` sets the register for those.
+- User-facing product copy and marketing text.
+- Text that you quote from a file, from documentation, or from another source. Keep the quoted text exactly as it is.
+- Existing text that you do not rewrite. This file does not comply with these rules yet.
+
+Rules:
+- Use short sentences. Keep procedural sentences to 20 words or fewer. Keep descriptive sentences to 25 words or fewer.
+- Write one instruction per sentence. Do not join two instructions with "and" or a semicolon.
+- Use the active voice. Write "the migration adds a column", not "a column is added by the migration".
+- Use one word for one meaning. Do not switch between synonyms for the same thing.
+- Use simple verb tenses. Prefer the present tense.
+- Do not omit articles ("the", "a") or the word "that".
+- Do not use idioms, metaphors, or figures of speech. ASD-STE100 supplies an approved dictionary that this section does not include, so apply this rule with judgement. Standard git and engineering terms stay: "squash", "cherry-pick", "stash", "roll back", "race condition".
+- Keep technical names, code identifiers, file paths, commands, and error messages exactly as they are in the code.
+
+Two rules take priority over every rule above:
+- **Accuracy always wins over style.** Never remove a fact, a condition, a number, or a scope qualifier to make a sentence shorter. Keep the precision when a rule and precision conflict.
+- **A commit subject line follows `CONTRIBUTING.md`.** The subject uses the imperative mood. It omits articles to stay inside the character limit. Apply the rules above to the commit body only.
+
 ## Code Guidelines
 
 ### General Rules
@@ -213,6 +244,7 @@ Additional AI-specific rules:
 - Never use dynamic imports unless explicitly requested
 - Avoid unnecessary try/catch blocks
 - Never create markdown files after completing tasks (unless directly asked)
+- Comment in code only when the reason for the code is not clear from the code itself. Do not restate what the code does
 - Use time formatting utilities from `src/lib/formatters/time.ts` (e.g., `formatTimestamp`, `formatDate`, `formatDuration`)
 
 ### Dev-Only Components
@@ -279,6 +311,16 @@ I [force-pushed](<https://github.com/{upstream-owner}/{repo}/compare/{OLD}..{NEW
 Use the upstream repo URL (where the PR lives, not the fork), two dots (`..`), and full 40-character SHAs. For regular pushes, reference the new commits directly.
 
 Prefer describing changes from your working context when available. Fall back to diffing SHAs only when you lack context (e.g., pushing work from a previous session).
+
+A rebase that leaves the diff of the PR unchanged still needs the comment. GitHub's force-push event records the new head only, so the thread holds no link from the old head to the new head. Report the compare link and the reason on one line. Omit the change list.
+
+**Other comments on your own pull request**:
+The push comment above is always necessary. This rule covers comments on a pull request that you opened. It does not restrict a review of another pull request, and it does not restrict a new issue. Post any other comment on your own pull request only when the comment does one of these things:
+- The comment resolves a question that a reviewer asked.
+- The comment reports a blocker.
+- The comment explains why you did not apply a suggestion.
+
+Do not narrate each step. Do not repeat what the diff already shows.
 
 **Build Verification**:
 - Run `npm run build` **once after all changes are complete** — not after every individual step


### PR DESCRIPTION
Add a `Writing Style` section to `CLAUDE.md`.

The section tells agents to write in Simplified Technical English (ASD-STE100).

**Scope.** The section names the surfaces it covers: chat responses, commit messages, pull request descriptions, comments on GitHub, and `docs/`. It also names the surfaces it does not cover: release announcements, product copy, quoted text, and existing text that you do not rewrite. `.claude/skills/release/templates/discord.md` keeps the register for release announcements.

**Rules.** Short sentences, one instruction per sentence, active voice, one word for one meaning, simple tenses, no idioms. Code identifiers, paths, commands, and error messages stay unchanged.

**Two priority rules.** Accuracy always wins over style. Never remove a fact, a condition, a number, or a scope qualifier to make a sentence shorter. A commit subject line follows `CONTRIBUTING.md`, so it keeps the imperative mood and it omits articles.

Two other rules say when a comment is necessary. They sit in the sections that already hold the related instructions:

- `Git Workflow` > `Other comments on your own pull request` states that the push comment is always necessary. It limits other comments on your own PR to a reply that resolves a question, reports a blocker, or explains a suggestion that you did not apply. It does not restrict a review of another PR, and it does not restrict a new issue.
- `Code Guidelines` > `General Rules` states that a code comment explains the reason for the code, not the operation of the code.

`Git Workflow` also covers a rebase that leaves the diff unchanged. The push comment still applies. It reports the compare link and the reason, with no change list.

The change touches documentation only. No code changes.

## Examples from #601

These examples show the effect of the rules. Each one comes from the description, the review, or the reply comments of #601.

### 1. Description — the lead

Now:

> Two data improvements to the public MCP server, both born from agent testing:
>
> `get_subject`, `search` results and `list_hot_subjects` now carry `meetingName`, `meetingDate` and `administrativeBody` (the body that met, e.g. «Δημοτική Επιτροπή»; `null` when the record names none). Previously only `get_meeting` had the body — an agent needed a second call just to name it, and in testing labeled the wrong body in the meantime.

Rewritten:

> This PR makes two data changes to the public MCP server. Agent testing showed the need for both.
>
> `get_subject`, `search` and `list_hot_subjects` now return `meetingName`, `meetingDate` and `administrativeBody`. The `administrativeBody` field names the body that met, for example «Δημοτική Επιτροπή». The field is `null` when the record names no body. Before this change, only `get_meeting` returned the body. An agent had to make a second call to get the name. In tests, the agent named the wrong body.

"Born from" is a metaphor. The parenthesis and the semicolon hold separate facts, so they become separate sentences. The 44-word last sentence becomes three sentences.

### 2. Description — "Zero extra queries"

Now, as one sentence of 43 words:

> Zero extra queries: `requireVisibleMeeting` widens the select of the lookup it already does (returning `name` + `administrativeBody` alongside `released`/`dateTime`), search hits already hydrate `councilMeeting.administrativeBody`, and hot-subject rows already carried `meetingName`/`bodyName` — they were just dropped in the mapping.

Rewritten:

> The change adds no database queries. `requireVisibleMeeting` widens the select of the lookup that it already does. The lookup now returns `name` and `administrativeBody` with `released` and `dateTime`. Search hits already load `councilMeeting.administrativeBody`. Hot-subject rows already contain `meetingName` and `bodyName`. The mapping code discarded these two fields.

"Hydrate" and "carry" both mean "the record already has the data". One word for one meaning replaces both. The last sentence uses the active voice, so it names the actor. The original text hides the actor in "they were just dropped".

### 3. Description — the cache defect

Now:

> One gotcha fixed along the way: `unstable_cache` revives cached meetings with **string** dates, so the tool re-wraps `dateTime` before formatting — the first (cache-miss) call worked and every subsequent one 500'd until this.

Rewritten:

> This PR also corrects a defect. `unstable_cache` returns cached meetings with `dateTime` as a string. The tool now converts `dateTime` to a `Date` before it formats the value. Before the fix, the first call worked. Each subsequent call returned HTTP 500.

"Gotcha", "along the way" and "revives" go. "500'd" also goes. A number used as a verb is hard to read for a non-native speaker and for a translation tool.

### 4. Review — the main finding

Now:

> The rest is one theme; specifics are inline. `list_nearby_subjects` returns the same shape for four different states — genuinely nothing nearby, a municipality we don't cover, a failed proximity query, and something that happened just outside the meeting window. All four come back as an empty or municipality-wide-only list, and an agent will read every one of them aloud as "the council hasn't decided anything near you." The tool has no way to say "I don't know."

Rewritten:

> My remaining findings have one cause. See the inline comments for details.
>
> `list_nearby_subjects` returns the same response shape for four different states:
> - No subject is near the point.
> - We do not cover the municipality.
> - The proximity query failed.
> - The subject is older than the meeting window.
>
> Each state returns an empty list, or a list of municipality-wide subjects only. An agent reports all four states as "the council decided nothing near you". The tool cannot report an unknown result.

The original text holds the four states in one sentence. As a list, the reader can count the states and check each one.

### 5. Review — the three actions

Now, as one sentence of 78 words:

> Three of those four are worth closing before merge: the point-to-municipality lookup resolves δήμοι we don't publish, so the not-covered note is effectively unreachable and we claim coverage we don't have; the recency window is a count of meetings rather than a span of time, which for a busy council is far narrower than "recent" suggests; and the two proximity queries return empty on failure rather than erroring, so a transient database problem is indistinguishable from a quiet neighbourhood.

Rewritten:

> Correct three of these four states before you merge.
>
> 1. The point-to-municipality lookup resolves δήμοι that we do not publish. The not-covered note never occurs. The tool claims coverage that we do not have.
> 2. The recency window counts meetings. It does not measure a period of time. For a busy council, the window is much shorter than the word "recent" suggests.
> 3. The two proximity queries return an empty result when they fail. A temporary database fault looks the same as a quiet neighbourhood.

This example is the strongest one. Three requested actions in one sentence are easy to miss. As a numbered list, the author can answer each item.

### 6. Reply — text to remove

Now:

> I force-pushed taking the whole review — the rebase recipe first, then every finding. Thanks @kouloumos, the measured probes (18 points, the byte-identical A/B, the Πειραιάς case) made these unambiguous to act on.

Rewritten:

> I force-pushed. The push applies your rebase steps first, then each finding.

"Taking the whole review" and "recipe" are figures of speech. The second sentence praises the review method. It reports no change, and it answers no question. The comment-only-when-necessary rule removes it.

The same reply holds a sentence of 120 words that starts with "Smaller points, all taken". The sentence chains nine separate changes with semicolons. The rules make it nine short sentences, or a list of nine items. The content stays the same, and a reviewer can check each item.

Examples 4 and 5 show the main benefit. Both sentences hide a countable set of items. The length limit prevents this problem.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds writing rules for agent-generated text. It also defines when code comments and pull request comments are necessary.
- Requires Simplified Technical English for specified text.
- Preserves accuracy and commit subject conventions.
- Requires a comment after each push to an open pull request.
- Restricts other comments on an author's pull request.
- Limits code comments to explanations of reasons.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | The new wording resolves the previous conflict by excluding required push comments from the restriction on other comments. |

<sub>Reviews (3): Last reviewed commit: ["docs(claude): require Simplified Technic..."](https://github.com/schemalabz/opencouncil/commit/8aa08edf0614dbf89bc580f3a1a163aba71067d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52126954)</sub>

<!-- /greptile_comment -->