### PR TITLE
feat(transcribe): store utterance confidence scores from task results

### DIFF
--- a/prisma/migrations/20260818000000_add_utterance_confidence_scores/migration.sql
+++ b/prisma/migrations/20260818000000_add_utterance_confidence_scores/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Utterance" ADD COLUMN     "confidence" DOUBLE PRECISION,
+ADD COLUMN     "minWordConfidence" DOUBLE PRECISION,
+ADD COLUMN     "totalConfidence" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -350,6 +350,15 @@ model Utterance {
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
+  // Transcription confidence scores from the transcribe task (version 4+).
+  // Null for utterances imported from older task results.
+  // The scores describe the text as the ASR transcribed it. fixTranscript and
+  // user edits rewrite text and keep the scores, so join on lastModifiedBy to
+  // tell scored-as-transcribed utterances from corrected ones.
+  confidence        Float? // arithmetic mean of word confidences
+  minWordConfidence Float? // confidence of the least confident word
+  totalConfidence   Float? // product of word confidences ≈ P(every word is right)
+
   speakerSegment SpeakerSegment @relation(fields: [speakerSegmentId], references: [id], onDelete: Cascade)
   speakerSegmentId String
   uncertain Boolean @default(false)

--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -228,7 +228,11 @@ export interface Utterance {
     language: string;
     start: number;
     end: number;
-    confidence: number;
+    confidence: number; // arithmetic mean of word confidences
+    // Optional because processTaskResponse can replay results stored by
+    // transcribe task versions before 4, which lack these two scores.
+    minWordConfidence?: number; // confidence of the least confident word
+    totalConfidence?: number; // product of word confidences ≈ P(every word is right)
     channel: number;
     speaker: number;
     drift: number;

--- a/src/lib/tasks/__tests__/handleTranscribeResult.test.ts
+++ b/src/lib/tasks/__tests__/handleTranscribeResult.test.ts
@@ -68,17 +68,17 @@ const response = {
   },
 };
 
-describe('handleTranscribeResult — fixTranscript auto-chain', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockTaskFindUnique.mockResolvedValue(task);
-    mockMeetingUpdate.mockResolvedValue({ id: MEETING_ID });
-    mockSpeakerTagCreate.mockResolvedValue({ id: 'tag-1' });
-    mockSpeakerSegmentCreate.mockResolvedValue({ id: 'segment-1' });
-    mockRequestFixTranscript.mockResolvedValue({ id: 'fix-task-1' });
-    mockSendAutoFixAlert.mockResolvedValue(undefined);
-  });
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockTaskFindUnique.mockResolvedValue(task);
+  mockMeetingUpdate.mockResolvedValue({ id: MEETING_ID });
+  mockSpeakerTagCreate.mockResolvedValue({ id: 'tag-1' });
+  mockSpeakerSegmentCreate.mockResolvedValue({ id: 'segment-1' });
+  mockRequestFixTranscript.mockResolvedValue({ id: 'fix-task-1' });
+  mockSendAutoFixAlert.mockResolvedValue(undefined);
+});
 
