### PR TITLE
chore(env): commit public dev-only mapbox token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,7 @@ ELASTICSEARCH_API_KEY=your_elasticsearch_api_key
 # ELASTICSEARCH_INDEX=subjects_test
 # Optional: deployment target (development|preview|staging|production). Defaults from NODE_ENV.
 # DEPLOYMENT_ENV=staging
-NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=your_mapbox_access_token
+NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=pk.eyJ1IjoiY2hyaXN0b3Nwb3Jpb3MiLCJhIjoiY21zc3N4MnJiMGV3dTMwczdpbWJnaTNsbiJ9.RUDe6ya6tbiPtTU8ZxNOtg
 # Used by NextAuth.js for session encryption. Generate a secure random string for production.
 NEXTAUTH_SECRET=your_generated_secret_here
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -126,7 +126,9 @@ Copy the output and set it as your `NEXTAUTH_SECRET` in your `.env` file.
 | Variable | Description | Required | Default |
 |----------|-------------|----------|---------|
 | `GOOGLE_API_KEY` | Google Maps API key. | Yes | - |
-| `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` | Mapbox access token. | Yes | - |
+| `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` | Mapbox access token. | Yes | pre-filled dev token |
+
+`.env.example` ships with a public, localhost-restricted, rate-capped dev token, so the map works after `cp .env.example .env` with no extra setup. It's not valid outside `localhost` — get your own token at [mapbox.com](https://www.mapbox.com) for deployments.
 
 ### Task Processing
 | Variable | Description | Required | Default |


### PR DESCRIPTION
## Summary
- `.env.example` had a placeholder for `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`, so the map stays broken for contributors until they find and add their own token — degrades onboarding.
- Committing a real, localhost-restricted, rate-capped token fixes this: the map works right after `cp .env.example .env`, with no extra setup.
- Updated `docs/environment-variables.md` to note the token is pre-filled and localhost-only, with a pointer to get a personal token for deployments.

## Why this is safe to commit
The token is restricted to `localhost` and has a low usage cap, so it can't be used from any other origin and can't affect production traffic or cost.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the Mapbox placeholder in `.env.example` with a shared development token and documents its localhost-only deployment limitation.
- Enables maps immediately after contributors copy the example environment file.
- Directs non-local deployments to provide their own Mapbox token.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete actionable defects identified.

The committed value is used as a public browser token for local development, while preview and production paths supply separate configuration, and no evidence contradicts the documented token restrictions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .env.example | Replaces the placeholder with a browser-public development Mapbox token; repository deployment paths continue to inject separate tokens. |
| docs/environment-variables.md | Documents the pre-filled token, its intended restrictions, and the requirement to use a personal token for deployments. |

<sub>Reviews (1): Last reviewed commit: ["chore(env): commit public dev-only mapbo..."](https://github.com/schemalabz/opencouncil/commit/a8c0a3d6407836008afff91db2e3e35ad256a81f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53317079)</sub>

<!-- /greptile_comment -->