### PR TITLE
feat(mcp): tool annotations and categories

### DIFF
--- a/src/lib/mcp/__tests__/server.test.ts
+++ b/src/lib/mcp/__tests__/server.test.ts
@@ -27,12 +27,23 @@ const HIGHLIGHT_TOOLS = [
 const USER: McpIdentity = { type: 'user', userId: 'u1' };
 const SERVICE: McpIdentity = { type: 'service', keyName: 'bot' };
 
+const CATEGORIES = ['discovery', 'directory', 'meetings', 'highlights'];
+
+type RecordedToolConfig = {
+    annotations?: { readOnlyHint?: boolean };
+    _meta?: { category?: string };
+};
+
 /** What a connection with this identity would see in tools/list & prompts/list. */
 function advertised(identity: McpIdentity, { inRequestScope = true } = {}) {
     const tools: string[] = [];
     const prompts: string[] = [];
+    const meta: Record<string, RecordedToolConfig> = {};
     const recorder = {
-        registerTool: (name: string) => { tools.push(name); },
+        registerTool: (name: string, config: RecordedToolConfig) => {
+            tools.push(name);
+            meta[name] = config;
+        },
         registerPrompt: (name: string) => { prompts.push(name); },
     } as unknown as McpServer;
 
@@ -42,7 +53,7 @@ function advertised(identity: McpIdentity, { inRequestScope = true } = {}) {
     } else {
         register();
     }
-    return { tools, prompts };
+    return { tools, prompts, meta };
 }
 
 describe('highlight tools are advertised only on authenticated connections', () => {
@@ -73,5 +84,22 @@ describe('highlight tools are advertised only on authenticated connections', () 
     it('fails closed when there is no request scope at all', () => {
         expect(advertised(null, { inRequestScope: false }).tools)
             .toEqual(advertised(null).tools);
+    });
+});
+
+describe('tool metadata', () => {
+    // An invariant, not an inventory: adding a tool needs no test edit, but a
+    // tool registered without annotations (which would land in the client's
+    // "Other" permissions bucket) or with a category outside the known set
+    // (which would mint a stray $mcp_tool_category value in PostHog) fails
+    // here. Nothing else in the repo reads these fields, so this is the only
+    // place that can notice. Filtering into an array makes Jest name the
+    // offending tool.
+    it('gives every tool a readOnlyHint and a known category', () => {
+        const { tools, meta } = advertised(USER);
+        expect(tools.filter(name =>
+            typeof meta[name].annotations?.readOnlyHint !== 'boolean'
+            || !CATEGORIES.includes(meta[name]._meta?.category ?? '')
+        )).toEqual([]);
     });
 });

--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -879,6 +879,13 @@ export async function mcpCreateHighlight(
         );
     }
 
+    // Deliberately no `id`: the MCP surface only ever creates highlights, so
+    // this always takes upsertHighlightCore's create branch — the update
+    // branch (which deletes the previous utterance selection) is unreachable
+    // from here. The write-tool annotations in server.ts lean on exactly
+    // this: `destructiveHint: false` on create_highlight AND on
+    // generate_highlight_video (a re-render can only reformat content that
+    // cannot change). Adding a highlightId parameter would falsify both.
     const highlight = await upsertHighlightCore(identity, {
         name: args.name,
         meetingId: args.meetingId,

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -49,6 +49,15 @@ async function run(fn: () => Promise<unknown>): Promise<CallToolResult> {
     }
 }
 
+/**
+ * Tool grouping, stamped into each tool's `_meta`. Not decorative: the
+ * PostHog MCP analytics SDK reads exactly `_meta.category` into
+ * $mcp_tool_category, so these strings become analytics dimensions — keep
+ * them stable, and keep this union the only place they are defined.
+ */
+type ToolCategory = 'discovery' | 'directory' | 'meetings' | 'highlights';
+const category = (category: ToolCategory) => ({ category });
+
 const paginationShape = {
     page: z.number().int().min(1).default(1).describe('Page number, starting at 1'),
 };
@@ -58,6 +67,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         'search',
         {
             title: 'Search subjects',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('discovery'),
             description:
                 'Full-text and semantic search over council meeting subjects (agenda items). ' +
                 'Filter by city, person, party, topic or date range. Omit the query to list ' +
@@ -86,6 +97,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         'list_hot_subjects',
         {
             title: 'List hot subjects',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('discovery'),
             description:
                 'The most-discussed subjects across all municipalities over a recent period, ranked ' +
                 'by debate time — start here for "what is happening in the councils", a weekly ' +
@@ -107,6 +120,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         'list_nearby_subjects',
         {
             title: 'List subjects near a location',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('discovery'),
             description:
                 'Recent council subjects around a geographic point — "what has the council discussed ' +
                 'about this neighborhood" (for the decision and votes, follow up with get_subject). ' +
@@ -134,6 +149,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         'fetch',
         {
             title: 'Fetch a record',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('discovery'),
             description:
                 'Fetch the full content of a single record by id. Accepts a subject id (default), or ' +
                 'prefixed ids: "city:{cityId}", "person:{personId}", "party:{partyId}", "meeting:{cityId}/{meetingId}".',
@@ -148,6 +165,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         'list_cities',
         {
             title: 'List municipalities',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('directory'),
             description: 'List the municipalities available on OpenCouncil, with ids and counts.',
             inputSchema: z.object({}),
         },
@@ -158,6 +177,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         'get_city',
         {
             title: 'Get municipality',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('directory'),
             description: 'Get a municipality profile, including its political parties.',
             inputSchema: z.object({ cityId: z.string().min(1) }),
         },
@@ -168,6 +189,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         'list_people',
         {
             title: 'List council members',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('directory'),
             description: 'List the people (councillors, mayor, etc.) of a municipality with their roles and party.',
             inputSchema: z.object({
                 cityId: z.string().min(1),
@@ -181,6 +204,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         'get_person',
         {
             title: 'Get person',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('directory'),
             description: 'Get a person profile with all their roles. Use search with personIds to find what they discussed.',
             inputSchema: z.object({ personId: z.string().min(1) }),
         },
@@ -191,6 +216,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         'get_party',
         {
             title: 'Get party',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('directory'),
             description: 'Get a political party with its members.',
             inputSchema: z.object({ partyId: z.string().min(1) }),
         },
@@ -201,6 +228,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         'list_meetings',
         {
             title: 'List meetings',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('meetings'),
             description: 'List a municipality\'s council meetings, newest first (or soonest first for upcoming).',
             inputSchema: z.object({
                 cityId: z.string().min(1),
@@ -225,6 +254,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         'get_meeting',
         {
             title: 'Get meeting',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('meetings'),
             description:
                 'Get a council meeting with its agenda. Each subject carries discussionSeconds — how ' +
                 'long it was actually debated, the best proxy for which subjects mattered, since ' +
@@ -241,6 +272,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         'get_subject',
         {
             title: 'Get subject',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('meetings'),
             description:
                 'Get a subject (agenda item) in detail: description, per-speaker contribution summaries, ' +
                 'decision, votes. Carries its meeting context (meetingName, meetingDate, and ' +
@@ -258,6 +291,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         'get_subject_transcript',
         {
             title: 'Get subject transcript',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('meetings'),
             description:
                 'The verbatim transcript of everything said about one subject, as utterances with ids, ' +
                 'speaker names, roles (resolved as of the meeting date) and timestamps. Utterance ids ' +
@@ -275,6 +310,8 @@ export function registerOpenCouncilServer(server: McpServer) {
         'get_transcript',
         {
             title: 'Get meeting transcript',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('meetings'),
             description:
                 'The full transcript of a meeting as speaker segments, paginated. Speaker roles are ' +
                 'resolved as of the meeting date. Long — prefer ' +
@@ -385,6 +422,8 @@ function registerHighlightTools(server: McpServer) {
         'create_highlight',
         {
             title: 'Create highlight',
+            annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
+            _meta: category('highlights'),
             description:
                 'Create a highlight from a selection of a meeting\'s utterances (get utterance ids ' +
                 'from get_subject_transcript). The utterances need not be consecutive — skip filler ' +
@@ -407,6 +446,8 @@ function registerHighlightTools(server: McpServer) {
         'generate_highlight_video',
         {
             title: 'Generate highlight video',
+            annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            _meta: category('highlights'),
             description:
                 'Start rendering a highlight into a shareable video clip, in landscape or vertical ' +
                 '(9:16) format, with optional burnt-in subtitles and speaker name/party overlays — ' +
@@ -438,6 +479,8 @@ function registerHighlightTools(server: McpServer) {
         'list_highlights',
         {
             title: 'List highlights',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('highlights'),
             description:
                 'The highlights you can manage, newest first — your own, plus every highlight in ' +
                 'municipalities you administer. Use it to pick up work from a previous session ' +
@@ -455,6 +498,8 @@ function registerHighlightTools(server: McpServer) {
         'set_highlight_showcase',
         {
             title: 'Showcase a highlight',
+            annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+            _meta: category('highlights'),
             description:
                 'Publish (or unpublish) a rendered highlight on the municipality\'s pages on ' +
                 'opencouncil.gr. Needs a rendered video and city-administrator rights. Ask the ' +
@@ -472,6 +517,8 @@ function registerHighlightTools(server: McpServer) {
         'get_highlight',
         {
             title: 'Get highlight',
+            annotations: { readOnlyHint: true, openWorldHint: false },
+            _meta: category('highlights'),
             description:
                 'Get a highlight and the status of its video: not_generated, generating (with progress), ' +
                 'failed, or ready with the final video URL and the format it was rendered in. Use this ' +


### PR DESCRIPTION
When adding the OpenCouncil MCP to Claude, the permissions screen showed one tool under "Read-only" and nineteen under "Other" — because the read-only grouping comes from the MCP spec's `ToolAnnotations.readOnlyHint`, which we never set (the one correctly-grouped tool was PostHog's virtual `get_more_tools`, which ships its own annotation).

## What changes

- All sixteen read tools declare `{ readOnlyHint: true, openWorldHint: false }`.
- The three writes (`create_highlight`, `generate_highlight_video`, `set_highlight_showcase`) declare `readOnlyHint: false, destructiveHint: false` — they create, render, or toggle, never delete — plus `idempotentHint: true` on the latter two, where re-calling with the same arguments is a designed no-op. `openWorldHint: false` everywhere: these tools only touch OpenCouncil's own data.
- Every tool carries `_meta: { category }` (`discovery` / `directory` / `meetings` / `highlights`). The PostHog MCP SDK reads exactly this key into `$mcp_tool_category`, so tool-call analytics gain a grouping dimension for free.

Result: Claude's permission screen shows the sixteen read tools under "Read-only — always allow", and only the three highlight actions require per-use approval.

## Not included (checked, not possible today)

Server-level branding (`title`/`websiteUrl`/`icons` on `serverInfo`) — `createMcpHandler`'s option type only forwards `name`/`version`. Per-tool `icons` would also need a square icon asset (`public/logo.png` is 1606×1354). Both possible later; neither affects the permissions grouping.

## Testing

`npx tsc --noEmit` + MCP suite pass. Verified live on the dev server through the full stack (including the PostHog schema-injection wrapper): anonymous `tools/list` shows all 15 advertised tools with `readOnlyHint: true`; the authenticated list adds the three writes with their exact annotations; `_meta.category` rides along on every tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Declarative metadata only; tool execution, auth, and data access are unchanged.
> 
> **Overview**
> Adds MCP **tool annotations** and **category metadata** so clients can correctly group permissions and PostHog can dimension tool usage.
> 
> Read tools now declare `readOnlyHint: true` (plus `openWorldHint: false`), so clients like Claude can put them under always-allow read-only. The three highlight writes declare `readOnlyHint: false` and `destructiveHint: false`, with `idempotentHint: true` on `generate_highlight_video` and `set_highlight_showcase`.
> 
> Every tool also gets `_meta.category` (`discovery` / `directory` / `meetings` / `highlights`) for `$mcp_tool_category` analytics. A regression test asserts every registered tool has a boolean `readOnlyHint` and a known category.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cbb2e2ed8b4aa5ea0708eaf0f9f20d60451d4b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds MCP safety annotations and analytics categories to registered tools without changing their handlers.
- Marks public and authenticated read tools as read-only.
- Describes the three highlight actions as non-destructive and classifies two as idempotent.
- Assigns stable discovery, directory, meetings, and highlights categories.
- Adds an invariant test requiring every advertised tool to expose a read-only hint and recognized category.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/mcp/server.ts | Adds permission-related MCP annotations and analytics category metadata to every registered tool. |
| src/lib/mcp/__tests__/server.test.ts | Extends the registration recorder and verifies that all authenticated tools declare a read-only hint and recognized category. |
| src/lib/mcp/data.ts | Documents the create-only highlight behavior on which the non-destructive annotations rely. |

<sub>Reviews (2): Last reviewed commit: ["feat(mcp): tool annotations and categori..."](https://github.com/schemalabz/opencouncil/commit/0cbb2e2ed8b4aa5ea0708eaf0f9f20d60451d4b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52184213)</sub>

**Context used:**

- Knowledge Base — [MCP assistant integration](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/mcp-assistant.md)

<!-- /greptile_comment -->