### PR TITLE
fix(map): store subject coordinates in lng/lat order

### DIFF
--- a/prisma/migrations/20260814120000_swap_subject_location_coordinates/migration.sql
+++ b/prisma/migrations/20260814120000_swap_subject_location_coordinates/migration.sql
@@ -1,0 +1,17 @@
+-- Subject locations hold their coordinates in the reverse order.
+--
+-- The summarize pipeline emits `[lat, lng]`. createLocationInTx passes that array
+-- to ST_GeomFromGeoJSON, which reads it as `[lng, lat]`. Every subject location is
+-- therefore stored as POINT(lat lng). This migration flips those geometries to the
+-- correct POINT(lng lat) order.
+--
+-- Notification preference locations use a different writer, createLocation, which
+-- calls ST_MakePoint(longitude, latitude). Those rows are already correct, so the
+-- WHERE clause excludes them.
+--
+-- ST_FlipCoordinates handles every LocationType (point, lineString, polygon) and
+-- keeps the SRID.
+
+UPDATE "Location" AS l
+SET coordinates = ST_FlipCoordinates(l.coordinates)
+WHERE EXISTS (SELECT 1 FROM "Subject" s WHERE s."locationId" = l.id);

--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -407,7 +407,7 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                     >
                         <div className="h-[300px] w-full">
                             <Map
