### PR TITLE
perf(reviews): candidate-first admin review queries

### DIFF
--- a/.claude/skills/test-backup/SKILL.md
+++ b/.claude/skills/test-backup/SKILL.md
@@ -50,12 +50,12 @@ Resolve the backup into a single local file that the rest of the steps operate o
 
 ### 1a: Fetch or locate the file
 
-**S3 fetch mode** (no argument, or `latest`) — confirm the remote exists, find the newest dump, and download it. The date-partitioned paths (`.../YYYY/MM/DD/HH-MM/production.sql.gz`) sort lexicographically, so the greatest path is the latest:
+**S3 fetch mode** (no argument, or `latest`) — confirm the remote exists, find the newest dump, and download it. Paths follow `snapshooter/<target>/YYYY/MM/DD/HH-MM/production.sql.gz`. Sort on the date fields (field 3 onward), not the whole path: the bucket holds more than one `<target>` directory (Snapshooter targets get renamed), and a whole-path sort silently picks a stale dump from the alphabetically-last target:
 
 ```bash
 nix develop --command bash -c '
   rclone listremotes | grep -qx "oc-backups:" || { echo "Missing '\''oc-backups'\'' rclone remote. Run: nix develop --command bash .claude/skills/test-backup/setup-remote.sh"; exit 1; }
-  LATEST=$(rclone lsf -R --files-only --include "production.sql.gz" oc-backups:opencouncil-db-backups/ | sort | tail -1)
+  LATEST=$(rclone lsf -R --files-only --include "production.sql.gz" oc-backups:opencouncil-db-backups/ | sort -t/ -k3 | tail -1)
   [ -n "$LATEST" ] || { echo "No production.sql.gz found in bucket"; exit 1; }
   echo "Latest backup: $LATEST"
   rclone copyto "oc-backups:opencouncil-db-backups/$LATEST" /tmp/oc-test-backup.sql.gz

--- a/prisma/migrations/20260819120000_add_utterance_edit_utterance_id_index/migration.sql
+++ b/prisma/migrations/20260819120000_add_utterance_edit_utterance_id_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "UtteranceEdit_utteranceId_idx" ON "UtteranceEdit"("utteranceId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -972,6 +972,8 @@ model UtteranceEdit {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([utteranceId])
 }
 
 model Role {

--- a/src/app/[locale]/(admin)/admin/error.tsx
+++ b/src/app/[locale]/(admin)/admin/error.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useEffect } from 'react'
+import { AlertTriangle, RotateCcw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface ErrorPageProps {
+    error: Error & { digest?: string }
+    reset: () => void
+}
+
+/**
+ * Admin-scoped error boundary. Before it existed, any page failure under
+ * /admin fell through to the public root error page (issue #560 review).
+ * Failures in the admin layout itself (e.g. its auth guard) still do:
+ * an error.tsx renders inside its sibling layout, not around it.
+ */
+export default function AdminError({ error, reset }: ErrorPageProps) {
+    useEffect(() => {
+        // Log to console for client-side diagnostics; onRequestError handles server-side alerting.
+        console.error(error)
+    }, [error])
+
+    return (
+        <div className="container mx-auto px-4 py-16 flex flex-col items-center text-center gap-4">
+            <AlertTriangle className="h-10 w-10 text-muted-foreground" />
+            <h2 className="text-xl font-semibold">This admin page failed to load</h2>
+            <p className="text-muted-foreground max-w-md">
+                The error is logged with digest <code>{error.digest ?? 'n/a'}</code>. Try again, or check the server logs.
+            </p>
+            <Button variant="outline" onClick={reset}>
+                <RotateCcw className="h-4 w-4 mr-2" />
+                Try again
+            </Button>
+        </div>
+    )
+}

--- a/src/app/[locale]/(admin)/admin/page.tsx
+++ b/src/app/[locale]/(admin)/admin/page.tsx
@@ -1,6 +1,8 @@
 import { Bell, Clock, FileText, Landmark, MessageCircle, Search, Send, Users } from 'lucide-react';
 import { StatsCard } from '@/components/ui/stats-card';
-import { ReviewsOverviewWidget } from '@/components/admin/reviews/ReviewsOverviewWidget';
+import { Suspense } from 'react';
+import { ReviewsOverviewWidget, ReviewsOverviewSkeleton } from '@/components/admin/reviews/ReviewsOverviewWidget';
+import AdminWidgetErrorBoundary from '@/components/admin/AdminWidgetErrorBoundary';
 import { NotificationSubscribersChart } from '@/components/admin/NotificationSubscribersChart';
 import { getAdminDashboardStats, getNotificationSubscribersByCity } from '@/lib/db/adminStats';
 import { withUserAuthorizedToEdit } from '@/lib/auth';
@@ -126,8 +128,15 @@ export default async function Page() {
                 />
             </section>
 
+            {/* Boundary + Suspense: the widget's queries stream in without
+                blocking the dashboard, and a widget failure degrades to one
+                card instead of the whole route (issue #560's blast radius). */}
             <section>
-                <ReviewsOverviewWidget />
+                <AdminWidgetErrorBoundary label="Transcript reviews">
+                    <Suspense fallback={<ReviewsOverviewSkeleton />}>
+                        <ReviewsOverviewWidget />
+                    </Suspense>
+                </AdminWidgetErrorBoundary>
             </section>
         </div>
     );

--- a/src/app/[locale]/(admin)/admin/page.tsx
+++ b/src/app/[locale]/(admin)/admin/page.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@/i18n/routing';
 import { Bell, Clock, FileText, Landmark, MessageCircle, Search, Send, Users } from 'lucide-react';
 import { StatsCard } from '@/components/ui/stats-card';
 import { Suspense } from 'react';
@@ -132,6 +133,17 @@ export default async function Page() {
                 blocking the dashboard, and a widget failure degrades to one
                 card instead of the whole route (issue #560's blast radius). */}
             <section>
+                <div className="flex items-baseline justify-between mb-3">
+                    <h2 className="w-fit">Transcript Reviews</h2>
+                    {/* last30Days=false: the list then shows the same all-time
+                        population the widget counts. */}
+                    <Link
+                        href="/admin/reviews?last30Days=false"
+                        className="text-sm text-muted-foreground hover:text-foreground"
+                    >
+                        View all →
+                    </Link>
+                </div>
                 <AdminWidgetErrorBoundary label="Transcript reviews">
                     <Suspense fallback={<ReviewsOverviewSkeleton />}>
                         <ReviewsOverviewWidget />

--- a/src/app/[locale]/(admin)/admin/page.tsx
+++ b/src/app/[locale]/(admin)/admin/page.tsx
@@ -1,9 +1,6 @@
 import { Bell, Clock, FileText, Landmark, MessageCircle, Search, Send, Users } from 'lucide-react';
 import { StatsCard } from '@/components/ui/stats-card';
-// Temporarily disabled: getReviewStats() crashes the DB with shared-memory
-// errors under data growth (see investigation issue). Re-enable once the
-// reviews queries are fixed.
-// import { ReviewsOverviewWidget } from '@/components/admin/reviews/ReviewsOverviewWidget';
+import { ReviewsOverviewWidget } from '@/components/admin/reviews/ReviewsOverviewWidget';
 import { NotificationSubscribersChart } from '@/components/admin/NotificationSubscribersChart';
 import { getAdminDashboardStats, getNotificationSubscribersByCity } from '@/lib/db/adminStats';
 import { withUserAuthorizedToEdit } from '@/lib/auth';
@@ -129,11 +126,9 @@ export default async function Page() {
                 />
             </section>
 
-            {/* Temporarily disabled — see note on the import above.
             <section>
                 <ReviewsOverviewWidget />
             </section>
-            */}
         </div>
     );
 }

--- a/src/app/api/admin/reviews/volume-chart/route.ts
+++ b/src/app/api/admin/reviews/volume-chart/route.ts
@@ -33,7 +33,11 @@ export async function GET() {
           where: {
             type: { in: ['transcribe', 'fixTranscript', 'humanReview'] },
             status: 'succeeded'
-          }
+          },
+          // Only the fields the categorization reads. transcribe and
+          // fixTranscript rows carry the serialized transcript in their
+          // responseBody; 12 weeks of full rows is the #303 overflow again.
+          select: { type: true, status: true }
         },
         speakerSegments: {
           include: {

--- a/src/components/admin/AdminWidgetErrorBoundary.tsx
+++ b/src/components/admin/AdminWidgetErrorBoundary.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import React, { useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { AlertTriangle, RotateCcw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+    /** Names the widget in the fallback message. */
+    label: string
+    children: React.ReactNode
+}
+
+interface State {
+    hasError: boolean
+}
+
+function WidgetErrorFallback({ label, onRetry }: { label: string; onRetry: () => void }) {
+    const router = useRouter()
+    const [pending, startTransition] = useTransition()
+
+    return (
+        <div className="flex items-center gap-3 rounded-lg border p-6 text-muted-foreground">
+            <AlertTriangle className="h-5 w-5 shrink-0" />
+            <span className="flex-1">
+                {label} is unavailable. The rest of the dashboard is unaffected — server-side failures are in the server logs.
+            </span>
+            <Button
+                variant="outline"
+                size="sm"
+                disabled={pending}
+                onClick={() =>
+                    startTransition(() => {
+                        // Refresh first: re-rendering the children alone would
+                        // replay the errored payload and re-trip the boundary.
+                        router.refresh()
+                        onRetry()
+                    })
+                }
+            >
+                <RotateCcw className="h-4 w-4 mr-2" />
+                Retry
+            </Button>
+        </div>
+    )
+}
+
+/**
+ * Catches errors from a single dashboard widget so a failing widget
+ * degrades to one inert card instead of failing the whole admin route —
+ * the blast radius that issue #560's crash demonstrated. Server-component
+ * errors streamed inside a Suspense boundary re-throw at this position
+ * on the client, so this boundary contains those too; purely client-side
+ * errors are contained as well but reach no server-side telemetry.
+ */
+export default class AdminWidgetErrorBoundary extends React.Component<Props, State> {
+    constructor(props: Props) {
+        super(props)
+        this.state = { hasError: false }
+    }
+
+    static getDerivedStateFromError(): State {
+        return { hasError: true }
+    }
+
+    componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+        console.error(`[AdminWidgetErrorBoundary] ${this.props.label} failed:`, error, errorInfo)
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <WidgetErrorFallback
+                    label={this.props.label}
+                    onRetry={() => this.setState({ hasError: false })}
+                />
+            )
+        }
+
+        return this.props.children
+    }
+}

--- a/src/components/admin/reviews/ReviewsOverviewWidget.tsx
+++ b/src/components/admin/reviews/ReviewsOverviewWidget.tsx
@@ -4,6 +4,16 @@ import { CheckCircle2, Clock, AlertCircle } from 'lucide-react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 
+export function ReviewsOverviewSkeleton() {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {Array.from({ length: 4 }, (_, i) => (
+        <div key={i} className="h-28 rounded-lg border animate-pulse bg-muted/40" />
+      ))}
+    </div>
+  );
+}
+
 export async function ReviewsOverviewWidget() {
   const stats = await getReviewStats();
   

--- a/src/components/admin/reviews/ReviewsOverviewWidget.tsx
+++ b/src/components/admin/reviews/ReviewsOverviewWidget.tsx
@@ -1,12 +1,12 @@
 import { getReviewStats } from '@/lib/db/reviews';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { CheckCircle2, Clock, AlertCircle } from 'lucide-react';
-import Link from 'next/link';
-import { Button } from '@/components/ui/button';
+import { StatsCard } from '@/components/ui/stats-card';
+import { AlertCircle, CalendarCheck, CheckCircle2, Clock } from 'lucide-react';
 
 export function ReviewsOverviewSkeleton() {
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+    // Mirrors StatsCard's responsive grid and bottom margin so the section
+    // does not shift when the streamed content replaces the fallback.
+    <div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-4 mb-6">
       {Array.from({ length: 4 }, (_, i) => (
         <div key={i} className="h-28 rounded-lg border animate-pulse bg-muted/40" />
       ))}
@@ -16,45 +16,36 @@ export function ReviewsOverviewSkeleton() {
 
 export async function ReviewsOverviewWidget() {
   const stats = await getReviewStats();
-  
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Transcript Reviews</CardTitle>
-        <CardDescription>Track human review progress across officially supported cities</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-4">
-          <div className="flex flex-col items-center p-4 border rounded-lg">
-            <AlertCircle className="h-8 w-8 text-red-500 mb-2" />
-            <div className="text-2xl font-bold">{stats.needsReview}</div>
-            <div className="text-sm text-muted-foreground">Needs Review</div>
-          </div>
-          
-          <div className="flex flex-col items-center p-4 border rounded-lg">
-            <Clock className="h-8 w-8 text-yellow-500 mb-2" />
-            <div className="text-2xl font-bold">{stats.inProgress}</div>
-            <div className="text-sm text-muted-foreground">In Progress</div>
-          </div>
-          
-          <div className="flex flex-col items-center p-4 border rounded-lg">
-            <CheckCircle2 className="h-8 w-8 text-green-500 mb-2" />
-            <div className="text-2xl font-bold">{stats.completedToday}</div>
-            <div className="text-sm text-muted-foreground">Done Today</div>
-          </div>
-          
-          <div className="flex flex-col items-center p-4 border rounded-lg">
-            <CheckCircle2 className="h-8 w-8 text-blue-500 mb-2" />
-            <div className="text-2xl font-bold">{stats.completedThisWeek}</div>
-            <div className="text-sm text-muted-foreground">Done This Week</div>
-          </div>
-        </div>
-        
-        <Link href="/admin/reviews">
-          <Button className="w-full">View All Reviews</Button>
-        </Link>
-      </CardContent>
-    </Card>
+    <StatsCard
+      columns={4}
+      items={[
+        {
+          title: 'Needs Review',
+          value: stats.needsReview,
+          icon: <AlertCircle className="h-4 w-4" />,
+          description: 'no user edits yet, all time',
+        },
+        {
+          title: 'In Progress',
+          value: stats.inProgress,
+          icon: <Clock className="h-4 w-4" />,
+          description: 'has user edits, all time',
+        },
+        {
+          title: 'Completed Today',
+          value: stats.completedToday,
+          icon: <CheckCircle2 className="h-4 w-4" />,
+          description: 'human reviews finished today',
+        },
+        {
+          title: 'Completed This Week',
+          value: stats.completedThisWeek,
+          icon: <CalendarCheck className="h-4 w-4" />,
+          description: 'since the start of the week',
+        },
+      ]}
+    />
   );
 }
-

--- a/src/lib/db/reviews.ts
+++ b/src/lib/db/reviews.ts
@@ -566,13 +566,13 @@ function calculateSessionData(
 //
 // STAGE 1: DATABASE FILTERING (Prisma WHERE conditions)
 //   - Reduces dataset before fetching from database
-//   - Filters by task status (transcribe, humanReview)
-//   - Filters meetings where user has made ANY edits (for reviewer filter)
+//   - Filters by task status (transcribe, humanReview) and date
 //   - More efficient: Less data transferred and processed
 //
 // STAGE 2: JAVASCRIPT FILTERING (after fetch)
 //   - Calculates detailed review progress for each meeting
-//   - Verifies user is PRIMARY reviewer (most edits), not just any contributor
+//   - Applies the reviewer filter: verifies user is PRIMARY reviewer
+//     (most edits), not just any contributor
 //   - Excludes meetings that don't meet final criteria
 //
 // FILTER OPTIONS:
@@ -643,28 +643,6 @@ function buildStatusWhereConditions(show: ReviewFilterOptions['show']): Prisma.C
       // Just needs transcribe (includes all statuses)
       return hasTranscribe;
   }
-}
-
-/**
- * Build database where conditions for reviewer filtering
- */
-function buildReviewerWhereConditions(reviewerId: string): Prisma.CouncilMeetingWhereInput {
-  return {
-    speakerSegments: {
-      some: {
-        utterances: {
-          some: {
-            utteranceEdits: {
-              some: {
-                editedBy: 'user',
-                userId: reviewerId
-              }
-            }
-          }
-        }
-      }
-    }
-  };
 }
 
 /**
@@ -963,12 +941,11 @@ export async function getMeetingsNeedingReview(filters: ReviewFilterOptions = {}
   // Add date filter
   conditions.push(buildDateFilter(last30Days));
 
-  // Add reviewer filter if specified
-  // Note: This finds meetings where the user has made ANY edits
-  // The "primary reviewer" check happens after fetching
-  if (reviewerId) {
-    conditions.push(buildReviewerWhereConditions(reviewerId));
-  }
+  // The reviewerId filter is applied after aggregation (primary-reviewer
+  // check below). The deleted DB prefilter cost more than the aggregate it
+  // narrowed (measured 5.4s against 2.3s at 300 candidates on
+  // production-scale data): its nested-relation shape is the one issue
+  // #560 removed. Restoring it is a loss at any candidate count.
 
   // Combine all conditions
   const whereConditions = combineWhereConditions(conditions);

--- a/src/lib/db/reviews.ts
+++ b/src/lib/db/reviews.ts
@@ -681,6 +681,42 @@ function combineWhereConditions(
 
 
 /**
+ * Count how many of the given meetings have at least one user transcript edit.
+ *
+ * Candidate-first (issue #560): the caller supplies a small candidate list,
+ * and each candidate is probed through the UtteranceEdit(utteranceId) index.
+ * The LATERAL ... LIMIT 1 probe cannot be flattened into a join, so the
+ * planner cannot fall back to the whole-table parallel hash shape that
+ * exhausts shared memory at production scale — a plain EXISTS keeps that
+ * shape in the plan search space, held off only by a cost margin.
+ */
+async function countMeetingsWithUserEdits(meetings: MeetingId[]): Promise<number> {
+  if (meetings.length === 0) return 0;
+
+  const meetingPairs = Prisma.join(
+    meetings.map((m) => Prisma.sql`(${m.cityId}::text, ${m.meetingId}::text)`)
+  );
+
+  const [row] = await prisma.$queryRaw<[{ count: number }]>`
+    WITH candidates("cityId","meetingId") AS (VALUES ${meetingPairs})
+    SELECT count(*)::int AS "count"
+    FROM candidates c
+    JOIN LATERAL (
+      SELECT 1
+      FROM "SpeakerSegment" ss
+      JOIN "Utterance" u ON u."speakerSegmentId" = ss.id
+      JOIN "UtteranceEdit" ue ON ue."utteranceId" = u.id
+      WHERE ss."cityId" = c."cityId"
+        AND ss."meetingId" = c."meetingId"
+        AND ue."editedBy" = 'user'
+      LIMIT 1
+    ) hit ON true
+  `;
+
+  return row.count;
+}
+
+/**
  * Get aggregated stats for a meeting without loading full nested data
  * Used for efficient list views
  */
@@ -998,57 +1034,30 @@ export async function getMeetingsNeedingReview(filters: ReviewFilterOptions = {}
  */
 export async function getReviewStats(): Promise<ReviewStats> {
   await withUserAuthorizedToEdit({});
-  // We can derive needsReview/inProgress from presence of any user edits.
-  const baseNeedsAttentionWhere: Prisma.CouncilMeetingWhereInput = buildStatusWhereConditions('needsAttention');
+  // Candidate-first (issue #560): pick the needs-attention meetings via the
+  // small, indexed TaskStatus relation, then split them by presence of user
+  // edits with an indexed probe per candidate. Expressing that split as
+  // nested relation filters on CouncilMeeting made Postgres anti-join the
+  // full Utterance/UtteranceEdit tables on every /admin visit.
+  //
+  // The counts cover the all-time backlog of past meetings: a meeting only
+  // leaves the set when its humanReview succeeds, and future meetings are
+  // excluded because they cannot need review yet. The widget states the
+  // window and links the list with last30Days=false to show the same set.
+  const candidates = await prisma.councilMeeting.findMany({
+    where: {
+      AND: [
+        { city: CUSTOMER_CITY_WHERE },
+        buildStatusWhereConditions('needsAttention'),
+        buildDateFilter(false),
+      ],
+    },
+    select: { cityId: true, id: true },
+  });
 
-  const [needsReview, inProgress] = await Promise.all([
-    // Needs review = has transcribe, no humanReview, and NO user edits
-    prisma.councilMeeting.count({
-      where: {
-        AND: [
-          { city: CUSTOMER_CITY_WHERE },
-          baseNeedsAttentionWhere,
-          {
-            NOT: {
-              speakerSegments: {
-                some: {
-                  utterances: {
-                    some: {
-                      utteranceEdits: {
-                        some: { editedBy: 'user' },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        ],
-      },
-    }),
-    // In progress = has transcribe, no humanReview, and HAS user edits
-    prisma.councilMeeting.count({
-      where: {
-        AND: [
-          { city: CUSTOMER_CITY_WHERE },
-          baseNeedsAttentionWhere,
-          {
-            speakerSegments: {
-              some: {
-                utterances: {
-                  some: {
-                    utteranceEdits: {
-                      some: { editedBy: 'user' },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        ],
-      },
-    }),
-  ]);
+  const meetingIds: MeetingId[] = candidates.map((m) => ({ cityId: m.cityId, meetingId: m.id }));
+  const inProgress = await countMeetingsWithUserEdits(meetingIds);
+  const needsReview = meetingIds.length - inProgress;
 
   // Get completed reviews
   const now = new Date();

--- a/src/lib/db/reviews.ts
+++ b/src/lib/db/reviews.ts
@@ -63,7 +63,10 @@ const includePattern = {
     administrativeBody: { select: { id: true, name: true } },
     taskStatuses: {
       where: whereClause.reviewTaskStatuses(),
-      orderBy: { createdAt: 'desc' as const }
+      // Only the fields hasSucceededTask reads. The full rows carry the
+      // request/response payloads (~1.7 GB across production), which
+      // overflow the engine's result buffer on unfiltered lists (#303).
+      select: { type: true, status: true }
     }
   }),
 
@@ -1051,7 +1054,11 @@ export async function getReviewStats(): Promise<ReviewStats> {
       createdAt: {
         gte: startOfWeek
       }
-    }
+    },
+    // Guard, not an optimization: humanReview payloads are ~30 bytes today,
+    // but a full-row read here puts #303 back on /admin the day the task
+    // grows a real payload.
+    select: { createdAt: true }
   });
 
   const completedToday = completedReviews.filter(

--- a/tests/helpers/factories.ts
+++ b/tests/helpers/factories.ts
@@ -154,6 +154,7 @@ export async function createTaskStatus(meetingId: string, cityId: string, data?:
     status?: string
     requestBody?: string
     responseBody?: string | null
+    createdAt?: Date
 }) {
     return prisma.taskStatus.create({
         data: {
@@ -161,8 +162,26 @@ export async function createTaskStatus(meetingId: string, cityId: string, data?:
             status: data?.status ?? 'pending',
             requestBody: data?.requestBody ?? '{}',
             responseBody: data?.responseBody ?? null,
+            createdAt: data?.createdAt,
             councilMeetingId: meetingId,
             cityId,
+        },
+    })
+}
+
+export async function createUtteranceEdit(utteranceId: string, data?: {
+    editedBy?: 'user' | 'task'
+    userId?: string | null
+    beforeText?: string
+    afterText?: string
+}) {
+    return prisma.utteranceEdit.create({
+        data: {
+            utteranceId,
+            beforeText: data?.beforeText ?? 'before',
+            afterText: data?.afterText ?? 'after',
+            editedBy: data?.editedBy ?? 'user',
+            userId: data?.userId ?? null,
         },
     })
 }

--- a/tests/integration/reviews.queries.test.ts
+++ b/tests/integration/reviews.queries.test.ts
@@ -1,0 +1,183 @@
+/** @jest-environment node */
+import prisma from '@/lib/db/prisma'
+import { getReviewStats, getMeetingsNeedingReview } from '@/lib/db/reviews'
+import { ensureTestDb, resetDatabase } from '../helpers/test-db'
+import {
+    createCity,
+    createMeeting,
+    createSpeakerSegment,
+    createSpeakerTag,
+    createTaskStatus,
+    createUser,
+    createUtterance,
+    createUtteranceEdit,
+    signInAsSuperAdmin,
+} from '../helpers/factories'
+
+/**
+ * Characterization tests for the admin review queries (issues #560, #303).
+ * They pin the query semantics so the candidate-first rewrite cannot
+ * change behavior. Correctness only — the scale problem needs prod-size
+ * data and is verified separately with EXPLAIN.
+ */
+describe('review queries', () => {
+    beforeAll(async () => {
+        await ensureTestDb()
+    })
+
+    beforeEach(async () => {
+        await resetDatabase(prisma)
+        await signInAsSuperAdmin()
+    })
+
+    /** A supported-city meeting with one utterance; returns ids for edits. */
+    async function seedMeeting(params: {
+        cityId: string
+        meetingId: string
+        transcribe?: boolean
+        humanReview?: boolean
+        humanReviewCreatedAt?: Date
+        dateTime?: Date
+    }) {
+        await createMeeting(params.cityId, {
+            id: params.meetingId,
+            dateTime: params.dateTime ?? new Date(Date.now() - 24 * 60 * 60 * 1000),
+        })
+        if (params.transcribe !== false) {
+            await createTaskStatus(params.meetingId, params.cityId, {
+                type: 'transcribe', status: 'succeeded',
+            })
+        }
+        if (params.humanReview) {
+            await createTaskStatus(params.meetingId, params.cityId, {
+                type: 'humanReview', status: 'succeeded',
+                createdAt: params.humanReviewCreatedAt,
+            })
+        }
+        const tag = await createSpeakerTag()
+        const segment = await createSpeakerSegment(params.meetingId, params.cityId, {
+            speakerTagId: tag.id,
+        })
+        const utterance = await createUtterance(segment.id)
+        return { utterance }
+    }
+
+    describe('getReviewStats', () => {
+        it('splits needs-review and in-progress by presence of user edits', async () => {
+            await createCity({ id: 'city1', status: 'supported' })
+            const editor = await createUser('editor@example.com')
+
+            // No user edits -> needsReview
+            await seedMeeting({ cityId: 'city1', meetingId: 'm-untouched' })
+            // Task edits only -> still needsReview
+            const taskOnly = await seedMeeting({ cityId: 'city1', meetingId: 'm-task-only' })
+            await createUtteranceEdit(taskOnly.utterance.id, { editedBy: 'task' })
+            // User edit -> inProgress
+            const started = await seedMeeting({ cityId: 'city1', meetingId: 'm-started' })
+            await createUtteranceEdit(started.utterance.id, { editedBy: 'user', userId: editor.id })
+
+            const stats = await getReviewStats()
+            expect(stats.needsReview).toBe(2)
+            expect(stats.inProgress).toBe(1)
+        })
+
+        it('excludes completed, untranscribed, and unsupported-city meetings', async () => {
+            await createCity({ id: 'city1', status: 'supported' })
+            await createCity({ id: 'city2', name: 'Other', status: 'demo' })
+
+            // humanReview succeeded -> out of both counts, into completed
+            await seedMeeting({ cityId: 'city1', meetingId: 'm-done', humanReview: true })
+            // no transcribe -> ignored
+            await seedMeeting({ cityId: 'city1', meetingId: 'm-raw', transcribe: false })
+            // unsupported city -> ignored
+            await seedMeeting({ cityId: 'city2', meetingId: 'm-elsewhere' })
+
+            const stats = await getReviewStats()
+            expect(stats.needsReview).toBe(0)
+            expect(stats.inProgress).toBe(0)
+            expect(stats.completedToday).toBe(1)
+            expect(stats.completedThisWeek).toBe(1)
+        })
+
+        it('counts completions inside the current week only', async () => {
+            await createCity({ id: 'city1', status: 'supported' })
+            const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000)
+            await seedMeeting({
+                cityId: 'city1', meetingId: 'm-old-done',
+                humanReview: true, humanReviewCreatedAt: eightDaysAgo,
+            })
+
+            const stats = await getReviewStats()
+            expect(stats.completedToday).toBe(0)
+            expect(stats.completedThisWeek).toBe(0)
+        })
+    })
+
+    describe('getMeetingsNeedingReview', () => {
+        it('returns aggregate stats per meeting', async () => {
+            await createCity({ id: 'city1', status: 'supported' })
+            const editor = await createUser('editor@example.com')
+            const seeded = await seedMeeting({ cityId: 'city1', meetingId: 'm1' })
+            await createUtteranceEdit(seeded.utterance.id, { editedBy: 'user', userId: editor.id })
+
+            const items = await getMeetingsNeedingReview({ show: 'all' })
+            expect(items).toHaveLength(1)
+            expect(items[0].meetingId).toBe('m1')
+            expect(items[0].totalUtterances).toBe(1)
+            expect(items[0].userEditedUtterances).toBe(1)
+            expect(items[0].primaryReviewer?.userId).toBe(editor.id)
+        })
+
+        it('filters by primary reviewer, not by any contributor', async () => {
+            await createCity({ id: 'city1', status: 'supported' })
+            const primary = await createUser('primary@example.com')
+            const helper = await createUser('helper@example.com')
+
+            await createMeeting('city1', { id: 'm1', dateTime: new Date(Date.now() - 24 * 60 * 60 * 1000) })
+            await createTaskStatus('m1', 'city1', { type: 'transcribe', status: 'succeeded' })
+            const tag = await createSpeakerTag()
+            const segment = await createSpeakerSegment('m1', 'city1', { speakerTagId: tag.id })
+            const u1 = await createUtterance(segment.id)
+            const u2 = await createUtterance(segment.id, { startTimestamp: 10, endTimestamp: 20 })
+            const u3 = await createUtterance(segment.id, { startTimestamp: 20, endTimestamp: 30 })
+            // primary: 2 edits, helper: 1 edit
+            await createUtteranceEdit(u1.id, { editedBy: 'user', userId: primary.id })
+            await createUtteranceEdit(u2.id, { editedBy: 'user', userId: primary.id })
+            await createUtteranceEdit(u3.id, { editedBy: 'user', userId: helper.id })
+
+            const forPrimary = await getMeetingsNeedingReview({ show: 'all', reviewerId: primary.id })
+            expect(forPrimary).toHaveLength(1)
+
+            const forHelper = await getMeetingsNeedingReview({ show: 'all', reviewerId: helper.id })
+            expect(forHelper).toHaveLength(0)
+        })
+
+        it('honors the show filter transitions', async () => {
+            await createCity({ id: 'city1', status: 'supported' })
+            await seedMeeting({ cityId: 'city1', meetingId: 'm-open' })
+            await seedMeeting({ cityId: 'city1', meetingId: 'm-done', humanReview: true })
+
+            const needsAttention = await getMeetingsNeedingReview({ show: 'needsAttention' })
+            expect(needsAttention.map(i => i.meetingId)).toEqual(['m-open'])
+
+            const completed = await getMeetingsNeedingReview({ show: 'completed' })
+            expect(completed.map(i => i.meetingId)).toEqual(['m-done'])
+
+            const all = await getMeetingsNeedingReview({ show: 'all' })
+            expect(all.map(i => i.meetingId).sort()).toEqual(['m-done', 'm-open'])
+        })
+
+        it('bounds results to the last 30 days when asked', async () => {
+            await createCity({ id: 'city1', status: 'supported' })
+            const fortyDaysAgo = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000)
+            await seedMeeting({ cityId: 'city1', meetingId: 'm-recent' })
+            await seedMeeting({ cityId: 'city1', meetingId: 'm-old', dateTime: fortyDaysAgo })
+
+            const recent = await getMeetingsNeedingReview({ show: 'all', last30Days: true })
+            expect(recent.map(i => i.meetingId)).toEqual(['m-recent'])
+
+            const all = await getMeetingsNeedingReview({ show: 'all', last30Days: false })
+            expect(all.map(i => i.meetingId).sort()).toEqual(['m-old', 'm-recent'])
+        })
+    })
+})


### PR DESCRIPTION
## Why

The admin review feature failed in two unrelated ways as transcript data grew:

1. **Shared-memory crash (#560).** `getReviewStats` filtered `CouncilMeeting` through nested relations into `Utterance` and `UtteranceEdit`. Postgres planned parallel hash joins over both tables. The hash tables exhausted dynamic shared memory on the production node (error `53100`) and saturated the CPU.
2. **Result-size overflow (#303).** The reviews list loaded full `TaskStatus` rows. Their request and response payloads total ~1.7 GB on production. On the unfiltered list the marshaled result exceeds the query engine's string limit: `Failed to convert rust String into napi string`. The page failed before any shared-memory pressure. This root cause was found while verifying this PR against a restored production backup — it is not the mechanism #560 assumed for #303.

## What

- Add the index `UtteranceEdit(utteranceId)` (option 2 of #560; 18 MB on production data). The full index also serves the task-edit aggregate, which the partial variant from the issue cannot.
- Rewrite `getReviewStats` candidate-first (option 3): pick needs-attention meetings from the indexed `TaskStatus` relation, then split them with one indexed `EXISTS` probe. No query touches the full `Utterance`/`UtteranceEdit` tables on this path anymore.
- Drop the nested reviewer prefilter. The primary-reviewer check after aggregation already enforces the filter.
- Select only `type` and `status` from task statuses in the review includes — the only fields the code reads. This fixes #303.
- Re-enable the reviews overview widget on `/admin` (reverts the temporary disable from `e1835ae8`).
- Contain widget failures: a client error boundary plus Suspense around the widget, and an admin-scoped `error.tsx`. A widget failure degrades to one card with a Retry button, and the dashboard streams while the review queries run.
- Scope the stats to past meetings (`dateTime <= now`) and state each count's time window on its tile. The dashboard link opens the list with `last30Days=false` — the same population the widget counts.
- Rebuild the widget on the dashboard's `StatsCard` idiom; it predated that component and was the only element with its own card chrome.
- Fix the `test-backup` skill to sort backups by date across Snapshooter target directories. The old whole-path sort silently fetched a dump frozen at 2026-07-11 from a renamed target. The reproduction below depends on this fix.
- Characterization tests pin the query semantics (status split, completion windows, primary-reviewer filter, show transitions, date bound).

## Measurements

Restored production backup (2026-08-19; 655 meetings, 1.02M utterances, 461k edits) on local PostgreSQL 16:

| Path | main | this PR |
|---|---|---|
| `getReviewStats()` | 53100 crash on prod; 1.9 s hash-join shape locally | **212 ms** |
| Reviews list, unfiltered (#303 repro) | `Failed to convert rust String into napi string` | **8.7 s, 587 items** |
| Reviews list, default view | worked | 2.5 s |

The stats probe uses `JOIN LATERAL ... LIMIT 1`, which cannot be flattened into a hash join, so the 53100 plan shape is structurally unreachable on that path (verified under `enable_nestloop=off`: zero parallel-hash nodes). The batch aggregate keeps the planner's choice; its plans show no parallel hash today. The local node cannot reproduce the shared-memory exhaustion itself (its `/dev/shm` is large); the plan shapes are the evidence. The unfiltered list stays slow because the aggregate still walks every meeting's utterances once — acceptable for an admin page; option 4 of #560 (materialized view) is the next rung if it matters.

## Reproduce

1. Restore the latest production backup with the `test-backup` skill (S3 fetch mode).
2. Point `DATABASE_URL` and `DIRECT_URL` at the restored database — both, and as literal values; Prisma Migrate connects through `DIRECT_URL`, and an unset override falls back to the `.env` database.
3. Run `npx prisma migrate deploy`, then this probe with `npx tsx`:

```ts
import { getReviewStats, getMeetingsNeedingReview } from './src/lib/db/reviews';

