### PR TITLE
feat(scripts): check column compatibility before copying in copy_db.sh

### DIFF
--- a/scripts/copy_db.sh
+++ b/scripts/copy_db.sh
@@ -165,6 +165,59 @@ if [ "$FK_ERRORS" -gt 0 ]; then
 fi
 echo "Table order is valid."
 
+# Verify that every column of every copied table in the source also exists in the
+# target. The migration check above compares migration *names* only, so a target
+# that is ahead of the source (e.g. staging ahead of production) passes it even if
+# the extra migration dropped or renamed a column — which would make pg_dump's COPY
+# fail mid-run, after --clear has already wiped the target. Extra columns on the
+# target are fine (COPY uses an explicit column list from the source).
+# Note: this compares column names only, not types or enum labels.
+echo "Checking column compatibility for copied tables..."
+TABLE_IN_LIST=$(printf "'%s'," "${TABLES[@]}")
+TABLE_IN_LIST=${TABLE_IN_LIST%,}
+
+# Exclude generated columns from the source: pg_dump does not include them in COPY.
+SOURCE_COLUMNS=$(psql --set ON_ERROR_STOP=on "$SOURCE" -t -A -F $'\t' -c "
+    SELECT table_name, column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name IN ($TABLE_IN_LIST)
+      AND is_generated = 'NEVER'
+    ORDER BY table_name, ordinal_position;
+")
+if [ $? -ne 0 ]; then
+    echo -e "\033[31mFailed to query source columns. Aborting.\033[0m"
+    exit 1
+fi
+# Exclude generated columns from the target too: COPY cannot write into a generated
+# column, so a same-named generated column on the target must count as missing.
+TARGET_COLUMNS=$(psql --set ON_ERROR_STOP=on "$TARGET" -t -A -F $'\t' -c "
+    SELECT table_name, column_name
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name IN ($TABLE_IN_LIST)
+      AND is_generated = 'NEVER';
+")
+if [ $? -ne 0 ]; then
+    echo -e "\033[31mFailed to query target columns. Aborting.\033[0m"
+    exit 1
+fi
+
+COLUMN_ERRORS=0
+while IFS=$'\t' read -r tbl col; do
+    [ -z "$tbl" ] && continue
+    if ! grep -qxF "${tbl}"$'\t'"${col}" <<< "$TARGET_COLUMNS"; then
+        echo -e "\033[31mColumn mismatch: \"$tbl\".\"$col\" exists in source but not in target.\033[0m"
+        COLUMN_ERRORS=$((COLUMN_ERRORS + 1))
+    fi
+done <<< "$SOURCE_COLUMNS"
+
+if [ "$COLUMN_ERRORS" -gt 0 ]; then
+    echo -e "\033[31mFound $COLUMN_ERRORS column mismatch(es). The target schema has diverged from the source\033[0m"
+    echo -e "\033[31m(e.g. a migration on the target dropped or renamed columns). Copying would fail mid-run.\033[0m"
+    echo -e "\033[31mBring source and target to compatible schemas before copying. Aborting.\033[0m"
+    exit 1
+fi
+echo "Column compatibility OK."
+
 # Find nullable FK columns that reference tables NOT in our copy list (e.g. User).
 # Since we intentionally exclude user data for privacy, these columns must be NULLed
 # during copy to avoid FK violations against non-existent rows.


### PR DESCRIPTION
## Why

The migration check in `copy_db.sh` compares migration names only. A target that is ahead of the source passes the check. This is safe for additive migrations. It is not safe when the extra migration drops or renames a column of a copied table. The copy then fails in the middle of the run, because `pg_dump` emits a `COPY` column list that the target does not have. With `--clear`, the failure leaves the target tables empty.

Migration `20260811190506_city_status_demo_supported` is a current example. It removes `City.officialSupport` and rebuilds `City.status`. A copy from production to staging fails at the `City` table in the window when staging has the migration and production does not.

## What

Add a preflight check that runs before the `--clear` deletion. The check reads the column list of every copied table from both databases. The check aborts when the source has a column that the target lacks. Extra columns on the target stay valid, because `COPY` uses an explicit column list from the source. The check excludes generated columns on the source side, because `pg_dump` does not include them in `COPY`.

The check compares column names only. It does not compare types or enum labels. A failure from a type change can still occur during the copy, but it can no longer occur after `--clear` removed the data for a dropped or renamed column.

## Verification

I ran the script against a local throwaway cluster. A target without `City.officialSupport` made the check abort before any deletion. A compatible target passed the check and the copy proceeded.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a preflight schema-compatibility check before destructive clearing and updates it to treat generated target columns as unavailable for `COPY`.
- Queries source and target column metadata for every copied table.
- Aborts before deletion when a source column has no writable target counterpart.
- Excludes generated columns from both sides of the comparison, resolving the previously reported generated-target-column case.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/copy_db.sh | Adds the pre-copy column check and correctly excludes generated target columns, so the previously reported unsafe preflight pass is fixed. |

<sub>Reviews (2): Last reviewed commit: ["feat(scripts): check column compatibilit..."](https://github.com/schemalabz/opencouncil/commit/6a3a5d8a069a5e03d00331469c2c87f68508b3d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53114965)</sub>

<!-- /greptile_comment -->