-                                center={location.coordinates ? [location.coordinates.y, location.coordinates.x] : undefined}
+                                center={location.coordinates ? [location.coordinates.x, location.coordinates.y] : undefined}
                                 zoom={15}
                                 features={mapFeatures}
                                 animateRotation={false}

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -291,11 +291,12 @@ describe('debounce', () => {
 
 describe('subjectToMapFeature', () => {
   it('should convert subject to map feature', () => {
+    // ST_X is the longitude, ST_Y the latitude. GeoJSON wants [lng, lat].
     const subject = {
       id: '123',
       name: 'Test Subject',
       location: {
-        coordinates: { x: 10, y: 20 }
+        coordinates: { x: 23.74, y: 37.98 }
       }
     };
 
@@ -305,7 +306,7 @@ describe('subjectToMapFeature', () => {
       id: '123',
       geometry: {
         type: 'Point',
-        coordinates: [20, 10]
+        coordinates: [23.74, 37.98]
       },
       properties: {
         subjectId: '123',

--- a/src/lib/db/location.ts
+++ b/src/lib/db/location.ts
@@ -79,13 +79,8 @@ export async function findNearbyLocations(data: {
 
 /**
  * From a set of location ids, return those whose point lies within
- * `distanceInMeters` of `center` ([lng, lat]).
- *
- * Handles the known data issue where some location points were stored with
- * lat/lng swapped: if a point's stored coordinates fall outside Greece's
- * bounding box, we swap X/Y before measuring (mirrors calculateProximityMatches
- * in notifications.ts). Only `point` locations participate; other geometry
- * types are ignored.
+ * `distanceInMeters` of `center` ([lng, lat]). Only `point` locations
+ * participate; other geometry types are ignored.
  */
 export async function filterLocationIdsWithinRadius(
     locationIds: string[],
@@ -105,12 +100,7 @@ export async function filterLocationIdsWithinRadius(
         WHERE id = ANY(${locationIds}::text[])
           AND type = 'point'
           AND ST_DWithin(
-            CASE
-              WHEN ST_X(coordinates::geometry) < 19.5 OR ST_X(coordinates::geometry) > 28.5
-                OR ST_Y(coordinates::geometry) < 34.5 OR ST_Y(coordinates::geometry) > 41.5
-              THEN ST_SetSRID(ST_MakePoint(ST_Y(coordinates::geometry), ST_X(coordinates::geometry)), 4326)::geography
-              ELSE coordinates::geography
-            END,
+            coordinates::geography,
             ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326)::geography,
             ${distanceInMeters}
           )
@@ -120,8 +110,7 @@ export async function filterLocationIdsWithinRadius(
 
 /**
  * Distance in meters from `center` ([lng, lat]) to each of the given point
- * locations. Same swapped-coordinate handling as filterLocationIdsWithinRadius;
- * non-point locations are omitted from the result.
+ * locations. Non-point locations are omitted from the result.
  */
 export async function getLocationDistancesFromPoint(
     locationIds: string[],
@@ -134,12 +123,7 @@ export async function getLocationDistancesFromPoint(
     // map reads as "no pinned locations", which is a claim, not an error state.
     const rows = await prisma.$queryRaw<Array<{ id: string; meters: number }>>`
             SELECT id, ST_Distance(
-                CASE
-                  WHEN ST_X(coordinates::geometry) < 19.5 OR ST_X(coordinates::geometry) > 28.5
-                    OR ST_Y(coordinates::geometry) < 34.5 OR ST_Y(coordinates::geometry) > 41.5
-                  THEN ST_SetSRID(ST_MakePoint(ST_Y(coordinates::geometry), ST_X(coordinates::geometry)), 4326)::geography
-                  ELSE coordinates::geography
-                END,
+                coordinates::geography,
                 ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326)::geography
               ) AS meters
             FROM "Location"

--- a/src/lib/db/notifications.ts
+++ b/src/lib/db/notifications.ts
@@ -608,16 +608,7 @@ export async function savePetition(data: OnboardingData & {
 }
 
 /**
- * Check if coordinates are outside Greece bounds
- * Greece approximate bounds: lat 34.5-41.5, lng 19.5-28.5
- */
-function isOutsideGreece(lng: number, lat: number): boolean {
-    return lng < 19.5 || lng > 28.5 || lat < 34.5 || lat > 41.5;
-}
-
-/**
  * Calculate if any user locations are within specified distance of subject location
- * Handles inverted lat/lng for subject locations that appear outside Greece
  */
 export async function calculateProximityMatches(
     userLocationIds: string[],
@@ -629,55 +620,19 @@ export async function calculateProximityMatches(
     }
 
     try {
-        // Get subject location coordinates to check if they're inverted
-        const subjectCoords = await prisma.$queryRaw<Array<{ x: number; y: number }>>`
-            SELECT ST_X(coordinates::geometry) as x, ST_Y(coordinates::geometry) as y
-            FROM "Location"
-            WHERE id = ${subjectLocationId}
-            AND type = 'point'
+        const result = await prisma.$queryRaw<Array<{ count: bigint }>>`
+            SELECT COUNT(*) as count
+            FROM "Location" ul
+            CROSS JOIN "Location" sl
+            WHERE ul.id = ANY(${userLocationIds})
+            AND sl.id = ${subjectLocationId}
+            AND sl.type = 'point'
+            AND ST_DWithin(
+                ul.coordinates::geography,
+                sl.coordinates::geography,
+                ${distanceMeters}
+            )
         `;
-
-        if (!subjectCoords || subjectCoords.length === 0) {
-            return false;
-        }
-
-        const subjectLng = subjectCoords[0].x;
-        const subjectLat = subjectCoords[0].y;
-
-        // Check if subject location appears to be outside Greece (indicating inverted coordinates)
-        const needsSwap = isOutsideGreece(subjectLng, subjectLat);
-
-        // Use PostGIS to check if any user location is within distance of subject location
-        // If coordinates are inverted, swap them in the query
-        let result: Array<{ count: bigint }>;
-
-        if (needsSwap) {
-            // Swap lat/lng: use lat as lng and lng as lat
-            result = await prisma.$queryRaw<Array<{ count: bigint }>>`
-                SELECT COUNT(*) as count
-                FROM "Location" ul
-                WHERE ul.id = ANY(${userLocationIds})
-                AND ST_DWithin(
-                    ul.coordinates::geography,
-                    ST_SetSRID(ST_MakePoint(${subjectLat}, ${subjectLng}), 4326)::geography,
-                    ${distanceMeters}
-                )
-            `;
-        } else {
-            // Use coordinates as-is
-            result = await prisma.$queryRaw<Array<{ count: bigint }>>`
-                SELECT COUNT(*) as count
-                FROM "Location" ul
-                CROSS JOIN "Location" sl
-                WHERE ul.id = ANY(${userLocationIds})
-                AND sl.id = ${subjectLocationId}
-                AND ST_DWithin(
-                    ul.coordinates::geography,
-                    sl.coordinates::geography,
-                    ${distanceMeters}
-                )
-            `;
-        }
 
         return result[0] && Number(result[0].count) > 0;
     } catch (error) {
@@ -1863,21 +1818,11 @@ export async function getNotificationMapData(meetingId: string, cityId: string):
     allSubjects.forEach(subject => {
         if (subject.locationId && locationCoordinates[subject.locationId]) {
             const coords = locationCoordinates[subject.locationId];
-            let lng = coords.x;
-            let lat = coords.y;
-
-            // Check if subject location appears to be outside Greece (indicating inverted coordinates)
-            // If so, swap lat/lng for display
-            if (isOutsideGreece(lng, lat)) {
-                // Swap coordinates: lat becomes lng, lng becomes lat
-                [lng, lat] = [lat, lng];
-            }
-
             subjectLocations.push({
                 id: subject.id,
                 name: subject.name,
                 locationId: subject.locationId,
-                coordinates: [lng, lat],
+                coordinates: [coords.x, coords.y],
             });
         }
     });

--- a/src/lib/db/subject.ts
+++ b/src/lib/db/subject.ts
@@ -377,17 +377,7 @@ export async function getMapSubjectsCached(realm: Realm, filters: MapSubjectFilt
                 WHERE id IN (${Prisma.join(locationIds)})
             `;
             const geometryMap = new Map<string, GeoJSON.Geometry>(
-                geometries.map((g) => {
-                    const geom = JSON.parse(g.geometry) as GeoJSON.Geometry;
-                    // PostGIS may return [lat, lon]; GeoJSON needs [lon, lat] (swap Greek Points).
-                    if (geom.type === 'Point' && geom.coordinates.length === 2) {
-                        const [first, second] = geom.coordinates;
-                        if (first > 30 && first < 42 && second > 19 && second < 30) {
-                            geom.coordinates = [second, first];
-                        }
-                    }
-                    return [g.id, geom] as const;
-                }),
+                geometries.map((g) => [g.id, JSON.parse(g.geometry) as GeoJSON.Geometry] as const),
             );
 
             const located = subjects.filter((s) => s.locationId && geometryMap.has(s.locationId));

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -58,7 +58,7 @@ export function subjectToMapFeature(subject: SubjectWithRelations) {
     id: subject.id,
     geometry: {
       type: 'Point',
-      coordinates: [subject.location.coordinates.y, subject.location.coordinates.x]
+      coordinates: [subject.location.coordinates.x, subject.location.coordinates.y]
     },
     properties: {
       subjectId: subject.id,


### PR DESCRIPTION
## Problem

Subject pins on the landing map appear in the Indian Ocean on `opencouncil.fr` and in Saudi Arabia on `opencouncil.sr`. `opencouncil.gr` is correct, and the meeting page map is correct everywhere.

## Root cause

`Location.coordinates` holds subject pins as `POINT(lat lng)` — the reverse of the PostGIS and GeoJSON order. The dev database confirms it:

```
city    | avg ST_X | avg ST_Y
athens  |  37.987  |  23.745     <- ST_X is the latitude, ST_Y the longitude
```

The summarize pipeline emits `[lat, lng]` at `subjectEnrichment.ts:60` in opencouncil-tasks. `createLocationInTx` passes that array straight to `ST_GeomFromGeoJSON`, which reads it as `[lng, lat]`. Nothing between the two reorders it.

Notification preference locations use a different writer, `createLocation`, which calls `ST_MakePoint(longitude, latitude)`. Those rows are already correct. The table therefore holds two conventions at once.

Each reader compensated on its own, and only one of them was country-neutral:

| Reader | Compensation | Result outside Greece |
|---|---|---|
| Meeting map (`utils.ts`, `subject.tsx`) | swaps unconditionally | correct |
| Landing map (`subject.ts`) | swaps only inside a Greek bounding box | **reversed** |
| Proximity and notifications | swaps when outside Greece | correct |

The landing map gate was `first > 30 && first < 42 && second > 19 && second < 30`:

| City | stored `[ST_X, ST_Y]` | passes gate? | rendered `[lng, lat]` |
|---|---|---|---|
| Athens (37.98 N, 23.74 E) | `[37.98, 23.74]` | yes | `[23.74, 37.98]` correct |
| Paris (48.86 N, 2.35 E) | `[48.86, 2.35]` | no, 48.86 > 42 | `[48.86, 2.35]` Indian Ocean |
| Belgrade (44.79 N, 20.46 E) | `[44.79, 20.46]` | no, 44.79 > 42 | `[44.79, 20.46]` Saudi Arabia |

Subjects without a location stay correct because they use the `City.geometry` centroid, which is stored in the proper order. That is why only some pins move.

## The change

The database becomes the single source of truth. The migration flips the stored geometries, and every compensating heuristic goes away.

- Migration `20260814120000_swap_subject_location_coordinates` flips subject locations with `ST_FlipCoordinates`.
- `src/lib/db/subject.ts` drops the Greek bounding box gate on the landing map.
- `src/lib/utils.ts` and `src/components/meetings/subject/subject.tsx` read `[x, y]` instead of `[y, x]`.
- `src/lib/db/location.ts` drops the `CASE WHEN` blocks in both proximity queries.
- `src/lib/db/notifications.ts` drops `isOutsideGreece` and both of its call sites.

`getSummarizeRequestBody` in `src/lib/db/utils.ts` needs no change. It sends `[[x, y]]`, which becomes `[lng, lat]` after the migration. opencouncil-tasks ignores that field and re-geocodes from `locationText`.

### The migration

```sql
UPDATE "Location" AS l
SET coordinates = ST_FlipCoordinates(l.coordinates)
WHERE EXISTS (SELECT 1 FROM "Subject" s WHERE s."locationId" = l.id);
```

`ST_FlipCoordinates` handles every `LocationType` and keeps the SRID. The `WHERE` clause excludes notification preference locations, which are already correct.

A location can in principle belong to both a subject and a notification preference, because `saveNotificationPreferences` connects any location id that exists. Such a row needs no special handling. The subject writer created it, so it is stored reversed, and proximity matching already ran against reversed data. The flip corrects it.

## Deployment

**This pull request must ship together with the opencouncil-tasks change.** That change is one line in `src/lib/subjectEnrichment.ts:60`:

```ts
coordinates: [[locationLatLng.lat, locationLatLng.lng]]   // before
coordinates: [[locationLatLng.lng, locationLatLng.lat]]   // after
```

Order:

1. Merge and deploy this pull request. The migration runs in the DO App Platform build phase.
2. Deploy opencouncil-tasks.

Between step 1 and step 2, any new subject the summarize pipeline writes lands reversed again. Hold summarize runs until step 2 finishes, or re-run the `UPDATE` above afterwards to repair the stragglers.

3. Regenerate the seed data and publish it to `schemalabz/opencouncil-seed-data`.

Step 3 matters for new contributors. The migration does nothing on a fresh database, because it runs before the seed and the `Location` table is still empty. The published `seed_data.json` holds the reversed coordinates, and `seed.ts` re-inserts them through `ST_GeomFromGeoJSON` without reordering. This pull request removes the heuristics that used to hide that. A contributor who seeds from the current dump therefore gets Greek pins near the Iraq border. Run `npm run generate-seed` against production after step 1 to produce a corrected dump.

The migration applies during the build, before the new code serves traffic. In that window the meeting page map shows Greek pins in the wrong place. The landing map, proximity, and notifications stay correct through the window, because their old heuristics are no-ops on correctly ordered Greek data.

### Verification

After the deploy, no subject location should have a Greek latitude in `ST_X`:

```sql
SELECT count(*) FROM "Location" l
JOIN "Subject" s ON s."locationId" = l.id
WHERE ST_X(l.coordinates) BETWEEN 34 AND 42;   -- expect 0
```

### Rollback

Re-run the same `UPDATE` to flip the rows back, then revert the code. The flip is its own inverse.

## Testing

- `npx tsc --noEmit` is clean.
- `npm test` passes: 104 suites, 1400 tests. `subjectToMapFeature` was asserting the old swap and now asserts `[lng, lat]`.
- The migration ran against the dev database inside a transaction and rolled back. It flipped 159 rows, `POINT(35.4876457 24.0750792)` became `POINT(24.0750792 35.4876457)`, and the verification query returned 0.