const stats = await getReviewStats();
console.log(stats);
const items = await getMeetingsNeedingReview({ show: 'all', last30Days: false });
console.log(items.length);
```

On `main`, the second call throws the napi string error. On this branch, both calls return.

The branch merges current `main`, which added auth guards to the review data layer; the characterization suite signs in a superadmin accordingly.

PR #475 correctly identified a further latent limit on this path: the aggregate's `VALUES` list hits PostgreSQL's 32,767 bind-variable cap near ~16,000 meetings. Production is at ~600, so that cliff is not part of this fix, but the finding is documented here for when scale approaches it.

Closes #560. Closes #303.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restructures admin review queries to avoid loading large task payloads and expensive whole-table join plans, while restoring the review dashboard widget with localized failure handling.
- Adds an index and candidate-first query for review statistics.
- Narrows TaskStatus selections to fields consumed by review logic.
- Adds characterization coverage for review filtering and count semantics.
- Restores the dashboard widget with Suspense and error fallbacks.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/db/reviews.ts | Reworks review statistics around candidate meeting IDs and narrows TaskStatus projections; inspected consumers and database relationships remain compatible. |
| tests/integration/reviews.queries.test.ts | Adds characterization tests and now passes the Prisma client directly to resetDatabase without the previously reported any cast. |
| src/components/admin/AdminWidgetErrorBoundary.tsx | Adds widget-scoped fallback and retry behavior; no eligible blocking issue is tied to the prior test-cast thread. |
| prisma/schema.prisma | Declares the UtteranceEdit utteranceId index added by the accompanying migration. |
| src/app/[locale]/(admin)/admin/page.tsx | Restores the reviews overview widget under Suspense and a widget-level error boundary. |

<sub>Reviews (3): Last reviewed commit: ["fix(skills): pick the newest backup acro..."](https://github.com/schemalabz/opencouncil/commit/949a8e089e543b4cecdb25b454d3577ac1eb661b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54741882)</sub>

<!-- /greptile_comment -->