### PR TITLE
fix(landing): send the map petition CTA to the city petition page

### DIFF
--- a/src/app/[locale]/(other)/petition/page.tsx
+++ b/src/app/[locale]/(other)/petition/page.tsx
@@ -1,6 +1,5 @@
 import { Metadata } from "next";
 import { Suspense } from "react";
-import { CheckCircle2 } from 'lucide-react';
 import { PetitionMunicipalitySelector } from "@/components/onboarding/selectors/PetitionMunicipalitySelector";
 import { OpenCouncilDescription } from "@/components/landing/OpenCouncilDescription";
 import { getAllCitiesMinimalCached } from "@/lib/cache/queries";
@@ -71,14 +70,6 @@ export default async function PetitionPage() {
                             opencouncil.gr/about
                         </a>.
                     </p>
-
-                    {/* Success Message */}
-                    <div className="flex items-start gap-3 p-4 bg-green-50 border border-green-200 rounded-lg">
-                        <CheckCircle2 className="h-5 w-5 text-green-600 mt-0.5 flex-shrink-0" />
-                        <p className="text-sm sm:text-base text-green-800 font-medium leading-relaxed">
-                            Θα σας ενημερώσουμε όταν ο δήμος ενταχθεί στο δίκτυο OpenCouncil
-                        </p>
-                    </div>
                 </div>
             </div>
         </div>

--- a/src/components/landing/v2/hooks/useMapPopups.tsx
+++ b/src/components/landing/v2/hooks/useMapPopups.tsx
@@ -281,7 +281,7 @@ export function useMapPopups({
             <MunicipalityTooltip
                 name={clickedMunicipality.name}
                 petitionBucket={clickedMunicipality.petitionBucket}
-                onView={() => navigateRef.current('/petition')}
+                onView={() => navigateRef.current(`/${clickedMunicipality.id}/petition`)}
                 onClose={() => setClickedMunicipality(null)}
             />,
         );


### PR DESCRIPTION
## Problem

Two problems on the petition path from the landing page.

**1. The map petition CTA loses the municipality.** A visitor clicks an out-of-network δήμος on the map, or its row in the petitioned leaderboard. A tooltip opens for that δήμος with a "request it" button. The button sent the visitor to `/petition`, the generic page. That page only asks which municipality they mean — the question the tooltip already answers.

**2. The generic petition page shows a false success box.** A green box at the bottom of `/petition` said "Θα σας ενημερώσουμε όταν ο δήμος ενταχθεί στο δίκτυο OpenCouncil". The page is only a municipality picker, so the box appeared before the visitor did anything. It reads as a confirmation of a petition that nobody submitted.

## Changes

- `useMapPopups.tsx`: the tooltip now links to `/{cityId}/petition`. The tooltip already holds the city id, because `clickedMunicipality` comes from `/api/cities/at`.
- `petition/page.tsx`: the green box and its now-unused `CheckCircle2` import are removed.

The two other petition links on the landing stay on `/petition`, because they only hold a name that the visitor typed, not a city id:

- the search CTA for an unrecognized "δήμος X" (`MunicipalitiesList.tsx`)
- the notify popup for an out-of-network municipality (`NotifyPrompt.tsx`)

## Test

- `npx tsc --noEmit`, `npm run lint` and `npm test` (1400 tests) pass.
- `/petition` renders without the green box in the browser.
- The tooltip path has no live check here. My dev database still has the old `CityStatus` enum (`pending|unlisted|listed`) and holds no `pending` cities, so the landing page returns a `PrismaClientValidationError`. The preview deployment can show the tooltip path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small navigation and copy/UI tweaks on petition flows with no auth, data, or payment changes.
> 
> **Overview**
> The landing map **“request it”** flow now sends visitors to **`/{cityId}/petition`** instead of the generic **`/petition`** picker, using the municipality id already resolved from the map click.
> 
> The generic **`/petition`** page no longer shows a **green success message** that looked like a completed petition before anyone submitted anything; the unused **`CheckCircle2`** import is removed with it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db63d0fd90a3031641a6666ce7481cd17cda3161. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects the landing-page petition flow by sending map tooltip visitors directly to the selected municipality’s petition page and removes a premature success message from the generic municipality picker.
- Changes the map petition CTA from `/petition` to `/{cityId}/petition`.
- Removes the misleading success box and unused icon import from the generic petition page.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with both changes matching the existing petition route and page behavior.

The map API supplies the same City primary key consumed by the city-specific petition route, including for pending municipalities, while the generic-page change only removes misleading static UI.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/landing/v2/hooks/useMapPopups.tsx | The tooltip now passes the selected city’s database identifier to the existing city-specific petition route; the API and route use matching identifiers. |
| src/app/[locale]/(other)/petition/page.tsx | Removes the premature success message and its unused import without changing the municipality-selection behavior. |

<sub>Reviews (1): Last reviewed commit: ["fix(petition): remove the false success ..."](https://github.com/schemalabz/opencouncil/commit/db63d0fd90a3031641a6666ce7481cd17cda3161) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53361283)</sub>

<!-- /greptile_comment -->