### PR TITLE
feat(notis): paired PR previews

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -107,6 +107,13 @@ jobs:
 
             PR_NUM="$1"
 
+            # Paired notis preview (exists only for notis-touching PRs).
+            # Gate on command existence (host may predate the notis wiring);
+            # let REAL destroy failures print a warning like the main path.
+            if command -v notis-preview-destroy >/dev/null; then
+              sudo notis-preview-destroy "$PR_NUM" || echo "Warning: notis preview destroy failed"
+            fi
+
             echo "Destroying preview instance for PR #$PR_NUM..."
             sudo opencouncil-preview-destroy "$PR_NUM" || {
               echo "Warning: Failed to destroy preview cleanly"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -2,7 +2,9 @@ name: Deploy PR Preview
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    # `labeled` lets the preview-notis label trigger a paired notis deploy
+    # on an already-open PR; the root jobs skip every other label event.
+    types: [opened, synchronize, reopened, labeled]
     branches: [main]
 
 permissions:
@@ -27,6 +29,7 @@ jobs:
   # with write access deploy automatically via 'preview-auto', everyone
   # else (forks, dependabot) goes through the reviewer-gated 'preview'.
   gate:
+    if: github.event.action != 'labeled' || github.event.label.name == 'preview-notis'
     name: Determine Deploy Environment
     runs-on: ubuntu-latest
     outputs:
@@ -57,10 +60,12 @@ jobs:
 
   # Pre-flight checks (fast, run before expensive nix build)
   preflight:
+    if: github.event.action != 'labeled' || github.event.label.name == 'preview-notis'
     name: Pre-flight Checks
     runs-on: ubuntu-latest
     outputs:
       has-migrations: ${{ steps.check-migrations.outputs.has-migrations }}
+      deploy-notis: ${{ steps.check-notis.outputs.deploy-notis }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -94,6 +99,22 @@ jobs:
           else
             echo "has-migrations=false" >> $GITHUB_OUTPUT
             echo "✅ No migrations detected - preview will use shared staging database" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Check for notis changes
+        id: check-notis
+        run: |
+          set -euo pipefail
+          # Deploy a paired notis preview only when the PR touches notis (or
+          # carries the preview-notis label) — resource policy lives here in
+          # CI, not in the preview module.
+          CHANGED_NOTIS=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '^services/notis/\|^packages/ui/' || true)
+          HAS_LABEL="${{ contains(github.event.pull_request.labels.*.name, 'preview-notis') }}"
+          if [ -n "$CHANGED_NOTIS" ] || [ "$HAS_LABEL" = "true" ]; then
+            echo "deploy-notis=true" >> $GITHUB_OUTPUT
+            echo "🛰️ Notis changes detected — a paired notis preview will be deployed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "deploy-notis=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Check lockfile freshness
@@ -162,7 +183,7 @@ jobs:
               + '**Status:** Building...\n\n'
               + 'Follow along in the [workflow logs](' + logsUrl + ').\n\n'
               + '---\n'
-              + dbNote;
+              + dbNote + notisNote;
 
             let commentId;
             if (botComment) {
@@ -334,6 +355,61 @@ jobs:
             echo "Tasks API: https://pr-${LINKED_TASKS_PR}.$TASKS_PREVIEW_DOMAIN" >> $GITHUB_STEP_SUMMARY
           fi
 
+      - name: Deploy paired notis preview
+        id: notis-deploy
+        if: needs.preflight.outputs.deploy-notis == 'true'
+        env:
+          PREVIEW_HOST: ${{ secrets.PREVIEW_HOST }}
+          PREVIEW_USER: ${{ secrets.PREVIEW_USER || 'opencouncil' }}
+        run: |
+          set -euo pipefail
+          PR_NUM="${{ github.event.pull_request.number }}"
+          SSH_CMD="ssh -i ~/.ssh/deploy_key ${PREVIEW_USER}@${PREVIEW_HOST}"
+
+          # Rollout guard: the notis scripts exist on the host only once the
+          # companion nix-openclaw change is deployed. Skip (loudly) until then.
+          if ! $SSH_CMD "command -v notis-preview-create >/dev/null"; then
+            echo "::warning::notis-preview-create not on the preview host yet (nix-openclaw companion not deployed) — skipping notis preview"
+            echo "Notis preview: skipped (host not wired yet)" >> $GITHUB_STEP_SUMMARY
+            echo "deployed=skipped" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Building notis..."
+          NOTIS_STORE_PATH=$(nix build .#notis-prod --print-out-paths | tail -1)
+
+          # Push the closure to Cachix synchronously — the droplet's
+          # nix-store --realise can only substitute what is already uploaded
+          # (the action's async post-job push is too late; same reason the
+          # main app pushes ./result explicitly).
+          echo "Pushing notis closure to Cachix..."
+          cachix push "$CACHIX_CACHE_NAME" "$NOTIS_STORE_PATH"
+
+          echo "Creating paired notis preview..."
+          $SSH_CMD "sudo notis-preview-create '$PR_NUM' '$NOTIS_STORE_PATH'"
+
+          # App readiness is guaranteed by notis-preview-create itself (the
+          # pr-previews create script polls the instance and fails with the
+          # journal if the app never answers). This probe only verifies the
+          # PUBLIC route — DNS, TLS, and the Caddy vhost. Same allowlist:
+          # only a code proving the app answered through the proxy passes.
+          NOTIS_URL="https://notis-pr-$PR_NUM.opencouncil.dev"
+          CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "$NOTIS_URL" || true)
+          case "$CODE" in
+            2??|3??|401|403) : ;;
+            *)
+              sleep 10
+              CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "$NOTIS_URL" || true)
+              case "$CODE" in
+                2??|3??|401|403) : ;;
+                *)
+                  echo "::error::Notis preview unreachable through the proxy at $NOTIS_URL (HTTP ${CODE:-none})"
+                  exit 1 ;;
+              esac ;;
+          esac
+          echo "Notis preview: $NOTIS_URL (HTTP $CODE)" >> $GITHUB_STEP_SUMMARY
+          echo "deployed=true" >> $GITHUB_OUTPUT
+
       - name: Health check
         id: health-check
         run: |
