### PR TITLE
fix(search): guard stale results, keep history, restore introducer mark

### DIFF
--- a/src/components/persons/PersonAvatarList.tsx
+++ b/src/components/persons/PersonAvatarList.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { PersonBadge } from "./PersonBadge";
 import { cn } from "@/lib/utils";
+import { Pen } from "lucide-react";
 import { PersonWithRelations } from '@/lib/db/people';
 import { useRef, useState, useEffect, useCallback } from "react";
 
@@ -24,6 +25,21 @@ const STACK_SPACING: Record<AvatarSize, string> = {
     xl: '-space-x-4 sm:-space-x-6',
 };
 
+/** The introducer marker, scaled to the avatar it sits on. */
+const INTRODUCER_BADGE_SIZES: Record<AvatarSize, string> = {
+    sm: 'h-3.5 w-3.5',
+    md: 'h-4 w-4',
+    lg: 'h-4 w-4',
+    xl: 'h-4 w-4',
+};
+
+const INTRODUCER_ICON_SIZES: Record<AvatarSize, string> = {
+    sm: 'h-2 w-2 text-foreground',
+    md: 'h-2.5 w-2.5 text-foreground',
+    lg: 'h-2.5 w-2.5 text-foreground',
+    xl: 'h-2.5 w-2.5 text-foreground',
+};
+
 interface PersonAvatarListProps {
     users: PersonWithRelations[];
     className?: string;
@@ -35,6 +51,8 @@ interface PersonAvatarListProps {
     size?: AvatarSize;
     /** Overlap the circles into a stack, each ringed against the card and lifting on hover. */
     stacked?: boolean;
+    /** Marks this person as the subject's introducer with a pen badge. */
+    introducerId?: string;
 }
 
 export function PersonAvatarList({
@@ -46,6 +64,7 @@ export function PersonAvatarList({
     isHovered = false,
     size = 'md',
     stacked = false,
+    introducerId,
 }: PersonAvatarListProps) {
     const displayCount = Math.min(users.length, maxDisplayed);
     const remainingCount = numMore ?? (users.length - displayCount);
@@ -165,6 +184,14 @@ export function PersonAvatarList({
                             // by a fraction of the avatar, not of the avatar plus its padding.
                             className={stacked ? "p-0 sm:p-0 rounded-full" : undefined}
                         />
+                        {user.id === introducerId && (
+                            <div className={cn(
+                                "absolute top-0 left-0 flex items-center justify-center rounded-full bg-background ring-[1.5px] ring-background",
+                                INTRODUCER_BADGE_SIZES[size],
+                            )}>
+                                <Pen className={INTRODUCER_ICON_SIZES[size]} />
+                            </div>
+                        )}
                     </div>
                 ))}
                 {remainingCount > 0 && (

--- a/src/components/search/SearchPage.tsx
+++ b/src/components/search/SearchPage.tsx
@@ -98,7 +98,8 @@ export default function SearchPage() {
         // Any change other than paging itself invalidates the current page.
         // Keyed on which keys were passed, not on their values: clearing a filter
         // passes `undefined`, and that has to reset the page just like setting one.
-        if (Object.keys(updates).some(key => key !== 'page')) {
+        const changesFilters = Object.keys(updates).some(key => key !== 'page');
+        if (changesFilters) {
             params.set('page', '1');
         }
 
@@ -109,7 +110,17 @@ export default function SearchPage() {
             }
         }
 
-        router.push(`?${params.toString()}`, { scroll: false });
+        // Refining a search replaces the current entry; paging pushes a new one.
+        // Every pill click and every debounced keystroke goes through here, so
+        // pushing them all buried the entry the user arrived from: leaving
+        // /search took one Back press per filter they had touched. Paging still
+        // pushes, so Back returns to the previous page of results.
+        const href = `?${params.toString()}`;
+        if (changesFilters) {
+            router.replace(href, { scroll: false });
+        } else {
+            router.push(href, { scroll: false });
+        }
     }, [router, searchParams]);
 
     // One instance for both filter surfaces. They are mounted together (the
@@ -128,8 +139,17 @@ export default function SearchPage() {
         return () => clearTimeout(timeoutId);
     }, [localQuery, query, updateSearchParams]);
 
+    // Every run claims the next id, and only the newest one may write to state.
+    // Filter extraction is an AI call, so a request started earlier can finish
+    // later: without this, checking two topics in quick succession could leave
+    // the results of the first on screen while the filter bar shows both.
+    const searchRunIdRef = useRef(0);
+
     // Perform search
     const performSearch = useCallback(async () => {
+        const runId = ++searchRunIdRef.current;
+        const isCurrentRun = () => runId === searchRunIdRef.current;
+
         // Skip search if temporarily disabled
         if (SEARCH_TEMPORARILY_DISABLED) {
             setState(prev => ({ ...prev, results: [], total: 0, isLoading: false }));
@@ -172,6 +192,8 @@ export default function SearchPage() {
                 }
             }, { skipQueryLog });
 
+            if (!isCurrentRun()) return;
+
             setState({
                 results: response.results,
                 total: response.total,
@@ -194,6 +216,9 @@ export default function SearchPage() {
         } catch (err) {
             const error = err instanceof Error ? err : new Error('An error occurred during search');
             posthog.captureException(err);
+            // A superseded run's failure says nothing about the search on
+            // screen, so it must not replace its results with an error page.
+            if (!isCurrentRun()) return;
             setState(prev => ({ ...prev, error, isLoading: false }));
             toast({
                 variant: "destructive",

--- a/src/components/subject-card.tsx
+++ b/src/components/subject-card.tsx
@@ -69,6 +69,7 @@ export function SubjectCard({ subject, city, meeting, parties, persons, fullWidt
         <SubjectCardFooter
             stats={stats}
             speakers={fullDisplayedSpeakers}
+            introducerId={subject.introducedBy?.id}
             withdrawn={subject.withdrawn}
             withdrawnLabel={getWithdrawnLabel(t, subject)}
             minutesText={t('minutesCount', { count: stats.minutes })}

--- a/src/components/subject/SubjectCardFooter.tsx
+++ b/src/components/subject/SubjectCardFooter.tsx
@@ -7,6 +7,8 @@ interface SubjectCardFooterProps {
     stats: SubjectCardStats;
     /** Introducer + top speakers for the avatar row. */
     speakers: PersonWithRelations[];
+    /** The introducer, marked with a pen badge in the avatar row. */
+    introducerId?: string;
     withdrawn?: boolean;
     withdrawnLabel?: string;
     /** Localized speaking-time text, already pluralized (e.g. "12 minutes"). */
@@ -26,6 +28,7 @@ interface SubjectCardFooterProps {
 export function SubjectCardFooter({
     stats,
     speakers,
+    introducerId,
     withdrawn,
     withdrawnLabel,
     minutesText,
@@ -67,7 +70,7 @@ export function SubjectCardFooter({
                 <div className="w-full text-xs text-muted-foreground/70 italic">{withdrawnLabel}</div>
             ) : (
                 <div onClick={onAvatarsClick} className="w-full">
-                    <PersonAvatarList users={speakers} autoScroll={avatarsAutoScroll} isHovered={avatarsHovered} />
+                    <PersonAvatarList users={speakers} introducerId={introducerId} autoScroll={avatarsAutoScroll} isHovered={avatarsHovered} />
                 </div>
             )}
         </>

--- a/src/components/subject/SubjectRow.tsx
+++ b/src/components/subject/SubjectRow.tsx
@@ -197,7 +197,7 @@ export function SubjectRow({ subject, city, meeting, persons, showContext = true
                                     </div>
                                 )}
                                 <div className="shrink-0 sm:mt-auto" onClick={(e) => e.stopPropagation()}>
-                                    <PersonAvatarList users={speakers} size="sm" maxDisplayed={4} stacked />
+                                    <PersonAvatarList users={speakers} introducerId={subject.introducedBy?.id} size="sm" maxDisplayed={4} stacked />
                                 </div>
                             </>
                         )}


### PR DESCRIPTION
Follow-up to #643, from the review on that PR. #643 is merged; these are the three changes it asked for.

**Stale results could overwrite fresh ones.** `performSearch` had no cancellation. Filter extraction is an AI call, so a request that starts earlier can finish later: two topic clicks in quick succession could leave the results of the first on screen while the filter bar showed both. Each run now claims an id, and only the newest run writes to state. A superseded run also skips its analytics event and its error toast.

**Every filter click pushed a history entry.** `updateSearchParams` runs on each pill click and each debounced keystroke, so leaving `/search` took one Back press per filter the user had touched. Filter and query changes now use `router.replace`. Paging still pushes, so Back returns to the previous page of results.

**The introducer mark came back.** The redesign dropped the pen badge in the avatar row. It returns as an `introducerId` prop on `PersonAvatarList` instead of the old per-user `isIntroducer` flag, so the subject card and the new subject row both mark the introducer. The badge scales with the avatar size for the small stacked row. `EmbedSubjectCard` never passed the flag, so it is unchanged.

Verified: `npx tsc --noEmit` clean, `npm run lint` clean, `npx jest` 1547 passed across 109 suites. `npm run build` needs env vars that were not available locally, so CI is the first build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdMfhZMLYYv8HPjTHAnf85

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdMfhZMLYYv8HPjTHAnf85)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents stale search runs from updating visible state, changes filter refinements to replace browser-history entries while retaining pushed pagination entries, and restores introducer badges on subject avatars.
- Adds run identifiers to suppress stale search results, error state, toasts, and successful-search analytics.
- Uses history replacement for query and filter changes while preserving history pushes for pagination.
- Passes introducer IDs through subject cards and rows and renders a size-aware pen badge on matching avatars.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The stale-run guard prevents obsolete searches from replacing current UI state, the history behavior matches the stated navigation design, and both subject renderers pass the introducer identity to an avatar list whose ordering keeps a present introducer visible.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/search/SearchPage.tsx | Adds current-run guards around asynchronous search results and separates replacement-based filter navigation from pushed pagination. |
| src/components/persons/PersonAvatarList.tsx | Adds an optional introducer ID and renders a size-aware pen marker on the matching displayed avatar. |
| src/components/subject-card.tsx | Passes the subject introducer ID into the shared card footer. |
| src/components/subject/SubjectCardFooter.tsx | Threads the optional introducer ID through to the avatar list. |
| src/components/subject/SubjectRow.tsx | Enables the introducer marker in the compact stacked-avatar subject row. |

<sub>Reviews (1): Last reviewed commit: ["fix(search): guard stale results, keep h..."](https://github.com/schemalabz/opencouncil/commit/4ee3fc7a4c5afe75e8149d7434d193493285a704) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55616145)</sub>

<!-- /greptile_comment -->