### PR TITLE
Move PR previews to opencouncil.dev

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -16,6 +16,11 @@ concurrency:
 
 env:
   CACHIX_CACHE_NAME: ${{ secrets.CACHIX_CACHE_NAME || 'opencouncil' }}
+  # Preview hostnames: pr-<N>.<PREVIEW_DOMAIN>. Keep PREVIEW_DOMAIN in step with
+  # services.opencouncil-preview.previewDomain on the droplet — the droplet is
+  # what actually serves the host, this only names it for links and health checks.
+  PREVIEW_DOMAIN: opencouncil.dev
+  TASKS_PREVIEW_DOMAIN: tasks.opencouncil.dev
 
 jobs:
   # Route the deploy through the right environment: PRs authored by users
@@ -318,7 +323,7 @@ jobs:
 
           echo "### 🚀 Preview Deployed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Preview URL: https://pr-$PR_NUM.preview.opencouncil.gr" >> $GITHUB_STEP_SUMMARY
+          echo "Preview URL: https://pr-$PR_NUM.$PREVIEW_DOMAIN" >> $GITHUB_STEP_SUMMARY
           echo "Port: $PORT" >> $GITHUB_STEP_SUMMARY
           if [ "$HAS_MIGRATIONS" = "true" ]; then
             echo "Database: Isolated (PostGIS 3.3.5, seed data)" >> $GITHUB_STEP_SUMMARY
@@ -326,14 +331,14 @@ jobs:
             echo "Database: Shared staging" >> $GITHUB_STEP_SUMMARY
           fi
           if [ -n "${LINKED_TASKS_PR:-}" ]; then
-            echo "Tasks API: https://pr-${LINKED_TASKS_PR}.tasks.opencouncil.gr" >> $GITHUB_STEP_SUMMARY
+            echo "Tasks API: https://pr-${LINKED_TASKS_PR}.$TASKS_PREVIEW_DOMAIN" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Health check
         id: health-check
         run: |
           PR_NUM="${{ github.event.pull_request.number }}"
-          URL="https://pr-${PR_NUM}.preview.opencouncil.gr"
+          URL="https://pr-${PR_NUM}.${PREVIEW_DOMAIN}"
           for i in $(seq 1 10); do
             HTTP_CODE=$(curl -sL -o /dev/null -w '%{http_code}' --max-time 10 "$URL" || echo "000")
             if [ "$HTTP_CODE" = "200" ]; then
@@ -353,7 +358,7 @@ jobs:
           script: |
             const commentId = ${{ steps.pr-comment.outputs.comment-id }};
             const prNumber = context.payload.pull_request.number;
-            const previewUrl = 'https://pr-' + prNumber + '.preview.opencouncil.gr';
+            const previewUrl = 'https://pr-' + prNumber + '.' + process.env.PREVIEW_DOMAIN;
             const commitSha = context.payload.pull_request.head.sha.substring(0, 7);
             const healthStatus = '${{ steps.health-check.outputs.status }}';
             const logsUrl = context.serverUrl + '/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + context.runId;
