### PR TITLE
fix(mcp): stop reporting votes on get_subject

### DIFF
--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -14,7 +14,6 @@ import { requestGenerateHighlightCore } from '@/lib/tasks/generateHighlight-core
 import { NotFoundError, UnauthorizedError, BadRequestError, ForbiddenError } from '@/lib/api/errors';
 import { canSeeUnreleased, requireVisibleMeeting } from './gate';
 import { getRoleLabelAt, RoleTextTranslator } from '@/lib/utils/roles';
-import { calculateVoteResult } from '@/lib/utils/votes';
 import { roleWithRelationsInclude } from '@/lib/db/types';
 import { getTranslations } from 'next-intl/server';
 import {
@@ -365,11 +364,8 @@ export async function mcpGetSubject(subjectId: string, identity: McpIdentity) {
                 pdfUrl: subject.decision.pdfUrl,
             }
             : null,
-        votes: subject.votes.map(vote => ({ person: vote.person.name, vote: vote.voteType })),
-        // Precomputed tally so consumers (humans and agents alike) never have
-        // to count the array themselves — and with the same rules the site
-        // uses: PRESENT and DID_NOT_VOTE are declarations, not votes.
-        voteSummary: subject.votes.length > 0 ? calculateVoteResult(subject.votes) : null,
+        // Votes are withheld until the extraction pipeline is reliable. The
+        // site keeps showing them; the MCP API does not report them.
         url: urls.subject(subject.cityId, subject.councilMeetingId, subject.id),
     };
 }

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -124,7 +124,7 @@ export function registerOpenCouncilServer(server: McpServer) {
             _meta: category('discovery'),
             description:
                 'Recent council subjects around a geographic point — "what has the council discussed ' +
-                'about this neighborhood" (for the decision and votes, follow up with get_subject). ' +
+                'about this neighborhood" (for the decision, follow up with get_subject). ' +
                 'Resolves the covered municipality containing the point, then returns subjects ' +
                 'pinned within the radius first, followed by recent municipality-wide subjects; each ' +
                 'group is ranked by a recency/discussion blend, like the site\'s own nearby widgets. ' +
@@ -276,12 +276,11 @@ export function registerOpenCouncilServer(server: McpServer) {
             _meta: category('meetings'),
             description:
                 'Get a subject (agenda item) in detail: description, per-speaker contribution summaries, ' +
-                'decision, votes. Carries its meeting context (meetingName, meetingDate, and ' +
+                'decision. Carries its meeting context (meetingName, meetingDate, and ' +
                 'administrativeBody — the body that met, e.g. «Δημοτική Επιτροπή», or null when the ' +
                 'record names none). Speaker `role` labels are resolved as of the meeting date (get_person ' +
-                'lists roles across all time). Vote semantics: ABSTAIN is ΛΕΥΚΟ (a blank ballot, counted ' +
-                'in totalVotes); DID_NOT_VOTE is ΑΠΟΧΗ (a declaration of non-participation, not a vote). ' +
-                'For the verbatim discussion use get_subject_transcript.',
+                'lists roles across all time). This tool does not report the vote tally; the subject page ' +
+                'at `url` shows it. For the verbatim discussion use get_subject_transcript.',
             inputSchema: z.object({ subjectId: z.string().min(1) }),
         },
         (args, ctx: ServerContext) => run(() => mcpGetSubject(args.subjectId, identityFromContext(ctx)))


### PR DESCRIPTION
## Problem

The MCP `get_subject` tool returns a `votes` array and a `voteSummary` tally. The extraction pipeline that produces this data gives wrong results too often. A wrong tally is worse than no tally, because agents present it as a fact and cite it.

## Change

Withhold the vote data from the MCP API until the extraction is reliable:

- `get_subject` no longer returns `votes` or `voteSummary`.
- The `get_subject` description no longer documents vote semantics (ΛΕΥΚΟ / ΑΠΟΧΗ). It now states that the tool does not report the tally, and it points to the subject page at `url`.
- `list_nearby_subjects` no longer tells the agent to follow up for votes.

The change is one self-contained commit. Revert the commit after the extraction pipeline is reliable.

## Scope

The web app is untouched. The subject page, the admin decisions panel, and `src/lib/utils/votes.ts` still show and compute votes. The database keeps the records. Only the MCP response changes.

`get_subject_transcript` still returns `PROCEDURAL_VOTE` and `VOTE` utterances. That is the raw speech, not the extraction, so this PR keeps it.

## Verification

- `npx tsc --noEmit` is clean.
- The 4 MCP test suites pass (25 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow MCP API contract change with no auth, DB, or web UI impact; reduces risk of agents citing bad vote data.
> 
> **Overview**
> **MCP `get_subject` no longer exposes extracted vote data** (`votes` and `voteSummary`), because the pipeline often produces wrong tallies that agents treat as facts. A comment in `data.ts` documents the intentional omission; the web app and stored records are unchanged.
> 
> **Tool descriptions** in `server.ts` were updated: `get_subject` no longer documents ΛΕΥΚΟ/ΑΠΟΧΗ semantics and instead points agents to the subject page `url` for the tally; `list_nearby_subjects` no longer suggests following up for votes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e8f34b7a4e852f1f47429f39c3edf32592aabd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR temporarily withholds unreliable extracted vote data from MCP subject responses while preserving vote data elsewhere in the application.
- Removes `votes` and `voteSummary` from `mcpGetSubject`.
- Updates `get_subject` guidance to direct consumers to the subject page for the tally.
- Removes the nearby-subject instruction suggesting `get_subject` for votes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the implementation and advertised MCP contract consistently withhold the unreliable vote data.

The removed fields have no remaining repository consumers or response schemas, the obsolete tally import is removed, and all MCP descriptions that previously promised votes are updated consistently.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/mcp/data.ts | Removes extracted vote records and their computed tally from the MCP subject response without affecting visibility checks, transcripts, or web application data. |
| src/lib/mcp/server.ts | Aligns MCP tool descriptions with the intentionally reduced subject response and directs users to the subject page for vote information. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20schemalabz%2Fopencouncil%20PR%20%23618%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=schemalabz%2Fopencouncil&pr=618&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): stop reporting votes on get\_su..."](https://github.com/schemalabz/opencouncil/commit/0e8f34b7a4e852f1f47429f39c3edf32592aabd6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53077583)</sub>

**Context used:**

- Knowledge Base — [MCP assistant integration](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/mcp-assistant.md)

<!-- /greptile_comment -->