### PR TITLE
fix(i18n): resolve the locale for realm hosts in the proxy

### DIFF
--- a/messages/el.json
+++ b/messages/el.json
@@ -642,6 +642,7 @@
         "watchMeeting": "Παρακολουθήστε τη συνεδρίαση"
     },
     "Unsubscribe": {
+        "metaTitle": "Απεγγραφή | OpenCouncil",
         "invalidLinkTitle": "Μη έγκυρος σύνδεσμος",
         "invalidLinkDescription": "Αυτός ο σύνδεσμος απεγγραφής δεν είναι έγκυρος ή έχει λήξει.",
         "successCityTitle": "Απεγγραφή επιτυχής",

--- a/messages/en.json
+++ b/messages/en.json
@@ -654,6 +654,7 @@
         "active": "Member"
     },
     "Unsubscribe": {
+        "metaTitle": "Unsubscribe | OpenCouncil",
         "invalidLinkTitle": "Invalid link",
         "invalidLinkDescription": "This unsubscribe link is not valid or has expired.",
         "successCityTitle": "Successfully unsubscribed",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -642,6 +642,7 @@
     "watchMeeting": "Regardez la séance"
   },
   "Unsubscribe": {
+    "metaTitle": "Désinscription | OpenCouncil",
     "invalidLinkTitle": "Lien non valide",
     "invalidLinkDescription": "Ce lien de désinscription n'est pas valide ou a expiré.",
     "successCityTitle": "Désinscription réussie",

--- a/messages/sr.json
+++ b/messages/sr.json
@@ -654,6 +654,7 @@
         "active": "Члан"
     },
     "Unsubscribe": {
+        "metaTitle": "Одјава | OpenCouncil",
         "invalidLinkTitle": "Неважећа веза",
         "invalidLinkDescription": "Ова веза за одјаву није важећа или је истекла.",
         "successCityTitle": "Успешно сте се одјавили",

--- a/src/app/[locale]/(other)/unsubscribe/page.tsx
+++ b/src/app/[locale]/(other)/unsubscribe/page.tsx
@@ -6,18 +6,23 @@ import { XCircle } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
 
 // Token-personalized page — keep it out of search indexes.
-export const metadata: Metadata = {
-    title: 'Απεγγραφή | OpenCouncil',
-    robots: { index: false, follow: false },
-};
+export async function generateMetadata(props: Props): Promise<Metadata> {
+    const { locale } = await props.params;
+    const t = await getTranslations({ locale, namespace: 'Unsubscribe' });
+    return {
+        title: t('metaTitle'),
+        robots: { index: false, follow: false },
+    };
+}
 
 interface Props {
+    params: Promise<{ locale: string }>;
     searchParams: Promise<{ token?: string }>;
 }
 
 export default async function UnsubscribePage(props: Props) {
-    const searchParams = await props.searchParams;
-    const t = await getTranslations('Unsubscribe');
+    const [searchParams, { locale }] = await Promise.all([props.searchParams, props.params]);
+    const t = await getTranslations({ locale, namespace: 'Unsubscribe' });
     const token = searchParams.token;
 
     const data = token ? await verifyUnsubscribeToken(token) : null;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -201,12 +201,27 @@ async function proxyInner(req: NextRequest): Promise<Response | undefined> {
     ) {
         const localeUrl = req.nextUrl.clone();
         localeUrl.pathname = pathname === '/' ? `/${realmDefaultLocale}` : `/${realmDefaultLocale}${pathname}`;
-        // The [locale] segment handles rendering via setRequestLocale, but the
-        // root layout sits above it and (since we bypass next-intl's
-        // middleware here) has no locale to read for the <html lang> attr. Pass
-        // it via our own header, which the root layout reads explicitly — no
-        // dependency on next-intl's undocumented internal locale header.
         const requestHeaders = new Headers(req.headers);
+        // Resolve the rewritten path through next-intl and keep the request
+        // headers it sets. We can't just return its response: it leaves an
+        // already-correct /sr path alone and emits no rewrite, so the original
+        // unprefixed URL would 404. Next encodes request-header overrides as
+        // `x-middleware-request-*`, so copying them generically carries the
+        // locale across without naming a next-intl internal.
+        //
+        // Without this the [locale] layout's setRequestLocale is the only
+        // locale source on these hosts, and next-intl caches the first result
+        // for every implicit caller — so any page resolving translations
+        // before the layout serves the whole request in the app default
+        // locale (#606).
+        const localeRequest = new NextRequest(localeUrl, { headers: req.headers, method: req.method });
+        const intlResponse = await i18nMiddleware(localeRequest);
+        intlResponse?.headers.forEach((value, key) => {
+            const forwarded = /^x-middleware-request-(.+)$/i.exec(key);
+            if (forwarded) requestHeaders.set(forwarded[1], value);
+        });
+        // The root layout sits above the [locale] segment and reads this to set
+        // the <html lang> attr.
         requestHeaders.set(LOCALE_OVERRIDE_HEADER, realmDefaultLocale);
         return NextResponse.rewrite(localeUrl, { request: { headers: requestHeaders } });
     }


### PR DESCRIPTION
## The problem

The proxy serves `opencouncil.rs` and `opencouncil.fr` in their own locale. It rewrites an unprefixed path to the locale segment (`proxy.ts:157-183`). The browser keeps the unprefixed URL.

That branch returned before `i18nMiddleware`. next-intl therefore never set its request locale header on those hosts. `setRequestLocale` in `[locale]/layout.tsx:46` became the only locale source for the request.

next-intl caches the resolved configuration. The cache key is the locale argument. A call such as `getTranslations("mcp")` sends no locale, so its key is `undefined`. Every implicit caller in one request shares that single entry.

Next.js decides whether a page or its layout runs first. A page that resolves translations before the layout reads an empty locale. next-intl falls back to the app default `el`. It then stores that Greek configuration under the shared key. The layout later calls `getMessages()`, which is also implicit, and receives the same Greek configuration. `NextIntlClientProvider` sends those messages to every client component.

The result is a page that is entirely Greek under a correct `lang="sr"`. #606 fixed the `/mcp` page by passing the locale explicitly. Six implicit calls remain elsewhere. Each is correct today only because it happens to resolve late.

## What changes

**1. The proxy gives these hosts a locale source that does not depend on render order.**

The rewrite now resolves the target path through next-intl before returning. It copies the request headers next-intl sets. Next encodes those as `x-middleware-request-*`, so the copy is generic and this file does not name a next-intl internal header.

Returning next-intl's own response does not work. next-intl leaves an already-correct `/sr` path alone and emits no rewrite, so the original unprefixed URL returns 404. I confirmed this. The first attempt produced a 404 with `rewrite=null` and `intlLocale=sr`.

With a locale header always present, an implicit `getTranslations` resolves correctly regardless of ordering. That removes the cause rather than each symptom.

**2. `/unsubscribe` gets a localized title.**

This is independent of the above. The page declared a static `metadata` object with the hardcoded Greek string `'Απεγγραφή | OpenCouncil'`. Production serves that title on every realm and locale, while the body text is already correct. It now uses `generateMetadata` with a new `metaTitle` key in `el`, `en`, `fr` and `sr`. `sr-Latn` derives from `sr` at load time.

## Alternatives considered

**next-intl domain routing.** next-intl supports a `domains` config that maps a host to a default locale. It matches with `domains.find(cur => cur.domain === host)`, which is exact string equality. That breaks preview subdomains such as `pr-7.preview.opencouncil.fr`, `localhost:3000`, and the `?realm=` cookie override. `realmForHost` handles all three deliberately. The config is therefore not usable here.

**Explicit locales in every page.** This works. It fixes instances rather than the cause. A seventh page reintroduces the fault. Note that `src/app/__tests__/parallelize-server-awaits.test.ts` rewards folding an implicit call into a `Promise.all`. That move puts the call in the first position and breaks the page again. The test still passes.

## Trade

The old code avoided next-intl's internal header deliberately. This change still avoids naming it. It depends on Next's `x-middleware-request-*` convention instead. That is a different internal. Please weigh that choice.

`LOCALE_OVERRIDE_HEADER` is now arguably redundant. The root layout could resolve the locale through `getLocale()`. I left it in place to keep the diff small.

This change also makes the explicit locales from #606 unnecessary. They remain correct. I did not revert them.

## Verification

I removed both workarounds and ran the proxy change alone:

```
opencouncil.rs/mcp → 200 lang="sr" Питајте свог AI асистента…
opencouncil.fr/mcp → 200 lang="fr" Interrogez votre assistant IA…
```

The address bar keeps the unprefixed URL. No redirect occurs.

These paths are unchanged: `opencouncil.gr` (its default equals the app default, so it never enters this branch), `/lat/mcp` to `sr-Latn`, `/en/mcp` to `en` on both realms, `/about`, `/embed/meetings` and `/unsubscribe`.

`npx tsc --noEmit` reports 36 errors. `main` reports the same count. `npx jest` fails 2 suites. Those suites fail identically on `main`.

## Verified on the preview

The preview runs a production build. I used `?realm=serbia` and `?realm=france` to reach these hosts.

| Test | Result |
|---|---|
| `?realm=serbia` handshake | 302 to `/mcp`, cookie set, then 200. The URL stays unprefixed. |
| serbia: `/mcp`, `/about`, `/unsubscribe`, `/` | 200, `lang="sr"`, Serbian titles |
| france: `/mcp`, `/about`, `/unsubscribe` | 200, `lang="fr"`, French titles |
| prefixed trees | `/lat/mcp` gives `sr-Latn`. `/en/mcp` gives `en`. |
| RSC navigation (`RSC: 1`) | 200 `text/x-component`. 5 Serbian markers. 0 Greek markers. |
| POST parity | serbia, france and greece all return 404. No redirect occurs. |
| embeds | `EmbedWidget` strings per realm: 24 Serbian, 16 French, 2 Greek |
| `/profile` when signed in | `lang="sr"` and `<h1>Профил</h1>` |

Two of these matter most.

The POST test covers the largest behaviour change. Realm hosts never reached `i18nMiddleware` before. The greece realm is the control, because it never enters this branch. All three hosts behave the same way. No redirect occurs. A redirect would break a server action, because Next re-issues it as a GET without a body.

`/profile` calls `getTranslations` without a locale in its page component. It renders Serbian in a production build.

One reading needs an explanation. The embed pages contain 665 and 2985 Greek characters under the serbia realm. That text is the Athens data. The `EmbedWidget` UI strings are correct, as the table shows.

## Not covered

- A real server action from end to end. Next 16 keeps action ids in client chunks, so I could not extract one. The proxy reads neither the action id nor the body.
- The real `.rs` and `.fr` hostnames. The preview is a subdomain of `opencouncil.gr`. The realm therefore came from the cookie rather than from `realmForHost`.
- The Cloudflare chain in front of production. This change copies `x-forwarded-*` headers.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes realm-host rewrites establish next-intl’s request locale before rendering and localizes the unsubscribe page metadata.
- Runs the locale-prefixed realm path through the i18n middleware and forwards its request-header overrides into the final rewrite.
- Resolves unsubscribe page translations and metadata explicitly from the route locale.
- Adds the unsubscribe metadata title to each source translation catalog.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/proxy.ts | The realm-host rewrite now obtains and forwards next-intl’s locale request headers while preserving the existing unprefixed browser URL. |
| src/app/[locale]/(other)/unsubscribe/page.tsx | The page and its generated metadata now resolve translations explicitly using the route locale. |
| messages/el.json | Adds the Greek unsubscribe metadata title. |
| messages/en.json | Adds the English unsubscribe metadata title. |
| messages/fr.json | Adds the French unsubscribe metadata title. |
| messages/sr.json | Adds the Serbian unsubscribe metadata title, which also feeds the derived Latin Serbian catalog. |

<sub>Reviews (3): Last reviewed commit: ["fix(i18n): give realm hosts a locale sou..."](https://github.com/schemalabz/opencouncil/commit/52862fad3d3c5e8e1e094d1f07dd7f2e81e93c9e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52496578)</sub>

<!-- /greptile_comment -->


<!-- preview-link: tasks=95 -->
