### PR TITLE
feat(decisions): Decision.decisionNumber in minutes + reading eval export

### DIFF
--- a/messages/el.json
+++ b/messages/el.json
@@ -1103,6 +1103,7 @@
         "lastSearched": "Τελευταία αναζήτηση {time}",
         "lastUpdated": "Τελευταία ενημέρωση {time}",
         "decisionTitle": "Τίτλος",
+        "decisionNumber": "Αριθμός Απόφασης",
         "protocolNumber": "Αριθμός Πρωτοκόλλου",
         "publishDate": "Ημερομηνία Ανάρτησης",
         "viewDecision": "Προβολή απόφασης στη Διαύγεια",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1102,6 +1102,7 @@
         "lastSearched": "Last searched {time}",
         "lastUpdated": "Last updated {time}",
         "decisionTitle": "Title",
+        "decisionNumber": "Decision Number",
         "protocolNumber": "Protocol Number",
         "publishDate": "Publish Date",
         "viewDecision": "View decision on Diavgeia",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1103,6 +1103,7 @@
     "lastSearched": "Dernière recherche {time}",
     "lastUpdated": "Dernière mise à jour {time}",
     "decisionTitle": "Titre",
+    "decisionNumber": "Numéro de décision",
     "protocolNumber": "Numéro de protocole",
     "publishDate": "Date de publication",
     "viewDecision": "Afficher la décision sur Diavgeia",

--- a/messages/sr.json
+++ b/messages/sr.json
@@ -1102,6 +1102,7 @@
         "lastSearched": "Последња претрага {time}",
         "lastUpdated": "Последње ажурирање {time}",
         "decisionTitle": "Наслов",
+        "decisionNumber": "Број одлуке",
         "protocolNumber": "Број протокола",
         "publishDate": "Датум објављивања",
         "viewDecision": "Погледајте одлуку на платформи Diavgeia",

--- a/prisma/migrations/20260813220106_add_decision_number_and_meeting_date/migration.sql
+++ b/prisma/migrations/20260813220106_add_decision_number_and_meeting_date/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Decision" ADD COLUMN     "decisionNumber" TEXT,
+ADD COLUMN     "meetingDate" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -520,6 +520,8 @@ model Decision {
   subjectId      String    @unique
   ada            String?   @unique  // Diavgeia unique identifier (e.g., "91ΥΔΩΡΦ-ΓΥ6")
   protocolNumber String?             // Protocol number (e.g., "261/2024")
+  decisionNumber String?             // The number the decision carries (Αρ. Απόφασης), read from the document. Distinct from protocolNumber, which mirrors Diavgeia's field and means different things per municipality.
+  meetingDate    DateTime?           // The session the document says produced it. Lets a link be verified against the decision itself.
   title          String?             // Decision title from Diavgeia
   pdfUrl         String
   publishDate    DateTime?           // Date published on Diavgeia

--- a/scripts/export-decision-reading-eval.ts
+++ b/scripts/export-decision-reading-eval.ts
@@ -1,0 +1,96 @@
+/**
+ * Export one administrative body's already-linked decisions so model reading
+ * can be scored against them.
+ *
+ * Existing links are free labelled data: each one asserts that a decision
+ * belongs to a particular meeting. If we then read the decision and it names a
+ * different session, either the reading or the link is wrong — and both are
+ * worth knowing.
+ *
+ * Pipeline:
+ *   1. this script                                   -> reading-eval.json
+ *   2. opencouncil-tasks `evaluate-decision-reading` -> coverage + agreement
+ *
+ * Read-only.
+ *
+ * Usage:
+ *   npx tsx scripts/export-decision-reading-eval.ts --body <administrativeBodyId>
+ *   npx tsx scripts/export-decision-reading-eval.ts --body <id> --out /tmp/eval.json
+ */
+import { PrismaClient } from "@prisma/client";
+import fs from "fs";
+
+const prisma = new PrismaClient();
+
+function parseArgs() {
+    const argv = process.argv.slice(2);
+    const get = (flag: string) => {
+        const i = argv.indexOf(flag);
+        return i === -1 ? undefined : argv[i + 1];
+    };
+    const body = get("--body");
+    if (!body) throw new Error("--body <administrativeBodyId> is required");
+    return { body, out: get("--out") ?? "reading-eval.json" };
+}
+
+/**
+ * The document prints a local calendar date; CouncilMeeting.dateTime is UTC.
+ * A 22:00Z meeting is the next day in Athens, which is the date printed.
+ */
+function athensDate(d: Date): string {
+    return d.toLocaleDateString("en-CA", { timeZone: "Europe/Athens" });
+}
+
+async function main() {
+    const { body: bodyId, out } = parseArgs();
+
+    const body = await prisma.administrativeBody.findUnique({
+        where: { id: bodyId },
+        select: { id: true, name: true, cityId: true },
+    });
+    if (!body) throw new Error(`Administrative body "${bodyId}" not found`);
+
+    const meetings = await prisma.councilMeeting.findMany({
+        where: { administrativeBodyId: bodyId },
+        select: {
+            dateTime: true,
+            subjects: {
+                where: { decision: { isNot: null } },
+                select: { decision: { select: { ada: true, pdfUrl: true } } },
+            },
+        },
+    });
+
+    const decisions = meetings.flatMap((m) =>
+        m.subjects
+            .filter((s) => s.decision?.ada)
+            .map((s) => ({
+                ada: s.decision!.ada!,
+                pdfUrl: s.decision!.pdfUrl,
+                expectedMeetingDate: athensDate(m.dateTime),
+            })),
+    );
+
+    fs.writeFileSync(
+        out,
+        JSON.stringify(
+            {
+                city: body.cityId,
+                administrativeBody: { id: body.id, name: body.name },
+                decisions,
+            },
+            null,
+            2,
+        ),
+    );
+
+    console.log(`Exported ${body.cityId} / ${body.name} -> ${out}`);
+    console.log(`  linked decisions: ${decisions.length}`);
+}
+
+main()
+    .catch((e) => {
+        console.error(e);
+        process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());

--- a/src/components/meetings/admin/MinutesPreviewContent.tsx
+++ b/src/components/meetings/admin/MinutesPreviewContent.tsx
@@ -419,7 +419,7 @@ function TOCTable({ subjects, useSequentialNumbers }: { subjects: MinutesSubject
                         <td className="py-1 pr-2 text-gray-500">
                             {subject.withdrawn
                                 ? getWithdrawnLabelGreek(subject)
-                                : (subject.decision?.protocolNumber ?? '')}
+                                : (subject.decision?.decisionNumber ?? '')}
                         </td>
                     </tr>
                 ))}
