### PR TITLE
feat(decisions): DecisionCandidate — persist every read decision

### DIFF
--- a/prisma/migrations/20260814060950_add_decision_candidate/migration.sql
+++ b/prisma/migrations/20260814060950_add_decision_candidate/migration.sql
@@ -1,0 +1,38 @@
+-- CreateTable
+CREATE TABLE "DecisionCandidate" (
+    "id" TEXT NOT NULL,
+    "cityId" TEXT NOT NULL,
+    "ada" TEXT NOT NULL,
+    "title" TEXT,
+    "pdfUrl" TEXT NOT NULL,
+    "publishDate" TIMESTAMP(3),
+    "protocolNumber" TEXT,
+    "meetingDate" TIMESTAMP(3),
+    "decisionNumber" TEXT,
+    "readStatus" TEXT NOT NULL,
+    "councilMeetingId" TEXT,
+    "subjectId" TEXT,
+    "confidence" DOUBLE PRECISION,
+    "reasoning" TEXT,
+    "dismissedAt" TIMESTAMP(3),
+    "decisionId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DecisionCandidate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DecisionCandidate_decisionId_key" ON "DecisionCandidate"("decisionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DecisionCandidate_cityId_ada_key" ON "DecisionCandidate"("cityId", "ada");
+
+-- CreateIndex
+CREATE INDEX "DecisionCandidate_cityId_publishDate_idx" ON "DecisionCandidate"("cityId", "publishDate");
+
+-- CreateIndex
+CREATE INDEX "DecisionCandidate_councilMeetingId_idx" ON "DecisionCandidate"("councilMeetingId");
+
+-- AddForeignKey
+ALTER TABLE "DecisionCandidate" ADD CONSTRAINT "DecisionCandidate_decisionId_fkey" FOREIGN KEY ("decisionId") REFERENCES "Decision"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -539,6 +539,50 @@ model Decision {
   taskId    String?
   createdBy User?       @relation(fields: [createdById], references: [id], onDelete: SetNull)
   createdById String?
+
+  candidate DecisionCandidate?      // The suggestion this decision came from; survives promotion for revert + analysis.
+}
+
+/// A decision discovered on Diavgeia and, where possible, read. Unresolved rows
+/// (decisionId null, dismissedAt null) are work; resolved rows are the permanent
+/// record of how that work was decided. Rows are NEVER deleted on promotion —
+/// deleting the Decision reverts the assignment (onDelete: SetNull).
+///
+/// After promotion, subjectId/confidence/reasoning are the record of the
+/// suggestion AS MADE, not current truth: if an admin later moves the decision,
+/// they deliberately diverge — that is what makes acceptance analysis possible.
+model DecisionCandidate {
+  id     String @id @default(cuid())
+  cityId String
+  ada    String
+
+  // As published on Diavgeia
+  title          String?
+  pdfUrl         String
+  publishDate    DateTime?
+  protocolNumber String?     // faithful mirror of Diavgeia's field, whatever the municipality puts there
+
+  // As stated by the decision itself
+  meetingDate    DateTime?   // the session it says produced it (Athens-local date at midnight UTC)
+  decisionNumber String?     // its own Αρ. Απόφασης / Πράξη
+
+  readStatus String          // ok | no_meeting_date | unreadable | unread; only 'unread' is retried on later polls
+
+  // Resolution
+  councilMeetingId String?   // resolved from meetingDate; null = no such meeting in our data
+  subjectId        String?   // proposed subject; null = belongs to the meeting, unplaced
+  confidence       Float?
+  reasoning        String?
+  dismissedAt      DateTime?
+  decisionId       String?   @unique
+  decision         Decision? @relation(fields: [decisionId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([cityId, ada])
+  @@index([cityId, publishDate])
+  @@index([councilMeetingId])
 }
 
 enum NonAgendaReason {

--- a/scripts/export-decision-reading-eval.ts
+++ b/scripts/export-decision-reading-eval.ts
@@ -35,10 +35,10 @@ function parseArgs() {
 
 /**
  * The document prints a local calendar date; CouncilMeeting.dateTime is UTC.
- * A 22:00Z meeting is the next day in Athens, which is the date printed.
+ * A 22:00Z meeting is the next day locally, which is the date printed.
  */
-function athensDate(d: Date): string {
-    return d.toLocaleDateString("en-CA", { timeZone: "Europe/Athens" });
+function localDate(d: Date, timeZone: string): string {
+    return d.toLocaleDateString("en-CA", { timeZone });
 }
 
 async function main() {
@@ -46,7 +46,7 @@ async function main() {
 
     const body = await prisma.administrativeBody.findUnique({
         where: { id: bodyId },
-        select: { id: true, name: true, cityId: true },
+        select: { id: true, name: true, cityId: true, city: { select: { timezone: true } } },
     });
     if (!body) throw new Error(`Administrative body "${bodyId}" not found`);
 
@@ -67,7 +67,7 @@ async function main() {
             .map((s) => ({
                 ada: s.decision!.ada!,
                 pdfUrl: s.decision!.pdfUrl,
-                expectedMeetingDate: athensDate(m.dateTime),
+                expectedMeetingDate: localDate(m.dateTime, body.city.timezone),
             })),
     );
 

--- a/scripts/export-matching-eval.ts
+++ b/scripts/export-matching-eval.ts
@@ -35,8 +35,8 @@ function parseArgs() {
 }
 
 /** The document prints a local calendar date; CouncilMeeting.dateTime is UTC. */
-function athensDate(d: Date): string {
-    return d.toLocaleDateString("en-CA", { timeZone: "Europe/Athens" });
+function localDate(d: Date, timeZone: string): string {
+    return d.toLocaleDateString("en-CA", { timeZone });
 }
 
 async function main() {
@@ -46,7 +46,7 @@ async function main() {
         where: { id: bodyId },
         select: {
             id: true, name: true, cityId: true, diavgeiaUnitIds: true,
-            city: { select: { diavgeiaUid: true } },
+            city: { select: { diavgeiaUid: true, timezone: true } },
         },
     });
     if (!body) throw new Error(`Administrative body "${bodyId}" not found`);
@@ -74,7 +74,7 @@ async function main() {
         .filter((m) => m.subjects.some((s) => s.decision?.ada))
         .map((m) => ({
             meetingId: m.id,
-            meetingDate: athensDate(m.dateTime),
+            meetingDate: localDate(m.dateTime, body.city.timezone),
             subjects: m.subjects.map((s) => ({
                 subjectId: s.id,
                 name: s.name,

--- a/scripts/export-matching-eval.ts
+++ b/scripts/export-matching-eval.ts
@@ -1,0 +1,112 @@
+/**
+ * Export one administrative body's meetings — subjects plus their existing
+ * decision links as hidden ground truth — so matching can be scored against
+ * them.
+ *
+ * The links never reach the matcher: the eval CLI strips them and asks the
+ * pipeline's own matching core to re-derive them, then counts how often the
+ * known ADA is recovered (recall) and how often a proposal is right
+ * (precision).
+ *
+ * Pipeline:
+ *   1. this script                                    -> matching-eval.json
+ *   2. opencouncil-tasks `evaluate-decision-matching` -> recall + precision
+ *
+ * Read-only.
+ *
+ * Usage:
+ *   npx tsx scripts/export-matching-eval.ts --body <administrativeBodyId>
+ *   npx tsx scripts/export-matching-eval.ts --body <id> --out /tmp/eval.json
+ */
+import { PrismaClient } from "@prisma/client";
+import fs from "fs";
+
+const prisma = new PrismaClient();
+
+function parseArgs() {
+    const argv = process.argv.slice(2);
+    const get = (flag: string) => {
+        const i = argv.indexOf(flag);
+        return i === -1 ? undefined : argv[i + 1];
+    };
+    const body = get("--body");
+    if (!body) throw new Error("--body <administrativeBodyId> is required");
+    return { body, out: get("--out") ?? "matching-eval.json" };
+}
+
+/** The document prints a local calendar date; CouncilMeeting.dateTime is UTC. */
+function athensDate(d: Date): string {
+    return d.toLocaleDateString("en-CA", { timeZone: "Europe/Athens" });
+}
+
+async function main() {
+    const { body: bodyId, out } = parseArgs();
+
+    const body = await prisma.administrativeBody.findUnique({
+        where: { id: bodyId },
+        select: {
+            id: true, name: true, cityId: true, diavgeiaUnitIds: true,
+            city: { select: { diavgeiaUid: true } },
+        },
+    });
+    if (!body) throw new Error(`Administrative body "${bodyId}" not found`);
+    if (!body.city.diavgeiaUid) throw new Error(`City "${body.cityId}" has no diavgeiaUid`);
+
+    const meetings = await prisma.councilMeeting.findMany({
+        where: { administrativeBodyId: bodyId },
+        orderBy: { dateTime: "desc" },
+        select: {
+            id: true,
+            dateTime: true,
+            subjects: {
+                select: {
+                    id: true,
+                    name: true,
+                    agendaItemIndex: true,
+                    nonAgendaReason: true,
+                    decision: { select: { ada: true } },
+                },
+            },
+        },
+    });
+
+    const exported = meetings
+        .filter((m) => m.subjects.some((s) => s.decision?.ada))
+        .map((m) => ({
+            meetingId: m.id,
+            meetingDate: athensDate(m.dateTime),
+            subjects: m.subjects.map((s) => ({
+                subjectId: s.id,
+                name: s.name,
+                agendaItemIndex: s.agendaItemIndex,
+                nonAgendaReason: s.nonAgendaReason ?? null,
+                truthAda: s.decision?.ada ?? null,
+            })),
+        }));
+
+    fs.writeFileSync(
+        out,
+        JSON.stringify(
+            {
+                city: body.cityId,
+                administrativeBody: { id: body.id, name: body.name },
+                diavgeiaUid: body.city.diavgeiaUid,
+                diavgeiaUnitIds: body.diavgeiaUnitIds,
+                meetings: exported,
+            },
+            null,
+            2,
+        ),
+    );
+
+    const truthCount = exported.reduce((n, m) => n + m.subjects.filter((s) => s.truthAda).length, 0);
+    console.log(`Exported ${body.cityId} / ${body.name} -> ${out}`);
+    console.log(`  meetings with links: ${exported.length}, linked subjects: ${truthCount}`);
+}
+
+main()
+    .catch((e) => {
+        console.error(e);
+        process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());

--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -452,6 +452,15 @@ export interface PollDecisionsRequest extends TaskRequest {
             needsExtraction?: boolean;
         };
     }>;
+    /** Fetch window, derived from the city's publication-lag history. Absent = tasks uses its legacy 45-day window. */
+    window?: { fromDate: string; toDate: string };
+    /**
+     * Reading-cache handshake, scoped by the WINDOW, not the meeting: every
+     * DecisionCandidate the city holds whose publishDate falls inside the poll
+     * window. Presence + readStatus decide whether tasks reads again;
+     * meetingDate decides which partition the decision belongs to.
+     */
+    knownDecisions?: Array<{ ada: string; meetingDate: string | null; readStatus: string }>;
 }
 
 export interface PollDecisionsMatch {

--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -463,6 +463,26 @@ export interface PollDecisionsRequest extends TaskRequest {
     knownDecisions?: Array<{ ada: string; meetingDate: string | null; readStatus: string }>;
 }
 
+/**
+ * A decision read in the poll window (issue #617). subjectId null = unplaced;
+ * rows declaring another meeting carry no matching fields.
+ */
+export interface PollDecisionsReadDecision {
+    ada: string;
+    title: string | null;
+    pdfUrl: string;
+    protocolNumber: string | null;   // Diavgeia's field, verbatim
+    publishDate: string | null;
+    meetingDate: string | null;
+    decisionNumber: string | null;
+    readStatus: string;
+    /** True when the reading was echoed from knownDecisions, not freshly read. */
+    fromKnown?: boolean;
+    subjectId: string | null;
+    confidence: number | null;
+    reasoning: string | null;
+}
+
 export interface PollDecisionsMatch {
     subjectId: string;
     ada: string; // Diavgeia unique ID (e.g., "ΨΘ82ΩΡΦ-7ΑΙ")
@@ -471,10 +491,14 @@ export interface PollDecisionsMatch {
     protocolNumber: string; // e.g., "231/2025"
     publishDate: string; // ISO date when published on Diavgeia
     matchConfidence: number; // 0-1 confidence score
+    reasoning?: string | null; // resolver's stated reasoning for this match
 }
 
 export interface PollDecisionsResult {
+    /** Every decision read in the poll window. Absent from older tasks versions. */
+    decisions?: PollDecisionsReadDecision[];
     matches: PollDecisionsMatch[];
+    /** Always empty since #617 phase 3; read-and-ignored for older tasks versions. */
     reassignments: Array<{
         ada: string;
         fromSubjectId: string;

--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -452,6 +452,8 @@ export interface PollDecisionsRequest extends TaskRequest {
             needsExtraction?: boolean;
         };
     }>;
+    /** The polled meeting's administrative-body name, for the (body, date) partition. */
+    administrativeBodyName?: string | null;
     /** Fetch window, derived from the city's publication-lag history. Absent = tasks uses its legacy 45-day window. */
     window?: { fromDate: string; toDate: string };
     /**
@@ -475,6 +477,8 @@ export interface PollDecisionsReadDecision {
     publishDate: string | null;
     meetingDate: string | null;
     decisionNumber: string | null;
+    /** The deliberative body as the document states it. */
+    body?: string | null;
     readStatus: string;
     /** True when the reading was echoed from knownDecisions, not freshly read. */
     fromKnown?: boolean;

--- a/src/lib/tasks/__tests__/decisionWindow.test.ts
+++ b/src/lib/tasks/__tests__/decisionWindow.test.ts
@@ -1,0 +1,25 @@
+import { deriveWindowDays } from '@/lib/tasks/decisionWindow';
+
+describe('deriveWindowDays', () => {
+    it('defaults to 30 when there is too little history', () => {
+        expect(deriveWindowDays([])).toBe(30);
+        expect(deriveWindowDays([3, 5, 7])).toBe(30);
+    });
+
+    it('uses p95 of the lags with 1.5x headroom', () => {
+        // 20 lags of 10 days: p95 = 10, x1.5 = 15
+        expect(deriveWindowDays(Array(20).fill(10))).toBe(15);
+    });
+
+    it('clamps to at least 14 days', () => {
+        expect(deriveWindowDays(Array(20).fill(2))).toBe(14);
+    });
+
+    it('clamps to at most 45 days', () => {
+        expect(deriveWindowDays(Array(20).fill(60))).toBe(45);
+    });
+
+    it('ignores negative lags (bad data)', () => {
+        expect(deriveWindowDays([-5, ...Array(20).fill(10)])).toBe(15);
+    });
+});

--- a/src/lib/tasks/decisionWindow.ts
+++ b/src/lib/tasks/decisionWindow.ts
@@ -1,0 +1,31 @@
+/**
+ * Fetch-window derivation for decision polling (issue #617 phase 3).
+ *
+ * The window's only job is to be wide enough — the declared session date does
+ * the precise work. Derived from the city's measured publication lags so it
+ * self-tunes as data accumulates; nothing is stored and there is no
+ * configuration to keep correct. Measured p95 lag is ≤21 days for every city.
+ */
+
+const DEFAULT_WINDOW_DAYS = 30;
+const MIN_WINDOW_DAYS = 14;
+const MAX_WINDOW_DAYS = 45;
+const MIN_SAMPLE = 10;
+const HEADROOM = 1.5;
+
+/**
+ * The Athens-local calendar date of a moment. Documents print local dates, and
+ * a meeting stored at local midnight is 21:00–22:00Z the PREVIOUS day — using
+ * the UTC date would off-by-one every declared-session comparison for it.
+ */
+export function athensDate(d: Date): string {
+    return d.toLocaleDateString('en-CA', { timeZone: 'Europe/Athens' });
+}
+
+/** p95 of the city's publish-lag history (days), with headroom, clamped. */
+export function deriveWindowDays(lagsDays: number[]): number {
+    const lags = lagsDays.filter((d) => d >= 0).sort((a, b) => a - b);
+    if (lags.length < MIN_SAMPLE) return DEFAULT_WINDOW_DAYS;
+    const p95 = lags[Math.min(lags.length - 1, Math.floor(lags.length * 0.95))];
+    return Math.min(MAX_WINDOW_DAYS, Math.max(MIN_WINDOW_DAYS, Math.ceil(p95 * HEADROOM)));
+}

--- a/src/lib/tasks/decisionWindow.ts
+++ b/src/lib/tasks/decisionWindow.ts
@@ -14,12 +14,13 @@ const MIN_SAMPLE = 10;
 const HEADROOM = 1.5;
 
 /**
- * The Athens-local calendar date of a moment. Documents print local dates, and
- * a meeting stored at local midnight is 21:00–22:00Z the PREVIOUS day — using
- * the UTC date would off-by-one every declared-session comparison for it.
+ * The city-local calendar date of a moment. Documents print local dates, and a
+ * meeting stored at local midnight is stored before midnight UTC — using the
+ * UTC date would off-by-one every declared-session comparison for it. Always
+ * pass City.timezone; realms make Athens an assumption, not a fact.
  */
-export function athensDate(d: Date): string {
-    return d.toLocaleDateString('en-CA', { timeZone: 'Europe/Athens' });
+export function localCalendarDate(d: Date, timeZone: string): string {
+    return d.toLocaleDateString('en-CA', { timeZone });
 }
 
 /** p95 of the city's publish-lag history (days), with headroom, clamped. */

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -10,7 +10,7 @@ import { upsertDecision, deleteDecision, getDecisionForSubject, DECISION_ELIGIBL
 export { getDecisionForSubject };
 import { withUserAuthorizedToEdit } from "../auth";
 import { getPeopleForMeeting } from "../db/people";
-import { deriveWindowDays, athensDate } from "./decisionWindow";
+import { deriveWindowDays, localCalendarDate } from "./decisionWindow";
 import { isRoleActiveAt, isMayorRole } from "../utils/roles";
 import { shouldSkipPolling, getBackoffState, getPollableMeetingDateRange, BACKOFF_SCHEDULE, MAX_POLLING_DAYS, LOGODOSIA_NAME_PATTERN } from "./pollDecisionsBackoff";
 import { sendPollDecisionsBatchStartedAlert, sendPollDecisionsBatchCompletedAlert } from "../discord";
@@ -48,11 +48,13 @@ export async function pollDecisionsForMeeting(
             city: {
                 select: {
                     diavgeiaUid: true,
+                    timezone: true,
                 },
             },
             administrativeBody: {
                 select: {
                     id: true,
+                    name: true,
                     diavgeiaUnitIds: true,
                 },
             },
@@ -120,8 +122,9 @@ export async function pollDecisionsForMeeting(
         WHERE s."cityId" = ${cityId} AND d."publishDate" IS NOT NULL
     `;
     const windowDays = deriveWindowDays(lagRows.map(r => Number(r.lag)));
-    const windowFromDate = athensDate(councilMeeting.dateTime);
-    const windowToDate = athensDate(new Date(councilMeeting.dateTime.getTime() + windowDays * 86400_000));
+    const cityTz = councilMeeting.city.timezone;
+    const windowFromDate = localCalendarDate(councilMeeting.dateTime, cityTz);
+    const windowToDate = localCalendarDate(new Date(councilMeeting.dateTime.getTime() + windowDays * 86400_000), cityTz);
 
     // Everything the city has already read whose publishDate falls in this
     // window — mostly neighbouring meetings' decisions, which is the point.
@@ -134,14 +137,15 @@ export async function pollDecisionsForMeeting(
     });
 
     const body: Omit<PollDecisionsRequest, 'callbackUrl'> = {
-        // Athens-local: documents print local dates, and the partition compares
+        // City-local: documents print local dates, and the partition compares
         // against this value. The UTC date is the previous day for meetings
         // stored at local midnight.
-        meetingDate: athensDate(councilMeeting.dateTime),
+        meetingDate: localCalendarDate(councilMeeting.dateTime, cityTz),
         diavgeiaUid: councilMeeting.city.diavgeiaUid,
         diavgeiaUnitIds: councilMeeting.administrativeBody?.diavgeiaUnitIds.length
             ? councilMeeting.administrativeBody.diavgeiaUnitIds
             : undefined,
+        administrativeBodyName: councilMeeting.administrativeBody?.name ?? null,
         mayorId: mayorPerson?.id,
         forceExtract: options?.forceExtract || undefined,
         people: peopleForRequest,
@@ -1183,17 +1187,20 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
         if (result.decisions?.length) {
             const meeting = await tx.councilMeeting.findUnique({
                 where: { cityId_id: { id: task.councilMeetingId, cityId: task.cityId } },
-                select: { administrativeBodyId: true },
+                select: { administrativeBodyId: true, city: { select: { timezone: true } } },
             });
             for (const d of result.decisions) {
                 // Resolve the declared session to one of our meetings (same body).
                 let councilMeetingId: string | null = null;
                 if (d.meetingDate && meeting?.administrativeBodyId) {
+                    // Double conversion is load-bearing: dateTime is a UTC-stored
+                    // timestamp, so the single-conversion form would interpret it
+                    // as already-local and shift midnight-stored meetings a day.
                     const target = await tx.$queryRaw<Array<{ id: string }>>`
                         SELECT id FROM "CouncilMeeting"
                         WHERE "cityId" = ${task.cityId}
                           AND "administrativeBodyId" = ${meeting.administrativeBodyId}
-                          AND ("dateTime" AT TIME ZONE 'Europe/Athens')::date = ${d.meetingDate}::date
+                          AND ("dateTime" AT TIME ZONE 'UTC' AT TIME ZONE ${meeting.city.timezone})::date = ${d.meetingDate}::date
                         LIMIT 1`;
                     councilMeetingId = target[0]?.id ?? null;
                 }

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -1073,10 +1073,9 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
     let processedCount = 0;
     let conflictCount = 0;
 
-    // Collect all subjectIds from matches, reassignments, and non-decision attendance for validation
+    // Collect all subjectIds from matches and non-decision attendance for validation
     const allSubjectIds = [
         ...result.matches.map(m => m.subjectId),
-        ...result.reassignments.flatMap(r => [r.fromSubjectId, r.toSubjectId]),
         ...(result.extractions?.nonDecisionSubjectAttendance?.map(a => a.subjectId) ?? []),
     ];
 
@@ -1090,19 +1089,15 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
     });
     const validSubjectIdSet = new Set(validSubjectIds.map(s => s.id));
 
-    // Validate every reassignment has a corresponding match to upsert,
-    // otherwise deleting the old decision would lose it permanently.
-    const matchSubjectIds = new Set(result.matches.map(m => m.subjectId));
-    for (const r of result.reassignments) {
-        if (!matchSubjectIds.has(r.toSubjectId)) {
-            throw new Error(`Reassignment for ${r.ada} has no corresponding match (${r.fromSubjectId} → ${r.toSubjectId})`);
+    if (result.reassignments?.length) {
+        // The pipeline no longer moves confirmed links (issue #617). An older
+        // tasks version proposed these; surface them and do nothing — a
+        // Decision is only ever deleted by an admin.
+        for (const r of result.reassignments) {
+            console.warn(`Ignoring pipeline reassignment proposal for ${r.ada}: ${r.fromSubjectId} → ${r.toSubjectId} (${r.reason})`);
         }
     }
 
-    // Wrap reassignments + upserts in a transaction to ensure atomicity.
-    // Reassignments delete old decisions to free ADA unique constraints before
-    // upserting new ones — without a transaction, a failed upsert after a
-    // successful delete would permanently lose decision data.
     await prisma.$transaction(async (tx) => {
         // Step 1: Detect ADA conflicts — find ADAs that already exist on other subjects
         const matchAdas = result.matches.map(m => m.ada).filter((ada): ada is string => ada != null);
@@ -1111,23 +1106,7 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
             : [];
         const adaToExistingSubject = new Map(existingDecisions.map(d => [d.ada!, d.subjectId]));
 
-        // Build set of ADAs being reassigned — these are handled explicitly, not conflicts
-        const reassignedAdas = new Set(result.reassignments.map(r => r.ada));
-
-        // Step 2: Process reassignments — delete old decisions to free ADA unique constraint
-        if (result.reassignments.length > 0) {
-            for (const r of result.reassignments) {
-                if (!validSubjectIdSet.has(r.fromSubjectId) || !validSubjectIdSet.has(r.toSubjectId)) {
-                    console.warn(`Poll decisions: skipping invalid reassignment ${r.ada} (${r.fromSubjectId} → ${r.toSubjectId}) for task ${taskId}`);
-                    continue;
-                }
-                await tx.decision.deleteMany({ where: { subjectId: r.fromSubjectId } });
-                reassignmentCount++;
-                console.log(`Reassigned ADA ${r.ada}: ${r.fromSubjectId} → ${r.toSubjectId}: ${r.reason}`);
-            }
-        }
-
-        // Step 3: Upsert new matches (including reassigned ones), recording conflicts
+        // Step 2: Upsert new matches, recording conflicts
         for (const match of result.matches) {
             // Skip any subjectIds that don't belong to this meeting
             if (!validSubjectIdSet.has(match.subjectId)) {
@@ -1138,7 +1117,7 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
             // Check for ADA conflict: ADA exists on a different subject and isn't being reassigned
             if (match.ada) {
                 const existingSubjectId = adaToExistingSubject.get(match.ada);
-                if (existingSubjectId && existingSubjectId !== match.subjectId && !reassignedAdas.has(match.ada)) {
+                if (existingSubjectId && existingSubjectId !== match.subjectId) {
                     // Record the claim on the incoming subject, skip the upsert
                     await tx.subject.update({
                         where: { id: match.subjectId },
@@ -1196,6 +1175,78 @@ export async function handlePollDecisionsResult(taskId: string, result: PollDeci
             // Track this ADA so later matches in the same batch see it as taken
             if (match.ada) {
                 adaToExistingSubject.set(match.ada, match.subjectId);
+            }
+        }
+
+        // Step 3: DecisionCandidate — persist every decision read in the window
+        // (issue #617). Rows survive promotion; deleting the Decision reverts.
+        if (result.decisions?.length) {
+            const meeting = await tx.councilMeeting.findUnique({
+                where: { cityId_id: { id: task.councilMeetingId, cityId: task.cityId } },
+                select: { administrativeBodyId: true },
+            });
+            for (const d of result.decisions) {
+                // Resolve the declared session to one of our meetings (same body).
+                let councilMeetingId: string | null = null;
+                if (d.meetingDate && meeting?.administrativeBodyId) {
+                    const target = await tx.$queryRaw<Array<{ id: string }>>`
+                        SELECT id FROM "CouncilMeeting"
+                        WHERE "cityId" = ${task.cityId}
+                          AND "administrativeBodyId" = ${meeting.administrativeBodyId}
+                          AND ("dateTime" AT TIME ZONE 'Europe/Athens')::date = ${d.meetingDate}::date
+                        LIMIT 1`;
+                    councilMeetingId = target[0]?.id ?? null;
+                }
+                const promoted = await tx.decision.findUnique({
+                    where: { ada: d.ada },
+                    select: { id: true },
+                });
+
+                await tx.decisionCandidate.upsert({
+                    where: { cityId_ada: { cityId: task.cityId, ada: d.ada } },
+                    create: {
+                        cityId: task.cityId,
+                        ada: d.ada,
+                        title: d.title,
+                        pdfUrl: d.pdfUrl,
+                        publishDate: d.publishDate ? new Date(d.publishDate) : null,
+                        protocolNumber: d.protocolNumber,
+                        meetingDate: d.meetingDate ? new Date(`${d.meetingDate}T00:00:00Z`) : null,
+                        decisionNumber: d.decisionNumber,
+                        readStatus: d.readStatus,
+                        councilMeetingId,
+                        subjectId: d.subjectId,
+                        confidence: d.confidence,
+                        reasoning: d.reasoning,
+                        decisionId: promoted?.id ?? null,
+                    },
+                    update: {
+                        // Reading fields refresh only when this poll actually read
+                        // the document — a knownDecisions echo carries no new
+                        // information and must not blank a stored reading.
+                        ...(!d.fromKnown && d.readStatus !== 'unread' ? {
+                            meetingDate: d.meetingDate ? new Date(`${d.meetingDate}T00:00:00Z`) : null,
+                            decisionNumber: d.decisionNumber,
+                            readStatus: d.readStatus,
+                            councilMeetingId,
+                        } : {}),
+                        // The suggestion is recorded once, as made; later polls
+                        // never overwrite an accepted suggestion's record.
+                        ...(d.subjectId && !promoted ? { subjectId: d.subjectId, confidence: d.confidence, reasoning: d.reasoning } : {}),
+                        ...(promoted ? { decisionId: promoted.id } : {}),
+                    },
+                });
+
+                // Promotion copies the document's self-declared identity onto the Decision.
+                if (promoted && (d.decisionNumber || d.meetingDate)) {
+                    await tx.decision.update({
+                        where: { id: promoted.id },
+                        data: {
+                            ...(d.decisionNumber ? { decisionNumber: d.decisionNumber } : {}),
+                            ...(d.meetingDate ? { meetingDate: new Date(`${d.meetingDate}T00:00:00Z`) } : {}),
+                        },
+                    });
+                }
             }
         }
     });

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -10,6 +10,7 @@ import { upsertDecision, deleteDecision, getDecisionForSubject, DECISION_ELIGIBL
 export { getDecisionForSubject };
 import { withUserAuthorizedToEdit } from "../auth";
 import { getPeopleForMeeting } from "../db/people";
+import { deriveWindowDays, athensDate } from "./decisionWindow";
 import { isRoleActiveAt, isMayorRole } from "../utils/roles";
 import { shouldSkipPolling, getBackoffState, getPollableMeetingDateRange, BACKOFF_SCHEDULE, MAX_POLLING_DAYS, LOGODOSIA_NAME_PATTERN } from "./pollDecisionsBackoff";
 import { sendPollDecisionsBatchStartedAlert, sendPollDecisionsBatchCompletedAlert } from "../discord";
@@ -109,8 +110,34 @@ export async function pollDecisionsForMeeting(
     }
     const sortedSubjects = sortSubjectsByDiscussionOrder(councilMeeting.subjects, firstUtteranceBySubject);
 
+    // Window from the city's measured publication lags; the declared session
+    // date does the precise work, the window only has to be wide enough.
+    const lagRows = await prisma.$queryRaw<Array<{ lag: number }>>`
+        SELECT EXTRACT(EPOCH FROM (d."publishDate" - cm."dateTime")) / 86400 AS lag
+        FROM "Decision" d
+        JOIN "Subject" s ON s.id = d."subjectId"
+        JOIN "CouncilMeeting" cm ON cm.id = s."councilMeetingId" AND cm."cityId" = s."cityId"
+        WHERE s."cityId" = ${cityId} AND d."publishDate" IS NOT NULL
+    `;
+    const windowDays = deriveWindowDays(lagRows.map(r => Number(r.lag)));
+    const windowFromDate = athensDate(councilMeeting.dateTime);
+    const windowToDate = athensDate(new Date(councilMeeting.dateTime.getTime() + windowDays * 86400_000));
+
+    // Everything the city has already read whose publishDate falls in this
+    // window — mostly neighbouring meetings' decisions, which is the point.
+    const known = await prisma.decisionCandidate.findMany({
+        where: {
+            cityId,
+            publishDate: { gte: new Date(windowFromDate), lte: new Date(`${windowToDate}T23:59:59Z`) },
+        },
+        select: { ada: true, meetingDate: true, readStatus: true },
+    });
+
     const body: Omit<PollDecisionsRequest, 'callbackUrl'> = {
-        meetingDate: councilMeeting.dateTime.toISOString().split('T')[0],
+        // Athens-local: documents print local dates, and the partition compares
+        // against this value. The UTC date is the previous day for meetings
+        // stored at local midnight.
+        meetingDate: athensDate(councilMeeting.dateTime),
         diavgeiaUid: councilMeeting.city.diavgeiaUid,
         diavgeiaUnitIds: councilMeeting.administrativeBody?.diavgeiaUnitIds.length
             ? councilMeeting.administrativeBody.diavgeiaUnitIds
@@ -118,6 +145,12 @@ export async function pollDecisionsForMeeting(
         mayorId: mayorPerson?.id,
         forceExtract: options?.forceExtract || undefined,
         people: peopleForRequest,
+        window: { fromDate: windowFromDate, toDate: windowToDate },
+        knownDecisions: known.map(k => ({
+            ada: k.ada,
+            meetingDate: k.meetingDate ? k.meetingDate.toISOString().split('T')[0] : null,
+            readStatus: k.readStatus,
+        })),
         subjects: sortedSubjects.map(s => ({
             subjectId: s.id,
             name: s.name,

--- a/tests/helpers/builders.ts
+++ b/tests/helpers/builders.ts
@@ -123,6 +123,7 @@ export function makePersonWithRoles(overrides: {
 }
 
 export function makePollDecisionsResult(params: {
+    decisions?: PollDecisionsResult['decisions']
     matches?: PollDecisionsMatch[]
     reassignments?: PollDecisionsResult['reassignments']
     unmatchedSubjects?: PollDecisionsResult['unmatchedSubjects']
@@ -131,6 +132,7 @@ export function makePollDecisionsResult(params: {
     costs?: PollDecisionsResult['costs']
 }): PollDecisionsResult {
     return {
+        ...(params.decisions ? { decisions: params.decisions } : {}),
         matches: params.matches ?? [],
         reassignments: params.reassignments ?? [],
         unmatchedSubjects: params.unmatchedSubjects ?? [],

--- a/tests/integration/decision-candidates.test.ts
+++ b/tests/integration/decision-candidates.test.ts
@@ -118,6 +118,25 @@ describe('handlePollDecisionsResult — decisions list (DecisionCandidate ingest
         expect(candidate!.councilMeetingId).toBe(otherMeetingId)
     })
 
+    test('a midnight-stored meeting resolves by its LOCAL calendar date', async () => {
+        // 2025-06-17T21:00Z is 2025-06-18 00:00 in Athens (EEST). The document
+        // prints the 18th; the naive single-conversion SQL resolved the 17th.
+        const body2 = await createAdministrativeBody(cityId, { notificationBehavior: 'NOTIFICATIONS_DISABLED' })
+        const midnight = await createMeeting(cityId, {
+            id: 'm-midnight',
+            administrativeBodyId: body2.id,
+            dateTime: new Date('2025-06-17T21:00:00Z'),
+        })
+        const task = await createTaskStatus(midnight.id, cityId, { type: 'pollDecisions' })
+
+        await handlePollDecisionsResult(task.id, makePollDecisionsResult({
+            decisions: [makeReadDecision({ ada: 'ADA-M', meetingDate: '2025-06-18' })],
+        }))
+
+        const candidate = await prisma.decisionCandidate.findUnique({ where: { cityId_ada: { cityId, ada: 'ADA-M' } } })
+        expect(candidate!.councilMeetingId).toBe(midnight.id)
+    })
+
     test('a decision declaring an unknown session keeps councilMeetingId null', async () => {
         const task = await createTaskStatus(meetingId, cityId, { type: 'pollDecisions' })
 

--- a/tests/integration/decision-candidates.test.ts
+++ b/tests/integration/decision-candidates.test.ts
@@ -1,0 +1,208 @@
+/** @jest-environment node */
+
+// Mock modules with JSX templates that can't be parsed with jsx: "preserve"
+jest.mock('@/lib/tasks/generateHighlight', () => ({
+    handleGenerateHighlightResult: jest.fn(),
+}))
+
+jest.mock('@/lib/auth', () => ({
+    withUserAuthorizedToEdit: jest.fn(),
+    isUserAuthorizedToEdit: jest.fn().mockResolvedValue(true),
+}))
+
+import prisma from '@/lib/db/prisma'
+import { handlePollDecisionsResult } from '@/lib/tasks/pollDecisions'
+import { resetDatabase } from '../helpers/test-db'
+import {
+    createAdministrativeBody,
+    createCity,
+    createMeeting,
+    createSubject,
+    createTaskStatus,
+} from '../helpers/factories'
+import { makePollDecisionsMatch, makePollDecisionsResult } from '../helpers/builders'
+import type { PollDecisionsReadDecision } from '@/lib/apiTypes'
+
+function makeReadDecision(overrides: Partial<PollDecisionsReadDecision> & { ada: string }): PollDecisionsReadDecision {
+    return {
+        title: `Decision ${overrides.ada}`,
+        pdfUrl: `https://diavgeia.gov.gr/doc/${overrides.ada}`,
+        protocolNumber: null,
+        publishDate: '2025-01-16',
+        meetingDate: null,
+        decisionNumber: null,
+        readStatus: 'ok',
+        fromKnown: false,
+        subjectId: null,
+        confidence: null,
+        reasoning: null,
+        ...overrides,
+    }
+}
+
+describe('handlePollDecisionsResult — decisions list (DecisionCandidate ingestion)', () => {
+    let cityId: string
+    let meetingId: string
+    let otherMeetingId: string
+
+    beforeEach(async () => {
+        await resetDatabase(prisma as any)
+
+        const city = await createCity({ id: 'c1' })
+        cityId = city.id
+        const body = await createAdministrativeBody(cityId, {
+            notificationBehavior: 'NOTIFICATIONS_DISABLED',
+        })
+        // Meeting dates are Athens-local midnights: 2025-01-10 and 2025-01-17
+        const meeting = await createMeeting(cityId, {
+            id: 'm1',
+            administrativeBodyId: body.id,
+            dateTime: new Date('2025-01-10T10:00:00Z'),
+        })
+        const other = await createMeeting(cityId, {
+            id: 'm2',
+            administrativeBodyId: body.id,
+            dateTime: new Date('2025-01-17T10:00:00Z'),
+        })
+        meetingId = meeting.id
+        otherMeetingId = other.id
+    })
+
+    test('every read decision becomes a candidate; matched ones are promoted with decisionId', async () => {
+        const subjectA = await createSubject(meetingId, cityId, { name: 'Subject A', agendaItemIndex: 1 })
+        const task = await createTaskStatus(meetingId, cityId, { type: 'pollDecisions' })
+
+        await handlePollDecisionsResult(task.id, makePollDecisionsResult({
+            matches: [makePollDecisionsMatch({ subjectId: subjectA.id, ada: 'ADA-1' })],
+            decisions: [
+                makeReadDecision({
+                    ada: 'ADA-1',
+                    meetingDate: '2025-01-10',
+                    decisionNumber: '42/2025',
+                    subjectId: subjectA.id,
+                    confidence: 0.9,
+                    reasoning: 'Title matches',
+                }),
+                makeReadDecision({ ada: 'ADA-2', meetingDate: '2025-01-10' }),
+            ],
+        }))
+
+        // Matched decision promoted: candidate linked via decisionId, reading copied onto the Decision
+        const decision = await prisma.decision.findUnique({ where: { subjectId: subjectA.id } })
+        expect(decision).not.toBeNull()
+        expect(decision!.decisionNumber).toBe('42/2025')
+        expect(decision!.meetingDate?.toISOString()).toBe('2025-01-10T00:00:00.000Z')
+
+        const promoted = await prisma.decisionCandidate.findUnique({ where: { cityId_ada: { cityId, ada: 'ADA-1' } } })
+        expect(promoted!.decisionId).toBe(decision!.id)
+        expect(promoted!.subjectId).toBe(subjectA.id)
+        expect(promoted!.confidence).toBe(0.9)
+        expect(promoted!.reasoning).toBe('Title matches')
+        expect(promoted!.councilMeetingId).toBe(meetingId)
+
+        // Unmatched decision persists as an unresolved candidate for the meeting
+        const unplaced = await prisma.decisionCandidate.findUnique({ where: { cityId_ada: { cityId, ada: 'ADA-2' } } })
+        expect(unplaced!.decisionId).toBeNull()
+        expect(unplaced!.subjectId).toBeNull()
+        expect(unplaced!.councilMeetingId).toBe(meetingId)
+    })
+
+    test('a decision declaring a neighbouring meeting resolves to that meeting', async () => {
+        const task = await createTaskStatus(meetingId, cityId, { type: 'pollDecisions' })
+
+        await handlePollDecisionsResult(task.id, makePollDecisionsResult({
+            decisions: [makeReadDecision({ ada: 'ADA-N', meetingDate: '2025-01-17' })],
+        }))
+
+        const candidate = await prisma.decisionCandidate.findUnique({ where: { cityId_ada: { cityId, ada: 'ADA-N' } } })
+        expect(candidate!.councilMeetingId).toBe(otherMeetingId)
+    })
+
+    test('a decision declaring an unknown session keeps councilMeetingId null', async () => {
+        const task = await createTaskStatus(meetingId, cityId, { type: 'pollDecisions' })
+
+        await handlePollDecisionsResult(task.id, makePollDecisionsResult({
+            decisions: [makeReadDecision({ ada: 'ADA-U', meetingDate: '2024-06-01' })],
+        }))
+
+        const candidate = await prisma.decisionCandidate.findUnique({ where: { cityId_ada: { cityId, ada: 'ADA-U' } } })
+        expect(candidate).not.toBeNull()
+        expect(candidate!.councilMeetingId).toBeNull()
+    })
+
+    test('a knownDecisions echo never blanks a stored reading', async () => {
+        // First poll reads the document
+        const task1 = await createTaskStatus(meetingId, cityId, { type: 'pollDecisions' })
+        await handlePollDecisionsResult(task1.id, makePollDecisionsResult({
+            decisions: [makeReadDecision({ ada: 'ADA-E', meetingDate: '2025-01-10', decisionNumber: '7/2025' })],
+        }))
+
+        // Second poll echoes it from knownDecisions: reading fields carry no new information
+        const task2 = await createTaskStatus(meetingId, cityId, { type: 'pollDecisions' })
+        await handlePollDecisionsResult(task2.id, makePollDecisionsResult({
+            decisions: [makeReadDecision({
+                ada: 'ADA-E',
+                meetingDate: '2025-01-10',
+                decisionNumber: null,   // the echo does not carry the number
+                fromKnown: true,
+            })],
+        }))
+
+        const candidate = await prisma.decisionCandidate.findUnique({ where: { cityId_ada: { cityId, ada: 'ADA-E' } } })
+        expect(candidate!.decisionNumber).toBe('7/2025')
+    })
+
+    test('an unaccepted suggestion refreshes; a promoted one is preserved as made', async () => {
+        const subjectA = await createSubject(meetingId, cityId, { name: 'Subject A', agendaItemIndex: 1 })
+        const subjectB = await createSubject(meetingId, cityId, { name: 'Subject B', agendaItemIndex: 2 })
+
+        // Poll 1 suggests subjectA; poll 2 changes its mind to subjectB —
+        // nothing was accepted yet, so the latest pipeline opinion wins.
+        const task1 = await createTaskStatus(meetingId, cityId, { type: 'pollDecisions' })
+        await handlePollDecisionsResult(task1.id, makePollDecisionsResult({
+            decisions: [makeReadDecision({ ada: 'ADA-S', meetingDate: '2025-01-10', subjectId: subjectA.id, confidence: 0.7, reasoning: 'first' })],
+        }))
+        const task2 = await createTaskStatus(meetingId, cityId, { type: 'pollDecisions' })
+        await handlePollDecisionsResult(task2.id, makePollDecisionsResult({
+            decisions: [makeReadDecision({ ada: 'ADA-S', meetingDate: '2025-01-10', decisionNumber: '9/2025', subjectId: subjectB.id, confidence: 0.9, reasoning: 'second' })],
+        }))
+
+        let candidate = await prisma.decisionCandidate.findUnique({ where: { cityId_ada: { cityId, ada: 'ADA-S' } } })
+        expect(candidate!.decisionNumber).toBe('9/2025')
+        expect(candidate!.subjectId).toBe(subjectB.id)
+        expect(candidate!.reasoning).toBe('second')
+
+        // Poll 3 promotes the match to subjectB. From now on the suggestion is
+        // the record of what was accepted — poll 4's different opinion is ignored.
+        const task3 = await createTaskStatus(meetingId, cityId, { type: 'pollDecisions' })
+        await handlePollDecisionsResult(task3.id, makePollDecisionsResult({
+            matches: [makePollDecisionsMatch({ subjectId: subjectB.id, ada: 'ADA-S' })],
+            decisions: [makeReadDecision({ ada: 'ADA-S', meetingDate: '2025-01-10', subjectId: subjectB.id, confidence: 0.9, reasoning: 'second' })],
+        }))
+        const task4 = await createTaskStatus(meetingId, cityId, { type: 'pollDecisions' })
+        await handlePollDecisionsResult(task4.id, makePollDecisionsResult({
+            decisions: [makeReadDecision({ ada: 'ADA-S', meetingDate: '2025-01-10', subjectId: subjectA.id, confidence: 0.5, reasoning: 'revisionist' })],
+        }))
+
+        candidate = await prisma.decisionCandidate.findUnique({ where: { cityId_ada: { cityId, ada: 'ADA-S' } } })
+        expect(candidate!.decisionId).not.toBeNull()
+        expect(candidate!.subjectId).toBe(subjectB.id)
+        expect(candidate!.confidence).toBe(0.9)
+        expect(candidate!.reasoning).toBe('second')
+    })
+
+    test('retried callback is idempotent', async () => {
+        const subjectA = await createSubject(meetingId, cityId, { name: 'Subject A', agendaItemIndex: 1 })
+        const task = await createTaskStatus(meetingId, cityId, { type: 'pollDecisions' })
+        const result = makePollDecisionsResult({
+            matches: [makePollDecisionsMatch({ subjectId: subjectA.id, ada: 'ADA-R' })],
+            decisions: [makeReadDecision({ ada: 'ADA-R', meetingDate: '2025-01-10', subjectId: subjectA.id, confidence: 0.9 })],
+        })
+
+        await handlePollDecisionsResult(task.id, result)
+        await handlePollDecisionsResult(task.id, result)
+
+        expect(await prisma.decisionCandidate.count()).toBe(1)
+        expect(await prisma.decision.count()).toBe(1)
+    })
+})


### PR DESCRIPTION
Implements #617 phase 3 (app side), stacked on #621. New `DecisionCandidate` table: every decision the poll reads becomes a row — unresolved rows are the work queue, promoted rows keep a `decisionId` back-reference so deleting a `Decision` reverts the assignment and accepted suggestions stay analyzable as-made. The request now carries a derived fetch window (p95 publication lag, clamped 14–45d), window-scoped `knownDecisions`, and the meeting's administrative-body name for the (body, date) partition. All calendar dates derive from `City.timezone` (realms make Athens an assumption), and the candidate meeting-resolution SQL uses the load-bearing double conversion — the single-conversion form silently shifted midnight-stored meetings a day back, regression-tested now. Reassignment proposals from older tasks versions are logged and ignored. Integration tests cover ingestion: promotion, neighbouring-meeting resolution, the knownDecisions-echo guard, suggestion semantics, idempotent callbacks.

Pairs with schemalabz/opencouncil-tasks#85. Migration is additive. Refs #617.

<!-- preview-link: tasks=85 -->









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds durable decision candidates and extends decision polling to persist every read decision.

- Adds the `DecisionCandidate` schema and migration.
- Derives city-local polling windows from publication-lag history.
- Extends task requests and callbacks with read-decision data.
- Preserves promoted candidates for reassignment and evaluation.
- Adds decision-window and ingestion coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| prisma/schema.prisma | Adds the durable `DecisionCandidate` model and its optional one-to-one link to `Decision`. |
| prisma/migrations/20260814060950_add_decision_candidate/migration.sql | Creates the additive candidate table, indexes, uniqueness constraints, and delete-to-null decision relation. |
| src/lib/tasks/pollDecisions.ts | Adds city-local polling windows, known-decision request data, and transactional candidate persistence. |
| src/lib/tasks/decisionWindow.ts | Adds local calendar conversion and bounded publication-lag window derivation. |
| src/lib/apiTypes.ts | Extends the task boundary with polling-window, reading-cache, and read-decision contracts. |
| tests/integration/decision-candidates.test.ts | Covers candidate ingestion, promotion, meeting resolution, reading preservation, and callback idempotency. |

<sub>Reviews (9): Last reviewed commit: ["fix(decisions): derive local dates from ..."](https://github.com/schemalabz/opencouncil/commit/a4ee36add0dad1495fb7c44316f6abf3382b19ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53272277)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Background task orchestration](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/background-task-orchestration.md)
- Knowledge Base — [Database access and civic models](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/database-access-and-models.md)
- Knowledge Base — [Meeting publication and records](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/meeting-publication.md)
- Knowledge Base — [Platform data and integrations](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/platform-data-and-integrations.md)
</details>


<!-- /greptile_comment -->