+describe('handleTranscribeResult — fixTranscript auto-chain', () => {
   it('auto-triggers fixTranscript with force after a successful import', async () => {
     await handleTranscribeResult('task-1', response as never);
 
@@ -127,5 +127,58 @@ describe('handleTranscribeResult — fixTranscript auto-chain', () => {
     await expect(handleTranscribeResult('task-1', response as never)).rejects.toThrow('Task not found');
 
     expect(mockRequestFixTranscript).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleTranscribeResult — utterance confidence scores', () => {
+  const withUtterance = (utterance: Record<string, unknown>) => ({
+    ...response,
+    transcript: {
+      transcription: {
+        utterances: [utterance],
+        speakers: [{ speaker: 0, match: null }],
+      },
+    },
+  });
+
+  const createdUtterances = () =>
+    mockSpeakerSegmentCreate.mock.calls[0][0].data.utterances.createMany.data;
+
+  it('stores the confidence scores carried by transcribe v4 results', async () => {
+    const scored = withUtterance({
+      start: 0, end: 1, speaker: 0, text: 'hello', drift: 0,
+      confidence: 0.97, minWordConfidence: 0.61, totalConfidence: 0.55,
+    });
+
+    await handleTranscribeResult('task-1', scored as never);
+
+    expect(createdUtterances()).toEqual([
+      expect.objectContaining({ confidence: 0.97, minWordConfidence: 0.61, totalConfidence: 0.55 }),
+    ]);
+  });
+
+  it('rounds the scores to 4 significant figures', async () => {
+    // exp() and running products emit full-precision doubles, which gzip poorly
+    const scored = withUtterance({
+      start: 0, end: 1, speaker: 0, text: 'hello', drift: 0,
+      confidence: 0.9712345678901234, minWordConfidence: 0.6149999999999999, totalConfidence: 0.5500000000000001,
+    });
+
+    await handleTranscribeResult('task-1', scored as never);
+
+    expect(createdUtterances()).toEqual([
+      expect.objectContaining({ confidence: 0.9712, minWordConfidence: 0.615, totalConfidence: 0.55 }),
+    ]);
+  });
+
+  it('stores null min and total scores when replaying a pre-v4 result', async () => {
+    // Results stored by transcribe versions before 4 carry only the mean confidence
+    const preV4 = withUtterance({ start: 0, end: 1, speaker: 0, text: 'hello', drift: 0, confidence: 0.9 });
+
+    await handleTranscribeResult('task-1', preV4 as never);
+
+    expect(createdUtterances()).toEqual([
+      expect.objectContaining({ confidence: 0.9, minWordConfidence: null, totalConfidence: null }),
+    ]);
   });
 });

--- a/src/lib/tasks/transcribe.ts
+++ b/src/lib/tasks/transcribe.ts
@@ -9,6 +9,10 @@ import { requestTranscribeInternal, deleteExistingSpeakerData } from "./transcri
 import { requestFixTranscript } from "./fixTranscript";
 import { sendTaskAdminAlert } from "../discord";
 
+// Full-precision doubles are near-incompressible and inflate the meeting page
+// payload; 4 significant figures is far finer than the ASR signal warrants.
+const round4 = (v: number | null | undefined) => (v == null ? null : Number(v.toPrecision(4)));
+
 /**
  * Public entry point for transcription. Authorizes the caller, then delegates to
  * requestTranscribeInternal (which the unauthenticated poll-livestreams cron also calls).
@@ -198,6 +202,12 @@ export async function handleTranscribeResult(taskId: string, response: Transcrib
                                     endTimestamp: utterance.end,
                                     text: utterance.text,
                                     drift: utterance.drift,
+                                    // Replayed results from transcribe versions before 4
+                                    // lack the scores; null keeps "unknown" distinct from
+                                    // a real value.
+                                    confidence: round4(utterance.confidence),
+                                    minWordConfidence: round4(utterance.minWordConfidence),
+                                    totalConfidence: round4(utterance.totalConfidence),
                                 }))
                             }
                         }


### PR DESCRIPTION
## Summary

schemalabz/opencouncil-tasks#89 adds two confidence scores to each utterance in the transcribe result: `minWordConfidence` and `totalConfidence`. Transcribe task version 4 sends them next to the existing mean `confidence`. The import handler dropped all three scores. This PR stores them.

## Changes

- Add three nullable `Float` columns to the `Utterance` model: `confidence` (mean of word confidences), `minWordConfidence` (least confident word), `totalConfidence` (product of word confidences).
- Add migration `20260818000000_add_utterance_confidence_scores`.
- `handleTranscribeResult` writes the scores when it creates utterances.
- Mirror the two new fields on the `Utterance` interface in `apiTypes.ts`. They are optional there because `processTaskResponse` can replay stored results from task versions before 4. The handler stores `null` for missing scores.
- Add two tests for the handler: one for a v4 result, one for a replayed pre-v4 result.

## Design notes

- The columns are nullable and have no default. A default of 1 would claim full confidence for old utterances. Null keeps "unknown" distinct from a real score.
- No backfill is possible: the pipeline does not store `Word` rows, so the scores for existing utterances are not recoverable. A re-transcribe stores them.
- The mean `confidence` is included because the handler dropped it before this change. Without it, the stored trio is incomplete.

## Testing

- `npm test` — 105 suites pass, including the two new handler tests.
- `npx tsc --noEmit` — clean.
- `npm run build` with the same dummy env as the Nix build — passes.
- This container has no local database, so `prisma migrate dev --create-only` cannot run. The migration SQL comes from `prisma migrate diff --from-schema-datamodel --to-schema-datamodel --script` with the repo-pinned Prisma 5.22.0. The diff engine is the same one `migrate dev` uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQr6jhRWwMFtuv2oVqPj75

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQr6jhRWwMFtuv2oVqPj75)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds nullable confidence-score fields to utterances and persists rounded values from transcription task results while retaining compatibility with older results.
- Adds the corresponding Prisma schema fields and database migration.
- Stores mean, minimum-word, and total confidence during transcript import.
- Covers current and pre-v4 task results with handler tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| prisma/migrations/20260818000000_add_utterance_confidence_scores/migration.sql | Adds three nullable double-precision columns matching the Prisma model. |
| prisma/schema.prisma | Defines nullable utterance confidence fields without assigning misleading defaults to historical records. |
| src/lib/apiTypes.ts | Extends the transcription utterance result shape with optional v4 confidence fields. |
| src/lib/tasks/transcribe.ts | Rounds and persists confidence values while mapping missing legacy fields to null. |
| src/lib/tasks/__tests__/handleTranscribeResult.test.ts | Tests v4 score persistence, significant-figure rounding, and replay of older task results. |

<sub>Reviews (2): Last reviewed commit: ["feat(transcribe): store utterance confid..."](https://github.com/schemalabz/opencouncil/commit/d4f910123a95a711309ab351875b8ea89a4cb86e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54331190)</sub>

<!-- /greptile_comment -->