### PR TITLE
feat(decisions): manual assignment of unplaced decisions; retire claimedAda

### DIFF
--- a/messages/el/admin.json
+++ b/messages/el/admin.json
@@ -277,7 +277,17 @@
       "removeDecision": "Αφαίρεση απόφασης",
       "removeDecisionDescription": "Αποσύνδεση απόφασης και διαγραφή εξαγόμενων δεδομένων.",
       "extractionReset": "Η εξαγωγή διαγράφηκε",
-      "decisionRemoved": "Η απόφαση αφαιρέθηκε"
+      "decisionRemoved": "Η απόφαση αφαιρέθηκε",
+      "unplacedTitle": "Ατοποθέτητες αποφάσεις",
+      "unplacedDescription": "Αποφάσεις που αναφέρουν αυτή την συνεδρίαση, αλλά δεν έχουν συνδεθεί με κάποιο θέμα. Επιβεβαιώστε ή απορρίψτε την αντιστοίχιση με αυτό το θέμα.",
+      "unplacedSuggestion": "Προτεινόμενο θέμα",
+      "unplacedConflict": "Ήδη συνδεδεμένη με",
+      "unplacedChooseSubject": "Επιλέξτε θέμα…",
+      "unplacedAssign": "Αντιστοίχιση",
+      "unplacedDismiss": "Απόρριψη",
+      "unplacedAssigned": "Η απόφαση αντιστοιχίστηκε",
+      "unplacedDismissed": "Η υποψήφια αντιστοίχηση απορρίφθηκε",
+      "unplacedNoFreeSubjects": "Όλα τα θέματα έχουν ήδη αποφάσεις"
     },
     "export": {
       "docx": "Εξαγωγή σε DOCX",

--- a/messages/en/admin.json
+++ b/messages/en/admin.json
@@ -277,7 +277,17 @@
       "removeDecision": "Remove decision",
       "removeDecisionDescription": "Unlink decision and clear all extracted data.",
       "extractionReset": "Extraction reset",
-      "decisionRemoved": "Decision removed"
+      "decisionRemoved": "Decision removed",
+      "unplacedTitle": "Unplaced decisions",
+      "unplacedDescription": "Decisions that mention this meeting, but have not yet been linked to a subject. Confirm or dismiss the assignment to this subject.",
+      "unplacedSuggestion": "Suggested subject",
+      "unplacedConflict": "Already linked to",
+      "unplacedChooseSubject": "Choose a subject…",
+      "unplacedAssign": "Assign",
+      "unplacedDismiss": "Dismiss",
+      "unplacedAssigned": "Decision assigned",
+      "unplacedDismissed": "Candidate dismissed",
+      "unplacedNoFreeSubjects": "All subjects already have decisions"
     },
     "export": {
       "docx": "Export to DOCX",

--- a/messages/fr/admin.json
+++ b/messages/fr/admin.json
@@ -277,7 +277,17 @@
       "removeDecision": "Supprimer la décision",
       "removeDecisionDescription": "Dissociez la décision et effacez toutes les données extraites.",
       "extractionReset": "Extraction réinitialisée",
-      "decisionRemoved": "Décision supprimée"
+      "decisionRemoved": "Décision supprimée",
+      "unplacedTitle": "Décisions non placées",
+      "unplacedDescription": "Décisions dont le document déclare cette séance, sans sujet lié. Affectez-les à leur sujet ou rejetez celles qui ne relèvent pas de cette séance.",
+      "unplacedSuggestion": "Sujet suggéré",
+      "unplacedConflict": "Déjà liée à",
+      "unplacedChooseSubject": "Choisir un sujet…",
+      "unplacedAssign": "Affecter",
+      "unplacedDismiss": "Rejeter",
+      "unplacedAssigned": "Décision affectée",
+      "unplacedDismissed": "Candidate rejetée",
+      "unplacedNoFreeSubjects": "Tous les sujets ont déjà des décisions"
     },
     "export": {
       "docx": "Exporter en DOCX",

--- a/messages/sr/admin.json
+++ b/messages/sr/admin.json
@@ -277,7 +277,17 @@
             "removeDecision": "Уклони одлуку",
             "removeDecisionDescription": "Уклоните везу са одлуком и обришите све издвојене податке.",
             "extractionReset": "Издвајање ресетовано",
-            "decisionRemoved": "Одлука уклоњена"
+            "decisionRemoved": "Одлука уклоњена",
+            "unplacedTitle": "Nepovezane odluke",
+            "unplacedDescription": "Odluke čiji dokument navodi ovu sednicu, još nepovezane sa tačkom dnevnog reda. Dodelite ih tački ili odbacite one koje ne pripadaju ovde.",
+            "unplacedSuggestion": "Predložena tačka",
+            "unplacedConflict": "Već povezana sa",
+            "unplacedChooseSubject": "Izaberite tačku…",
+            "unplacedAssign": "Dodeli",
+            "unplacedDismiss": "Odbaci",
+            "unplacedAssigned": "Odluka dodeljena",
+            "unplacedDismissed": "Kandidat odbačen",
+            "unplacedNoFreeSubjects": "Sve tačke već imaju odluke"
         },
         "export": {
             "docx": "Извезите у DOCX",

--- a/prisma/migrations/20260814072650_retire_claimed_ada/migration.sql
+++ b/prisma/migrations/20260814072650_retire_claimed_ada/migration.sql
@@ -1,0 +1,21 @@
+-- Migrate existing claims into DecisionCandidate rows (issue #617 phase 4):
+-- a claim becomes an unresolved candidate proposing the claiming subject; the
+-- conflict stays derivable via the ADA join to the holding Decision.
+INSERT INTO "DecisionCandidate" ("id", "cityId", "ada", "pdfUrl", "readStatus", "councilMeetingId", "subjectId", "createdAt", "updatedAt")
+SELECT DISTINCT ON (s."cityId", s."claimedAda")
+       gen_random_uuid(), s."cityId", s."claimedAda",
+       'https://diavgeia.gov.gr/doc/' || s."claimedAda",
+       'unread', s."councilMeetingId", s.id, NOW(), NOW()
+FROM "Subject" s
+WHERE s."claimedAda" IS NOT NULL
+-- A poll may already have created a candidate row for this ADA (deploys are
+-- order-free). Keep that row, but carry the claim over as its proposed subject
+-- when the row is still unresolved and has no proposal of its own — otherwise
+-- the claiming subject's association would be lost with the column drop.
+ON CONFLICT ("cityId", "ada") DO UPDATE SET "subjectId" = EXCLUDED."subjectId"
+WHERE "DecisionCandidate"."decisionId" IS NULL
+  AND "DecisionCandidate"."dismissedAt" IS NULL
+  AND "DecisionCandidate"."subjectId" IS NULL;
+
+-- AlterTable
+ALTER TABLE "Subject" DROP COLUMN "claimedAda";

--- a/prisma/migrations/20260824190000_backfill_legacy_decision_candidates/migration.sql
+++ b/prisma/migrations/20260824190000_backfill_legacy_decision_candidates/migration.sql
@@ -1,0 +1,21 @@
+-- Every legacy Decision with an ADA becomes an assigned candidate row
+-- (issue #617 phase 4). Two things depend on this substrate:
+-- unlinking a decision stays reversible (onDelete: SetNull returns the
+-- candidate to the meeting's unplaced list), and the knownDecisions
+-- handshake can schedule the document for reading — readStatus 'unread'
+-- keeps the row eligible, because the backfill records that the link
+-- exists, never that it is correct: production links contain known errors.
+-- The reading fields stay null until a poll reads the document; there was
+-- no recorded suggestion, so subjectId stays null too.
+INSERT INTO "DecisionCandidate" ("id", "cityId", "ada", "pdfUrl", "title", "publishDate", "protocolNumber", "readStatus", "councilMeetingId", "decisionId", "createdAt", "updatedAt")
+SELECT gen_random_uuid(), s."cityId", d.ada, d."pdfUrl", d.title, d."publishDate", d."protocolNumber",
+       'unread', s."councilMeetingId", d.id, NOW(), NOW()
+FROM "Decision" d
+JOIN "Subject" s ON s.id = d."subjectId"
+WHERE d.ada IS NOT NULL
+-- An ADA already occupied by a claim-derived or poll-created candidate keeps
+-- its existing row. Accepted edge: a decision whose ADA is held by another
+-- subject's claim gets no backing candidate, so unlinking it stays
+-- destructive — the admin UI warns on rows without one, the same branch as
+-- the ADA-null decisions this migration deliberately skips.
+ON CONFLICT ("cityId", "ada") DO NOTHING;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -509,7 +509,6 @@ model Subject {
   // Temporary field for ADA conflict resolution.
   // Set when a poll detects that an ADA already belongs to another subject's decision.
   // Cleared to null once admin resolves the conflict (reassign or dismiss).
-  claimedAda String?
 
   @@index([cityId, councilMeetingId])
   @@index([discussedInId])

--- a/src/app/api/cities/[cityId]/meetings/[meetingId]/decisions/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/[meetingId]/decisions/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { withUserAuthorizedToEdit } from '@/lib/auth';
 import { getDecisionsForMeeting, getExtractedDataForMeeting, getMeetingAttendance, upsertDecision, deleteDecision, clearExtractedDataForMeeting, resetExtractionForSubject } from '@/lib/db/decisions';
+import { getUnresolvedCandidatesForMeeting, assignCandidate, dismissCandidate } from '@/lib/db/decisionCandidates';
 import prisma from '@/lib/db/prisma';
 import { revalidateTag } from 'next/cache';
 import { z } from 'zod';
@@ -13,12 +14,13 @@ export async function GET(
     const params = await props.params;
     await withUserAuthorizedToEdit({ cityId: params.cityId });
 
-    const [decisions, extractedData, meetingAttendance] = await Promise.all([
+    const [decisions, extractedData, meetingAttendance, candidates] = await Promise.all([
         getDecisionsForMeeting(params.cityId, params.meetingId),
         getExtractedDataForMeeting(params.cityId, params.meetingId),
         getMeetingAttendance(params.cityId, params.meetingId),
+        getUnresolvedCandidatesForMeeting(params.cityId, params.meetingId),
     ]);
-    return NextResponse.json({ decisions, extractedData, meetingAttendance });
+    return NextResponse.json({ decisions, extractedData, meetingAttendance, candidates });
 }
 
 const upsertSchema = z.object({
@@ -110,6 +112,8 @@ export async function DELETE(
 const postSchema = z.discriminatedUnion('action', [
     z.object({ action: z.literal('clearExtractedData') }),
     z.object({ action: z.literal('resetExtraction'), subjectId: z.string().min(1) }),
+    z.object({ action: z.literal('assignCandidate'), candidateId: z.string().min(1), subjectId: z.string().min(1) }),
+    z.object({ action: z.literal('dismissCandidate'), candidateId: z.string().min(1) }),
 ]);
 
 export async function POST(
@@ -130,6 +134,33 @@ export async function POST(
         const result = await clearExtractedDataForMeeting(params.cityId, params.meetingId);
         revalidateTag(`city:${params.cityId}:meetings`, 'max');
         return NextResponse.json(result);
+    }
+
+    if (parsed.data.action === 'assignCandidate') {
+        // Verify the target subject belongs to this city and meeting
+        const subject = await prisma.subject.findFirst({
+            where: { id: parsed.data.subjectId, cityId: params.cityId, councilMeetingId: params.meetingId },
+        });
+        if (!subject) {
+            return NextResponse.json({ error: 'Subject not found in this meeting' }, { status: 404 });
+        }
+        const session = await auth();
+        try {
+            await assignCandidate(params.cityId, params.meetingId, parsed.data.candidateId, parsed.data.subjectId, session?.user?.id);
+        } catch (e) {
+            return NextResponse.json({ error: e instanceof Error ? e.message : 'Assignment failed' }, { status: 409 });
+        }
+        revalidateTag(`city:${params.cityId}:meetings`, 'max');
+        return NextResponse.json({ success: true });
+    }
+
+    if (parsed.data.action === 'dismissCandidate') {
+        try {
+            await dismissCandidate(params.cityId, params.meetingId, parsed.data.candidateId);
+        } catch (e) {
+            return NextResponse.json({ error: e instanceof Error ? e.message : 'Dismiss failed' }, { status: 409 });
+        }
+        return NextResponse.json({ success: true });
     }
 
     // action === 'resetExtraction'

--- a/src/components/admin/diavgeia/PollingStats.tsx
+++ b/src/components/admin/diavgeia/PollingStats.tsx
@@ -31,7 +31,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Search, Clock, Activity, CalendarClock, ArrowUpDown, ChevronDown, Eye, Copy, Check, ExternalLink, Loader2, AlertTriangle } from 'lucide-react';
-import { resolveAdaConflict } from '@/lib/tasks/pollDecisions';
+import { resolveCandidateConflict } from '@/lib/tasks/pollDecisions';
 import { useUrlParams } from '@/hooks/useUrlParams';
 import { formatRelativeTime } from '@/lib/formatters/time';
 
@@ -84,6 +84,7 @@ interface StillPollingMeeting {
 }
 
 interface AdaConflict {
+  candidateId: string;
   claimingSubject: {
     id: string;
     name: string;
@@ -291,7 +292,7 @@ function ConflictsSection({ conflicts }: { conflicts: AdaConflict[] }) {
     setResolvingAda(conflict.ada);
     setError(null);
     try {
-      await resolveAdaConflict(conflict.claimingSubject.id, resolution);
+      await resolveCandidateConflict(conflict.candidateId, resolution);
       updateParam('_t', String(Date.now()));
     } catch (err) {
       console.error('Failed to resolve conflict:', err);

--- a/src/components/meetings/admin/DecisionsPanel.tsx
+++ b/src/components/meetings/admin/DecisionsPanel.tsx
@@ -14,6 +14,8 @@ import { useTranslations } from 'next-intl';
 import { ExternalLink, FileCheck, FileX, Loader2, Bot, UserIcon, Plus, X, Clock, ChevronRight, ChevronDown, Users, Vote, Search, MoreHorizontal, RotateCcw } from 'lucide-react';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { DecisionWithSource, MeetingAttendanceRecord, SubjectExtractedData } from '@/lib/db/decisions';
+import { MeetingCandidate } from '@/lib/db/decisionCandidateShape';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { LinkOrDrop } from '@/components/ui/link-or-drop';
 import { getPollingHistoryForMeeting, requestPollDecisions } from '@/lib/tasks/pollDecisions';
 import { calculateVoteResult } from '@/lib/utils/votes';
@@ -41,6 +43,12 @@ interface DecisionsPanelProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
 }
+
+/** MeetingCandidate as it arrives over JSON — dates serialized to strings. */
+type CandidateView = Omit<MeetingCandidate, 'publishDate' | 'meetingDate'> & {
+    publishDate: string | null;
+    meetingDate: string | null;
+};
 
 function CollapsibleMarkdown({ content, showMoreLabel, showLessLabel }: {
     content: string;
@@ -171,6 +179,9 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
         p.roles.some(r => isRoleActiveAt(r, meetingDate) && isMayorRole(r))
     )?.id ?? null;
     const [decisions, setDecisions] = useState<Record<string, DecisionWithSource>>({});
+    const [candidates, setCandidates] = useState<CandidateView[]>([]);
+    const [candidateSel, setCandidateSel] = useState<Record<string, string>>({});
+    const [candidateBusy, setCandidateBusy] = useState<string | null>(null);
     const [extractedData, setExtractedData] = useState<Record<string, SubjectExtractedData>>({});
     const [meetingAttendance, setMeetingAttendance] = useState<MeetingAttendanceRecord[]>([]);
     const [expandedManualEntry, setExpandedManualEntry] = useState<string | null>(null);
@@ -193,12 +204,13 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
         try {
             const response = await fetch(`/api/cities/${meeting.cityId}/meetings/${meeting.id}/decisions`);
             if (!response.ok) return;
-            const data: { decisions: DecisionWithSource[]; extractedData: SubjectExtractedData[]; meetingAttendance: MeetingAttendanceRecord[] } = await response.json();
+            const data: { decisions: DecisionWithSource[]; extractedData: SubjectExtractedData[]; meetingAttendance: MeetingAttendanceRecord[]; candidates?: CandidateView[] } = await response.json();
             const decisionMap: Record<string, DecisionWithSource> = {};
             for (const d of data.decisions) {
                 decisionMap[d.subjectId] = d;
             }
             setDecisions(decisionMap);
+            setCandidates(data.candidates ?? []);
             const extractedMap: Record<string, SubjectExtractedData> = {};
             for (const e of data.extractedData) {
                 extractedMap[e.subjectId] = e;
@@ -297,6 +309,45 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
             toast({ title: t('toasts.errorRemovingDecision.title'), description: `${error}`, variant: 'destructive' });
         } finally {
             setRemovingSubjectId(null);
+        }
+    };
+
+    const handleAssignCandidate = async (candidateId: string, subjectId: string) => {
+        setCandidateBusy(candidateId);
+        try {
+            const response = await fetch(`/api/cities/${meeting.cityId}/meetings/${meeting.id}/decisions`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'assignCandidate', candidateId, subjectId }),
+            });
+            if (!response.ok) {
+                const err = await response.json().catch(() => null);
+                throw new Error(err?.error ?? 'Assignment failed');
+            }
+            toast({ title: t('decisions.unplacedAssigned') });
+            fetchDecisions();
+        } catch (error) {
+            toast({ title: `${error instanceof Error ? error.message : error}`, variant: 'destructive' });
+        } finally {
+            setCandidateBusy(null);
+        }
+    };
+
+    const handleDismissCandidate = async (candidateId: string) => {
+        setCandidateBusy(candidateId);
+        try {
+            const response = await fetch(`/api/cities/${meeting.cityId}/meetings/${meeting.id}/decisions`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'dismissCandidate', candidateId }),
+            });
+            if (!response.ok) throw new Error('Dismiss failed');
+            toast({ title: t('decisions.unplacedDismissed') });
+            fetchDecisions();
+        } catch (error) {
+            toast({ title: `${error}`, variant: 'destructive' });
+        } finally {
+            setCandidateBusy(null);
         }
     };
 
@@ -680,9 +731,12 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
                                                         )}
                                                         <Badge variant="default" className="bg-green-600 text-xs">
                                                             <FileCheck className="h-3 w-3 mr-1" />
-                                                            {decision.protocolNumber || decision.ada || t('decisions.linked')}
+                                                            {/* The decision's own number; Diavgeia's protocolNumber is a
+                                                                filing protocol in some municipalities, so it is only a
+                                                                fallback until decisionNumber is backfilled. */}
+                                                            {decision.decisionNumber || decision.protocolNumber || decision.ada || t('decisions.linked')}
                                                         </Badge>
-                                                        {decision.protocolNumber && decision.ada && (
+                                                        {(decision.decisionNumber || decision.protocolNumber) && decision.ada && (
                                                             <span className="text-xs text-muted-foreground">{decision.ada}</span>
                                                         )}
                                                         <Tooltip>
@@ -963,6 +1017,89 @@ export function DecisionsPanel({ open, onOpenChange }: DecisionsPanelProps) {
                         </TooltipProvider>
                     )}
                 </div>
+
+                {/* Unplaced decisions — candidates known to belong to this session (issue #617) */}
+                {candidates.length > 0 && (
+                    <div className="pt-3 border-t">
+                        <div className="mb-2">
+                            <h3 className="text-sm font-medium">{t('decisions.unplacedTitle')} ({candidates.length})</h3>
+                            <p className="text-xs text-muted-foreground">{t('decisions.unplacedDescription')}</p>
+                        </div>
+                        <div className="space-y-2">
+                            {candidates.map(c => {
+                                const freeSubjects = subjects
+                                    .filter(s => !decisions[s.id])
+                                    .sort((a, b) => (a.agendaItemIndex ?? 999) - (b.agendaItemIndex ?? 999));
+                                const suggestedSubject = c.subjectId ? subjects.find(s => s.id === c.subjectId) : null;
+                                const selected = candidateSel[c.id] ?? (suggestedSubject && !decisions[suggestedSubject.id] ? suggestedSubject.id : undefined);
+                                const busy = candidateBusy === c.id;
+                                return (
+                                    <div key={c.id} className="rounded-md border p-2 text-sm">
+                                        <div className="flex items-start justify-between gap-3">
+                                            <div className="min-w-0">
+                                                <a href={c.pdfUrl} target="_blank" rel="noreferrer" className="font-medium hover:underline inline-flex items-center gap-1">
+                                                    {c.decisionNumber ? `${c.decisionNumber} — ` : ''}{c.title ?? c.ada}
+                                                    <ExternalLink className="h-3 w-3 shrink-0" />
+                                                </a>
+                                                <div className="text-xs text-muted-foreground mt-0.5 flex flex-wrap items-center gap-2">
+                                                    <span className="font-mono">{c.ada}</span>
+                                                    {c.meetingDate && <span>{c.meetingDate.slice(0, 10)}</span>}
+                                                    <Badge variant="outline" className="h-4 px-1 text-[10px]">{c.readStatus}</Badge>
+                                                </div>
+                                                {suggestedSubject && (
+                                                    <div className="text-xs text-muted-foreground mt-0.5">
+                                                        {t('decisions.unplacedSuggestion')}: {suggestedSubject.name}
+                                                        {c.confidence != null ? ` (${c.confidence.toFixed(2)})` : ''}
+                                                    </div>
+                                                )}
+                                                {c.conflict && (
+                                                    <div className="text-xs text-destructive mt-0.5">
+                                                        {t('decisions.unplacedConflict')}: {c.conflict.subjectName}
+                                                    </div>
+                                                )}
+                                            </div>
+                                            <div className="flex items-center gap-2 shrink-0">
+                                                {freeSubjects.length > 0 ? (
+                                                    <Select value={selected} onValueChange={(v) => setCandidateSel(prev => ({ ...prev, [c.id]: v }))}>
+                                                        <SelectTrigger className="h-7 w-56 text-xs">
+                                                            <SelectValue placeholder={t('decisions.unplacedChooseSubject')} />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                            {freeSubjects.map(s => (
+                                                                <SelectItem key={s.id} value={s.id} className="text-xs">
+                                                                    {s.agendaItemIndex != null ? `#${s.agendaItemIndex} ` : ''}{s.name}
+                                                                </SelectItem>
+                                                            ))}
+                                                        </SelectContent>
+                                                    </Select>
+                                                ) : (
+                                                    <span className="text-xs text-muted-foreground">{t('decisions.unplacedNoFreeSubjects')}</span>
+                                                )}
+                                                <Button
+                                                    size="sm"
+                                                    className="h-7 text-xs"
+                                                    disabled={busy || !selected || !!c.conflict}
+                                                    onClick={() => selected && handleAssignCandidate(c.id, selected)}
+                                                >
+                                                    {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : t('decisions.unplacedAssign')}
+                                                </Button>
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline"
+                                                    className="h-7 text-xs"
+                                                    disabled={busy}
+                                                    onClick={() => handleDismissCandidate(c.id)}
+                                                >
+                                                    {t('decisions.unplacedDismiss')}
+                                                </Button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </div>
+                )}
 
                 {/* Danger zone — Delete extractions (bottom of dialog) */}
                 {extractedSubjects.length > 0 && (

--- a/src/lib/db/__tests__/decisionCandidates.test.ts
+++ b/src/lib/db/__tests__/decisionCandidates.test.ts
@@ -1,0 +1,32 @@
+import { shapeCandidates, type AdaHolder } from '@/lib/db/decisionCandidateShape';
+
+function row(ada: string, overrides: Partial<Parameters<typeof shapeCandidates>[0][0]> = {}) {
+    return {
+        id: `cand-${ada}`,
+        ada,
+        title: null,
+        pdfUrl: `https://diavgeia.gov.gr/doc/${ada}`,
+        publishDate: null,
+        meetingDate: null,
+        decisionNumber: null,
+        readStatus: 'ok',
+        subjectId: null,
+        confidence: null,
+        reasoning: null,
+        ...overrides,
+    };
+}
+
+describe('shapeCandidates', () => {
+    it('marks a candidate whose ADA is held by another subject as conflicting', () => {
+        const holders: AdaHolder[] = [{ ada: 'A1', subjectId: 'sub-9', subjectName: 'Έγκριση προϋπολογισμού' }];
+        const shaped = shapeCandidates([row('A1'), row('A2')], holders);
+        expect(shaped[0].conflict).toEqual({ subjectId: 'sub-9', subjectName: 'Έγκριση προϋπολογισμού' });
+        expect(shaped[1].conflict).toBeNull();
+    });
+
+    it('passes candidate fields through unchanged', () => {
+        const shaped = shapeCandidates([row('A1', { decisionNumber: '425/2026', subjectId: 'sub-1', confidence: 0.9 })], []);
+        expect(shaped[0]).toMatchObject({ ada: 'A1', decisionNumber: '425/2026', subjectId: 'sub-1', confidence: 0.9, conflict: null });
+    });
+});

--- a/src/lib/db/decisionCandidateShape.ts
+++ b/src/lib/db/decisionCandidateShape.ts
@@ -1,0 +1,54 @@
+import { DecisionCandidate } from "@prisma/client";
+
+/** Pure shaping for meeting decision candidates — kept prisma-free for unit tests. */
+
+export interface MeetingCandidate {
+    id: string;
+    ada: string;
+    title: string | null;
+    pdfUrl: string;
+    publishDate: Date | null;
+    meetingDate: Date | null;
+    decisionNumber: string | null;
+    readStatus: string;
+    /** The pipeline's suggested subject, if any. */
+    subjectId: string | null;
+    confidence: number | null;
+    reasoning: string | null;
+    /** Set when another subject's Decision already holds this ADA. */
+    conflict: { subjectId: string; subjectName: string } | null;
+}
+
+type CandidateRow = Pick<
+    DecisionCandidate,
+    'id' | 'ada' | 'title' | 'pdfUrl' | 'publishDate' | 'meetingDate' | 'decisionNumber'
+    | 'readStatus' | 'subjectId' | 'confidence' | 'reasoning'
+>;
+
+export interface AdaHolder {
+    ada: string;
+    subjectId: string;
+    subjectName: string;
+}
+
+/** Pure: attach conflict info (which subject's Decision holds each ADA) to candidate rows. */
+export function shapeCandidates(rows: CandidateRow[], holders: AdaHolder[]): MeetingCandidate[] {
+    const holderByAda = new Map(holders.map(h => [h.ada, h]));
+    return rows.map(r => {
+        const holder = holderByAda.get(r.ada);
+        return {
+            id: r.id,
+            ada: r.ada,
+            title: r.title,
+            pdfUrl: r.pdfUrl,
+            publishDate: r.publishDate,
+            meetingDate: r.meetingDate,
+            decisionNumber: r.decisionNumber,
+            readStatus: r.readStatus,
+            subjectId: r.subjectId,
+            confidence: r.confidence,
+            reasoning: r.reasoning,
+            conflict: holder ? { subjectId: holder.subjectId, subjectName: holder.subjectName } : null,
+        };
+    });
+}

--- a/src/lib/db/decisionCandidates.ts
+++ b/src/lib/db/decisionCandidates.ts
@@ -50,10 +50,10 @@ export async function getUnresolvedCandidatesForMeeting(cityId: string, meetingI
  * the candidate to it. Throws with a human-readable message when the subject
  * already has a decision or the ADA is held elsewhere — the panel surfaces it.
  */
-export async function assignCandidate(cityId: string, candidateId: string, subjectId: string, userId?: string): Promise<void> {
+export async function assignCandidate(cityId: string, meetingId: string, candidateId: string, subjectId: string, userId?: string): Promise<void> {
     await prisma.$transaction(async (tx) => {
         const candidate = await tx.decisionCandidate.findUnique({ where: { id: candidateId } });
-        if (!candidate || candidate.cityId !== cityId) throw new Error('Candidate not found');
+        if (!candidate || candidate.cityId !== cityId || candidate.councilMeetingId !== meetingId) throw new Error('Candidate not found');
         if (candidate.decisionId || candidate.dismissedAt) throw new Error('Candidate is already resolved');
 
         const subjectTaken = await tx.decision.findUnique({ where: { subjectId }, select: { id: true } });
@@ -88,9 +88,16 @@ export async function assignCandidate(cityId: string, candidateId: string, subje
     });
 }
 
-export async function dismissCandidate(cityId: string, candidateId: string): Promise<void> {
-    const candidate = await prisma.decisionCandidate.findUnique({ where: { id: candidateId } });
-    if (!candidate || candidate.cityId !== cityId) throw new Error('Candidate not found');
-    if (candidate.decisionId || candidate.dismissedAt) throw new Error('Candidate is already resolved');
-    await prisma.decisionCandidate.update({ where: { id: candidateId }, data: { dismissedAt: new Date() } });
+export async function dismissCandidate(cityId: string, meetingId: string, candidateId: string): Promise<void> {
+    // Conditional write: a concurrent assignment between read and update would
+    // otherwise leave a row both assigned and dismissed.
+    const updated = await prisma.decisionCandidate.updateMany({
+        where: { id: candidateId, cityId, councilMeetingId: meetingId, decisionId: null, dismissedAt: null },
+        data: { dismissedAt: new Date() },
+    });
+    if (updated.count === 0) {
+        const candidate = await prisma.decisionCandidate.findUnique({ where: { id: candidateId }, select: { cityId: true, councilMeetingId: true } });
+        if (!candidate || candidate.cityId !== cityId || candidate.councilMeetingId !== meetingId) throw new Error('Candidate not found');
+        throw new Error('Candidate is already resolved');
+    }
 }

--- a/src/lib/db/decisionCandidates.ts
+++ b/src/lib/db/decisionCandidates.ts
@@ -1,0 +1,96 @@
+import prisma from "./prisma";
+import { shapeCandidates, type MeetingCandidate } from "./decisionCandidateShape";
+
+export { shapeCandidates, type MeetingCandidate, type AdaHolder } from "./decisionCandidateShape";
+
+/**
+ * Meeting-scoped access to DecisionCandidate (issue #617 phase 4).
+ *
+ * Unresolved rows (decisionId null, dismissedAt null) are the decisions we know
+ * belong to a meeting but could not place automatically. Assigning one creates
+ * the Decision and links it via decisionId; deleting the Decision reverts the
+ * assignment through onDelete: SetNull — no code needed here for revert.
+ */
+
+export async function getUnresolvedCandidatesForMeeting(cityId: string, meetingId: string): Promise<MeetingCandidate[]> {
+    const rows = await prisma.decisionCandidate.findMany({
+        where: {
+            cityId,
+            councilMeetingId: meetingId,
+            decisionId: null,
+            dismissedAt: null,
+            // not_a_decision names the document, not the reader: agendas and
+            // mayoral acts are nobody's work queue.
+            readStatus: { not: 'not_a_decision' },
+        },
+        orderBy: [{ publishDate: 'asc' }, { ada: 'asc' }],
+        select: {
+            id: true, ada: true, title: true, pdfUrl: true, publishDate: true,
+            meetingDate: true, decisionNumber: true, readStatus: true,
+            subjectId: true, confidence: true, reasoning: true,
+        },
+    });
+    if (rows.length === 0) return [];
+
+    const holders = await prisma.decision.findMany({
+        where: { ada: { in: rows.map(r => r.ada) } },
+        select: { ada: true, subjectId: true, subject: { select: { name: true } } },
+    });
+
+    return shapeCandidates(
+        rows,
+        holders
+            .filter((h): h is typeof h & { ada: string } => h.ada !== null)
+            .map(h => ({ ada: h.ada, subjectId: h.subjectId, subjectName: h.subject.name })),
+    );
+}
+
+/**
+ * Assign an unresolved candidate to a subject: creates the Decision and links
+ * the candidate to it. Throws with a human-readable message when the subject
+ * already has a decision or the ADA is held elsewhere — the panel surfaces it.
+ */
+export async function assignCandidate(cityId: string, candidateId: string, subjectId: string, userId?: string): Promise<void> {
+    await prisma.$transaction(async (tx) => {
+        const candidate = await tx.decisionCandidate.findUnique({ where: { id: candidateId } });
+        if (!candidate || candidate.cityId !== cityId) throw new Error('Candidate not found');
+        if (candidate.decisionId || candidate.dismissedAt) throw new Error('Candidate is already resolved');
+
+        const subjectTaken = await tx.decision.findUnique({ where: { subjectId }, select: { id: true } });
+        if (subjectTaken) throw new Error('Subject already has a decision — remove it first');
+
+        const adaHolder = await tx.decision.findUnique({ where: { ada: candidate.ada }, select: { subjectId: true } });
+        if (adaHolder) throw new Error('This decision is already linked to another subject');
+
+        const decision = await tx.decision.create({
+            data: {
+                subjectId,
+                ada: candidate.ada,
+                title: candidate.title,
+                pdfUrl: candidate.pdfUrl,
+                protocolNumber: candidate.protocolNumber,
+                publishDate: candidate.publishDate,
+                decisionNumber: candidate.decisionNumber,
+                meetingDate: candidate.meetingDate,
+                createdById: userId ?? null,
+            },
+        });
+
+        await tx.decisionCandidate.update({
+            where: { id: candidateId },
+            data: {
+                decisionId: decision.id,
+                // Record the accepted placement when the pipeline had no suggestion;
+                // an existing suggestion stays as-made for acceptance analysis.
+                ...(candidate.subjectId ? {} : { subjectId }),
+            },
+        });
+    });
+}
+
+export async function dismissCandidate(cityId: string, candidateId: string): Promise<void> {
+    const candidate = await prisma.decisionCandidate.findUnique({ where: { id: candidateId } });
+    if (!candidate || candidate.cityId !== cityId) throw new Error('Candidate not found');
+    if (candidate.decisionId || candidate.dismissedAt) throw new Error('Candidate is already resolved');
+    await prisma.decisionCandidate.update({ where: { id: candidateId }, data: { dismissedAt: new Date() } });
+}

--- a/src/lib/db/decisionCandidates.ts
+++ b/src/lib/db/decisionCandidates.ts
@@ -1,4 +1,5 @@
 import prisma from "./prisma";
+import { DataSource } from "@prisma/client";
 import { shapeCandidates, type MeetingCandidate } from "./decisionCandidateShape";
 
 export { shapeCandidates, type MeetingCandidate, type AdaHolder } from "./decisionCandidateShape";
@@ -100,4 +101,152 @@ export async function dismissCandidate(cityId: string, meetingId: string, candid
         if (!candidate || candidate.cityId !== cityId || candidate.councilMeetingId !== meetingId) throw new Error('Candidate not found');
         throw new Error('Candidate is already resolved');
     }
+}
+
+/** A candidate whose proposed subject collides with an ADA already held elsewhere. */
+export interface CandidateConflict {
+    candidateId: string;
+    ada: string;
+    claimingSubject: { id: string; name: string; cityId: string; councilMeetingId: string };
+    existingDecision: {
+        title: string | null;
+        pdfUrl: string;
+        currentSubject: { id: string; name: string; cityId: string; councilMeetingId: string };
+    } | null;
+}
+
+/**
+ * Conflicting candidates: unresolved, with a proposed subject, whose ADA a
+ * Decision on a DIFFERENT subject already holds. Replaces the old
+ * Subject.claimedAda listing — same shape, plus candidateId for resolution.
+ */
+export async function getConflictingCandidates(filter?: { cityId?: string; councilMeetingId?: string }): Promise<CandidateConflict[]> {
+    const candidates = await prisma.decisionCandidate.findMany({
+        where: {
+            decisionId: null,
+            dismissedAt: null,
+            subjectId: { not: null },
+            ...(filter?.cityId && { cityId: filter.cityId }),
+            ...(filter?.councilMeetingId && { councilMeetingId: filter.councilMeetingId }),
+        },
+        select: { id: true, ada: true, subjectId: true },
+    });
+    if (candidates.length === 0) return [];
+
+    const [holders, claimingSubjects] = await Promise.all([
+        prisma.decision.findMany({
+            where: { ada: { in: candidates.map(c => c.ada) } },
+            select: {
+                ada: true, title: true, pdfUrl: true,
+                subject: { select: { id: true, name: true, cityId: true, councilMeetingId: true } },
+            },
+        }),
+        prisma.subject.findMany({
+            where: { id: { in: candidates.map(c => c.subjectId!).filter(Boolean) } },
+            select: { id: true, name: true, cityId: true, councilMeetingId: true, decision: { select: { id: true } } },
+        }),
+    ]);
+    const holderByAda = new Map(holders.filter(h => h.ada).map(h => [h.ada!, h]));
+    const subjectById = new Map(claimingSubjects.map(s => [s.id, s]));
+
+    const conflicts: CandidateConflict[] = [];
+    for (const c of candidates) {
+        const holder = holderByAda.get(c.ada);
+        const claiming = c.subjectId ? subjectById.get(c.subjectId) : undefined;
+        if (!holder || !claiming || holder.subject.id === claiming.id) continue;
+        // A claimant that got its own decision since is a stale claim, not an
+        // actionable conflict (parity with the old claimedAda clearing).
+        if (claiming.decision) continue;
+        conflicts.push({
+            candidateId: c.id,
+            ada: c.ada,
+            claimingSubject: { id: claiming.id, name: claiming.name, cityId: claiming.cityId, councilMeetingId: claiming.councilMeetingId },
+            existingDecision: {
+                title: holder.title,
+                pdfUrl: holder.pdfUrl,
+                currentSubject: holder.subject,
+            },
+        });
+    }
+    return conflicts;
+}
+
+/**
+ * Admin resolution of a conflicting candidate. 'dismiss' rejects the claim;
+ * 'reassign' moves the Decision from its current subject to the claiming one —
+ * an admin action, unlike the pipeline, which never moves confirmed links.
+ */
+export async function applyCandidateConflictResolution(
+    candidateId: string,
+    resolution: 'reassign' | 'dismiss',
+): Promise<void> {
+    await prisma.$transaction(async (tx) => {
+        const candidate = await tx.decisionCandidate.findUnique({ where: { id: candidateId } });
+        if (!candidate) throw new Error('Candidate not found');
+        if (candidate.decisionId || candidate.dismissedAt) return; // resolved concurrently — nothing to do
+
+        if (resolution === 'dismiss' || !candidate.subjectId) {
+            await tx.decisionCandidate.update({ where: { id: candidateId }, data: { dismissedAt: new Date() } });
+            return;
+        }
+
+        // Only move the decision if the claiming subject doesn't already have one
+        const existingOnClaiming = await tx.decision.findUnique({ where: { subjectId: candidate.subjectId } });
+        if (existingOnClaiming) {
+            await tx.decisionCandidate.update({ where: { id: candidateId }, data: { dismissedAt: new Date() } });
+            return;
+        }
+
+        const holding = await tx.decision.findUnique({
+            where: { ada: candidate.ada },
+            include: { subject: { select: { cityId: true } } },
+        });
+        if (holding) {
+            // Defensive: polls are per-city so cross-city conflicts shouldn't occur,
+            // but guard against it to prevent modifying another city's data.
+            if (holding.subject.cityId !== candidate.cityId) {
+                throw new Error('Cannot reassign a decision that belongs to a different city');
+            }
+            // Delete to free the ADA unique constraint (this also releases the
+            // holder's own candidate via onDelete: SetNull), then recreate on
+            // the claiming subject with the candidate's reading fields.
+            // The extracted rows cascade from Subject, not Decision, so drop
+            // them explicitly or the old subject keeps votes and attendance
+            // from a document that no longer belongs to it (mirrors
+            // deleteDecision in ./decisions).
+            await tx.subjectAttendance.deleteMany({ where: { subjectId: holding.subjectId, source: DataSource.decision } });
+            await tx.subjectVote.deleteMany({ where: { subjectId: holding.subjectId, source: DataSource.decision } });
+            await tx.decision.delete({ where: { id: holding.id } });
+            const moved = await tx.decision.create({
+                data: {
+                    subjectId: candidate.subjectId,
+                    ada: holding.ada,
+                    pdfUrl: holding.pdfUrl,
+                    protocolNumber: holding.protocolNumber,
+                    title: holding.title,
+                    publishDate: holding.publishDate,
+                    decisionNumber: candidate.decisionNumber ?? holding.decisionNumber,
+                    meetingDate: candidate.meetingDate ?? holding.meetingDate,
+                    taskId: holding.taskId,
+                    createdById: holding.createdById,
+                },
+            });
+            await tx.decisionCandidate.update({ where: { id: candidateId }, data: { decisionId: moved.id } });
+        } else {
+            // Holder vanished concurrently — plain assignment
+            const created = await tx.decision.create({
+                data: {
+                    subjectId: candidate.subjectId,
+                    ada: candidate.ada,
+                    title: candidate.title,
+                    pdfUrl: candidate.pdfUrl,
+                    protocolNumber: candidate.protocolNumber,
+                    publishDate: candidate.publishDate,
+                    decisionNumber: candidate.decisionNumber,
+                    meetingDate: candidate.meetingDate,
+                },
+            });
+            await tx.decisionCandidate.update({ where: { id: candidateId }, data: { decisionId: created.id } });
+        }
+    });
 }

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -11,6 +11,7 @@ export { getDecisionForSubject };
 import { withUserAuthorizedToEdit } from "../auth";
 import { getPeopleForMeeting } from "../db/people";
 import { deriveWindowDays, localCalendarDate } from "./decisionWindow";
+import { getConflictingCandidates, applyCandidateConflictResolution } from "../db/decisionCandidates";
 import { isRoleActiveAt, isMayorRole } from "../utils/roles";
 import { shouldSkipPolling, getBackoffState, getPollableMeetingDateRange, BACKOFF_SCHEDULE, MAX_POLLING_DAYS, LOGODOSIA_NAME_PATTERN } from "./pollDecisionsBackoff";
 import { sendPollDecisionsBatchStartedAlert, sendPollDecisionsBatchCompletedAlert } from "../discord";
@@ -546,67 +547,18 @@ export async function getPollingStats(cityId?: string, councilMeetingId?: string
         ])];
     }
 
-    // ADA conflicts: subjects with claimedAda set
-    const claimingSubjects = await prisma.subject.findMany({
-        where: {
-            claimedAda: { not: null },
-            ...(cityId && { cityId }),
-            ...(councilMeetingId && { councilMeetingId }),
-        },
-        select: {
-            id: true,
-            name: true,
-            cityId: true,
-            councilMeetingId: true,
-            claimedAda: true,
-        },
+    // ADA conflicts: unresolved candidates whose proposed subject collides with
+    // an ADA already held by another subject's Decision (issue #617 phase 4).
+    const candidateConflicts = await getConflictingCandidates({
+        ...(cityId && { cityId }),
+        ...(councilMeetingId && { councilMeetingId }),
     });
-
-    // Look up existing decisions for the claimed ADAs
-    const claimedAdas = claimingSubjects.map(s => s.claimedAda!);
-    const existingDecisionsForClaims = claimedAdas.length > 0
-        ? await prisma.decision.findMany({
-            where: { ada: { in: claimedAdas } },
-            select: {
-                ada: true,
-                title: true,
-                pdfUrl: true,
-                subjectId: true,
-                subject: {
-                    select: {
-                        id: true,
-                        name: true,
-                        cityId: true,
-                        councilMeetingId: true,
-                    },
-                },
-            },
-        })
-        : [];
-    const decisionByAda = new Map(existingDecisionsForClaims.map(d => [d.ada!, d]));
-
-    const conflicts = claimingSubjects.map(claiming => {
-        const existingDecision = decisionByAda.get(claiming.claimedAda!);
-        return {
-            claimingSubject: {
-                id: claiming.id,
-                name: claiming.name,
-                cityId: claiming.cityId,
-                councilMeetingId: claiming.councilMeetingId,
-            },
-            ada: claiming.claimedAda!,
-            existingDecision: existingDecision ? {
-                title: existingDecision.title,
-                pdfUrl: existingDecision.pdfUrl,
-                currentSubject: {
-                    id: existingDecision.subject.id,
-                    name: existingDecision.subject.name,
-                    cityId: existingDecision.subject.cityId,
-                    councilMeetingId: existingDecision.subject.councilMeetingId,
-                },
-            } : null,
-        };
-    });
+    const conflicts = candidateConflicts.map(c => ({
+        candidateId: c.candidateId,
+        claimingSubject: c.claimingSubject,
+        ada: c.ada,
+        existingDecision: c.existingDecision,
+    }));
 
     // Recent poll tasks for the "Recent Polls" table
     const recentPollTasks = await prisma.taskStatus.findMany({
@@ -831,87 +783,19 @@ export async function getLastPollTimeForMeeting(
     return lastTask?.createdAt.toISOString() ?? null;
 }
 
-export async function resolveAdaConflict(
-    subjectId: string,
+export async function resolveCandidateConflict(
+    candidateId: string,
     resolution: 'reassign' | 'dismiss',
 ) {
-    const subject = await prisma.subject.findUnique({
-        where: { id: subjectId },
-        select: { id: true, cityId: true, claimedAda: true },
+    const candidate = await prisma.decisionCandidate.findUnique({
+        where: { id: candidateId },
+        select: { cityId: true },
     });
-
-    if (!subject) {
-        throw new Error("Subject not found");
+    if (!candidate) {
+        throw new Error('Candidate not found');
     }
-
-    await withUserAuthorizedToEdit({ cityId: subject.cityId });
-
-    if (!subject.claimedAda) {
-        throw new Error("Subject has no claimed ADA");
-    }
-
-    if (resolution === 'dismiss') {
-        await prisma.subject.update({
-            where: { id: subjectId },
-            data: { claimedAda: null },
-        });
-        return;
-    }
-
-    // resolution === 'reassign'
-    await prisma.$transaction(async (tx) => {
-        // Re-read claimedAda inside the transaction to avoid using a stale value
-        const freshSubject = await tx.subject.findUnique({
-            where: { id: subjectId },
-            select: { claimedAda: true },
-        });
-
-        if (!freshSubject?.claimedAda) {
-            // Claim was resolved concurrently — nothing to do
-            return;
-        }
-
-        // Only move the decision if the claiming subject doesn't already have one
-        const existingOnClaiming = await tx.decision.findUnique({
-            where: { subjectId },
-        });
-
-        if (!existingOnClaiming) {
-            const existingDecision = await tx.decision.findUnique({
-                where: { ada: freshSubject.claimedAda },
-                include: { subject: { select: { cityId: true } } },
-            });
-
-            if (existingDecision) {
-                // Defensive: polls are per-city so cross-city conflicts shouldn't occur,
-                // but guard against it to prevent modifying another city's data.
-                if (existingDecision.subject.cityId !== subject.cityId) {
-                    throw new Error("Cannot reassign a decision that belongs to a different city");
-                }
-
-                // Delete existing decision to free ADA unique constraint, then recreate on claiming subject
-                await tx.decision.delete({ where: { id: existingDecision.id } });
-                await tx.decision.create({
-                    data: {
-                        subjectId,
-                        ada: existingDecision.ada,
-                        pdfUrl: existingDecision.pdfUrl,
-                        protocolNumber: existingDecision.protocolNumber,
-                        title: existingDecision.title,
-                        publishDate: existingDecision.publishDate,
-                        taskId: existingDecision.taskId,
-                        createdById: existingDecision.createdById,
-                    },
-                });
-            }
-        }
-
-        // Always clear the claim
-        await tx.subject.update({
-            where: { id: subjectId },
-            data: { claimedAda: null },
-        });
-    });
+    await withUserAuthorizedToEdit({ cityId: candidate.cityId });
+    await applyCandidateConflictResolution(candidateId, resolution);
 }
 
 /** Per-meeting entry in the batch completion summary. */
@@ -1122,10 +1006,25 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
             if (match.ada) {
                 const existingSubjectId = adaToExistingSubject.get(match.ada);
                 if (existingSubjectId && existingSubjectId !== match.subjectId) {
-                    // Record the claim on the incoming subject, skip the upsert
-                    await tx.subject.update({
-                        where: { id: match.subjectId },
-                        data: { claimedAda: match.ada },
+                    // Record the conflicting proposal as a candidate, skip the upsert
+                    await tx.decisionCandidate.upsert({
+                        where: { cityId_ada: { cityId: task.cityId, ada: match.ada } },
+                        create: {
+                            cityId: task.cityId,
+                            ada: match.ada,
+                            title: match.decisionTitle ?? null,
+                            pdfUrl: match.pdfUrl,
+                            publishDate: match.publishDate ? new Date(match.publishDate) : null,
+                            protocolNumber: match.protocolNumber ?? null,
+                            readStatus: 'unread',
+                            councilMeetingId: task.councilMeetingId,
+                            subjectId: match.subjectId,
+                            confidence: match.matchConfidence,
+                            reasoning: match.reasoning ?? null,
+                        },
+                        // Recorded once; the join to the holding Decision is what
+                        // surfaces the conflict in the admin views.
+                        update: {},
                     });
                     conflictCount++;
                     console.log(`ADA conflict: ${match.ada} already belongs to subject ${existingSubjectId}, claimed by subject ${match.subjectId}`);
@@ -1157,9 +1056,24 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
                 // Concurrent poll race: another transaction committed a decision with the same
                 // ADA between our conflict check and this upsert. Fall back to recording a claim.
                 if (match.ada && (e as { code?: string })?.code === 'P2002') {
-                    await tx.subject.update({
-                        where: { id: match.subjectId },
-                        data: { claimedAda: match.ada },
+                    await tx.decisionCandidate.upsert({
+                        where: { cityId_ada: { cityId: task.cityId, ada: match.ada } },
+                        create: {
+                            cityId: task.cityId,
+                            ada: match.ada,
+                            title: match.decisionTitle ?? null,
+                            pdfUrl: match.pdfUrl,
+                            publishDate: match.publishDate ? new Date(match.publishDate) : null,
+                            protocolNumber: match.protocolNumber ?? null,
+                            readStatus: 'unread',
+                            councilMeetingId: task.councilMeetingId,
+                            subjectId: match.subjectId,
+                            confidence: match.matchConfidence,
+                            reasoning: match.reasoning ?? null,
+                        },
+                        // Recorded once; the join to the holding Decision is what
+                        // surfaces the conflict in the admin views.
+                        update: {},
                     });
                     conflictCount++;
                     console.log(`ADA conflict (concurrent): ${match.ada} claimed by subject ${match.subjectId}`);
@@ -1167,12 +1081,6 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
                 }
                 throw e;
             }
-
-            // Clear any stale conflict claim now that this subject has a valid decision
-            await tx.subject.updateMany({
-                where: { id: match.subjectId, claimedAda: { not: null } },
-                data: { claimedAda: null },
-            });
 
             processedCount++;
 

--- a/tests/integration/decision-candidate-actions.test.ts
+++ b/tests/integration/decision-candidate-actions.test.ts
@@ -1,0 +1,209 @@
+/** @jest-environment node */
+
+import prisma from '@/lib/db/prisma'
+import { DataSource } from '@prisma/client'
+import { assignCandidate, dismissCandidate, applyCandidateConflictResolution } from '@/lib/db/decisionCandidates'
+import { deleteDecision } from '@/lib/db/decisions'
+import { resetDatabase } from '../helpers/test-db'
+import {
+    createAdministrativeBody,
+    createCity,
+    createMeeting,
+    createPerson,
+    createSubject,
+} from '../helpers/factories'
+
+function makeCandidate(cityId: string, ada: string, data?: {
+    councilMeetingId?: string | null
+    subjectId?: string | null
+    decisionId?: string | null
+    dismissedAt?: Date | null
+    decisionNumber?: string | null
+}) {
+    return prisma.decisionCandidate.create({
+        data: {
+            cityId,
+            ada,
+            pdfUrl: `https://diavgeia.gov.gr/doc/${ada}`,
+            title: `Decision ${ada}`,
+            readStatus: 'ok',
+            meetingDate: new Date('2025-01-10T00:00:00Z'),
+            decisionNumber: data?.decisionNumber ?? '12/2025',
+            councilMeetingId: data?.councilMeetingId ?? null,
+            subjectId: data?.subjectId ?? null,
+            decisionId: data?.decisionId ?? null,
+            dismissedAt: data?.dismissedAt ?? null,
+        },
+    })
+}
+
+describe('decision candidate actions — assign, dismiss, conflict resolution', () => {
+    let cityId: string
+    let meetingId: string
+    let otherMeetingId: string
+
+    beforeEach(async () => {
+        await resetDatabase(prisma as any)
+
+        const city = await createCity({ id: 'c1' })
+        cityId = city.id
+        const body = await createAdministrativeBody(cityId, {
+            notificationBehavior: 'NOTIFICATIONS_DISABLED',
+        })
+        const meeting = await createMeeting(cityId, {
+            id: 'm1',
+            administrativeBodyId: body.id,
+            dateTime: new Date('2025-01-10T10:00:00Z'),
+        })
+        const other = await createMeeting(cityId, {
+            id: 'm2',
+            administrativeBodyId: body.id,
+            dateTime: new Date('2025-01-17T10:00:00Z'),
+        })
+        meetingId = meeting.id
+        otherMeetingId = other.id
+    })
+
+    test('assignCandidate creates the decision from reading fields and links the candidate', async () => {
+        const subject = await createSubject(meetingId, cityId, { id: 's1', agendaItemIndex: 1 })
+        const candidate = await makeCandidate(cityId, 'ADA-1', { councilMeetingId: meetingId })
+
+        await assignCandidate(cityId, meetingId, candidate.id, subject.id)
+
+        const decision = await prisma.decision.findUnique({ where: { subjectId: subject.id } })
+        expect(decision).not.toBeNull()
+        expect(decision!.ada).toBe('ADA-1')
+        expect(decision!.decisionNumber).toBe('12/2025')
+        // No excerpt: the next poll must pick it up as needsExtraction
+        expect(decision!.excerpt).toBeNull()
+
+        const after = await prisma.decisionCandidate.findUnique({ where: { id: candidate.id } })
+        expect(after!.decisionId).toBe(decision!.id)
+        // The accepted placement is recorded when the pipeline had no suggestion
+        expect(after!.subjectId).toBe(subject.id)
+    })
+
+    test('assignCandidate preserves an existing pipeline suggestion as made', async () => {
+        const suggested = await createSubject(meetingId, cityId, { id: 's1', agendaItemIndex: 1 })
+        const actual = await createSubject(meetingId, cityId, { id: 's2', agendaItemIndex: 2 })
+        const candidate = await makeCandidate(cityId, 'ADA-1', {
+            councilMeetingId: meetingId,
+            subjectId: suggested.id,
+        })
+
+        await assignCandidate(cityId, meetingId, candidate.id, actual.id)
+
+        const after = await prisma.decisionCandidate.findUnique({ where: { id: candidate.id } })
+        expect(after!.subjectId).toBe(suggested.id)
+        const decision = await prisma.decision.findUnique({ where: { subjectId: actual.id } })
+        expect(decision).not.toBeNull()
+    })
+
+    test('assignCandidate rejects a candidate from another meeting', async () => {
+        const subject = await createSubject(meetingId, cityId, { id: 's1', agendaItemIndex: 1 })
+        const candidate = await makeCandidate(cityId, 'ADA-1', { councilMeetingId: otherMeetingId })
+
+        await expect(assignCandidate(cityId, meetingId, candidate.id, subject.id))
+            .rejects.toThrow('Candidate not found')
+        expect(await prisma.decision.count()).toBe(0)
+    })
+
+    test('assignCandidate rejects when the subject already has a decision or the ADA is held', async () => {
+        const taken = await createSubject(meetingId, cityId, { id: 's1', agendaItemIndex: 1 })
+        const free = await createSubject(meetingId, cityId, { id: 's2', agendaItemIndex: 2 })
+        await prisma.decision.create({
+            data: { subjectId: taken.id, ada: 'ADA-HELD', pdfUrl: 'https://diavgeia.gov.gr/doc/ADA-HELD' },
+        })
+
+        const candidate = await makeCandidate(cityId, 'ADA-1', { councilMeetingId: meetingId })
+        await expect(assignCandidate(cityId, meetingId, candidate.id, taken.id))
+            .rejects.toThrow('already has a decision')
+
+        const heldCandidate = await makeCandidate(cityId, 'ADA-HELD', { councilMeetingId: meetingId })
+        await expect(assignCandidate(cityId, meetingId, heldCandidate.id, free.id))
+            .rejects.toThrow('already linked to another subject')
+    })
+
+    test('dismissCandidate is race-safe: an assigned candidate cannot be dismissed', async () => {
+        const subject = await createSubject(meetingId, cityId, { id: 's1', agendaItemIndex: 1 })
+        const candidate = await makeCandidate(cityId, 'ADA-1', { councilMeetingId: meetingId })
+
+        await assignCandidate(cityId, meetingId, candidate.id, subject.id)
+        await expect(dismissCandidate(cityId, meetingId, candidate.id))
+            .rejects.toThrow('already resolved')
+
+        const after = await prisma.decisionCandidate.findUnique({ where: { id: candidate.id } })
+        expect(after!.dismissedAt).toBeNull()
+    })
+
+    test('dismissCandidate rejects the wrong meeting and dismisses in the right one', async () => {
+        const candidate = await makeCandidate(cityId, 'ADA-1', { councilMeetingId: meetingId })
+
+        await expect(dismissCandidate(cityId, otherMeetingId, candidate.id))
+            .rejects.toThrow('Candidate not found')
+
+        await dismissCandidate(cityId, meetingId, candidate.id)
+        const after = await prisma.decisionCandidate.findUnique({ where: { id: candidate.id } })
+        expect(after!.dismissedAt).not.toBeNull()
+    })
+
+    test('conflict reassign moves the decision and drops the old subject\'s extracted rows', async () => {
+        const oldSubject = await createSubject(meetingId, cityId, { id: 's1', agendaItemIndex: 1 })
+        const claiming = await createSubject(meetingId, cityId, { id: 's2', agendaItemIndex: 2 })
+        const person = await createPerson(cityId)
+
+        const holding = await prisma.decision.create({
+            data: {
+                subjectId: oldSubject.id,
+                ada: 'ADA-1',
+                pdfUrl: 'https://diavgeia.gov.gr/doc/ADA-1',
+                excerpt: 'extracted text',
+            },
+        })
+        // Extraction wrote rows against the old subject; a manual row must survive
+        await prisma.subjectAttendance.create({
+            data: { subjectId: oldSubject.id, personId: person.id, status: 'PRESENT', source: DataSource.decision },
+        })
+        await prisma.subjectVote.create({
+            data: { subjectId: oldSubject.id, personId: person.id, voteType: 'FOR', source: DataSource.decision },
+        })
+        await prisma.subjectVote.create({
+            data: { subjectId: oldSubject.id, personId: person.id, voteType: 'AGAINST', source: DataSource.manual },
+        })
+
+        const candidate = await makeCandidate(cityId, 'ADA-1', {
+            councilMeetingId: meetingId,
+            subjectId: claiming.id,
+        })
+
+        await applyCandidateConflictResolution(candidate.id, 'reassign')
+
+        // Decision moved; recreated without excerpt so the next poll re-extracts
+        expect(await prisma.decision.findUnique({ where: { id: holding.id } })).toBeNull()
+        const moved = await prisma.decision.findUnique({ where: { subjectId: claiming.id } })
+        expect(moved!.ada).toBe('ADA-1')
+        expect(moved!.excerpt).toBeNull()
+
+        // The old subject keeps no decision-sourced rows, only the manual one
+        expect(await prisma.subjectAttendance.count({ where: { subjectId: oldSubject.id } })).toBe(0)
+        const votes = await prisma.subjectVote.findMany({ where: { subjectId: oldSubject.id } })
+        expect(votes).toHaveLength(1)
+        expect(votes[0].source).toBe(DataSource.manual)
+
+        const after = await prisma.decisionCandidate.findUnique({ where: { id: candidate.id } })
+        expect(after!.decisionId).toBe(moved!.id)
+    })
+
+    test('deleting an assigned decision reverts the candidate to the unresolved pool', async () => {
+        const subject = await createSubject(meetingId, cityId, { id: 's1', agendaItemIndex: 1 })
+        const candidate = await makeCandidate(cityId, 'ADA-1', { councilMeetingId: meetingId })
+        await assignCandidate(cityId, meetingId, candidate.id, subject.id)
+
+        await deleteDecision(subject.id)
+
+        const after = await prisma.decisionCandidate.findUnique({ where: { id: candidate.id } })
+        expect(after!.decisionId).toBeNull()
+        expect(after!.dismissedAt).toBeNull()
+        expect(await prisma.subjectVote.count({ where: { subjectId: subject.id } })).toBe(0)
+    })
+})

--- a/tests/integration/task-handlers.test.ts
+++ b/tests/integration/task-handlers.test.ts
@@ -5,7 +5,7 @@ jest.mock('@/lib/tasks/generateHighlight', () => ({
     handleGenerateHighlightResult: jest.fn(),
 }))
 
-// Mock auth for resolveAdaConflict tests
+// Mock auth for resolveCandidateConflict tests
 jest.mock('@/lib/auth', () => ({
     withUserAuthorizedToEdit: jest.fn(),
     isUserAuthorizedToEdit: jest.fn().mockResolvedValue(true),
@@ -14,7 +14,7 @@ jest.mock('@/lib/auth', () => ({
 import prisma from '@/lib/db/prisma'
 import { handleProcessAgendaResult } from '@/lib/tasks/processAgenda'
 import { handleSummarizeResult } from '@/lib/tasks/summarize'
-import { handlePollDecisionsResult, resolveAdaConflict } from '@/lib/tasks/pollDecisions'
+import { handlePollDecisionsResult, resolveCandidateConflict } from '@/lib/tasks/pollDecisions'
 import { resetDatabase } from '../helpers/test-db'
 import {
     createAdministrativeBody,
@@ -683,14 +683,12 @@ describe('handlePollDecisionsResult', () => {
         expect(decisions[1].ada).toBe('ADA-2')
         expect(decisions[1].subjectId).toBe(subjectB.id)
 
-        // No claimedAda set
-        const subjects = await prisma.subject.findMany({
-            where: { claimedAda: { not: null } },
-        })
-        expect(subjects).toHaveLength(0)
+        // No conflicting candidates recorded
+        const candidates = await prisma.decisionCandidate.findMany()
+        expect(candidates).toHaveLength(0)
     })
 
-    test('ADA conflict detected — claim set, other matches still saved', async () => {
+    test('ADA conflict detected — conflicting candidate recorded, other matches still saved', async () => {
         // Meeting 1 subject already has a decision with ADA-X
         const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
         await prisma.decision.create({
@@ -709,15 +707,18 @@ describe('handlePollDecisionsResult', () => {
             ],
         }))
 
-        // SubjectB should have claimedAda set, no decision created
-        const updatedB = await prisma.subject.findUnique({ where: { id: subjectB.id } })
-        expect(updatedB!.claimedAda).toBe('ADA-X')
+        // The conflicting proposal is recorded as an unresolved candidate; no decision created
+        const candidateB = await prisma.decisionCandidate.findUnique({ where: { cityId_ada: { cityId, ada: 'ADA-X' } } })
+        expect(candidateB).not.toBeNull()
+        expect(candidateB!.subjectId).toBe(subjectB.id)
+        expect(candidateB!.decisionId).toBeNull()
+        expect(candidateB!.dismissedAt).toBeNull()
         const decisionB = await prisma.decision.findUnique({ where: { subjectId: subjectB.id } })
         expect(decisionB).toBeNull()
 
-        // SubjectC should have a normal decision, no claimedAda
-        const updatedC = await prisma.subject.findUnique({ where: { id: subjectC.id } })
-        expect(updatedC!.claimedAda).toBeNull()
+        // SubjectC should have a normal decision, no candidate recorded for it
+        const candidateY = await prisma.decisionCandidate.findUnique({ where: { cityId_ada: { cityId, ada: 'ADA-Y' } } })
+        expect(candidateY).toBeNull()
         const decisionC = await prisma.decision.findUnique({ where: { subjectId: subjectC.id } })
         expect(decisionC).not.toBeNull()
         expect(decisionC!.ada).toBe('ADA-Y')
@@ -753,12 +754,11 @@ describe('handlePollDecisionsResult', () => {
         expect(decision!.ada).toBe('ADA-X')
         expect(decision!.pdfUrl).toBe('https://example.com/new.pdf')
 
-        // No claimedAda set
-        const subject = await prisma.subject.findUnique({ where: { id: subjectA.id } })
-        expect(subject!.claimedAda).toBeNull()
+        // No conflicting candidates recorded
+        expect(await prisma.decisionCandidate.count()).toBe(0)
     })
 
-    test('multiple conflicts in one poll — both get claimedAda, non-conflicting matches saved', async () => {
+    test('multiple conflicts in one poll — both recorded as candidates, non-conflicting matches saved', async () => {
         // Existing decisions in meeting 1
         const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
         const subjectB = await createSubject(meetingId1, cityId, { name: 'Subject B', agendaItemIndex: 2 })
@@ -783,11 +783,11 @@ describe('handlePollDecisionsResult', () => {
             ],
         }))
 
-        // SubjectC and SubjectD should have claimedAda
-        const updatedC = await prisma.subject.findUnique({ where: { id: subjectC.id } })
-        expect(updatedC!.claimedAda).toBe('ADA-X')
-        const updatedD = await prisma.subject.findUnique({ where: { id: subjectD.id } })
-        expect(updatedD!.claimedAda).toBe('ADA-Y')
+        // Both conflicting proposals recorded as unresolved candidates
+        const candX = await prisma.decisionCandidate.findUnique({ where: { cityId_ada: { cityId, ada: 'ADA-X' } } })
+        expect(candX!.subjectId).toBe(subjectC.id)
+        const candY = await prisma.decisionCandidate.findUnique({ where: { cityId_ada: { cityId, ada: 'ADA-Y' } } })
+        expect(candY!.subjectId).toBe(subjectD.id)
 
         // SubjectE should have a normal decision
         const decisionE = await prisma.decision.findUnique({ where: { subjectId: subjectE.id } })
@@ -801,23 +801,20 @@ describe('handlePollDecisionsResult', () => {
         expect(decisionD).toBeNull()
     })
 
-    test('subsequent poll overwrites prior unresolved claimedAda', async () => {
+    test('subsequent poll records an additional conflicting candidate; both persist', async () => {
         // SubjectA in meeting 1 already owns ADA-X
         const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
         await prisma.decision.create({
             data: { subjectId: subjectA.id, ada: 'ADA-X', pdfUrl: 'https://example.com/x.pdf' },
         })
 
-        // SubjectB in meeting 2 — first poll claims ADA-X
+        // SubjectB in meeting 2 — first poll proposes ADA-X (conflict)
         const subjectB = await createSubject(meetingId2, cityId, { name: 'Subject B', agendaItemIndex: 1 })
         const task1 = await createTaskStatus(meetingId2, cityId, { type: 'pollDecisions' })
 
         await handlePollDecisionsResult(task1.id, makePollDecisionsResult({
             matches: [makePollDecisionsMatch({ subjectId: subjectB.id, ada: 'ADA-X' })],
         }))
-
-        const afterPoll1 = await prisma.subject.findUnique({ where: { id: subjectB.id } })
-        expect(afterPoll1!.claimedAda).toBe('ADA-X')
 
         // Second poll — same subject now matches ADA-Y (also owned by someone else)
         const subjectC = await createSubject(meetingId1, cityId, { name: 'Subject C', agendaItemIndex: 2 })
@@ -831,38 +828,47 @@ describe('handlePollDecisionsResult', () => {
             matches: [makePollDecisionsMatch({ subjectId: subjectB.id, ada: 'ADA-Y' })],
         }))
 
-        // claimedAda is overwritten — only the latest claim is preserved
-        const afterPoll2 = await prisma.subject.findUnique({ where: { id: subjectB.id } })
-        expect(afterPoll2!.claimedAda).toBe('ADA-Y')
+        // Candidates persist as the record of every proposal — one per ADA
+        const candidates = await prisma.decisionCandidate.findMany({ orderBy: { ada: 'asc' } })
+        expect(candidates).toHaveLength(2)
+        expect(candidates[0].ada).toBe('ADA-X')
+        expect(candidates[0].subjectId).toBe(subjectB.id)
+        expect(candidates[1].ada).toBe('ADA-Y')
+        expect(candidates[1].subjectId).toBe(subjectB.id)
     })
 
-    test('successful upsert clears stale claimedAda', async () => {
-        // SubjectA owns ADA-X, SubjectB previously claimed it
+    test('a decision on the claiming subject makes its old claim a stale non-conflict', async () => {
+        const { getConflictingCandidates } = await import('@/lib/db/decisionCandidates')
+        // SubjectA owns ADA-X; SubjectB has an unresolved candidate claiming it
         const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
         await prisma.decision.create({
             data: { subjectId: subjectA.id, ada: 'ADA-X', pdfUrl: 'https://example.com/x.pdf' },
         })
         const subjectB = await createSubject(meetingId2, cityId, { name: 'Subject B', agendaItemIndex: 1 })
-        await prisma.subject.update({ where: { id: subjectB.id }, data: { claimedAda: 'ADA-X' } })
+        await prisma.decisionCandidate.create({
+            data: {
+                cityId, ada: 'ADA-X', pdfUrl: 'https://example.com/x.pdf',
+                readStatus: 'unread', councilMeetingId: meetingId2, subjectId: subjectB.id,
+            },
+        })
+        expect(await getConflictingCandidates({ cityId })).toHaveLength(1)
 
         // New poll gives subjectB a different, non-conflicting ADA
         const task = await createTaskStatus(meetingId2, cityId, { type: 'pollDecisions' })
-
         await handlePollDecisionsResult(task.id, makePollDecisionsResult({
             matches: [makePollDecisionsMatch({ subjectId: subjectB.id, ada: 'ADA-NEW' })],
         }))
 
-        // Decision created and stale claimedAda cleared
+        // Decision created; the old claim stays recorded but is no longer an
+        // actionable conflict (the claiming subject has its own decision now)
         const decision = await prisma.decision.findUnique({ where: { subjectId: subjectB.id } })
-        expect(decision).not.toBeNull()
         expect(decision!.ada).toBe('ADA-NEW')
-
-        const updated = await prisma.subject.findUnique({ where: { id: subjectB.id } })
-        expect(updated!.claimedAda).toBeNull()
+        expect(await prisma.decisionCandidate.count()).toBe(1)
+        expect(await getConflictingCandidates({ cityId })).toHaveLength(0)
     })
 })
 
-describe('resolveAdaConflict', () => {
+describe('resolveCandidateConflict', () => {
     let cityId: string
     let meetingId1: string
     let meetingId2: string
@@ -881,32 +887,40 @@ describe('resolveAdaConflict', () => {
         meetingId2 = meeting2.id
     })
 
-    test('dismiss — clears claimedAda without moving the decision', async () => {
+    async function createClaim(ada: string, subjectId: string, extra: Record<string, unknown> = {}) {
+        return prisma.decisionCandidate.create({
+            data: {
+                cityId, ada,
+                pdfUrl: `https://diavgeia.gov.gr/doc/${ada}`,
+                readStatus: 'unread',
+                councilMeetingId: meetingId2,
+                subjectId,
+                ...extra,
+            },
+        })
+    }
+
+    test('dismiss — marks the candidate dismissed without moving the decision', async () => {
         const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
         await prisma.decision.create({
             data: { subjectId: subjectA.id, ada: 'ADA-X', pdfUrl: 'https://example.com/x.pdf', title: 'Original' },
         })
-
         const subjectB = await createSubject(meetingId2, cityId, { name: 'Subject B', agendaItemIndex: 1 })
-        await prisma.subject.update({ where: { id: subjectB.id }, data: { claimedAda: 'ADA-X' } })
+        const claim = await createClaim('ADA-X', subjectB.id)
 
-        await resolveAdaConflict(subjectB.id, 'dismiss')
+        await resolveCandidateConflict(claim.id, 'dismiss')
 
-        // claimedAda cleared
-        const updatedB = await prisma.subject.findUnique({ where: { id: subjectB.id } })
-        expect(updatedB!.claimedAda).toBeNull()
+        const updated = await prisma.decisionCandidate.findUnique({ where: { id: claim.id } })
+        expect(updated!.dismissedAt).not.toBeNull()
+        expect(updated!.decisionId).toBeNull()
 
-        // Original decision untouched
+        // Original decision untouched, no decision on claiming subject
         const decisionA = await prisma.decision.findUnique({ where: { subjectId: subjectA.id } })
-        expect(decisionA).not.toBeNull()
         expect(decisionA!.ada).toBe('ADA-X')
-
-        // No decision on claiming subject
-        const decisionB = await prisma.decision.findUnique({ where: { subjectId: subjectB.id } })
-        expect(decisionB).toBeNull()
+        expect(await prisma.decision.findUnique({ where: { subjectId: subjectB.id } })).toBeNull()
     })
 
-    test('reassign — moves decision to the claiming subject', async () => {
+    test('reassign — moves the decision to the claiming subject and links the candidate', async () => {
         const subjectA = await createSubject(meetingId1, cityId, { name: 'Subject A', agendaItemIndex: 1 })
         await prisma.decision.create({
             data: {
@@ -917,43 +931,44 @@ describe('resolveAdaConflict', () => {
                 protocolNumber: '42/2025',
             },
         })
-
         const subjectB = await createSubject(meetingId2, cityId, { name: 'Subject B', agendaItemIndex: 1 })
-        await prisma.subject.update({ where: { id: subjectB.id }, data: { claimedAda: 'ADA-X' } })
+        const claim = await createClaim('ADA-X', subjectB.id, { decisionNumber: '17/2025' })
 
-        await resolveAdaConflict(subjectB.id, 'reassign')
+        await resolveCandidateConflict(claim.id, 'reassign')
 
-        // claimedAda cleared
-        const updatedB = await prisma.subject.findUnique({ where: { id: subjectB.id } })
-        expect(updatedB!.claimedAda).toBeNull()
-
-        // Decision moved to subjectB
+        // Decision moved to subjectB, enriched with the candidate's reading
         const decisionB = await prisma.decision.findUnique({ where: { subjectId: subjectB.id } })
         expect(decisionB).not.toBeNull()
         expect(decisionB!.ada).toBe('ADA-X')
         expect(decisionB!.pdfUrl).toBe('https://example.com/x.pdf')
         expect(decisionB!.title).toBe('Original Title')
         expect(decisionB!.protocolNumber).toBe('42/2025')
+        expect(decisionB!.decisionNumber).toBe('17/2025')
 
-        // No decision on original subject
-        const decisionA = await prisma.decision.findUnique({ where: { subjectId: subjectA.id } })
-        expect(decisionA).toBeNull()
+        // No decision on original subject; candidate linked to the moved decision
+        expect(await prisma.decision.findUnique({ where: { subjectId: subjectA.id } })).toBeNull()
+        const updated = await prisma.decisionCandidate.findUnique({ where: { id: claim.id } })
+        expect(updated!.decisionId).toBe(decisionB!.id)
     })
 
-    test('reassign — when existing decision was deleted, just clears claim', async () => {
+    test('reassign — when the holding decision was deleted, completes the assignment from candidate data', async () => {
+        // Semantics change vs claimedAda (2026-08-14): the old claim carried no
+        // document data, so a vanished holder could only clear the claim. A
+        // candidate carries everything needed, so admin intent is honoured by
+        // creating the decision.
         const subjectB = await createSubject(meetingId2, cityId, { name: 'Subject B', agendaItemIndex: 1 })
-        await prisma.subject.update({ where: { id: subjectB.id }, data: { claimedAda: 'ADA-X' } })
+        const claim = await createClaim('ADA-X', subjectB.id, { title: 'From candidate', decisionNumber: '9/2025' })
 
-        // No decision with ADA-X exists (it was deleted)
-        await resolveAdaConflict(subjectB.id, 'reassign')
+        await resolveCandidateConflict(claim.id, 'reassign')
 
-        // claimedAda cleared
-        const updatedB = await prisma.subject.findUnique({ where: { id: subjectB.id } })
-        expect(updatedB!.claimedAda).toBeNull()
-
-        // No decision created
         const decisionB = await prisma.decision.findUnique({ where: { subjectId: subjectB.id } })
-        expect(decisionB).toBeNull()
+        expect(decisionB).not.toBeNull()
+        expect(decisionB!.ada).toBe('ADA-X')
+        expect(decisionB!.title).toBe('From candidate')
+        expect(decisionB!.decisionNumber).toBe('9/2025')
+
+        const updated = await prisma.decisionCandidate.findUnique({ where: { id: claim.id } })
+        expect(updated!.decisionId).toBe(decisionB!.id)
     })
 
     test('reassign — when claiming subject already has a decision, dismisses instead', async () => {
@@ -961,27 +976,20 @@ describe('resolveAdaConflict', () => {
         await prisma.decision.create({
             data: { subjectId: subjectA.id, ada: 'ADA-X', pdfUrl: 'https://example.com/x.pdf' },
         })
-
         const subjectB = await createSubject(meetingId2, cityId, { name: 'Subject B', agendaItemIndex: 1 })
-        // SubjectB already has its own decision
         await prisma.decision.create({
             data: { subjectId: subjectB.id, ada: 'ADA-Y', pdfUrl: 'https://example.com/y.pdf' },
         })
-        await prisma.subject.update({ where: { id: subjectB.id }, data: { claimedAda: 'ADA-X' } })
+        const claim = await createClaim('ADA-X', subjectB.id)
 
-        await resolveAdaConflict(subjectB.id, 'reassign')
+        await resolveCandidateConflict(claim.id, 'reassign')
 
-        // claimedAda cleared
-        const updatedB = await prisma.subject.findUnique({ where: { id: subjectB.id } })
-        expect(updatedB!.claimedAda).toBeNull()
+        const updated = await prisma.decisionCandidate.findUnique({ where: { id: claim.id } })
+        expect(updated!.dismissedAt).not.toBeNull()
 
-        // SubjectB keeps its original decision (ADA-Y)
-        const decisionB = await prisma.decision.findUnique({ where: { subjectId: subjectB.id } })
-        expect(decisionB!.ada).toBe('ADA-Y')
-
-        // SubjectA keeps its decision (ADA-X) — not moved
-        const decisionA = await prisma.decision.findUnique({ where: { subjectId: subjectA.id } })
-        expect(decisionA!.ada).toBe('ADA-X')
+        // Both decisions unchanged
+        expect((await prisma.decision.findUnique({ where: { subjectId: subjectB.id } }))!.ada).toBe('ADA-Y')
+        expect((await prisma.decision.findUnique({ where: { subjectId: subjectA.id } }))!.ada).toBe('ADA-X')
     })
 })
 


### PR DESCRIPTION
Implements #617 phase 4, stacked on #623. The meeting admin panel gains an "Unplaced decisions" section — candidates known to belong to the session, with the pipeline's suggestion pre-selected, assignable to any decision-free subject or dismissible; revert is the existing remove-decision flow (`onDelete: SetNull`). `Subject.claimedAda` is retired: claims migrate to candidate rows in the migration that drops the column, the PollingStats conflicts table and its reassign/dismiss action now run on candidates, with one deliberate change — reassigning when the holding decision has vanished completes the assignment from candidate data instead of only clearing the claim. The designed review UX is a deliberate follow-up.

App-only. Refs #617.

<!-- preview-link: tasks=85 -->











<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces `Subject.claimedAda` with durable decision candidates and adds meeting-admin assignment and dismissal actions.
- Migrates legacy claims and existing decisions into candidate records.
- Adds meeting-scoped candidate reads, assignment, dismissal, and conflict resolution.
- Updates polling statistics, the decisions panel, translations, and integration coverage.

<h3>Confidence Score: 2/5</h3>

The PR is not safe to merge because claim migration can lose subject associations, and concurrent candidate actions can persist contradictory resolution state.

The migration still drops legacy claim ownership when a candidate already has a proposal. Assignment and conflict reassignment also write `decisionId` without confirming that dismissal has not committed.

**Files Needing Attention:** prisma/migrations/20260814072650_retire_claimed_ada/migration.sql; src/lib/db/decisionCandidates.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| prisma/migrations/20260814072650_retire_claimed_ada/migration.sql | The migration retires `claimedAda`, but its conflict predicate still loses claims when an existing candidate already has a proposal. |
| src/lib/db/decisionCandidates.ts | The new candidate workflow supports assignment and conflict resolution, but its final writes can overwrite concurrent dismissal. |
| src/app/api/cities/[cityId]/meetings/[meetingId]/decisions/route.ts | The route adds meeting-scoped candidate actions and now validates both candidate and target-subject meeting scope. |
| src/lib/tasks/pollDecisions.ts | Polling and operational conflict handling now use candidate records instead of `claimedAda`. |
| src/components/meetings/admin/DecisionsPanel.tsx | The meeting admin interface adds controls for assigning or dismissing unresolved candidates. |
| tests/integration/decision-candidate-actions.test.ts | The tests cover normal candidate actions but do not establish safe assignment or reassignment against concurrent dismissal. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20schemalabz%2Fopencouncil%20PR%20%23622%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=schemalabz%2Fopencouncil&pr=622&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Flib%2Fdb%2FdecisionCandidates.ts%3A80-88%0A**Assignment%20overwrites%20concurrent%20dismissal**%0A%0AIf%20assignment%20and%20dismissal%20overlap%2C%20assignment%20checks%20the%20candidate%20before%20dismissal%20commits%2C%20then%20writes%20%60decisionId%60%20without%20rechecking%20%60dismissedAt%60.%20The%20candidate%20ends%20with%20both%20terminal%20fields%20populated%20and%20disappears%20from%20unresolved%20views%20with%20contradictory%20resolution%20state.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20const%20updated%20%3D%20await%20tx.decisionCandidate.updateMany%28%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20where%3A%20%7B%20id%3A%20candidateId%2C%20decisionId%3A%20null%2C%20dismissedAt%3A%20null%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20data%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20decisionId%3A%20decision.id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20Record%20the%20accepted%20placement%20when%20the%20pipeline%20had%20no%20suggestion%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20an%20existing%20suggestion%20stays%20as-made%20for%20acceptance%20analysis.%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20...%28candidate.subjectId%20%3F%20%7B%7D%20%3A%20%7B%20subjectId%20%7D%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%20%20if%20%28updated.count%20%3D%3D%3D%200%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20throw%20new%20Error%28'Candidate%20is%20already%20resolved'%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Asrc%2Flib%2Fdb%2FdecisionCandidates.ts%3A234%0A**Reassignment%20overwrites%20concurrent%20dismissal**%0A%0AIf%20conflict%20reassignment%20and%20dismissal%20overlap%2C%20both%20reassignment%20branches%20write%20%60decisionId%60%20after%20only%20an%20initial%20resolution%20check.%20The%20candidate%20can%20end%20with%20both%20%60dismissedAt%60%20and%20%60decisionId%60%2C%20while%20the%20decision%20is%20still%20moved%20or%20created.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=schemalabz%2Fopencouncil&pr=622&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/lib/db/decisionCandidates.ts:80-88
**Assignment overwrites concurrent dismissal**

If assignment and dismissal overlap, assignment checks the candidate before dismissal commits, then writes `decisionId` without rechecking `dismissedAt`. The candidate ends with both terminal fields populated and disappears from unresolved views with contradictory resolution state.

```suggestion
        const updated = await tx.decisionCandidate.updateMany({
            where: { id: candidateId, decisionId: null, dismissedAt: null },
            data: {
                decisionId: decision.id,
                // Record the accepted placement when the pipeline had no suggestion;
                // an existing suggestion stays as-made for acceptance analysis.
                ...(candidate.subjectId ? {} : { subjectId }),
            },
        });
        if (updated.count === 0) {
            throw new Error('Candidate is already resolved');
        }
```

### Issue 2
src/lib/db/decisionCandidates.ts:234
**Reassignment overwrites concurrent dismissal**

If conflict reassignment and dismissal overlap, both reassignment branches write `decisionId` after only an initial resolution check. The candidate can end with both `dismissedAt` and `decisionId`, while the decision is still moved or created.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (11): Last reviewed commit: ["feat(decisions): backfill legacy decisio..."](https://github.com/schemalabz/opencouncil/commit/a540d569b9d0c118073c2afead46e035879318db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53272153)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Database access and civic models](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/database-access-and-models.md)
- Knowledge Base — [Meeting publication and records](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/meeting-publication.md)
- Knowledge Base — [Background task orchestration](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/background-task-orchestration.md)
- Knowledge Base — [Administrative workflows](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/administrative-workflows.md)
</details>


<!-- /greptile_comment -->