### PR TITLE
Feature/subject rows on meeting page

### DIFF
--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/page.tsx
@@ -107,22 +107,16 @@ export default function MeetingPage() {
                     </div>
                 )}
 
-                {(beforeAgendaSubjects.length > 0 || outOfAgendaSubjects.length > 0) && (
-                    <div className={`max-w-4xl mx-auto ${beforeAgendaSubjects.length <= 1 && outOfAgendaSubjects.length <= 1 ? "flex flex-col lg:flex-row lg:flex-wrap gap-x-8" : "flex flex-col"}`}>
-                        <SubjectSection
-                            title={subjectCategories.beforeAgenda.label}
-                            explainerText={subjectCategories.beforeAgenda.explainerText}
-                            subjects={beforeAgendaSubjects}
-                            className="flex-1 min-w-0"
-                        />
-                        <SubjectSection
-                            title={subjectCategories.outOfAgenda.label}
-                            explainerText={subjectCategories.outOfAgenda.explainerText}
-                            subjects={outOfAgendaSubjects}
-                            className="flex-1 min-w-0"
-                        />
-                    </div>
-                )}
+                <SubjectSection
+                    title={subjectCategories.beforeAgenda.label}
+                    explainerText={subjectCategories.beforeAgenda.explainerText}
+                    subjects={beforeAgendaSubjects}
+                />
+                <SubjectSection
+                    title={subjectCategories.outOfAgenda.label}
+                    explainerText={subjectCategories.outOfAgenda.explainerText}
+                    subjects={outOfAgendaSubjects}
+                />
 
                 {(beforeAgendaSubjects.length > 0 || outOfAgendaSubjects.length > 0) && agendaSubjects.length > 0 && (
                     <div className="max-w-4xl mx-auto mt-10"><hr className="border-border" /></div>

--- a/src/components/meetings/subject-section.tsx
+++ b/src/components/meetings/subject-section.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { SubjectWithRelations } from "@/lib/db/subject";
 import { Statistics } from "@/lib/statistics";
-import { SubjectCard } from "../subject-card";
+import { SubjectRow } from "../subject/SubjectRow";
 import { useCouncilMeetingData } from "./CouncilMeetingDataContext";
 import { useState } from "react";
 import { useTranslations } from "next-intl";
@@ -17,7 +17,6 @@ interface SubjectSectionProps {
     sortMode?: 'speakingTime' | 'agendaIndex';
     onSortModeChange?: (mode: 'speakingTime' | 'agendaIndex') => void;
     showSortToggle?: boolean;
-    className?: string;
 }
 
 export function SubjectSection({
@@ -27,9 +26,8 @@ export function SubjectSection({
     sortMode,
     onSortModeChange,
     showSortToggle,
-    className,
 }: SubjectSectionProps) {
-    const { city, meeting, parties, people } = useCouncilMeetingData();
+    const { city, meeting, people } = useCouncilMeetingData();
     const t = useTranslations("Subject");
     const [showExplainer, setShowExplainer] = useState(false);
     const [showAll, setShowAll] = useState(false);
@@ -39,13 +37,8 @@ export function SubjectSection({
     const hasMore = subjects.length > INITIAL_VISIBLE;
     const visibleSubjects = showAll ? subjects : subjects.slice(0, INITIAL_VISIBLE);
 
-    // When few subjects, cards stack vertically; otherwise use multi-column grid
-    const cardGridClass = subjects.length <= 2
-        ? "flex flex-col gap-4 flex-1"
-        : "flex flex-wrap gap-4 flex-1 [&>*]:w-full [&>*]:sm:w-[calc(50%-0.5rem)] [&>*]:lg:w-[calc(33.333%-0.75rem)] [&>*]:lg:min-w-[calc(33.333%-0.75rem)]";
-
     return (
-        <section className={cn("mt-8 flex flex-col", className ?? "w-full max-w-4xl mx-auto")}>
+        <section className="mt-8 flex flex-col w-full max-w-4xl mx-auto">
             <div className="flex flex-col gap-3 mb-5">
                 <div>
                     <div className="flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5">
@@ -98,15 +91,15 @@ export function SubjectSection({
                 )}
             </div>
 
-            <div className={cardGridClass}>
+            <div className="flex flex-col gap-4 flex-1">
                 {visibleSubjects.map(subject => (
-                    <SubjectCard
+                    <SubjectRow
                         key={subject.id}
                         subject={subject}
                         city={city}
                         meeting={meeting}
-                        parties={parties}
                         persons={people}
+                        showContext={false}
                     />
                 ))}
             </div>

--- a/src/components/subject/SubjectRow.tsx
+++ b/src/components/subject/SubjectRow.tsx
@@ -25,7 +25,7 @@ interface SubjectRowProps {
     city: City;
     meeting: CouncilMeeting & { administrativeBody?: AdministrativeBody | null };
     persons: PersonWithRelations[];
-    /** Show the city / body / date line — off when the row already sits inside a meeting. */
+    /** Show the city / body / date line and the meeting name — off when the row already sits inside its meeting. */
     showContext?: boolean;
     openInNewTab?: boolean;
     /** The row was opened. Fires for a new tab too, where the Link navigates itself. */
@@ -153,7 +153,7 @@ export function SubjectRow({ subject, city, meeting, persons, showContext = true
                             )}
 
                             <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                                <MetaItem icon={ScrollText}>{getLocalizedName(meeting, locale)}</MetaItem>
+                                {showContext && <MetaItem icon={ScrollText}>{getLocalizedName(meeting, locale)}</MetaItem>}
                                 <MetaItem icon={MapPin}>{locationText ?? t("noLocation")}</MetaItem>
                             </div>
                         </div>
@@ -199,7 +199,10 @@ export function SubjectRow({ subject, city, meeting, persons, showContext = true
                                         )}
                                     </div>
                                 )}
-                                <div className="shrink-0 sm:mt-auto" onClick={(e) => e.stopPropagation()}>
+                                {/* ml-auto, not just the parent's justify-between: a subject with no
+                                    speaking stats has only this child, and justify-between would drop
+                                    the avatars to the left edge. */}
+                                <div className="ml-auto shrink-0 sm:mt-auto" onClick={(e) => e.stopPropagation()}>
                                     <PersonAvatarList users={speakers} introducerId={subject.introducedBy?.id} size="sm" maxDisplayed={4} stacked />
                                 </div>
                             </>


### PR DESCRIPTION
Depends on #643. This branch starts from `fix/search-ui-redesign`, so it shows
that PR's commits until #643 merges. This branch adds 1 commit of its own.

## Summary

The meeting page now shows its subjects with `SubjectRow`, the same full-width
row component that the search page uses. Before this change, the meeting page
showed the subjects as `SubjectCard` tiles in a responsive grid. A reader who
opened a meeting from a search result met two different presentations of one
thing.

This is a presentation change. It adds no query, no API, and no schema change.

## Changes

- `SubjectSection` renders `SubjectRow` in place of `SubjectCard`. Each section
  stacks its rows in one column, because a row is already full width.
- The "before agenda" and "out of agenda" sections lose the wrapper that put
  them side by side. All three sections now render the same way. The unused
  `className` prop of `SubjectSection` goes away with that wrapper.
- `SubjectSection` no longer passes `parties` to the row. `SubjectRow` reads the
  party colours from the subject statistics. The old `SubjectCard` declared the
  `parties` prop but never used it.
- `showContext` in `SubjectRow` now also hides the meeting name. Inside a
  meeting, every row repeated the name of the meeting that the reader is
  already on. `SubjectCard` already hid its context line and its meeting name
  together under this flag, so the row now matches the card.
- The speaker avatars get `ml-auto`. The parent uses `justify-between`. A
  subject with no speaking statistics has only the avatars as a child, so
  `justify-between` pushed the avatars to the left edge. This case is common on
  a meeting page and rare in search results. It also affects search rows that
  have no statistics.

## Verification

I ran the app against the staging database and opened `/argos/may12_2026`. This
meeting is unreleased, so the check needs a session with edit rights.

- The rows render in all three sections. The topic filter still narrows them.
  The "most discussed / agenda order" toggle works. The "show all" button
  expands the list.
- At a 375px viewport, the page has no horizontal overflow.
- The search page keeps its context line and its meeting name, because it passes
  `showContext={true}`.

`npm test` passes with 1461 tests. `npm run build` passes.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces meeting-page subject cards with full-width subject rows and simplifies the section layout.
- Renders `SubjectRow` consistently across all subject categories.
- Hides repeated meeting context inside meeting pages.
- Keeps speaker avatars aligned when speaking statistics are absent.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/page.tsx | The page now renders the two secondary subject sections independently in a consistent vertical layout. |
| src/components/meetings/subject-section.tsx | The section now renders full-width `SubjectRow` components and removes obsolete card-grid properties. |
| src/components/subject/SubjectRow.tsx | The row hides repeated meeting context when requested and right-aligns speaker avatars without statistics. |

<sub>Reviews (3): Last reviewed commit: ["feat(meetings): show subjects as full-wi..."](https://github.com/schemalabz/opencouncil/commit/cfd1eec87ca591d2652b44e1ff2b848d0987c0b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55523767)</sub>

<!-- /greptile_comment -->