@@ -370,7 +375,7 @@ jobs:
               + '**Database:** ' + (hasMigrations ? 'Isolated (PostGIS 3.3.5, seed data)' : 'Shared staging') + '\n';
 
             if (linkedTasksPr) {
-              body += '**Tasks API:** https://pr-' + linkedTasksPr + '.tasks.opencouncil.gr\n';
+              body += '**Tasks API:** https://pr-' + linkedTasksPr + '.' + process.env.TASKS_PREVIEW_DOMAIN + '\n';
             }
 
             body += '\nThe preview will be automatically updated when you push new commits.\n'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ To verify a change in a running app (e.g. during PR review) without the magic-li
 ## Preview Server
 
 PR previews run on a NixOS droplet (`ssh root@159.89.98.26`), managed by [nix-openclaw](https://github.com/schemalabz/nix-openclaw). Each PR gets:
-- **App**: `https://pr-N.preview.opencouncil.gr` (port `3000 + N`)
+- **App**: `https://pr-N.opencouncil.dev` (port `3000 + N`)
 - **DB** (migration PRs): local PostgreSQL on port `5432 + N`, user/db both `opencouncil`, trust auth
 
 `psql` is on the system PATH. For debugging, direct DB manipulation, and deployment details see [docs/guides/preview-deployments.md](./docs/guides/preview-deployments.md).

--- a/docs/guides/preview-deployments.md
+++ b/docs/guides/preview-deployments.md
@@ -28,7 +28,7 @@ On the droplet, each PR maps to:
 | File | Purpose |
 |------|---------|
 | `flake.nix` → `opencouncil-prod` | `buildNpmPackage` producing a Next.js standalone build |
-| `flake.nix` → `nixosModules.opencouncil-preview` | Self-contained NixOS module: systemd service, Caddy, sudo rules, management scripts, garbage collection |
+| `flake.nix` → `previews.opencouncil` | Preview config export (start script, DB lifecycle hooks) consumed by the generic [pr-previews](https://github.com/schemalabz/pr-previews) NixOS module, which generates the systemd service, Caddy vhosts, sudo rules, and management scripts |
 | `.github/workflows/preview-deploy.yml` | Build + deploy on PR open/sync (includes health check) |
 | `.github/workflows/preview-cleanup.yml` | Teardown on PR close |
 
@@ -86,7 +86,7 @@ The droplet consumes the NixOS module directly from the flake. You need two file
       system = "x86_64-linux";
       modules = [
         (nixpkgs + "/nixos/modules/virtualisation/digital-ocean-config.nix")
-        opencouncil.nixosModules.opencouncil-preview
+        pr-previews.nixosModules.default
         ./configuration.nix
       ];
     };
@@ -104,10 +104,14 @@ The droplet consumes the NixOS module directly from the flake. You need two file
 
   networking.hostName = "opencouncil-preview";
 
-  services.opencouncil-preview = {
+  services.pr-previews = {
     enable = true;
-    envFile = "/var/lib/opencouncil-previews/.env";
-    cachix.enable = true;
+    user = "opencouncil";
+    group = "opencouncil";
+    projects.opencouncil = lib.mkMerge [
+      opencouncil.previews.opencouncil
+      { envFile = "/var/lib/opencouncil-previews/.env"; }
+    ];
   };
 
   services.openssh = {
@@ -132,7 +136,7 @@ The module is self-contained — it includes Caddy, firewall rules, sudo rules, 
 
 ### Updating the Module
 
-When `nixosModules.opencouncil-preview` changes in the repo, pull the update on the droplet:
+When the `previews.opencouncil` export (or the pr-previews module) changes, pull the update on the droplet:
 
 ```bash
 # Update the opencouncil flake input to latest commit

--- a/docs/guides/preview-deployments.md
+++ b/docs/guides/preview-deployments.md
@@ -1,6 +1,6 @@
 # PR Preview Deployments
 
-Automated per-PR preview environments on a NixOS droplet. Each PR gets a subdomain (`pr-123.preview.opencouncil.gr`), a systemd service, and Caddy reverse proxy entry. All previews share a staging database.
+Automated per-PR preview environments on a NixOS droplet. Each PR gets a subdomain (`pr-123.opencouncil.dev`), a systemd service, and Caddy reverse proxy entry. All previews share a staging database.
 
 ## How It Works
 
@@ -21,7 +21,7 @@ On the droplet, each PR maps to:
 - **Port**: `3000 + PR_NUMBER` (PR #123 → port 3123)
 - **Service**: `opencouncil-preview@3123.service`
 - **Caddy config**: `/etc/caddy/conf.d/pr-123.conf` → reverse proxy to `localhost:3123`
-- **URL**: `https://pr-123.preview.opencouncil.gr`
+- **URL**: `https://pr-123.opencouncil.dev`
 
 ## Repository Files
 
@@ -48,7 +48,25 @@ The `opencouncil-prod` package in `flake.nix` uses `buildNpmPackage` with these 
 
 - NixOS droplet
 - Minimum: 2 GB RAM, 20 GB disk
-- DNS: `A preview → <ip>` and `A *.preview → <ip>` for `opencouncil.gr`
+- DNS. `opencouncil.dev` is delegated to the DigitalOcean nameservers, the same
+  as `opencouncil.gr`. Add the domain under **Networking → Domains**, then add
+  two records that point at the droplet IP:
+
+  | Type | Hostname | Value |
+  |------|----------|-------|
+  | A | `@` | `<droplet-ip>` |
+  | A | `*` | `<droplet-ip>` |
+
+  A DNS wildcard matches one label only. A preview host must therefore stay one
+  label deep: `pr-123.opencouncil.dev` resolves, `pr-123.preview.opencouncil.dev`
+  does not. Do not put a TLS-terminating proxy in front of these records. Caddy
+  answers the ACME challenge itself, and a proxy in front of it blocks the
+  challenge.
+
+  `.dev` is on the HSTS preload list, so browsers force HTTPS on every preview.
+  Caddy issues one certificate per hostname on demand, which satisfies that.
+  Previews also stop consuming the Let's Encrypt certificate quota of
+  `opencouncil.gr`.
 
 ### Configuration
 
@@ -124,6 +142,42 @@ nix flake update opencouncil --flake /etc/nixos
 nixos-rebuild switch --flake /etc/nixos#preview
 ```
 
+### Changing the Preview Domain
+
+The domain lives in three places. Change all three together:
+
+1. `services.opencouncil-preview.previewDomain` in the module (`flake.nix`). It
+   sets the Caddy vhost of each preview and the `NEXTAUTH_URL` of each instance.
+2. `PREVIEW_DOMAIN` in `.github/workflows/preview-deploy.yml`. It sets the
+   health-check URL and the URL in the PR comment.
+3. `PREVIEW_DOMAIN` in `src/lib/realm.ts`. `isKnownRealmHost` gates the SEO
+   redirects and the magic-link host rewrite on it. A preview on a host that
+   this constant does not cover stops reproducing production.
+
+To keep the old hostnames alive during the move, set `legacyPreviewDomain` to
+the previous domain. Each preview then gets a second vhost,
+`pr-<N>.<legacyPreviewDomain>`, that 301s to the new URL. Old DNS must stay in
+place while this option is set. Set the option back to `null` after every open
+PR redeploys.
+
+An open PR keeps its old Caddy config until its next deployment. To move the
+existing previews immediately, regenerate their configs on the droplet:
+
+```bash
+for f in /etc/caddy/conf.d/pr-*.conf; do
+  n=$(basename "$f" .conf)
+  n=${n#pr-}
+  port=$((3000 + n))
+  caddy-add-preview "$n"
+  systemctl is-active --quiet "opencouncil-preview@$port" && systemctl restart "opencouncil-preview@$port"
+done
+```
+
+`nixos-rebuild switch` normally restarts the instances itself, because the new
+`NEXTAUTH_URL` changes the unit. The explicit restart makes that certain. A
+preview that keeps the old `NEXTAUTH_URL` serves on the new host but still mails
+magic links that point at the old one.
+
 ### SSH Key for GitHub Actions
 
 Generate on the droplet. Note: the `opencouncil` user's home is `/var/lib/opencouncil-previews` (set by the NixOS module), so `authorized_keys` must go there:
@@ -148,7 +202,7 @@ The app requires many env vars at runtime (API keys, storage config, etc.). Thes
 - `PORT` — `basePort + PR_NUMBER`
 - `NODE_ENV=production`
 - `HOSTNAME=0.0.0.0`
-- `NEXTAUTH_URL` — `https://pr-<N>.preview.opencouncil.gr` (used for all URL construction: callbacks, emails, etc.)
+- `NEXTAUTH_URL` — `https://pr-<N>.opencouncil.dev` (used for all URL construction: callbacks, emails, etc.)
 
 **Shared (env file at `/var/lib/opencouncil-previews/.env`):**
 
@@ -266,7 +320,7 @@ ssh root@$DROPLET "sudo opencouncil-preview-create 999 $(readlink ./result)"
 ### 4. Verify
 
 ```bash
-curl -sI https://pr-999.preview.opencouncil.gr | head -20
+curl -sI https://pr-999.opencouncil.dev | head -20
 ```
 
 ### 5. Teardown
@@ -320,7 +374,7 @@ STORE_PATH=$(readlink ./result)
 ssh root@<droplet-ip> "sudo opencouncil-preview-create 9999 '$STORE_PATH' --with-db"
 
 # 5. Test the preview
-curl -I https://pr-9999.preview.opencouncil.gr
+curl -I https://pr-9999.opencouncil.dev
 
 # 6. Check logs if needed
 ssh root@<droplet-ip> "journalctl -u opencouncil-preview@12999 -n 50"
@@ -360,13 +414,13 @@ psql -h 127.0.0.1 -p $((5432 + PR_NUM)) -U opencouncil -d opencouncil
 
 ## Testing Other Realms
 
-Preview hosts are subdomains of `opencouncil.gr`, so every preview resolves to
-the **greece** realm by Host header — and some realm domains (e.g.
+`opencouncil.dev` belongs to no realm, so every preview resolves to the
+**greece** realm by Host header — and some realm domains (e.g.
 `opencouncil.rs`) have no DNS at all yet. To review another realm, append
 `?realm=<realm>` to any preview URL:
 
 ```
-https://pr-288.preview.opencouncil.gr/?realm=serbia
+https://pr-288.opencouncil.dev/?realm=serbia
 ```
 
 The proxy stores the realm in an `oc-realm` cookie (30 days) and redirects to
@@ -395,7 +449,7 @@ sudo opencouncil-preview-create <num> "$STORE_PATH" --with-db
 To avoid this, prefer creating additive migrations instead of amending existing ones. If you must amend, remember to reset the preview DB afterwards.
 
 **Preview not accessible:**
-1. DNS: `dig pr-123.preview.opencouncil.gr` should resolve to droplet IP
+1. DNS: `dig pr-123.opencouncil.dev` should resolve to droplet IP
 2. Caddy: `systemctl status caddy` + check `/etc/caddy/conf.d/pr-123.conf` exists
 3. Service: `systemctl status opencouncil-preview@3123` should be active
 4. Logs: `journalctl -u opencouncil-preview@3123 -n 100`

--- a/docs/guides/serbian-localization.md
+++ b/docs/guides/serbian-localization.md
@@ -68,7 +68,7 @@ Style conventions:
 `opencouncil.rs` has no DNS yet, so use the `?realm=serbia` override on any
 non-production host (see the preview deployments guide):
 
-- **PR preview**: open `https://pr-N.preview.opencouncil.gr/?realm=serbia`.
+- **PR preview**: open `https://pr-N.opencouncil.dev/?realm=serbia`.
   The seed data includes a Belgrade review fixture — open `/beograd` for a
   released meeting with a Cyrillic-stored and a Latin-stored speaker segment,
   agenda subjects and Serbian topics; use the Ћир | Lat switcher (or the

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -32,7 +32,7 @@ graph TB
     end
 
     subgraph preview_droplet ["Preview Droplet (NixOS · nix-openclaw)"]
-        app_preview["🌐 PR Previews<br/><i>pr-N.preview.opencouncil.gr</i>"]
+        app_preview["🌐 PR Previews<br/><i>pr-N.opencouncil.dev</i>"]
         db_preview[("🗄️ Isolated DB<br/><i>migration PRs only</i>")]
     end
 
@@ -87,7 +87,7 @@ graph TB
 |-------------|-----|--------|----------|-------------|
 | **Production** | opencouncil.gr | `production` | Production DB (DO Managed PostgreSQL) | `:3005` |
 | **Staging** | staging.opencouncil.gr | `main` | Staging DB (DO Managed PostgreSQL) | `:3006` (tasks.opencouncil.gr) |
-| **PR Previews** | pr-N.preview.opencouncil.gr | PR branch | Staging DB (shared), or isolated DB for migration PRs | — |
+| **PR Previews** | pr-N.opencouncil.dev | PR branch | Staging DB (shared), or isolated DB for migration PRs | — |
 | **Local** | localhost:3000 | any | Local (Nix/Docker) or Remote Dev DB | — |
 
 ## How Deployments Work

--- a/flake.nix
+++ b/flake.nix
@@ -1453,7 +1453,10 @@ EOF
         prismaEnv = self.lib.mkPrismaEnv;
         opensslEnv = self.lib.mkOpenSslEnv;
       in {
-        hostPattern = "pr-@id@.preview.opencouncil.gr";
+        hostPattern = "pr-@id@.opencouncil.dev";
+        # Keep the old preview URLs answering with 301s during the move;
+        # drop once the migration settles.
+        redirectFrom = [ "pr-@id@.preview.opencouncil.gr" ];
         basePort = 3000;
         caddyBaseVirtualHost = true;
 

--- a/src/lib/__tests__/realm.test.ts
+++ b/src/lib/__tests__/realm.test.ts
@@ -2,6 +2,7 @@ import {
     realmForHost,
     createRealmResolver,
     isKnownRealmHost,
+    PREVIEW_DOMAIN,
     computeForeignLocales,
     foreignLocalesForRealm,
     isRealm,
@@ -60,14 +61,14 @@ describe('realmForHost', () => {
         expect(realmForHost('opencouncil.rs')).toBe('serbia');
     });
 
-    it('resolves preview subdomains of a realm domain to that realm', () => {
-        expect(realmForHost('pr-7.preview.opencouncil.gr')).toBe('greece');
-        expect(realmForHost('pr-7.preview.opencouncil.fr')).toBe('france');
-        expect(realmForHost('pr-7.preview.opencouncil.cy')).toBe('cyprus');
-        expect(realmForHost('pr-7.preview.opencouncil.rs')).toBe('serbia');
+    it('resolves subdomains of a realm domain to that realm', () => {
+        expect(realmForHost('www.opencouncil.gr')).toBe('greece');
+        expect(realmForHost('www.opencouncil.fr')).toBe('france');
+        expect(realmForHost('www.opencouncil.cy')).toBe('cyprus');
+        expect(realmForHost('www.opencouncil.rs')).toBe('serbia');
     });
 
-    it.each([null, undefined, '', 'localhost:3000', 'example.com'])(
+    it.each([null, undefined, '', 'localhost:3000', 'example.com', 'pr-7.opencouncil.dev'])(
         'defaults %p to greece',
         (host) => {
             expect(realmForHost(host)).toBe('greece');
@@ -80,7 +81,21 @@ describe('isKnownRealmHost', () => {
         expect(isKnownRealmHost('opencouncil.gr')).toBe(true);
         expect(isKnownRealmHost('opencouncil.fr')).toBe(true);
         expect(isKnownRealmHost('opencouncil.cy')).toBe(true);
-        expect(isKnownRealmHost('pr-7.preview.opencouncil.fr')).toBe(true);
+        expect(isKnownRealmHost('www.opencouncil.fr')).toBe(true);
+    });
+
+    // Previews belong to no realm, so `realmForHost` defaults them to greece —
+    // but they are still our own hosts, and the checks gated on this one (SEO
+    // redirects, magic-link host rewrite, OG metadata base) must run there too.
+    it('accepts the preview domain and its subdomains', () => {
+        expect(isKnownRealmHost(PREVIEW_DOMAIN)).toBe(true);
+        expect(isKnownRealmHost(`pr-7.${PREVIEW_DOMAIN}`)).toBe(true);
+        expect(isKnownRealmHost(`PR-7.${PREVIEW_DOMAIN.toUpperCase()}:443`)).toBe(true);
+    });
+
+    it('rejects a lookalike of the preview domain', () => {
+        expect(isKnownRealmHost(`${PREVIEW_DOMAIN}.evil.com`)).toBe(false);
+        expect(isKnownRealmHost(`evil${PREVIEW_DOMAIN}`)).toBe(false);
     });
 
     it('rejects unknown hosts', () => {
@@ -111,7 +126,7 @@ describe('isRealmApexHost', () => {
     });
 
     it('rejects subdomains (previews), localhost and unknown hosts', () => {
-        expect(isRealmApexHost('pr-7.preview.opencouncil.gr')).toBe(false);
+        expect(isRealmApexHost('pr-7.opencouncil.dev')).toBe(false);
         expect(isRealmApexHost('www.opencouncil.gr')).toBe(false);
         expect(isRealmApexHost('localhost:3000')).toBe(false);
         expect(isRealmApexHost('evil.com')).toBe(false);
@@ -121,8 +136,8 @@ describe('isRealmApexHost', () => {
 
 describe('realmOverride / effectiveRealm', () => {
     it('honors a valid override cookie on preview hosts and localhost', () => {
-        expect(realmOverride('pr-7.preview.opencouncil.gr', 'serbia')).toBe('serbia');
-        expect(effectiveRealm('pr-7.preview.opencouncil.gr', 'serbia')).toBe('serbia');
+        expect(realmOverride('pr-7.opencouncil.dev', 'serbia')).toBe('serbia');
+        expect(effectiveRealm('pr-7.opencouncil.dev', 'serbia')).toBe('serbia');
         expect(effectiveRealm('localhost:3000', 'france')).toBe('france');
     });
 
@@ -133,9 +148,9 @@ describe('realmOverride / effectiveRealm', () => {
     });
 
     it('ignores invalid or absent cookie values and falls back to the host realm', () => {
-        expect(realmOverride('pr-7.preview.opencouncil.gr', 'atlantis')).toBeUndefined();
-        expect(effectiveRealm('pr-7.preview.opencouncil.gr', 'atlantis')).toBe('greece');
-        expect(effectiveRealm('pr-7.preview.opencouncil.fr', undefined)).toBe('france');
+        expect(realmOverride('pr-7.opencouncil.dev', 'atlantis')).toBeUndefined();
+        expect(effectiveRealm('pr-7.opencouncil.dev', 'atlantis')).toBe('greece');
+        expect(effectiveRealm('www.opencouncil.fr', undefined)).toBe('france');
         expect(effectiveRealm('localhost:3000', undefined)).toBe('greece');
     });
 });
@@ -230,12 +245,12 @@ describe('metadataBaseForHost', () => {
     });
 
     it('uses the preview host itself, so a preview unfurls its own OG images', () => {
-        expect(metadataBaseForHost('pr-7.preview.opencouncil.gr', 'greece'))
-            .toBe('https://pr-7.preview.opencouncil.gr');
-        // The realm override makes a .gr preview render as serbia; the images
+        expect(metadataBaseForHost('pr-7.opencouncil.dev', 'greece'))
+            .toBe('https://pr-7.opencouncil.dev');
+        // The realm override makes a preview render as serbia; the images
         // still have to come from the preview, not from opencouncil.rs.
-        expect(metadataBaseForHost('pr-7.preview.opencouncil.gr', 'serbia'))
-            .toBe('https://pr-7.preview.opencouncil.gr');
+        expect(metadataBaseForHost('pr-7.opencouncil.dev', 'serbia'))
+            .toBe('https://pr-7.opencouncil.dev');
     });
 
     it('ignores a host we do not own', () => {

--- a/src/lib/__tests__/seo-redirects.test.ts
+++ b/src/lib/__tests__/seo-redirects.test.ts
@@ -34,7 +34,7 @@ describe('wwwRedirectTarget', () => {
     });
 
     it('leaves nested subdomains alone', () => {
-        expect(wwwRedirectTarget('www.pr-7.preview.opencouncil.fr', '/x', '')).toBeNull();
+        expect(wwwRedirectTarget('www.staging.opencouncil.fr', '/x', '')).toBeNull();
         expect(wwwRedirectTarget('opencouncil.chania.gr', '/x', '')).toBeNull();
     });
 
@@ -112,8 +112,10 @@ describe('foreignLocaleRedirectPath', () => {
         expect(foreignLocaleRedirectPath('opencouncil.fr', '/elefsina')).toBeNull();
     });
 
-    it('applies on realm subdomains like preview hosts', () => {
-        expect(foreignLocaleRedirectPath('pr-7.preview.opencouncil.gr', '/fr/athens')).toBe('/athens');
+    it('applies on realm subdomains and on preview hosts', () => {
+        expect(foreignLocaleRedirectPath('www.opencouncil.gr', '/fr/athens')).toBe('/athens');
+        // Previews resolve to greece by default, and must reproduce its redirects.
+        expect(foreignLocaleRedirectPath('pr-7.opencouncil.dev', '/fr/athens')).toBe('/athens');
     });
 
     it('strips Serbian prefixes on non-Serbian hosts, using the /lat URL prefix for sr-Latn', () => {
@@ -140,8 +142,8 @@ describe('foreignLocaleRedirectPath', () => {
     it('with a realm override, treats the host as that realm', () => {
         // Preview host (greece by Host) overridden to serbia: Serbian locales
         // become native, Greek becomes foreign — mirroring opencouncil.rs.
-        expect(foreignLocaleRedirectPath('pr-7.preview.opencouncil.gr', '/lat/beograd', 'serbia')).toBeNull();
-        expect(foreignLocaleRedirectPath('pr-7.preview.opencouncil.gr', '/el/beograd', 'serbia')).toBe('/beograd');
+        expect(foreignLocaleRedirectPath('pr-7.opencouncil.dev', '/lat/beograd', 'serbia')).toBeNull();
+        expect(foreignLocaleRedirectPath('pr-7.opencouncil.dev', '/el/beograd', 'serbia')).toBe('/beograd');
         // Even on unknown hosts (localhost) the override applies, so the
         // emulation is faithful in local dev too.
         expect(foreignLocaleRedirectPath('localhost:3000', '/el/beograd', 'serbia')).toBe('/beograd');

--- a/src/lib/auth/__tests__/requestLocale.test.ts
+++ b/src/lib/auth/__tests__/requestLocale.test.ts
@@ -39,7 +39,7 @@ describe('localeForRequest', () => {
 
     it('honors a realm override on a preview host, so previews send the real email', () => {
         expect(
-            localeForRequest(reqWith({ host: 'pr-7.preview.opencouncil.gr', cookie: 'oc-realm=serbia' }))
+            localeForRequest(reqWith({ host: 'pr-7.opencouncil.dev', cookie: 'oc-realm=serbia' }))
         ).toBe('sr');
     });
 

--- a/src/lib/auth/__tests__/signInUrl.test.ts
+++ b/src/lib/auth/__tests__/signInUrl.test.ts
@@ -70,12 +70,23 @@ describe('signInUrlForRequest', () => {
         expect(result).toBe(greekUrl);
     });
 
-    it('allows a preview subdomain of a realm domain', () => {
+    it('allows a subdomain of a realm domain', () => {
         const result = signInUrlForRequest(
             greekUrl,
-            reqWith({ 'x-forwarded-host': 'pr-7.preview.opencouncil.fr' })
+            reqWith({ 'x-forwarded-host': 'www.opencouncil.fr' })
         );
-        expect(new URL(result).host).toBe('pr-7.preview.opencouncil.fr');
+        expect(new URL(result).host).toBe('www.opencouncil.fr');
+    });
+
+    // Previews belong to no realm, so the host allowlist has to admit the
+    // preview domain in its own right — otherwise every preview would mail out
+    // links pointing at whichever host the build's NEXTAUTH_URL names.
+    it('allows a preview host', () => {
+        const result = signInUrlForRequest(
+            greekUrl,
+            reqWith({ 'x-forwarded-host': 'pr-7.opencouncil.dev' })
+        );
+        expect(new URL(result).host).toBe('pr-7.opencouncil.dev');
     });
 
     // Auth.js resolves the relative `redirectTo` against NEXTAUTH_URL's origin

--- a/src/lib/email/__tests__/emailLocale.test.ts
+++ b/src/lib/email/__tests__/emailLocale.test.ts
@@ -29,8 +29,8 @@ describe('emailBaseUrlForRealm', () => {
     });
 
     it('keeps a preview host, so preview emails point at the preview', () => {
-        setNextAuthUrl('https://pr-577.preview.opencouncil.gr');
-        expect(emailBaseUrlForRealm('serbia')).toBe('https://pr-577.preview.opencouncil.gr');
+        setNextAuthUrl('https://pr-577.opencouncil.dev');
+        expect(emailBaseUrlForRealm('serbia')).toBe('https://pr-577.opencouncil.dev');
     });
 
     it('keeps a local dev host', () => {

--- a/src/lib/realm.ts
+++ b/src/lib/realm.ts
@@ -80,11 +80,24 @@ const hostMatchesDomain = (host: string, domain: string): boolean =>
     host === domain || host.endsWith(`.${domain}`);
 
 /**
+ * The domain PR previews are served from: `pr-165.opencouncil.dev` for PR #165.
+ *
+ * It belongs to no realm — a preview resolves to `greece` like any other
+ * unrecognised host, and reaches the other realms through `?realm=` (see
+ * `REALM_OVERRIDE_COOKIE`). It is still one of our own hosts, so
+ * `isKnownRealmHost` accepts it: the SEO redirects, the magic-link host rewrite
+ * and the OG metadata base are gated on that check, and a preview that skipped
+ * them would stop reproducing production.
+ */
+export const PREVIEW_DOMAIN = 'opencouncil.dev';
+
+/**
  * Builds a resolver mapping a Host header value to a realm of `realms`, or null
  * when none matches. The port is stripped and the host lowercased so
  * `localhost:3000`-style hosts and a spoofed `Host: opencouncil.fr` both work;
- * each realm's domain matches as the apex or any subdomain (so preview hosts
- * like `pr-7.preview.opencouncil.fr` resolve correctly). Domains are checked
+ * each realm's domain matches as the apex or any subdomain (so
+ * `www.opencouncil.fr` resolves to france, not to the default). Domains are
+ * checked
  * most-specific (longest) first — a subdomain is always longer than its parent
  * domain — so a realm hosted on a subdomain of another realm's domain wins over
  * the parent regardless of declaration order.
@@ -122,15 +135,17 @@ export function realmForHost(host: string | null | undefined): Realm {
 }
 
 /**
- * Whether a Host header value is one of our own domains (apex or subdomain of a
- * realm domain — so production and preview hosts match, but `localhost` and any
- * attacker-supplied host do not). Unlike `realmForHost` (which defaults unknown
- * hosts to `greece`), this is a strict membership check — use it before trusting
- * a request's Host for anything sensitive, e.g. building a magic-link URL.
+ * Whether a Host header value is one of our own domains: a realm domain or
+ * `PREVIEW_DOMAIN`, as the apex or any subdomain — so production and preview
+ * hosts match, but `localhost` and any attacker-supplied host do not. Unlike
+ * `realmForHost` (which defaults unknown hosts to `greece`), this is a strict
+ * membership check — use it before trusting a request's Host for anything
+ * sensitive, e.g. building a magic-link URL.
  */
 export function isKnownRealmHost(host: string | null | undefined): boolean {
     const normalized = (host ?? '').split(':')[0].toLowerCase();
     if (!normalized) return false;
+    if (hostMatchesDomain(normalized, PREVIEW_DOMAIN)) return true;
     return Object.values(REALMS).some(({ domain }) => hostMatchesDomain(normalized, domain));
 }
 
@@ -139,8 +154,9 @@ export function isKnownRealmHost(host: string | null | undefined): boolean {
  * `isRealmApexHost`). Set by the proxy when a request arrives with
  * `?realm=<realm>`; read by the proxy, `getRealm()` and `realmForBrowser()` so
  * previews and localhost can be viewed as any realm despite their Host
- * resolving elsewhere (preview hosts are subdomains of opencouncil.gr, and
- * some realm domains — e.g. opencouncil.rs — have no DNS yet).
+ * resolving elsewhere (preview hosts are subdomains of `PREVIEW_DOMAIN`, which
+ * belongs to no realm, and some realm domains — e.g. opencouncil.rs — have no
+ * DNS yet).
  */
 export const REALM_OVERRIDE_COOKIE = 'oc-realm';
 
@@ -153,8 +169,8 @@ export function isRealm(value: string | null | undefined): value is Realm {
 
 /**
  * Whether a Host header value is exactly a realm's canonical production apex
- * (`opencouncil.gr`, not `pr-7.preview.opencouncil.gr` or `localhost`). The
- * realm override is honored only on non-apex hosts: production domains must
+ * (`opencouncil.gr`, not `pr-7.opencouncil.dev` or `localhost`). The realm
+ * override is honored only on non-apex hosts: production domains must
  * stay deterministic per-Host for SEO and CDN sanity, while previews and local
  * dev — which can't reach other realms by Host at all — get the escape hatch.
  */
@@ -239,9 +255,10 @@ export function getRealmBaseUrl(realm: Realm): string {
  * cannot be reviewed on the PR that makes it — the preview page keeps showing
  * whatever production draws.
  *
- * Only hosts under a realm domain earn that (`isKnownRealmHost`), so an
- * arbitrary `Host:` header can never steer a page's image URL to a domain we do
- * not own. Everything else (localhost, direct IP) keeps the canonical URL.
+ * Only hosts we own earn that (`isKnownRealmHost`, which covers the realm
+ * domains and `PREVIEW_DOMAIN`), so an arbitrary `Host:` header can never steer
+ * a page's image URL to a domain we do not own. Everything else (localhost,
+ * direct IP) keeps the canonical URL.
  */
 export function metadataBaseForHost(host: string | null | undefined, realm: Realm): string {
     if (!isRealmApexHost(host) && isKnownRealmHost(host)) {

--- a/src/lib/utils/__tests__/hreflang.test.ts
+++ b/src/lib/utils/__tests__/hreflang.test.ts
@@ -37,10 +37,19 @@ describe('buildCanonicalAlternates', () => {
         });
     });
 
-    it('resolves preview subdomains to their realm', async () => {
-        currentHost = 'pr-7.preview.opencouncil.fr';
+    it('resolves realm subdomains to their realm', async () => {
+        currentHost = 'www.opencouncil.fr';
         expect(await buildCanonicalAlternates('/x')).toEqual({
             canonical: 'https://opencouncil.fr/x',
+        });
+    });
+
+    // A preview must never canonicalize to itself — the whole point of the
+    // canonical is to point crawlers at the production page.
+    it('canonicalizes a preview host to the production apex', async () => {
+        currentHost = 'pr-7.opencouncil.dev';
+        expect(await buildCanonicalAlternates('/x')).toEqual({
+            canonical: 'https://opencouncil.gr/x',
         });
     });
 });


### PR DESCRIPTION
Previews move from `pr-N.preview.opencouncil.gr` to `pr-N.opencouncil.dev`. The tasks preview link moves to `tasks.opencouncil.dev` with them.

## Why the host is not only a label

Preview hosts used to be subdomains of `opencouncil.gr`, so `isKnownRealmHost()` accepted them as a side effect of the realm domain match. Three behaviours are gated on that check:

- `signInUrlForRequest()` — repoints a magic link at the host the sign-in arrived on
- `foreignLocaleRedirectPath()` — the foreign-locale SEO 301s (`/fr/athens` → `/athens`)
- `metadataBaseForHost()` — makes a preview unfurl its own OG images instead of production's (added in #645)

`opencouncil.dev` matches no realm. A plain string swap would have moved previews to a host none of those checks recognise, and all three would have silently stopped reproducing production.

`PREVIEW_DOMAIN` in `src/lib/realm.ts` makes the preview domain a host we own in its own right. It joins no realm, so a preview still resolves to `greece` by Host and still reaches the other realms through `?realm=serbia`.

## What changed

| File | Change |
|---|---|
| `src/lib/realm.ts` | New exported `PREVIEW_DOMAIN`, accepted by `isKnownRealmHost` |
| `flake.nix` | `previewDomain` default → `opencouncil.dev`; new `legacyPreviewDomain` option |
| `.github/workflows/preview-deploy.yml` | Hardcoded URLs → workflow-level `PREVIEW_DOMAIN` / `TASKS_PREVIEW_DOMAIN` |
| tests | `.dev` preview cases; realm-subdomain cases kept separate, since they cover a different mechanism |
| docs | URLs, DNS requirements, and a new "Changing the Preview Domain" section |

`legacyPreviewDomain` gives each preview a second vhost that 301s to its new URL, so links in older PR comments keep working. Set it back to `null` once every open PR has redeployed, then retire the old DNS.

## This does not take effect on merge

The droplet serves the hostname, so the move needs three things outside this PR:

1. **DNS on `opencouncil.dev`** (delegated to the DigitalOcean nameservers, zone not created yet). `A @`, `A *` and `A *.tasks`, all to the preview droplet. `*.tasks` is separate because a wildcard covers one label only.
2. **`schemalabz/opencouncil-tasks`** — the same move for `previewDomain` and its workflow. Until that lands, the tasks URL in the PR comment here points at a host that does not resolve. It is display text only; `TASK_API_URL` is built on the droplet.
3. **A `nixos-rebuild` on the droplet**, after setting `legacyPreviewDomain` and `tasksPreview.domain` in its host config. `NEXTAUTH_URL` is baked into the systemd unit, so nothing short of a rebuild moves it.

Existing previews keep their old Caddy config until their next deployment. The new docs section has a loop to move them all at once.

## Verification

`npx tsc --noEmit`, `npm run lint` and the full Jest suite (107 suites, 1455 tests) pass. The NixOS module was evaluated both with and without `legacyPreviewDomain` set, and the generated `caddy-add-preview` script was checked to emit a correct heredoc in both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves application and tasks preview links to `opencouncil.dev` while retaining redirects from legacy preview hosts.
- Adds the preview domain to trusted realm-host handling for authentication, locale redirects, and metadata.
- Updates Nix preview host configuration and workflow-generated URLs.
- Revises tests and operational documentation for the domain migration and external rollout steps.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no blocking failure remaining in the eligible follow-up review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/realm.ts | Adds `opencouncil.dev` as a recognized preview domain while preserving default Greece realm resolution. |
| flake.nix | Changes generated preview hosts to `pr-N.opencouncil.dev` and configures redirects from legacy hosts. |
| .github/workflows/preview-deploy.yml | Centralizes application and tasks preview domains for health checks and displayed deployment links. |
| src/lib/__tests__/realm.test.ts | Separates realm-subdomain behavior from the new realm-independent preview-host behavior. |
| docs/guides/preview-deployments.md | Documents DNS, host configuration, migration sequencing, and legacy-domain retirement procedures. |

<sub>Reviews (3): Last reviewed commit: ["docs(guide): update preview guide to the..."](https://github.com/schemalabz/opencouncil/commit/403e82285e4d563cde81fef6066659d01d2b69ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54850998)</sub>

**Context used:**

- Knowledge Base — [Realm-aware authentication and transactional emails](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/realm-auth-emails.md)

<!-- /greptile_comment -->