### PR TITLE
feat(elastic): index administrative body and discussion duration metrics

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -164,6 +164,26 @@ PGSync requires helper views to denormalize complex relationships and handle Pos
 4. **SpeakerContributionSearchView** - Denormalizes speaker contributions
 5. **SubjectMetricsView** - Precomputes the per-subject discussion metrics
 6. **MeetingAdministrativeBodyView** - Flattens the Subject → CouncilMeeting → AdministrativeBody join and casts the type enum to text. Exposes only the id and the type, because search results hydrate the full body from PostgreSQL
+7. **CitySearchView** - Casts the `Realm` enum to text. Every other `City` column reaches the index as a direct column
+
+### Realm, Not Country
+
+The index stores `city_realm` (`greece`, `france`, `cyprus`, `serbia`), not an ISO country code.
+
+PostgreSQL holds no country column. `REALMS` in `src/lib/realm.ts` maps a realm to its country, and
+`getRealmCountry()` reads that map. A `CASE` expression in SQL would copy the map into a second place
+that no test covers, so a new realm would sync an empty or wrong country. A caller that needs the
+country resolves it from `city_realm` in application code.
+7. **CitySearchView** - Casts the `Realm` enum to text. Every other `City` column reaches the index as a direct column
+
+### Realm, Not Country
+
+The index stores `city_realm` (`greece`, `france`, `cyprus`, `serbia`), not an ISO country code.
+
+PostgreSQL holds no country column. `REALMS` in `src/lib/realm.ts` maps a realm to its country, and
+`getRealmCountry()` reads that map. A `CASE` expression in SQL would copy the map into a second place
+that no test covers, so a new realm would sync an empty or wrong country. A caller that needs the
+country resolves it from `city_realm` in application code.
 
 ### Discussion Metrics
 

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -161,6 +161,40 @@ PGSync requires helper views to denormalize complex relationships and handle Pos
 1. **LocationSearchView** - Converts PostGIS geometry to GeoJSON format
 2. **IntroducedByPartyView** - Resolves party affiliation through the `Role` table
 3. **SubjectSpeakerSegmentSearchView** - Denormalizes speaker segments with concatenated utterances
