### PR TITLE
Embed the walkthrough video on /mcp and complete the connect steps

### DIFF
--- a/messages/el/mcp.json
+++ b/messages/el/mcp.json
@@ -21,19 +21,26 @@
         "copy": "Αντιγραφή",
         "copied": "Αντιγράφηκε"
     },
+    "video": {
+        "title": "Οδηγός σε βίντεο",
+        "caption": "Τέσσερα λεπτά: πώς συνδέετε το Claude και το ChatGPT, και τι μπορείτε να ρωτήσετε στη συνέχεια.",
+        "iframeTitle": "Πώς να συνδέσετε το Claude και το ChatGPT με το OpenCouncil"
+    },
     "clients": {
         "claude": {
             "title": "Claude",
             "step1": "Στο claude.ai, ανοίξτε Settings → Connectors.",
             "step2": "Πατήστε «Add custom connector».",
-            "step3": "Δώστε το όνομα OpenCouncil και επικολλήστε τη διεύθυνση.",
+            "step3": "Δώστε το όνομα OpenCouncil και επικολλήστε τη διεύθυνση. Τα υπόλοιπα πεδία μένουν κενά.",
+            "step4": "Πατήστε «Add» και μετά «Connect» — ο connector εμφανίζεται ως συνδεδεμένος.",
             "openSettings": "Άνοιγμα ρυθμίσεων claude.ai"
         },
         "chatgpt": {
             "title": "ChatGPT",
             "step1": "Στο ChatGPT, ανοίξτε Settings → Apps & Connectors και ενεργοποιήστε το Developer mode (στο Advanced).",
-            "step2": "Πατήστε «Create» για νέο connector.",
+            "step2": "Επιστρέψτε στα Apps & Connectors και πατήστε «Create».",
             "step3": "Δώστε το όνομα OpenCouncil, επικολλήστε τη διεύθυνση και επιλέξτε «No authentication».",
+            "step4": "Πατήστε «Create» και μετά «Connect» — ο connector εμφανίζεται ως συνδεδεμένος.",
             "openSettings": "Άνοιγμα ρυθμίσεων ChatGPT"
         },
         "claudeCode": {

--- a/messages/en/mcp.json
+++ b/messages/en/mcp.json
@@ -21,19 +21,26 @@
         "copy": "Copy",
         "copied": "Copied"
     },
+    "video": {
+        "title": "Video walkthrough",
+        "caption": "Four minutes: how to connect Claude and ChatGPT, and what you can ask afterwards. The video is in Greek.",
+        "iframeTitle": "How to connect Claude and ChatGPT with OpenCouncil"
+    },
     "clients": {
         "claude": {
             "title": "Claude",
             "step1": "In claude.ai, open Settings → Connectors.",
             "step2": "Click \"Add custom connector\".",
-            "step3": "Name it OpenCouncil and paste the address.",
+            "step3": "Name it OpenCouncil and paste the address. Leave the other fields empty.",
+            "step4": "Click \"Add\", then \"Connect\" — the connector shows as connected.",
             "openSettings": "Open claude.ai settings"
         },
         "chatgpt": {
             "title": "ChatGPT",
             "step1": "In ChatGPT, open Settings → Apps & Connectors and enable Developer mode (under Advanced).",
-            "step2": "Click \"Create\" to add a connector.",
+            "step2": "Go back to Apps & Connectors and click \"Create\".",
             "step3": "Name it OpenCouncil, paste the address, and choose \"No authentication\".",
+            "step4": "Click \"Create\", then \"Connect\" — the connector shows as connected.",
             "openSettings": "Open ChatGPT settings"
         },
         "claudeCode": {

--- a/messages/fr/mcp.json
+++ b/messages/fr/mcp.json
@@ -21,19 +21,26 @@
         "copy": "Copier",
         "copied": "Copié"
     },
+    "video": {
+        "title": "Guide en vidéo",
+        "caption": "Quatre minutes : comment connecter Claude et ChatGPT, et ce que vous pouvez demander ensuite. La vidéo est en grec.",
+        "iframeTitle": "Comment connecter Claude et ChatGPT à OpenCouncil"
+    },
     "clients": {
         "claude": {
             "title": "Claude",
             "step1": "Dans claude.ai, ouvrez Settings → Connectors.",
             "step2": "Cliquez sur « Add custom connector ».",
-            "step3": "Nommez-le OpenCouncil et collez l'adresse.",
+            "step3": "Nommez-le OpenCouncil et collez l'adresse. Laissez les autres champs vides.",
+            "step4": "Cliquez sur « Add », puis sur « Connect » — le connecteur s'affiche comme connecté.",
             "openSettings": "Ouvrir les réglages claude.ai"
         },
         "chatgpt": {
             "title": "ChatGPT",
             "step1": "Dans ChatGPT, ouvrez Settings → Apps & Connectors et activez le Developer mode (sous Advanced).",
-            "step2": "Cliquez sur « Create » pour ajouter un connecteur.",
+            "step2": "Revenez à Apps & Connectors et cliquez sur « Create ».",
             "step3": "Nommez-le OpenCouncil, collez l'adresse et choisissez « No authentication ».",
+            "step4": "Cliquez sur « Create », puis sur « Connect » — le connecteur s'affiche comme connecté.",
             "openSettings": "Ouvrir les réglages ChatGPT"
         },
         "claudeCode": {

--- a/messages/sr/mcp.json
+++ b/messages/sr/mcp.json
@@ -21,19 +21,26 @@
         "copy": "Копирај",
         "copied": "Копирано"
     },
+    "video": {
+        "title": "Видео упутство",
+        "caption": "Четири минута: како да повежете Claude и ChatGPT и шта затим можете да питате. Видео је на грчком.",
+        "iframeTitle": "Како да повежете Claude и ChatGPT са OpenCouncil-ом"
+    },
     "clients": {
         "claude": {
             "title": "Claude",
             "step1": "У claude.ai, отворите Settings → Connectors.",
             "step2": "Кликните на „Add custom connector“.",
-            "step3": "Назовите га OpenCouncil и налепите адресу.",
+            "step3": "Назовите га OpenCouncil и налепите адресу. Остала поља оставите празна.",
+            "step4": "Кликните на „Add“, па на „Connect“ — конектор се приказује као повезан.",
             "openSettings": "Отвори подешавања claude.ai"
         },
         "chatgpt": {
             "title": "ChatGPT",
             "step1": "У ChatGPT-у, отворите Settings → Apps & Connectors и укључите Developer mode (под Advanced).",
-            "step2": "Кликните на „Create“ за нови конектор.",
+            "step2": "Вратите се на Apps & Connectors и кликните на „Create“.",
             "step3": "Назовите га OpenCouncil, налепите адресу и изаберите „No authentication“.",
+            "step4": "Кликните на „Create“, па на „Connect“ — конектор се приказује као повезан.",
             "openSettings": "Отвори подешавања ChatGPT-а"
         },
         "claudeCode": {

--- a/src/app/[locale]/(other)/mcp/page.tsx
+++ b/src/app/[locale]/(other)/mcp/page.tsx
@@ -96,6 +96,21 @@ export default async function McpPage(props: { params: Promise<{ locale: string 
                     <CopyButton value={serverUrl} />
                 </div>
 
+                {/* video walkthrough */}
+                <div className="mt-10">
+                    <h3 className="!text-left text-lg font-semibold">{t("video.title")}</h3>
+                    <p className="mt-2 leading-relaxed text-muted-foreground">{t("video.caption")}</p>
+                    <div className="mt-4 aspect-[100/65] overflow-hidden rounded-xl border bg-muted/40">
+                        <iframe
+                            src="https://www.loom.com/embed/14194bb035464ce6abcd76b8b8faf873"
+                            title={t("video.iframeTitle")}
+                            loading="lazy"
+                            allowFullScreen
+                            className="h-full w-full"
+                        />
+                    </div>
+                </div>
+
                 <div className="mt-10 grid gap-x-12 gap-y-10 sm:grid-cols-2">
                     {(["claude", "chatgpt"] as const).map(client => (
                         <div key={client}>
@@ -110,9 +125,9 @@ export default async function McpPage(props: { params: Promise<{ locale: string 
                                 {t(`clients.${client}.title`)}
                             </h3>
                             <ol className="mt-3 list-decimal space-y-2 pl-5 leading-relaxed text-muted-foreground marker:text-orange">
-                                <li>{t(`clients.${client}.step1`)}</li>
-                                <li>{t(`clients.${client}.step2`)}</li>
-                                <li>{t(`clients.${client}.step3`)}</li>
+                                {(["step1", "step2", "step3", "step4"] as const).map(step => (
+                                    <li key={step}>{t(`clients.${client}.${step}`)}</li>
+                                ))}
                             </ol>
                             <a
                                 href={


### PR DESCRIPTION
Updates `/mcp` from the [walkthrough video](https://www.loom.com/share/14194bb035464ce6abcd76b8b8faf873).

## Instructions

The video shows the full connect flow for Claude and ChatGPT. The page steps stopped one click early. A reader who followed them reached the screen that says "You are not connected to OpenCouncil yet" and got no next step.

**Claude**
- Step 3 now says that the other fields stay empty.
- New step 4: click "Add", then "Connect".

**ChatGPT**
- Step 2 now says to return to Apps & Connectors first. Developer mode opens a different screen, so "Create" is not on screen after step 1.
- New step 4: click "Create", then "Connect".

The page renders the steps in a loop over `step1`–`step4` instead of three hard-coded list items.

## Video

The video goes above the two step lists, under the server address that it tells the viewer to copy. The container uses the Loom aspect ratio (`aspect-[100/65]`). The iframe is lazy-loaded.

The recording is in Greek. The `en`, `fr` and `sr` captions say so.

## Translations

All four locales carry the new `video` block and the new `step4` keys. `sr-Latn` derives from `sr` at load time.

## Verification

- `npm test` — 1439 passed, including `translations`, `sr-glossary` and `sr-latn-catalog`.
- `npm run build`, `npx tsc --noEmit` and `npm run lint` — clean.
- Rendered `/mcp` on a local dev server and checked the layout at 1280px and 390px. The video block, the caption and both four-step lists render as expected.
- The container blocks third-party frames, so the Loom player itself could not load in the browser here. I checked the embed URL over HTTP instead: it returns 200, sends no `X-Frame-Options`, and its CSP sets no `frame-ancestors` directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJ5p8nYcAQhTK2wWMqB1Hx

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJ5p8nYcAQhTK2wWMqB1Hx)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR embeds a localized Loom walkthrough on `/mcp` and completes the Claude and ChatGPT connection instructions.
- Adds localized video titles, captions, and accessible iframe titles across all source catalogs.
- Adds the missing fourth connection step and clarifies preceding instructions.
- Replaces three hard-coded list items with a loop rendering all four steps.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified.

The iframe is permitted by the repository’s deployed headers, and every supported locale receives the newly referenced translation keys, including the derived Serbian Latin catalog.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/[locale]/(other)/mcp/page.tsx | Adds the responsive, lazy-loaded Loom embed and renders four localized setup steps without an identified functional regression. |
| messages/el/mcp.json | Adds complete Greek video metadata and revised four-step Claude and ChatGPT instructions. |
| messages/en/mcp.json | Adds complete English video metadata and revised four-step Claude and ChatGPT instructions. |
| messages/fr/mcp.json | Adds complete French video metadata and revised four-step Claude and ChatGPT instructions. |
| messages/sr/mcp.json | Adds complete Serbian video metadata and instructions, with keys preserved for runtime Serbian Latin derivation. |

<sub>Reviews (1): Last reviewed commit: ["feat(mcp): embed walkthrough video and c..."](https://github.com/schemalabz/opencouncil/commit/ff8aa7cd8669816c5d6716fa105a65efc31e6914) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54771575)</sub>

<!-- /greptile_comment -->