@@ -364,6 +440,7 @@ jobs:
             const logsUrl = context.serverUrl + '/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + context.runId;
             const hasMigrations = '${{ needs.preflight.outputs.has-migrations }}' === 'true';
             const linkedTasksPr = '${{ steps.preview-links.outputs.tasks-pr }}';
+            const notisDeployed = '${{ steps.notis-deploy.outputs.deployed }}' === 'true';
 
             const dbNote = hasMigrations
               ? '*This preview uses an **isolated database** with seed data (migrations were applied).*'
@@ -373,6 +450,10 @@ jobs:
               + '**Preview URL:** ' + previewUrl + '\n'
               + '**Commit:** `' + commitSha + '`\n'
               + '**Database:** ' + (hasMigrations ? 'Isolated (PostGIS 3.3.5, seed data)' : 'Shared staging') + '\n';
+
+            if (notisDeployed) {
+              body += '**Notis:** https://notis-pr-' + prNumber + '.opencouncil.dev\n';
+            }
 
             if (linkedTasksPr) {
               body += '**Tasks API:** https://pr-' + linkedTasksPr + '.' + process.env.TASKS_PREVIEW_DOMAIN + '\n';

--- a/docs/guides/preview-deployments.md
+++ b/docs/guides/preview-deployments.md
@@ -271,6 +271,31 @@ The NixOS module loads this file via systemd `EnvironmentFile=`. Optional vars (
 | `PREVIEW_HOST` | Droplet IP (e.g., `113.54.65.12`) |
 | `PREVIEW_USER` | `opencouncil` |
 
+## Paired Notis Previews
+
+A PR that touches `services/notis/` or `packages/ui/` (or carries the
+`preview-notis` label) also gets a notis preview in the same workflow run:
+
+- The URL is `https://notis-pr-N.opencouncil.dev` (port 20000+N).
+- CI builds it from `.#notis-prod`. The `start.sh` entrypoint pins Node 24
+  (the `engines` requirement), so the preview runs the toolchain that built
+  it.
+- The instance points `OPENCOUNCIL_BASE_URL` and `NOTIS_MCP_URL` at the
+  same PR's main preview, not at production. The pr-previews `siblings`
+  context computes those URLs.
+- The cleanup workflow destroys the notis preview together with the main
+  one when the PR closes.
+
+Manual management mirrors the main app: `notis-preview-list`,
+`notis-preview-logs <N>`, `sudo notis-preview-create <N> <store-path>`,
+and `sudo notis-preview-destroy <N>`. The shared env lives in
+`/var/lib/notis-previews/.env`. It holds `NOTIS_ADMIN_SECRET` and a dummy
+`ANTHROPIC_API_KEY` — the trust model allows preview-grade secrets only,
+so agent calls fail by design.
+
+The per-PR notis database and the shared-cookie session validation are not
+wired yet. They land with the notis-db PR.
+
 ## Manual Management
 
 SSH to the droplet, then:

--- a/flake.nix
+++ b/flake.nix
@@ -1390,8 +1390,92 @@ EOF
               exec newsboat -u "$urls_file" -C "$config_file" -c "$tmp_dir/cache.db"
             '';
           };
+          # Notis production build (services/notis workspace). Standalone Next
+          # server; runtime pinned to Node 24 per its engines requirement —
+          # the preview execs $out/start.sh so it always runs on this toolchain
+          # (runtime-ownership rule, see pr-previews README).
+          notis-prod = (pkgs.buildNpmPackage.override { nodejs = pkgs-unstable.nodejs_24; }) {
+            pname = "notis-prod";
+            version = "0.1.0";
+            src = ./.;
+
+            npmDeps = mkNpmDeps pkgs;
+            npmConfigHook = pkgs.importNpmLock.npmConfigHook;
+            makeCacheWritable = true;
+            npmFlags = [ "--legacy-peer-deps" ];
+            npmInstallFlags = [ "--ignore-scripts" ];
+
+            nativeBuildInputs = mkNpmNativeBuildInputs pkgs;
+            buildInputs = mkNpmBuildInputs pkgs;
+
+            preBuild = ''
+              export HOME=$TMPDIR
+              ${mkPrismaEnv pkgs}
+              export SKIP_ENV_VALIDATION=1
+              npm run postinstall
+              # Next's type-check resolves from the workspace root (turbopack.root),
+              # which pulls in root files importing the generated Prisma client.
+              npx prisma generate
+            '';
+
+            # NB: buildNpmPackage has no `npmBuild` attr — the real knob is
+            # npmBuildFlags (appended to `npm run build`).
+            npmBuildFlags = [ "--workspace=notis" ];
+
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $out
+
+              shopt -s dotglob
+              cp -r services/notis/.next/standalone/* $out/
+              shopt -u dotglob
+
+              # Static + public assets live next to the workspace's server.js
+              cp -r services/notis/.next/static $out/services/notis/.next/static
+              # Next's monorepo standalone output does NOT include public/ —
+              # copy it in (the target dir does not pre-exist).
+              if [ -d services/notis/public ]; then
+                mkdir -p $out/services/notis/public
+                cp -rn services/notis/public/* $out/services/notis/public/
+              fi
+
+              # Runtime-owned entrypoint: Node 24 from this flake's unstable
+              # pin. The store is read-only but Next's fetch cache writes to
+              # .next/cache under the server's __dirname — so mirror the app
+              # into a writable work dir (same pattern as the main app's
+              # start.sh): symlink everything, copy server.js (its __dirname
+              # must resolve inside the work dir), real .next/cache.
+              cat > $out/start.sh <<EOF
+              #!${pkgs.runtimeShell}
+              set -euo pipefail
+              APP="$out/services/notis"
+              RUN="\''${NOTIS_RUN_DIR:-/tmp/notis-run-\$\$}"
+              mkdir -p "\$RUN/services/notis/.next/cache"
+              ln -sfn "$out/node_modules" "\$RUN/node_modules"
+              for item in "\$APP"/*; do
+                name="\$(basename "\$item")"
+                case "\$name" in
+                  server.js) rm -f "\$RUN/services/notis/server.js"; cp "\$item" "\$RUN/services/notis/server.js" ;;
+                  .next) : ;;
+                  *) ln -sfn "\$item" "\$RUN/services/notis/\$name" ;;
+                esac
+              done
+              for item in "\$APP/.next"/*; do
+                name="\$(basename "\$item")"
+                [ "\$name" = cache ] || ln -sfn "\$item" "\$RUN/services/notis/.next/\$name"
+              done
+              cd "\$RUN/services/notis"
+              exec ${pkgs-unstable.nodejs_24}/bin/node server.js
+              EOF
+              chmod +x $out/start.sh
+              runHook postInstall
+            '';
+
+            meta = { description = "Notis production build"; mainProgram = "start.sh"; };
+          };
+
         in {
-          inherit oc-dev oc-dev-db-nix oc-dev-db-nix-locked oc-dev-db-docker oc-dev-cache oc-dev-app-local oc-studio oc-cleanup oc-rss opencouncil-prod;
+          inherit oc-dev oc-dev-db-nix oc-dev-db-nix-locked oc-dev-db-docker oc-dev-cache oc-dev-app-local oc-studio oc-cleanup oc-rss opencouncil-prod notis-prod;
         });
 
       checks = forAllSystems (_system: pkgs: _pkgs-unstable:
@@ -1448,6 +1532,29 @@ EOF
 
       # Preview deployment config for the generic preview module in nix-openclaw.
       # See nix-openclaw/generic-preview.nix for the full interface spec.
+      # Notis preview config (paired with the same PR's opencouncil preview
+      # via the pr-previews `siblings` context). Consumed by the preview host:
+      #   services.pr-previews.projects = opencouncil.previews // ...;
+      # The host supplies envFile with NOTIS_ADMIN_SECRET and a (dummy)
+      # ANTHROPIC_API_KEY — see docs/guides/preview-deployments.md.
+      previews.notis = {
+        hostPattern = "notis-pr-@id@.opencouncil.dev";
+        # 20000+N: clear of the main app (3000+N), tasks (4000+N), and the
+        # ad-hoc isolated-DB ports (5432+N) — 5000+N would collide with a DB
+        # whenever notis PR = DB PR + 432.
+        basePort = 20000;
+        environment = [ "NODE_ENV=production" "HOSTNAME=0.0.0.0" ];
+
+        startScript = _: ctx: ''
+          # Point the REST proxies and MCP wakes at this PR's paired main
+          # preview instead of production.
+          export OPENCOUNCIL_BASE_URL="${ctx.siblings.opencouncil.url}"
+          export NOTIS_MCP_URL="${ctx.siblings.opencouncil.url}/mcp"
+          export NOTIS_RUN_DIR="$PR_DIR/work"
+          exec "$APP_DIR/start.sh"
+        '';
+      };
+
       previews.opencouncil = let
         postgresCompat = self.lib.mkPostgresCompat;
         prismaEnv = self.lib.mkPrismaEnv;

--- a/services/notis/next.config.ts
+++ b/services/notis/next.config.ts
@@ -3,6 +3,9 @@ import path from "node:path";
 import "./src/env.mjs";
 
 const nextConfig: NextConfig = {
+  // Self-contained server bundle for Nix preview deployments (same pattern
+  // as the main app).
+  output: "standalone",
   transpilePackages: ["@opencouncil/ui"],
   // Pin the workspace root: without this, Next walks up looking for lockfiles
   // and can pick a stray one outside the repo (e.g. ~/package-lock.json),


### PR DESCRIPTION
Gives notis its first preview deployments: PRs that touch `services/notis/` or `packages/ui/` (or carry a `preview-notis` label) get a paired notis instance at `notis-pr-N.opencouncil.dev` alongside the main preview, wired to talk to *that PR's* main preview instead of production.

**Two commits:**
1. **`.#notis-prod`** — Nix production build of the notis workspace (standalone Next output, `npmBuildFlags --workspace=notis`, root prisma client generated for the workspace-root type-check). Runtime ownership: `start.sh` pins **Node 24** from this flake's unstable input per notis's `engines` requirement — notis previews run on Node 24 today, regardless of the host or the main app's toolchain.
2. **`previews.notis` export + CI wiring** — single-label hostname under the preview wildcard parent, port 5000+N, `OPENCOUNCIL_BASE_URL`/`NOTIS_MCP_URL` resolved to the sibling main preview via the pr-previews `siblings` context. Deploy gated in CI (path filter / label); cleanup destroys tolerantly.

**Deliberately absent**: per-PR database and shared-cookie pairing — notis on main has neither yet; they land with #632, whose own preview (once this merges) will be the first end-to-end exercise of that machinery.

**Verified** in the VM e2e: notis boots on its own Node 24 with dummy secrets and serves; the running process's `OPENCOUNCIL_BASE_URL` points at the same-PR sibling preview.

After merge, nix-openclaw needs its input bump + `projects.notis` host wiring (envFile with `NOTIS_ADMIN_SECRET` + dummy `ANTHROPIC_API_KEY` per the trust model) — companion change ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

















<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds paired Notis preview builds, deployment and cleanup automation, sibling-preview URL configuration, and supporting documentation.
- Builds Notis as a standalone Next.js application using Node 24.
- Deploys eligible Notis previews at a dedicated per-PR hostname.
- Adds bounded public-route readiness checks and paired cleanup.
- Documents preview operation, runtime configuration, and current database limitations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/preview-deploy.yml | Adds eligibility detection, paired Notis deployment, bounded public-route validation, and preview-link reporting; the previously reported readiness failures are addressed. |
| .github/workflows/preview-cleanup.yml | Tolerantly destroys the paired Notis preview when the host exposes the companion command. |
| flake.nix | Adds the Node 24 standalone Notis package and per-PR preview configuration targeting the sibling OpenCouncil preview. |
| services/notis/next.config.ts | Enables standalone Next.js output for the Nix deployment artifact. |
| docs/guides/preview-deployments.md | Documents paired Notis preview URLs, lifecycle commands, secrets, and current database and session limitations. |

<sub>Reviews (9): Last reviewed commit: ["docs(guide): document paired notis previ..."](https://github.com/schemalabz/opencouncil/commit/f895851336f7e7de420fe5331ff7032e10fcbe3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55553868)</sub>

<!-- /greptile_comment -->