+4. **SpeakerContributionSearchView** - Denormalizes speaker contributions
+5. **SubjectMetricsView** - Precomputes the per-subject discussion metrics
+6. **MeetingAdministrativeBodyView** - Flattens the Subject → CouncilMeeting → AdministrativeBody join and casts the type enum to text. Exposes only the id and the type, because search results hydrate the full body from PostgreSQL
+
+### Discussion Metrics
+
+`SubjectMetricsView` precomputes two scalar fields, because a nested array costs a nested query to
+aggregate at search time. They exist for score rescoring. The search API exposes no filter on them:
+
+| Field | Meaning |
+|-------|---------|
+| `contributor_count` | Number of `SpeakerContribution` rows on the subject |
+| `discussion_speaking_seconds` | Time the council spent speaking about the subject |
+
+`contributor_count` counts rows, the same measure as `getContributionCount()` in `src/lib/utils.ts`.
+The count comes from `SpeakerContribution`, the model that replaces `SubjectSpeakerSegment`, so a
+subject that predates the contribution pipeline reports zero contributors.
+
+`discussion_speaking_seconds` repeats `getDiscussionSecondsForSubjects()` in `src/lib/db/subject.ts`, so
+the index agrees with the number the subject page shows:
+
+- **Primary source**: utterances tagged `SUBJECT_DISCUSSION`. The summarize task writes these tags.
+- **Excluded**: procedural segments, which are not part of a discussion.
+- **Fallback**: `SubjectSpeakerSegment`, and only for a subject with no tagged utterance at all. A
+  subject whose tagged utterances are all procedural reports 0 instead of falling back.
+
+Both sources sum the parts rather than measure the span from the first mention to the last, so a
+subject that the council revisits reports the time spent on it. The name avoids the word "duration"
+because `calculateMeetingDurationMs()` uses it for a wall-clock span.
+
+> **Never name the root table in `base_tables`.** `SubjectMetricsView` is keyed on the subject id, so
+> it is tempting to declare `base_tables: ["Subject"]`. That is what `SubjectSearchView` did, and it
+> made PGSync route `Subject` DELETE events as child re-syncs, so deleted subjects stayed in the
+> index. Declare only the tables the view actually reads.
 4. **SpeakerContributionSearchView** - Denormalizes speaker contributions with party resolution
 
 ### Create the Views

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -11,6 +11,7 @@ This document describes how OpenCouncil uses Elasticsearch to provide powerful s
 4. [Configure PostgreSQL Views](#configure-postgresql-views)
 5. [Configure the Ingest Pipeline](#configure-the-ingest-pipeline)
 6. [Set up PGSync](#set-up-pgsync)
+   - [Deploying a Schema Change](#deploying-a-schema-change)
 7. [Sync Data](#sync-data)
 8. [Search Examples](#search-examples)
 9. [Best Practices & FAQ](#best-practices--faq)
@@ -300,7 +301,9 @@ Expected output: `"description": "Ενημέρωση από τον Δήμαρχ�
 
 ### Schema Configuration
 
-> **Important**: The sync configuration is defined in `elasticsearch/schema.json`. Changing this schema effectively changes the structure of documents in Elasticsearch and requires re-indexing the entire index.
+> **Important**: The sync configuration is defined in `elasticsearch/schema.json`. A change to this file
+> changes the structure of the documents in Elasticsearch. Some changes need a new index; most do not.
+> See [Deploying a Schema Change](#deploying-a-schema-change).
 
 The `elasticsearch/schema.json` file defines:
 - **Index mapping**: Elasticsearch field types, analyzers
@@ -312,6 +315,100 @@ The `elasticsearch/schema.json` file defines:
 **Resources for understanding the schema:**
 - [PGSync Schema Documentation](https://pgsync.com/schema/) - Official guide to schema configuration
 - [PGSync Examples](https://github.com/toluaina/pgsync/tree/main/examples) - Example schemas for various use cases
+
+### Deploying a Schema Change
+
+PGSync sends the `mapping` block from `schema.json` **only when it creates the index**
+(`pgsync/search_client.py`, `if not indices.exists(...)`). On an index that already exists the block is
+inert. The local E2E harness recreates its index on every run (see
+[Testing Schema Changes](#testing-schema-changes)), so it always takes the create path — the path
+production never takes.
+
+Two consequences follow. A new field needs an explicit mapping call against the live index. That call is
+also sufficient: an additive change needs no new index.
+
+#### 1. Rehearse the mapping change
+
+The mapping call is atomic and idempotent — one conflicting field rejects the whole request, so it can
+never apply half a change, and re-running an unchanged block does nothing. It is still a write to the
+live index, and one of its outcomes commits you to a much larger job. Find out which outcome you are
+getting on a copy first.
+
+```bash
+AUTH="Authorization: ApiKey $ELASTICSEARCH_API_KEY"
+JSON="Content-Type: application/json"
+IDX="${ELASTICSEARCH_INDEX:-subjects}"
+
+# copy the live mapping into a throwaway index
+curl -sS -H "$AUTH" "$ELASTICSEARCH_URL/$IDX/_mapping" \
+| python3 -c "import json,sys;m=list(json.load(sys.stdin).values())[0]['mappings'];m.pop('_meta',None);print(json.dumps({'mappings':m}))" \
+| curl -sS -X PUT -H "$AUTH" -H "$JSON" "$ELASTICSEARCH_URL/mapping-rehearsal" --data-binary @-
+
+# apply the declared block to the copy and read the response
+python3 -c "import json;print(json.dumps({'properties':json.load(open('elasticsearch/schema.json'))[0]['mapping']}))" \
+| curl -sS -X PUT -H "$AUTH" -H "$JSON" "$ELASTICSEARCH_URL/mapping-rehearsal/_mapping" --data-binary @-
+
+curl -sS -X DELETE -H "$AUTH" "$ELASTICSEARCH_URL/mapping-rehearsal"
+```
+
+The response tells you which change you are making:
+
+| Response | Change | Existing documents | Action |
+|---|---|---|---|
+| `400 illegal_argument_exception` | a field changed type, analyzer, or `inference_id` | keep the old mapping | build a new index, sync it, switch `ELASTICSEARCH_INDEX`. Do not run the live call. |
+| `acknowledged`, new top-level field | additive | hold no value yet | continue below |
+| `acknowledged`, new **sub**field on an existing field (`.keyword`, `.semantic`) | additive to the mapping only | **silently hold no value, and a backfill cannot fill them** | every document must be rewritten with its source text |
+
+> The third row is why the rehearsal is worth the two minutes. It succeeds, so running it on the live
+> index commits you before you know the cost. The mapping reads as correct and no error appears, but the
+> subfield exists only for documents written after the call. Verify such a change by querying the new
+> field for an **old** document — never by reading the mapping back.
+
+#### 2. Deploy
+
+The index name comes from `ELASTICSEARCH_INDEX` (default `subjects`). Staging and preview leave it unset
+and read the production index, so there is one index to migrate.
+
+1. **Views** — `psql "$DATABASE_URL" < elasticsearch/views.sql`, on every database PGSync reads.
+2. **Mapping** — the same call as the rehearsal, against `$IDX` instead of `mapping-rehearsal`. Run it
+   before any document carries the new field: a field that reaches the index first gets its type from
+   dynamic mapping, so a string becomes `text` + `.keyword` rather than `keyword`, permanently.
+   `location_id` is already in this state.
+3. **Schema** — deploy the new `schema.json` and restart the PGSync daemon.
+4. **Backfill** — fill the documents that already exist (below).
+5. **Verify** — below.
+
+Step 3 must precede step 4. A live-sync write from the old `schema.json` is a full-document `index`
+operation, so it replaces the document and drops the new fields.
+
+#### 3. Backfill
+
+Elasticsearch never fills a new field on documents that already exist. Two ways to fill them:
+
+| | Cost | Notes |
+|---|---|---|
+| PGSync `--bootstrap` | re-embeds every document — tens of minutes on a single inference allocation | full re-read of Postgres, and the replication slot stalls for the duration |
+| bulk `update` carrying only the new fields | no inference at all | `name` and `description` are absent from the request, so no inference request is generated |
+
+Prefer the bulk `update`.
+
+#### 4. Verify
+
+```bash
+# the index matches the repository: no undeclared fields, no type conflicts
+diff <(python3 -c "import json;print('\n'.join(sorted(json.load(open('elasticsearch/schema.json'))[0]['mapping'])))") \
+     <(curl -sS -H "$AUTH" "$ELASTICSEARCH_URL/$IDX/_mapping" \
+       | python3 -c "import json,sys;print('\n'.join(sorted(k for k in list(json.load(sys.stdin).values())[0]['mappings']['properties'] if k!='_meta')))")
+
+# a keyword field aggregates. A field that fell back to `text` fails here.
+curl -sS -H "$AUTH" -H "$JSON" "$ELASTICSEARCH_URL/$IDX/_search?size=0" \
+  -d '{"aggs":{"t":{"terms":{"field":"administrative_body_type"}}}}'
+```
+
+Then spot-check a document that predates the change, and confirm a semantic query still returns its
+usual results.
+
+`_cat/indices` reports `docs.count` including nested documents. Use `_count` for the number of subjects.
 
 ### Deployment and Sync Operations
 
@@ -826,6 +923,35 @@ A: PGSync's live sync receives WAL events with the base table's original column 
 3. Use `transform.rename` to map to the desired Elasticsearch field name (`"id": "contribution_id"`)
 
 This ensures bootstrap (reads from view) and live sync (reads from WAL) both work correctly.
+
+**Q: When do the discussion metrics refresh?**  
+A: PGSync rebuilds the whole document when it re-syncs a `Subject`, and it re-syncs a `Subject` only when
+the `Subject` row itself changes. A change to a child table does not trigger it, whatever `base_tables`
+declares (see [Testing Live Sync](#testing-live-sync-important)) — the aggregate source rows carry their
+own primary keys, which cannot match a subject id.
+
+Both metrics therefore depend on their data committing together with a `Subject` write:
+
+- `contributor_count` — `saveSubjectsForMeeting` writes the subjects and their contributions in one
+  transaction, so the count is always current.
+- `discussion_speaking_seconds` — the summarize task's utterance discussion tags are applied inside that
+  same transaction for this reason. Written afterwards, they would never reach the index and every newly
+  summarized subject would report 0.
+
+So a writer that changes an utterance's discussion tag must do it alongside the subject write. Test both
+bootstrap and live sync after you change the aggregates in `SubjectMetricsView`. Touch the parent `Subject`
+row if the numbers look stale.
+
+**Q: Why does an edit to an administrative body not appear in search?**  
+A: `MeetingAdministrativeBodyView` has the primary key `(id, cityId)` of `CouncilMeeting`, so only
+`CouncilMeeting` is declared as its base table. Moving a meeting to another body is a `CouncilMeeting`
+write and syncs on its own. Editing the body row is not, so a type change reaches the index only when the
+meeting or one of its subjects is next written.
+
+A rename needs no sync at all: the index stores `administrative_body_id` and `administrative_body_type`
+and no names, because search results hydrate the full body from PostgreSQL. Only a corrected `type` goes
+stale, and it self-heals on the next write to the meeting or the subject. Update the `Subject` row to
+force it sooner.
 
 **Q: How is the speaker segments text concatenated?**  
 A: The `SubjectSpeakerSegmentSearchView` view concatenates all utterance texts within each speaker segment using `string_agg()`, ordered by timestamp. PGSync reads from this view and indexes the concatenated text.

--- a/elasticsearch/schema.json
+++ b/elasticsearch/schema.json
@@ -37,6 +37,7 @@
         "analyzer": "standard",
         "fields": { "keyword": { "type": "keyword", "ignore_above": 256 } }
       },
+      "city_realm": { "type": "keyword" },
       "councilMeeting_id": { "type": "keyword" },
       "meeting_date": { "type": "date" },
       "meeting_name": { "type": "text", "analyzer": "greek" },
@@ -397,6 +398,19 @@
             "rename": {
               "id": "contribution_id"
             }
+          }
+        },
+        {
+          "table": "CitySearchView",
+          "schema": "public",
+          "base_tables": ["City"],
+          "primary_key": ["id"],
+          "columns": ["realm"],
+          "label": "city_realm",
+          "relationship": {
+            "variant": "scalar",
+            "type": "one_to_one",
+            "foreign_key": { "parent": ["cityId"], "child": ["id"] }
           }
         },
         {

--- a/elasticsearch/schema.json
+++ b/elasticsearch/schema.json
@@ -41,6 +41,8 @@
       "meeting_date": { "type": "date" },
       "meeting_name": { "type": "text", "analyzer": "greek" },
       "meeting_released": { "type": "boolean" },
+      "administrative_body_id": { "type": "keyword" },
+      "administrative_body_type": { "type": "keyword" },
       "topic_id": { "type": "keyword" },
       "topic_name": {
         "type": "text",
@@ -82,6 +84,8 @@
       "updated_at": { "type": "date" },
       "context": { "type": "text", "analyzer": "greek" },
       "context_citation_urls": { "type": "keyword" },
+      "contributor_count": { "type": "integer" },
+      "discussion_speaking_seconds": { "type": "float" },
       "speaker_segments": {
         "type": "nested",
         "properties": {
@@ -393,6 +397,58 @@
             "rename": {
               "id": "contribution_id"
             }
+          }
+        },
+        {
+          "table": "MeetingAdministrativeBodyView",
+          "schema": "public",
+          "base_tables": ["CouncilMeeting", "AdministrativeBody"],
+          "primary_key": ["id", "cityId"],
+          "columns": ["administrative_body_id"],
+          "label": "administrative_body_id",
+          "relationship": {
+            "variant": "scalar",
+            "type": "one_to_one",
+            "foreign_key": { "parent": ["councilMeetingId", "cityId"], "child": ["id", "cityId"] }
+          }
+        },
+        {
+          "table": "MeetingAdministrativeBodyView",
+          "schema": "public",
+          "base_tables": ["CouncilMeeting", "AdministrativeBody"],
+          "primary_key": ["id", "cityId"],
+          "columns": ["administrative_body_type"],
+          "label": "administrative_body_type",
+          "relationship": {
+            "variant": "scalar",
+            "type": "one_to_one",
+            "foreign_key": { "parent": ["councilMeetingId", "cityId"], "child": ["id", "cityId"] }
+          }
+        },
+        {
+          "table": "SubjectMetricsView",
+          "schema": "public",
+          "base_tables": ["SpeakerContribution", "Utterance", "SpeakerSegment", "Summary", "SubjectSpeakerSegment"],
+          "primary_key": ["id"],
+          "columns": ["contributor_count"],
+          "label": "contributor_count",
+          "relationship": {
+            "variant": "scalar",
+            "type": "one_to_one",
+            "foreign_key": { "parent": ["id"], "child": ["id"] }
+          }
+        },
+        {
+          "table": "SubjectMetricsView",
+          "schema": "public",
+          "base_tables": ["SpeakerContribution", "Utterance", "SpeakerSegment", "Summary", "SubjectSpeakerSegment"],
+          "primary_key": ["id"],
+          "columns": ["discussion_speaking_seconds"],
+          "label": "discussion_speaking_seconds",
+          "relationship": {
+            "variant": "scalar",
+            "type": "one_to_one",
+            "foreign_key": { "parent": ["id"], "child": ["id"] }
           }
         }
       ]

--- a/elasticsearch/schema.json
+++ b/elasticsearch/schema.json
@@ -414,11 +414,9 @@
           }
         },
         {
-          "table": "MeetingAdministrativeBodyView",
+          "table": "CouncilMeeting",
           "schema": "public",
-          "base_tables": ["CouncilMeeting", "AdministrativeBody"],
-          "primary_key": ["id", "cityId"],
-          "columns": ["administrative_body_id"],
+          "columns": ["administrativeBodyId"],
           "label": "administrative_body_id",
           "relationship": {
             "variant": "scalar",
@@ -429,7 +427,7 @@
         {
           "table": "MeetingAdministrativeBodyView",
           "schema": "public",
-          "base_tables": ["CouncilMeeting", "AdministrativeBody"],
+          "base_tables": ["CouncilMeeting"],
           "primary_key": ["id", "cityId"],
           "columns": ["administrative_body_type"],
           "label": "administrative_body_type",

--- a/elasticsearch/validate-views.sql
+++ b/elasticsearch/validate-views.sql
@@ -148,6 +148,8 @@ WHERE tagged.seconds > 0;
 -- 7. Validate MeetingAdministrativeBodyView - two-hop join and enum cast
 -- ============================================================================
 \echo '7. Validating MeetingAdministrativeBodyView...'
+-- The expected values come from pg_enum, not a hardcoded list, so a new AdministrativeBodyType
+-- flows through the cast on its own instead of failing this check.
 SELECT
   COUNT(*) AS total_meetings,
   COUNT(administrative_body_id) AS with_body,
@@ -155,8 +157,12 @@ SELECT
   CASE
     WHEN COUNT(CASE WHEN administrative_body_id IS NOT NULL AND administrative_body_type IS NULL THEN 1 END) > 0
       THEN 'FAIL: Body present but type missing'
-    WHEN COUNT(CASE WHEN administrative_body_type NOT IN ('council', 'committee', 'community') THEN 1 END) > 0
-      THEN 'FAIL: Unexpected administrative body type'
+    WHEN COUNT(CASE WHEN administrative_body_type NOT IN (
+      SELECT e.enumlabel FROM pg_enum e
+      INNER JOIN pg_type t ON t.oid = e.enumtypid
+      WHERE t.typname = 'AdministrativeBodyType'
+    ) THEN 1 END) > 0
+      THEN 'FAIL: Type outside the AdministrativeBodyType enum'
     ELSE 'PASS: Types resolve correctly'
   END AS validation_result
 FROM "MeetingAdministrativeBodyView";

--- a/elasticsearch/validate-views.sql
+++ b/elasticsearch/validate-views.sql
@@ -26,7 +26,8 @@ WHERE schemaname = 'public'
     'SubjectSpeakerSegmentSearchView',
     'SpeakerContributionSearchView',
     'SubjectMetricsView',
-    'MeetingAdministrativeBodyView'
+    'MeetingAdministrativeBodyView',
+    'CitySearchView'
   )
 ORDER BY viewname;
 
@@ -159,6 +160,39 @@ SELECT
     ELSE 'PASS: Types resolve correctly'
   END AS validation_result
 FROM "MeetingAdministrativeBodyView";
+
+\echo ''
+
+-- ============================================================================
+-- 8. Validate CitySearchView - realm enum cast
+-- ============================================================================
+\echo '8. Validating CitySearchView...'
+-- The expected values come from pg_enum, not from a hardcoded list. A new realm must
+-- flow through the cast on its own, so this check must not fail when someone adds one.
+SELECT
+  COUNT(*) AS total_cities,
+  COUNT(realm) AS with_realm,
+  CASE
+    WHEN COUNT(*) - COUNT(realm) > 0
+      THEN 'FAIL: Realm must never be NULL'
+    WHEN COUNT(CASE WHEN realm NOT IN (
+      SELECT e.enumlabel FROM pg_enum e
+      INNER JOIN pg_type t ON t.oid = e.enumtypid
+      WHERE t.typname = 'Realm'
+    ) THEN 1 END) > 0
+      THEN 'FAIL: Realm outside the Realm enum'
+    ELSE 'PASS: Realms cast to text correctly'
+  END AS validation_result
+FROM "CitySearchView";
+
+\echo ''
+\echo '   Cities per realm:'
+SELECT
+  realm,
+  COUNT(*) AS cities
+FROM "CitySearchView"
+GROUP BY 1
+ORDER BY 2 DESC;
 
 \echo ''
 

--- a/elasticsearch/validate-views.sql
+++ b/elasticsearch/validate-views.sql
@@ -24,7 +24,9 @@ WHERE schemaname = 'public'
     'LocationSearchView',
     'IntroducedByPartyView',
     'SubjectSpeakerSegmentSearchView',
-    'SpeakerContributionSearchView'
+    'SpeakerContributionSearchView',
+    'SubjectMetricsView',
+    'MeetingAdministrativeBodyView'
   )
 ORDER BY viewname;
 
@@ -90,6 +92,73 @@ SELECT
   COUNT(geojson) AS with_geojson,
   COUNT(*) - COUNT(geojson) AS missing_geojson
 FROM "LocationSearchView";
+
+\echo ''
+
+-- ============================================================================
+-- 6. Validate SubjectMetricsView - discussion metrics
+-- ============================================================================
+\echo '6. Validating SubjectMetricsView (discussion metrics)...'
+SELECT
+  COUNT(*) AS total_subjects,
+  COUNT(CASE WHEN contributor_count IS NULL OR discussion_speaking_seconds IS NULL THEN 1 END) AS null_metrics,
+  COUNT(CASE WHEN contributor_count < 0 OR discussion_speaking_seconds < 0 THEN 1 END) AS negative_metrics,
+  CASE
+    WHEN COUNT(CASE WHEN contributor_count IS NULL OR discussion_speaking_seconds IS NULL THEN 1 END) > 0
+      THEN 'FAIL: Metrics must never be NULL'
+    WHEN COUNT(CASE WHEN contributor_count < 0 OR discussion_speaking_seconds < 0 THEN 1 END) > 0
+      THEN 'FAIL: Negative metrics found'
+    ELSE 'PASS: Metrics are non-null and non-negative'
+  END AS validation_result
+FROM "SubjectMetricsView";
+
+\echo ''
+\echo '   Checking the speaking time reads the current source (tagged utterances)...'
+-- The regression this catches: the view sums SubjectSpeakerSegment, which the summarize task
+-- no longer writes, so every subject from the contribution pipeline reports 0 seconds.
+WITH tagged AS (
+  SELECT u."discussionSubjectId" AS id,
+         SUM(u."endTimestamp" - u."startTimestamp")
+           FILTER (WHERE sm.type IS NULL OR sm.type::text <> 'procedural') AS seconds
+  FROM "Utterance" u
+  INNER JOIN "SpeakerSegment" ss ON ss.id = u."speakerSegmentId"
+  LEFT JOIN "Summary" sm ON sm."speakerSegmentId" = ss.id
+  WHERE u."discussionStatus"::text = 'SUBJECT_DISCUSSION'
+    AND u."discussionSubjectId" IS NOT NULL
+  GROUP BY 1
+)
+SELECT
+  COUNT(*) AS subjects_with_tagged_time,
+  COUNT(CASE WHEN v.discussion_speaking_seconds = 0 THEN 1 END) AS reporting_zero,
+  CASE
+    WHEN COUNT(*) = 0
+      THEN 'SKIP: No tagged utterances in this database'
+    WHEN COUNT(CASE WHEN v.discussion_speaking_seconds = 0 THEN 1 END) > 0
+      THEN 'FAIL: Subjects with tagged discussion time report 0 seconds'
+    ELSE 'PASS: Speaking time follows the tagged utterances'
+  END AS validation_result
+FROM tagged
+INNER JOIN "SubjectMetricsView" v ON v.id = tagged.id
+WHERE tagged.seconds > 0;
+
+\echo ''
+
+-- ============================================================================
+-- 7. Validate MeetingAdministrativeBodyView - two-hop join and enum cast
+-- ============================================================================
+\echo '7. Validating MeetingAdministrativeBodyView...'
+SELECT
+  COUNT(*) AS total_meetings,
+  COUNT(administrative_body_id) AS with_body,
+  COUNT(*) - COUNT(administrative_body_id) AS without_body,
+  CASE
+    WHEN COUNT(CASE WHEN administrative_body_id IS NOT NULL AND administrative_body_type IS NULL THEN 1 END) > 0
+      THEN 'FAIL: Body present but type missing'
+    WHEN COUNT(CASE WHEN administrative_body_type NOT IN ('council', 'committee', 'community') THEN 1 END) > 0
+      THEN 'FAIL: Unexpected administrative body type'
+    ELSE 'PASS: Types resolve correctly'
+  END AS validation_result
+FROM "MeetingAdministrativeBodyView";
 
 \echo ''
 

--- a/elasticsearch/views.sql
+++ b/elasticsearch/views.sql
@@ -143,6 +143,95 @@ LEFT JOIN LATERAL (
 \echo '✓ SpeakerContributionSearchView created'
 \echo ''
 
+-- View 5: Per-subject discussion metrics
+-- Why this view? A nested array costs a nested query to aggregate at search time, so the
+-- contributor count and the speaking time are precomputed here as scalar columns. They feed
+-- score rescoring, not search filters.
+--
+-- IMPORTANT: base_tables in schema.json must never name Subject, the root table. A child node
+-- that claims the root table makes PGSync route Subject DELETE events as child re-syncs, and
+-- deleted subjects then stay in the index. That is why SubjectSearchView was removed. This view
+-- reads only the tables the aggregates come from.
+--
+-- contributor_count counts SpeakerContribution rows, which matches getContributionCount() in
+-- src/lib/utils.ts. Both feed the same discussion signal, so they must agree. The count comes
+-- from SpeakerContribution, the model that replaces SubjectSpeakerSegment, so a subject that
+-- predates the contribution pipeline reports zero contributors.
+--
+-- discussion_speaking_seconds must equal what the subject page shows, so it repeats
+-- getDiscussionSecondsForSubjects in src/lib/db/subject.ts:
+--   - Tagged SUBJECT_DISCUSSION utterances are the primary source. The summarize task writes
+--     them inside the subject transaction; it no longer writes SubjectSpeakerSegment.
+--   - Procedural segments do not count towards a discussion.
+--   - SubjectSpeakerSegment is the fallback, and only for a subject with no tagged utterance at
+--     all. A subject whose tagged utterances are all procedural reports 0 rather than falling
+--     back, which is why each branch uses HAVING COUNT(*) > 0.
+-- Both branches sum the parts, so a subject that the council revisits reports the time spent on
+-- it, not the span from the first mention to the last. The name says "speaking" because
+-- "duration" already means a wall-clock span here (see calculateMeetingDurationMs).
+\echo 'Creating SubjectMetricsView...'
+CREATE OR REPLACE VIEW "SubjectMetricsView" AS
+SELECT
+  s.id,
+  (
+    SELECT COUNT(*)
+    FROM "SpeakerContribution" sc
+    WHERE sc."subjectId" = s.id
+  ) AS contributor_count,
+  COALESCE(tagged.seconds, legacy.seconds, 0) AS discussion_speaking_seconds
+FROM "Subject" s
+LEFT JOIN LATERAL (
+  SELECT COALESCE(
+    SUM(u."endTimestamp" - u."startTimestamp")
+      FILTER (WHERE sm.type IS NULL OR sm.type::text <> 'procedural'),
+    0
+  ) AS seconds
+  FROM "Utterance" u
+  INNER JOIN "SpeakerSegment" ss ON ss.id = u."speakerSegmentId"
+  LEFT JOIN "Summary" sm ON sm."speakerSegmentId" = ss.id
+  WHERE u."discussionSubjectId" = s.id
+    AND u."discussionStatus"::text = 'SUBJECT_DISCUSSION'
+  HAVING COUNT(*) > 0
+) tagged ON true
+LEFT JOIN LATERAL (
+  SELECT COALESCE(
+    SUM(ss."endTimestamp" - ss."startTimestamp")
+      FILTER (WHERE sm.type IS NULL OR sm.type::text <> 'procedural'),
+    0
+  ) AS seconds
+  FROM "SubjectSpeakerSegment" sss
+  INNER JOIN "SpeakerSegment" ss ON ss.id = sss."speakerSegmentId"
+  LEFT JOIN "Summary" sm ON sm."speakerSegmentId" = ss.id
+  WHERE sss."subjectId" = s.id
+  HAVING COUNT(*) > 0
+) legacy ON true;
+\echo '✓ SubjectMetricsView created'
+\echo ''
+
+-- View 6: Administrative body of the meeting a subject belongs to
+-- Why this view? Subject reaches AdministrativeBody only through CouncilMeeting,
+-- which PGSync cannot express as a single relationship. This view:
+--   - Flattens the two-hop join into one row per meeting
+--   - Casts the AdministrativeBodyType enum to text, which Elasticsearch can index
+--
+-- Only the id and the type are exposed. Search filters on both, and search results
+-- hydrate the full administrativeBody from PostgreSQL, so indexing the names would
+-- duplicate data that no query reads.
+--
+-- IMPORTANT: Primary key columns keep their original names (`id`, `cityId`).
+-- See the note on SpeakerContributionSearchView for why WAL requires this.
+\echo 'Creating MeetingAdministrativeBodyView...'
+CREATE OR REPLACE VIEW "MeetingAdministrativeBodyView" AS
+SELECT
+  cm.id,  -- Keep as `id`/`cityId` for WAL compatibility
+  cm."cityId",
+  ab.id AS administrative_body_id,
+  ab.type::text AS administrative_body_type
+FROM "CouncilMeeting" cm
+LEFT JOIN "AdministrativeBody" ab ON ab.id = cm."administrativeBodyId";
+\echo '✓ MeetingAdministrativeBodyView created'
+\echo ''
+
 -- ============================================================================
 -- VERIFICATION CHECKS
 -- ============================================================================
@@ -155,12 +244,12 @@ LEFT JOIN LATERAL (
 \echo '1. Checking if all views exist...'
 SELECT 
   CASE 
-    WHEN COUNT(*) = 4 THEN '   ✓ All 4 views exist'
-    ELSE '   ✗ Missing views! Expected 4, found ' || COUNT(*)::text
+    WHEN COUNT(*) = 6 THEN '   ✓ All 6 views exist'
+    ELSE '   ✗ Missing views! Expected 6, found ' || COUNT(*)::text
   END AS result
 FROM pg_views
 WHERE schemaname = 'public'
-  AND viewname IN ('LocationSearchView', 'IntroducedByPartyView', 'SubjectSpeakerSegmentSearchView', 'SpeakerContributionSearchView');
+  AND viewname IN ('LocationSearchView', 'IntroducedByPartyView', 'SubjectSpeakerSegmentSearchView', 'SpeakerContributionSearchView', 'SubjectMetricsView', 'MeetingAdministrativeBodyView');
 \echo ''
 
 -- Check 2: LocationSearchView - verify it returns data
@@ -248,6 +337,51 @@ SELECT
 FROM "SpeakerContributionSearchView"
 WHERE text IS NOT NULL AND text != ''
 LIMIT 3;
+\echo ''
+
+-- Check 7: SubjectMetricsView - verify the discussion metrics
+\echo '7. Checking SubjectMetricsView data...'
+SELECT
+  COUNT(*) AS total_subjects,
+  COUNT(*) FILTER (WHERE contributor_count > 0) AS subjects_with_contributors,
+  COUNT(*) FILTER (WHERE discussion_speaking_seconds > 0) AS subjects_with_speaking_time,
+  ROUND(MAX(discussion_speaking_seconds)::numeric, 1) AS longest_discussion_seconds
+FROM "SubjectMetricsView";
+\echo ''
+
+\echo '   Source of discussion_speaking_seconds:'
+\echo '   (production data is mostly tagged utterances; seeded data is mostly the fallback)'
+SELECT
+  COUNT(*) FILTER (WHERE u.n > 0) AS from_tagged_utterances,
+  COUNT(*) FILTER (WHERE u.n = 0 AND sss.n > 0) AS from_legacy_fallback,
+  COUNT(*) FILTER (WHERE u.n = 0 AND sss.n = 0) AS no_timing_source
+FROM "Subject" s
+LEFT JOIN LATERAL (
+  SELECT COUNT(*) AS n FROM "Utterance" x
+  WHERE x."discussionSubjectId" = s.id AND x."discussionStatus"::text = 'SUBJECT_DISCUSSION'
+) u ON true
+LEFT JOIN LATERAL (
+  SELECT COUNT(*) AS n FROM "SubjectSpeakerSegment" x WHERE x."subjectId" = s.id
+) sss ON true;
+\echo ''
+
+-- Check 8: MeetingAdministrativeBodyView - verify administrative body resolution
+\echo '8. Checking MeetingAdministrativeBodyView data...'
+SELECT
+  COUNT(*) AS total_meetings,
+  COUNT(administrative_body_id) AS meetings_with_body,
+  COUNT(*) - COUNT(administrative_body_id) AS meetings_missing_body,
+  COUNT(DISTINCT administrative_body_type) AS distinct_types
+FROM "MeetingAdministrativeBodyView";
+\echo ''
+
+\echo '   Meetings per administrative body type:'
+SELECT
+  COALESCE(administrative_body_type, '(none)') AS administrative_body_type,
+  COUNT(*) AS meetings
+FROM "MeetingAdministrativeBodyView"
+GROUP BY 1
+ORDER BY 2 DESC;
 \echo ''
 
 -- Final Summary

--- a/elasticsearch/views.sql
+++ b/elasticsearch/views.sql
@@ -232,6 +232,23 @@ LEFT JOIN "AdministrativeBody" ab ON ab.id = cm."administrativeBodyId";
 \echo '✓ MeetingAdministrativeBodyView created'
 \echo ''
 
+-- View 7: Realm of the city a subject belongs to
+-- Why this view? Only to cast the Realm enum to text, which Elasticsearch can index.
+-- Every other City column reaches the index as a direct column on a child node.
+--
+-- The index stores the realm, not an ISO country code. The realm -> country map lives in REALMS
+-- in src/lib/realm.ts, and getRealmCountry() reads it. Repeating that map in SQL would make a
+-- second source of truth that no test covers, so a new realm would sync a wrong or empty
+-- country. A caller that wants the country resolves it from the realm in application code.
+\echo 'Creating CitySearchView...'
+CREATE OR REPLACE VIEW "CitySearchView" AS
+SELECT
+  c.id,  -- Keep as `id` for WAL compatibility
+  c.realm::text AS realm
+FROM "City" c;
+\echo '✓ CitySearchView created'
+\echo ''
+
 -- ============================================================================
 -- VERIFICATION CHECKS
 -- ============================================================================
@@ -244,12 +261,12 @@ LEFT JOIN "AdministrativeBody" ab ON ab.id = cm."administrativeBodyId";
 \echo '1. Checking if all views exist...'
 SELECT 
   CASE 
-    WHEN COUNT(*) = 6 THEN '   ✓ All 6 views exist'
-    ELSE '   ✗ Missing views! Expected 6, found ' || COUNT(*)::text
+    WHEN COUNT(*) = 7 THEN '   ✓ All 7 views exist'
+    ELSE '   ✗ Missing views! Expected 7, found ' || COUNT(*)::text
   END AS result
 FROM pg_views
 WHERE schemaname = 'public'
-  AND viewname IN ('LocationSearchView', 'IntroducedByPartyView', 'SubjectSpeakerSegmentSearchView', 'SpeakerContributionSearchView', 'SubjectMetricsView', 'MeetingAdministrativeBodyView');
+  AND viewname IN ('LocationSearchView', 'IntroducedByPartyView', 'SubjectSpeakerSegmentSearchView', 'SpeakerContributionSearchView', 'SubjectMetricsView', 'MeetingAdministrativeBodyView', 'CitySearchView');
 \echo ''
 
 -- Check 2: LocationSearchView - verify it returns data
@@ -380,6 +397,24 @@ SELECT
   COALESCE(administrative_body_type, '(none)') AS administrative_body_type,
   COUNT(*) AS meetings
 FROM "MeetingAdministrativeBodyView"
+GROUP BY 1
+ORDER BY 2 DESC;
+\echo ''
+
+-- Check 9: CitySearchView - verify the realm cast
+\echo '9. Checking CitySearchView data...'
+SELECT
+  COUNT(*) AS total_cities,
+  COUNT(realm) AS cities_with_realm,
+  COUNT(*) - COUNT(realm) AS cities_missing_realm
+FROM "CitySearchView";
+\echo ''
+
+\echo '   Cities per realm:'
+SELECT
+  COALESCE(realm, '(none)') AS realm,
+  COUNT(*) AS cities
+FROM "CitySearchView"
 GROUP BY 1
 ORDER BY 2 DESC;
 \echo ''

--- a/elasticsearch/views.sql
+++ b/elasticsearch/views.sql
@@ -214,9 +214,15 @@ LEFT JOIN LATERAL (
 --   - Flattens the two-hop join into one row per meeting
 --   - Casts the AdministrativeBodyType enum to text, which Elasticsearch can index
 --
--- Only the id and the type are exposed. Search filters on both, and search results
--- hydrate the full administrativeBody from PostgreSQL, so indexing the names would
--- duplicate data that no query reads.
+-- Only the type reaches the index through this view. administrative_body_id is
+-- CouncilMeeting."administrativeBodyId" verbatim (the join can only reproduce it), so
+-- schema.json reads that column straight off CouncilMeeting and gets normal WAL routing
+-- for a meeting that moves to another body. The id column stays here because
+-- validate-views.sql pairs it with the type, and because CREATE OR REPLACE VIEW cannot
+-- drop a column from an existing view.
+--
+-- The names are not indexed: search results hydrate the full administrativeBody from
+-- PostgreSQL, so indexing them would duplicate data that no query reads.
 --
 -- IMPORTANT: Primary key columns keep their original names (`id`, `cityId`).
 -- See the note on SpeakerContributionSearchView for why WAL requires this.

--- a/elasticsearch/views.sql
+++ b/elasticsearch/views.sql
@@ -320,7 +320,7 @@ FROM "SubjectSpeakerSegmentSearchView";
 \echo '   Sample data from SubjectSpeakerSegmentSearchView:'
 SELECT 
   subject_id,
-  segment_id,
+  id AS segment_id,
   speaker_person_name,
   speaker_party_name,
   LEFT(text, 50) || '...' AS text_preview

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -6,14 +6,20 @@ import { getPartiesForCity } from "./parties";
 import { getTopics } from "./topics";
 import { getCity } from "./cities";
 import { getCouncilMeeting } from "./meetings";
-import { RequestOnTranscript, SummarizeRequest, TranscribeRequest, Subject } from "../apiTypes";
+import { RequestOnTranscript, SummarizeRequest, SummarizeResult, TranscribeRequest, Subject } from "../apiTypes";
 import prisma from "./prisma";
 import { getSubjectsForMeeting, extractUtteranceIdsFromContributions } from "./subject";
-import { Subject as DbSubject } from "@prisma/client";
+import { DiscussionStatus, Subject as DbSubject } from "@prisma/client";
 import { getPartyFromRoles, getRoleNameForPerson } from "../utils";
 import { roleWithRelationsInclude } from "./types";
 import { categorizeSubjectsForUpsert } from "./subject-helpers";
 import { getRealmCountry } from "@/lib/realm";
+
+// discussionStatus arrives from the external task server, so it is validated before it
+// reaches Prisma. An unknown value is a PrismaClientValidationError, which would abort the
+// whole subject transaction. src/lib/db/speakerSegments.ts validates the same field on the
+// editor path, where an invalid value is a caller error and throws.
+const VALID_DISCUSSION_STATUSES = new Set<string>(Object.values(DiscussionStatus));
 
 // Type for the Prisma interactive transaction client
 type PrismaTxClient = Omit<typeof prisma, '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'>;
@@ -284,6 +290,73 @@ async function linkDiscussedInReferences(
 // --- Exported functions ---
 
 /**
+ * Applies the summarize task's utterance discussion tags inside the caller's transaction.
+ *
+ * These tags must commit together with the subjects they point at. PGSync re-indexes a subject
+ * only when the Subject row itself changes, so tags written after the subject transaction
+ * commits never reach the search index and the discussion metrics stay at their pre-tagging
+ * values. See "Deploying a Schema Change" in elasticsearch/README.md.
+ *
+ * Rows are grouped by (subject, status) so one meeting costs tens of statements rather than
+ * thousands. An id that no longer exists simply matches nothing, so a regenerated transcript
+ * needs no separate existence check.
+ *
+ * @param tx            the caller's transaction client
+ * @param statuses      utterance discussion statuses from the summarize response
+ * @param subjectIdMap  API subject identifier -> database subject id
+ * @returns the number of utterances actually tagged
+ */
+async function applyUtteranceDiscussionStatusesInTx(
+    tx: PrismaTxClient,
+    statuses: SummarizeResult['utteranceDiscussionStatuses'],
+    subjectIdMap: Map<string, string>
+): Promise<number> {
+    // Keep the last entry per utterance; the response can repeat one. Entries carrying a
+    // status outside the enum are dropped here rather than allowed to abort the transaction.
+    const deduped = new Map<string, SummarizeResult['utteranceDiscussionStatuses'][number]>();
+    let unknownStatuses = 0;
+    for (const status of statuses) {
+        if (!VALID_DISCUSSION_STATUSES.has(status.status)) {
+            console.warn(`Unknown discussionStatus "${status.status}" for utterance ${status.utteranceId} - skipping`);
+            unknownStatuses++;
+            continue;
+        }
+        if (deduped.has(status.utteranceId)) {
+            console.warn(`Duplicate utterance ID in response: ${status.utteranceId} - keeping last entry`);
+        }
+        deduped.set(status.utteranceId, status);
+    }
+
+    // Group by the pair actually written, so each group is a single updateMany.
+    const groups = new Map<string, { subjectId: string | null; status: DiscussionStatus; utteranceIds: string[] }>();
+    for (const entry of deduped.values()) {
+        const subjectDbId = entry.subjectId ? subjectIdMap.get(entry.subjectId) ?? null : null;
+        if (entry.subjectId && !subjectDbId) {
+            console.warn(`Could not find database subject for API subject ID: ${entry.subjectId}`);
+        }
+        const key = `${entry.status}::${subjectDbId ?? ''}`;
+        const group = groups.get(key) ?? { subjectId: subjectDbId, status: entry.status, utteranceIds: [] };
+        group.utteranceIds.push(entry.utteranceId);
+        groups.set(key, group);
+    }
+
+    let tagged = 0;
+    for (const group of groups.values()) {
+        const { count } = await tx.utterance.updateMany({
+            where: { id: { in: group.utteranceIds } },
+            data: { discussionStatus: group.status, discussionSubjectId: group.subjectId }
+        });
+        tagged += count;
+    }
+
+    console.log(
+        `Saved ${tagged} utterance discussion statuses in ${groups.size} statements ` +
+        `(${deduped.size - tagged} ids no longer exist, ${unknownStatuses} unknown statuses)`
+    );
+    return tagged;
+}
+
+/**
  * Save subjects for a meeting using upsert semantics: matches incoming subjects
  * to existing ones by numeric agendaItemIndex and updates in-place (preserving
  * database IDs). Subjects with BEFORE_AGENDA/OUT_OF_AGENDA are always replaced
@@ -299,6 +372,7 @@ export async function saveSubjectsForMeeting(
     subjects: Subject[],
     cityId: string,
     councilMeetingId: string,
+    utteranceDiscussionStatuses?: SummarizeResult['utteranceDiscussionStatuses'],
 ): Promise<Map<string, string>> {
     const { topicsByName, validSpeakerIds, existingIntroducerIds } = await validateSubjectPersons(subjects, cityId);
     const subjectIdMap = new Map<string, string>();
@@ -481,6 +555,12 @@ export async function saveSubjectsForMeeting(
                 councilMeetingId,
                 speakerContributions: subject.speakerContributions
             });
+        }
+
+        // Inside the transaction on purpose: the tags must commit with their subjects, or the
+        // search index never learns about them. See applyUtteranceDiscussionStatusesInTx.
+        if (utteranceDiscussionStatuses && utteranceDiscussionStatuses.length > 0) {
+            await applyUtteranceDiscussionStatusesInTx(tx, utteranceDiscussionStatuses, subjectIdMap);
         }
     }, { timeout: 60000 });
 

--- a/src/lib/tasks/summarize.ts
+++ b/src/lib/tasks/summarize.ts
@@ -145,82 +145,16 @@ export async function handleSummarizeResult(taskId: string, response: SummarizeR
     await prisma.$transaction(operations);
 
     // Save subjects: matches by agendaItemIndex to preserve existing IDs (avoids ES orphans)
-    const subjectNameToIdMap = await saveSubjectsForMeeting(
+    // The discussion tags go in with the subjects: they must commit together, or the search
+    // index keeps the pre-tagging discussion metrics (elasticsearch/README.md).
+    await saveSubjectsForMeeting(
         response.subjects,
         councilMeeting.cityId,
-        councilMeeting.id
+        councilMeeting.id,
+        response.utteranceDiscussionStatuses
     );
 
     console.log(`Saved summaries and topic labels for meeting ${councilMeeting.id}`);
-
-    // Save utterance discussion statuses (batch update for performance)
-    if (response.utteranceDiscussionStatuses && response.utteranceDiscussionStatuses.length > 0) {
-        // First, deduplicate by utteranceId (keep last entry if duplicates exist)
-        // This prevents trying to update the same utterance twice in one transaction
-        const statusMap = new Map<string, typeof response.utteranceDiscussionStatuses[0]>();
-        for (const status of response.utteranceDiscussionStatuses) {
-            if (statusMap.has(status.utteranceId)) {
-                console.warn(`Duplicate utterance ID in response: ${status.utteranceId} - keeping last entry`);
-            }
-            statusMap.set(status.utteranceId, status);
-        }
-        const dedupedStatuses = Array.from(statusMap.values());
-
-        // Validate which utterance IDs actually exist in the database
-        // This prevents errors if transcript was regenerated or modified
-        const utteranceIds = dedupedStatuses.map(s => s.utteranceId);
-        const existingUtterances = await prisma.utterance.findMany({
-            where: {
-                id: { in: utteranceIds }
-            },
-            select: { id: true }
-        });
-
-        const existingUtteranceIds = new Set(existingUtterances.map(u => u.id));
-
-        // Filter to only statuses for utterances that exist
-        const validStatuses = dedupedStatuses.filter(status => {
-            const exists = existingUtteranceIds.has(status.utteranceId);
-            if (!exists) {
-                console.warn(`Skipping discussion status for non-existent utterance: ${status.utteranceId}`);
-            }
-            return exists;
-        });
-
-        if (validStatuses.length === 0) {
-            console.warn(`No valid utterances found to update discussion statuses (${response.utteranceDiscussionStatuses.length} returned by API)`);
-        } else {
-            // Use updateMany with individual where clauses to avoid transaction issues
-            // This is more resilient than batched updates in a transaction
-            const updatePromises = validStatuses.map(async (utteranceStatus) => {
-                // Map the API subject identifier to the database subject ID
-                const dbSubjectId = utteranceStatus.subjectId ? subjectNameToIdMap.get(utteranceStatus.subjectId) : null;
-
-                if (utteranceStatus.subjectId && !dbSubjectId) {
-                    console.warn(`Could not find database subject for API subject ID: ${utteranceStatus.subjectId}`);
-                }
-
-                try {
-                    await prisma.utterance.update({
-                        where: {
-                            id: utteranceStatus.utteranceId
-                        },
-                        data: {
-                            discussionStatus: utteranceStatus.status,
-                            discussionSubjectId: dbSubjectId || null
-                        }
-                    });
-                } catch (error) {
-                    console.error(`Failed to update utterance ${utteranceStatus.utteranceId}:`, error);
-                    // Don't throw - continue with other updates
-                }
-            });
-
-            await Promise.all(updatePromises);
-
-            console.log(`Saved ${validStatuses.length} utterance discussion statuses (${response.utteranceDiscussionStatuses.length - validStatuses.length} skipped/duplicates)`);
-        }
-    }
 
     // Bust the meeting/subject cache now that all summarize results are persisted,
     // BEFORE sending notifications below. The notification send is rate-limited


### PR DESCRIPTION
## Why
Search ranks a subject by text relevance alone. A subject that the council debated for
an hour ranks the same as a passing mention. Elasticsearch holds no signal about the
size of a discussion, and no signal about the kind of meeting.
This PR indexes the signals. A follow-up PR uses them to rank the results.

This is the first out of the many PRs solving [625](https://github.com/schemalabz/opencouncil/issues/625)


## What
Three new fields on the `subjects` index:
| Field | Source |
|-------|--------|
| `contributor_count` | Number of `SpeakerContribution` rows on the subject |
| `discussion_speaking_seconds` | Time the council spent speaking about the subject |
| `administrative_body_id` / `administrative_body_type` | The body of the meeting: council, committee, or community |



`SubjectSearchView` precomputes the two metrics as scalar columns, because a nested
array costs a nested query to aggregate at search time. `discussion_speaking_seconds`
repeats `getDiscussionSecondsForSubjects()` in `src/lib/db/subject.ts`, so the index
agrees with the number the subject page shows: tagged `SUBJECT_DISCUSSION` utterances
first, procedural segments excluded, and the legacy `SubjectSpeakerSegment` table only
as a fallback.
The new `MeetingAdministrativeBodyView` flattens the `Subject` → `CouncilMeeting` →
`AdministrativeBody` join, which PGSync cannot express as one relationship.
No application code reads the new fields yet. The search API exposes no filter on them.


**Caution: We need re-indexing on each env after merging this PR**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds administrative-body metadata, city realm, contributor counts, and discussion speaking time to subject search documents.
- Adds Elasticsearch mappings and PGSync relationships for the new scalar fields.
- Adds PostgreSQL helper views and validation queries for metrics, administrative bodies, and realms.
- Moves utterance discussion-status persistence into the subject transaction so subject writes and indexed metrics are synchronized.
- Documents schema migration, backfill, verification, and refresh behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| elasticsearch/schema.json | Adds keyword and numeric mappings plus PGSync relationships for realm, administrative-body metadata, and subject metrics. |
| elasticsearch/views.sql | Adds helper views that compute subject metrics and flatten administrative-body and city-realm data. |
| elasticsearch/validate-views.sql | Extends view validation to cover metric integrity, administrative-body enum values, and city realms. |
| src/lib/db/utils.ts | Validates, deduplicates, batches, and transactionally persists summarize-task utterance discussion statuses. |
| src/lib/tasks/summarize.ts | Passes discussion statuses into the transactional subject-save operation and removes the later per-utterance persistence pass. |
| elasticsearch/README.md | Documents the new indexed fields and operational schema-deployment, backfill, and refresh requirements. |

<sub>Reviews (7): Last reviewed commit: ["docs(elastic): document the deploy path ..."](https://github.com/schemalabz/opencouncil/commit/e21aae0d7272850ec3d57635b9cfb6c8c7b464c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53347278)</sub>

<!-- /greptile_comment -->