@@ -494,7 +494,7 @@ function formatMemberList(members: MinutesMember[]) {
 }
 
 function SubjectFooter({ subject }: { subject: MinutesSubject }) {
-    const hasFooter = subject.voteResult || subject.decision?.protocolNumber;
+    const hasFooter = subject.voteResult || subject.decision?.decisionNumber;
     if (!hasFooter) return null;
 
     return (
@@ -542,9 +542,9 @@ function SubjectFooter({ subject }: { subject: MinutesSubject }) {
             )}
 
             {/* Decision number (right-aligned) */}
-            {subject.decision?.protocolNumber && (
+            {subject.decision?.decisionNumber && (
                 <p className="text-right font-bold mt-2">
-                    Αρ. Απόφασης: {subject.decision.protocolNumber}
+                    Αρ. Απόφασης: {subject.decision.decisionNumber}
                 </p>
             )}
         </div>

--- a/src/components/meetings/docx/MinutesDocx.ts
+++ b/src/components/meetings/docx/MinutesDocx.ts
@@ -542,7 +542,7 @@ function createTOCTable(subjects: MinutesSubject[], useSequentialNumbers: boolea
         const seqNum = useSequentialNumbers ? `${index + 1}` : `${subject.agendaItemIndex ?? ''}`;
         const decisionText = subject.withdrawn
             ? getWithdrawnLabelGreek(subject)
-            : (subject.decision?.protocolNumber ?? '');
+            : (subject.decision?.decisionNumber ?? '');
 
         return new TableRow({
             children: [
@@ -758,12 +758,15 @@ function createSubjectSection(subject: MinutesSubject): (Paragraph | Table)[] {
         }
     }
 
-    // Decision number (right-aligned)
-    if (subject.decision?.protocolNumber) {
+    // Decision number (right-aligned). decisionNumber, never protocolNumber:
+    // Diavgeia's protocol number means different things per municipality and
+    // is not the decision's own number everywhere. Blank is correct when
+    // unknown; a wrong number is not.
+    if (subject.decision?.decisionNumber) {
         paragraphs.push(new Paragraph({
             alignment: AlignmentType.RIGHT,
             spacing: { before: 120, after: 200 },
-            children: [new TextRun({ text: `Αρ. Απόφασης: ${subject.decision.protocolNumber}`, size: FONT_SIZE.BODY, bold: true })],
+            children: [new TextRun({ text: `Αρ. Απόφασης: ${subject.decision.decisionNumber}`, size: FONT_SIZE.BODY, bold: true })],
         }));
     }
 

--- a/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
+++ b/src/components/meetings/docx/__tests__/MinutesDocx.test.ts
@@ -1,3 +1,4 @@
+import JSZip from 'jszip';
 import { renderMinutesDocx } from '../MinutesDocx';
 import { MinutesData, MinutesSubject } from '@/lib/minutes/types';
 
@@ -85,6 +86,7 @@ describe('renderMinutesDocx', () => {
                     agendaItemIndex: 1,
                     name: 'Έγκριση προϋπολογισμού 2024',
                     decision: {
+                        decisionNumber: '123/2024',
                         protocolNumber: '123/2024',
                         excerpt: 'Εγκρίνει **ομόφωνα** τον προϋπολογισμό.',
                         references: '- Ν. 3852/2010\n- Ν. 4555/2018',
@@ -173,5 +175,33 @@ describe('renderMinutesDocx', () => {
         const blob = await renderMinutesDocx(data);
         expect(blob).toBeInstanceOf(Blob);
         expect(blob.size).toBeGreaterThan(0);
+    });
+});
+
+/** The rendered text lives in word/document.xml inside the docx zip. */
+async function docxText(data: MinutesData): Promise<string> {
+    const blob = await renderMinutesDocx(data);
+    const zip = await JSZip.loadAsync(Buffer.from(await blob.arrayBuffer()));
+    return zip.file('word/document.xml')!.async('string');
+}
+
+describe('MinutesDocx decision number', () => {
+    it('renders decisionNumber, not protocolNumber', async () => {
+        const text = await docxText(makeMinutesData({
+            subjects: [makeSubject({
+                decision: { decisionNumber: '425/2026', protocolNumber: '29967', excerpt: null, references: null },
+            })],
+        }));
+        expect(text).toContain('425/2026');
+        expect(text).not.toContain('29967');
+    });
+
+    it('renders nothing when decisionNumber is unknown, even if protocolNumber is set', async () => {
+        const text = await docxText(makeMinutesData({
+            subjects: [makeSubject({
+                decision: { decisionNumber: null, protocolNumber: '29967', excerpt: null, references: null },
+            })],
+        }));
+        expect(text).not.toContain('29967');
     });
 });

--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -42,6 +42,7 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
     const [isFetchingDecision, setIsFetchingDecision] = useState(false);
     const [localDecision, setLocalDecision] = useState<{
         ada: string | null;
+        decisionNumber: string | null;
         protocolNumber: string | null;
         title: string | null;
         pdfUrl: string;
@@ -309,6 +310,12 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                                             <tr>
                                                 <td className="py-1.5 pr-4 text-muted-foreground font-medium whitespace-nowrap">ΑΔΑ</td>
                                                 <td className="py-1.5">{decision.ada}</td>
+                                            </tr>
+                                        )}
+                                        {decision.decisionNumber && (
+                                            <tr>
+                                                <td className="py-1.5 pr-4 text-muted-foreground font-medium whitespace-nowrap">{t("decisionNumber")}</td>
+                                                <td className="py-1.5">{decision.decisionNumber}</td>
                                             </tr>
                                         )}
                                         {decision.protocolNumber && (

--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -415,11 +415,18 @@ export interface ExtractedDecisionData {
     subjectInfo: { number: number; isOutOfAgenda: boolean } | null;
     fromCache?: boolean;
     warnings?: DecisionWarning[];
-    /** Protocol number — from Diavgeia API or PDF extraction */
+    /** The decision's own number (Αρ. Απόφασης / Πράξη), extracted from the document. */
+    decisionNumber?: string | null;
+    /**
+     * @deprecated Older tasks versions sent the extracted decision number under this
+     * name. It was never Diavgeia's protocol number. Read for transition tolerance only.
+     */
     protocolNumber?: string | null;
     /** Metadata fetched from Diavgeia API for needsExtraction subjects */
     diavgeiaTitle?: string;
     diavgeiaPublishDate?: string;
+    /** Diavgeia's own protocolNumber field, mirrored verbatim. Municipality-defined semantics. */
+    diavgeiaProtocolNumber?: string;
 }
 
 /*

--- a/src/lib/db/decisions.ts
+++ b/src/lib/db/decisions.ts
@@ -243,6 +243,7 @@ export async function getMeetingAttendance(
 
 export async function getDecisionForSubject(subjectId: string): Promise<{
     ada: string | null;
+    decisionNumber: string | null;
     protocolNumber: string | null;
     title: string | null;
     pdfUrl: string;
@@ -255,6 +256,7 @@ export async function getDecisionForSubject(subjectId: string): Promise<{
     if (!decision) return null;
     return {
         ada: decision.ada,
+        decisionNumber: decision.decisionNumber,
         protocolNumber: decision.protocolNumber,
         title: decision.title,
         pdfUrl: decision.pdfUrl,

--- a/src/lib/minutes/getMinutesData.ts
+++ b/src/lib/minutes/getMinutesData.ts
@@ -251,6 +251,7 @@ export async function getMinutesData(
             } : null,
             discussedElsewhere,
             decision: s.decision ? {
+                decisionNumber: s.decision.decisionNumber ?? null,
                 protocolNumber: s.decision.protocolNumber,
                 excerpt: s.decision.excerpt ?? null,
                 references: s.decision.references ?? null,

--- a/src/lib/minutes/types.ts
+++ b/src/lib/minutes/types.ts
@@ -72,6 +72,9 @@ export interface MinutesSubject {
     }> | null;
 
     decision: {
+        /** The number the decision carries. Rendered as Αρ. Απόφασης. */
+        decisionNumber: string | null;
+        /** Diavgeia's protocol number. Municipality-defined; not necessarily the decision number. */
         protocolNumber: string | null;
         excerpt: string | null;
         references: string | null;

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -1187,14 +1187,24 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
                         return;
                     }
 
+                    // The extracted Αρ. Απόφασης goes to decisionNumber, never to
+                    // protocolNumber: Diavgeia's protocol field is municipality-defined
+                    // and stays a faithful mirror of what Diavgeia published. Older
+                    // tasks versions sent this value under `protocolNumber`, but that
+                    // slot could carry Diavgeia's protocol instead of the decision's
+                    // own number, so it is not trusted here — during deploy skew the
+                    // number stays null and the next poll's reading fills it.
+                    const extractedDecisionNumber = decision.decisionNumber ?? null;
+
                     // 1. Update Decision excerpt, references, and backfill metadata if missing
                     await tx.decision.updateMany({
                         where: { subjectId: decision.subjectId },
                         data: {
                             excerpt: decision.excerpt || null,
                             references: decision.references || null,
+                            ...(extractedDecisionNumber ? { decisionNumber: extractedDecisionNumber } : {}),
                             ...(!existingDecision.title && decision.diavgeiaTitle ? { title: decision.diavgeiaTitle } : {}),
-                            ...(!existingDecision.protocolNumber && decision.protocolNumber ? { protocolNumber: decision.protocolNumber } : {}),
+                            ...(!existingDecision.protocolNumber && decision.diavgeiaProtocolNumber ? { protocolNumber: decision.diavgeiaProtocolNumber } : {}),
                             ...(!existingDecision.publishDate && decision.diavgeiaPublishDate ? { publishDate: new Date(decision.diavgeiaPublishDate) } : {}),
                         },
                     });


### PR DESCRIPTION
Implements #617 phases 1–2 (app side). Adds `Decision.decisionNumber`/`meetingDate` (nullable, migration included) and renders `decisionNumber` in the minutes instead of `protocolNumber` — Diavgeia's protocol field is municipality-defined (measured: chania/argithea/samothraki use true protocols, most others put the decision number there, with per-document exceptions), so a blank is correct where a wrong number wasn't. The extraction callback now stores the extracted number in the new column and only ever backfills `protocolNumber` from Diavgeia's own metadata. `export-decision-reading-eval.ts` exports a body's links for the tasks-side harness.

Pairs with schemalabz/opencouncil-tasks#84. Refs #617.







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR separates a decision’s document-derived number from Diavgeia’s municipality-defined protocol number and uses the new value consistently in minutes output.

- Adds nullable decision-number and meeting-date fields with a Prisma migration.
- Stores extracted decision numbers separately while mirroring protocol metadata from Diavgeia.
- Aligns the administrative preview and DOCX minutes output.
- Adds a standalone decision-reading evaluation export.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/meetings/admin/MinutesPreviewContent.tsx | The prior preview mismatch is fixed; TOC and footer rendering now match the DOCX decision-number conditions. |
| src/components/meetings/docx/MinutesDocx.ts | Minutes now intentionally render the document-derived decision number and omit unverified protocol-number fallbacks. |
| src/lib/tasks/pollDecisions.ts | Extraction results now preserve the distinction between document-derived decision numbers and Diavgeia protocol metadata. |
| prisma/schema.prisma | Adds nullable decision metadata fields without changing existing record requirements. |
| prisma/migrations/20260813220106_add_decision_number_and_meeting_date/migration.sql | Adds the two nullable columns corresponding to the updated Prisma model. |
| scripts/export-decision-reading-eval.ts | Adds a read-only standalone export using the repository’s established script-level Prisma pattern. |

<sub>Reviews (6): Last reviewed commit: ["feat(decisions): store the extracted dec..."](https://github.com/schemalabz/opencouncil/commit/471f530867fba69dde6c2bae3a2b31acc5bfaae8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53271566)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Meeting publication and records](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/meeting-publication.md)
- Knowledge Base — [Background task orchestration](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/background-task-orchestration.md)
- Knowledge Base — [Database access and civic models](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/database-access-and-models.md)
</details>


<!-- /greptile_comment -->