### PR TITLE
fix(security): sanitize consultation comments and block seedUser privilege escalation

### DIFF
--- a/src/app/[locale]/(city)/[cityId]/consultation/[id]/comments/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/consultation/[id]/comments/page.tsx
@@ -12,6 +12,7 @@ import { getRealm } from "@/lib/realm.server";
 import { getRealmContactPhone } from "@/lib/realm";
 import { getLocalizedName } from "@/lib/formatters/name";
 import { localizeText } from "@/lib/serbian";
+import { getSafeHtmlContent } from "@/lib/utils/sanitize";
 
 interface PageProps {
     params: Promise<{ cityId: string; id: string; locale: string }>;
@@ -350,7 +351,7 @@ export default async function CommentsPage(props: PageProps) {
                                         </div>
                                         <div
                                             className="text-gray-700 prose prose-sm max-w-none"
-                                            dangerouslySetInnerHTML={{ __html: comment.body }}
+                                            dangerouslySetInnerHTML={{ __html: getSafeHtmlContent(comment.body) }}
                                         />
                                         {index < documentComments.length - 1 && (
                                             <div className="mt-4 border-b border-gray-100"></div>
@@ -383,7 +384,7 @@ export default async function CommentsPage(props: PageProps) {
                                         </div>
                                         <div
                                             className="text-gray-700 prose prose-sm max-w-none"
-                                            dangerouslySetInnerHTML={{ __html: comment.body }}
+                                            dangerouslySetInnerHTML={{ __html: getSafeHtmlContent(comment.body) }}
                                         />
                                         {index < locationComments.length - 1 && (
                                             <div className="mt-4 border-b border-gray-100"></div>

--- a/src/lib/db/notifications.ts
+++ b/src/lib/db/notifications.ts
@@ -10,6 +10,8 @@ import { sendPetitionReceivedAdminAlert, sendUserOnboardedAdminAlert, sendNotifi
 import { matchUsersToSubjects } from "@/lib/notifications/matching";
 import { generateEmailContent, generateSmsContent } from "@/lib/notifications/content";
 import { sendWelcomeMessages } from "@/lib/notifications/welcome";
+import { IS_DEV } from "@/lib/utils";
+import { saveNotificationPreferencesSchema, savePetitionSchema } from "@/lib/zod-schemas/onboarding";
 
 // Type definitions for user preferences data
 export type PetitionWithRelations = Petition & {
@@ -248,9 +250,25 @@ type OnboardingData = {
     phone?: string;
     email?: string; // For non-authenticated users
     name?: string;
-    // If provided, the user is being seeded from the seed-users API
-    // This bypasses the session check and the magic link check
+    // Dev-seed-only convenience: lets the seed-users API create users without a
+    // session and without a magic link. SECURITY: these actions are reachable as
+    // Server Actions from the public onboarding client, so this field is
+    // attacker-controllable. It is always run through sanitizeSeedUser(), which
+    // returns undefined off local dev and otherwise allow-lists benign fields —
+    // never isSuperAdmin or identity fields. Never spread the raw value.
     seedUser?: Partial<User>;
+}
+
+// Neutralize the dev-seed convenience field before it can influence auth or user
+// creation. Off local dev (production/preview: IS_DEV === false) it is ignored
+// entirely, so the onboarding Server Actions cannot skip the session check or
+// mass-assign privileges. In local dev only the four benign seed fields survive.
+function sanitizeSeedUser(
+    seedUser: Partial<User> | undefined
+): Partial<Pick<User, 'createdAt' | 'onboarded' | 'allowProductUpdates' | 'allowPetitionUpdates'>> | undefined {
+    if (!IS_DEV || !seedUser) return undefined;
+    const { createdAt, onboarded, allowProductUpdates, allowPetitionUpdates } = seedUser;
+    return { createdAt, onboarded, allowProductUpdates, allowPetitionUpdates };
 }
 
 /**
@@ -260,7 +278,14 @@ export async function saveNotificationPreferences(data: OnboardingData & {
     locationIds: string[];
     topicIds: string[];
 }): Promise<Result<NotificationPreference>> {
-    const { cityId, locationIds, topicIds, phone, email, name, seedUser } = data;
+    const validation = saveNotificationPreferencesSchema.safeParse(data);
+    if (!validation.success) {
+        return createError('Invalid input');
+    }
+    const { cityId, locationIds, topicIds, phone, email, name, seedUser: rawSeedUser } = data;
+    // Harden the attacker-controllable seed field: undefined off local dev, and
+    // otherwise stripped to benign fields only (see sanitizeSeedUser).
+    const seedUser = sanitizeSeedUser(rawSeedUser);
     // Only call getServerSession if not in seed/CLI mode (avoids Next.js request context requirement)
     const session = seedUser ? null : await getServerSession();
 
@@ -480,7 +505,14 @@ export async function savePetition(data: OnboardingData & {
     isResident: boolean;
     isCitizen: boolean;
 }): Promise<Result<Petition>> {
-    const { cityId, isResident, isCitizen, phone, email, name, seedUser } = data;
+    const validation = savePetitionSchema.safeParse(data);
+    if (!validation.success) {
+        return createError('Invalid input');
+    }
+    const { cityId, isResident, isCitizen, phone, email, name, seedUser: rawSeedUser } = data;
+    // Harden the attacker-controllable seed field: undefined off local dev, and
+    // otherwise stripped to benign fields only (see sanitizeSeedUser).
+    const seedUser = sanitizeSeedUser(rawSeedUser);
     const session = await getServerSession();
 
     let userId: string;

--- a/src/lib/zod-schemas/onboarding.ts
+++ b/src/lib/zod-schemas/onboarding.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+// Input validation for the public onboarding Server Actions
+// (saveNotificationPreferences / savePetition in src/lib/db/notifications.ts).
+//
+// These actions are reachable directly as Server Actions from the onboarding
+// client, so their arguments are untrusted. The schemas below validate the
+// shape of the known public fields. `.passthrough()` is deliberate: the
+// dev-only `seedUser` field is carried through and neutralized separately by
+// sanitizeSeedUser() — it must not be stripped here, or the dev seed route
+// would lose its seed fields. Privilege escalation via `seedUser` is closed in
+// sanitizeSeedUser(), not here; this schema only tightens the client input.
+
+// Shared public fields both onboarding actions accept.
+const onboardingBaseFields = {
+    cityId: z.string().min(1, "cityId is required"),
+    email: z.string().optional(),
+    phone: z.string().optional(),
+    name: z.string().optional(),
+};
+
+export const saveNotificationPreferencesSchema = z
+    .object({
+        ...onboardingBaseFields,
+        locationIds: z.array(z.string()),
+        topicIds: z.array(z.string()),
+    })
+    .passthrough();
+
+export const savePetitionSchema = z
+    .object({
+        ...onboardingBaseFields,
+        isResident: z.boolean(),
+        isCitizen: z.boolean(),
+    })
+    .passthrough();


### PR DESCRIPTION
## Summary

This PR closes two vulnerabilities found in a security review.

### 1. Stored XSS in consultation comments
The public consultation comments summary page renders each comment body with `dangerouslySetInnerHTML` and no sanitization. A signed-in user can store an event-handler payload (for example an `<img onerror>` attribute) in a comment. The script then runs in the app origin when anyone — including an admin who reviews feedback — opens the summary page. From an admin session, that script can drive same-origin requests (for example fetch `/api/admin/users`).

The two other components that render the same data already sanitize with the project's `getSafeHtmlContent` allow-list; this page was the one render path that skipped it.

**Fix:** wrap both render sites (document comments and location comments) in `getSafeHtmlContent` (`src/lib/utils/sanitize.ts`). Sanitizing on render also neutralizes comment rows that are already stored, so no data cleanup is needed.

### 2. `seedUser` mass-assignment privilege escalation
`saveNotificationPreferences` and `savePetition` run as Server Actions reachable from the public onboarding client, so their arguments are attacker-controlled. Both accept a `seedUser` field that skips the session check when present and is spread into `prisma.user.create`. A crafted action payload with `seedUser.isSuperAdmin` set to `true` mints a superadmin for an attacker-controlled email. The attacker then signs in with a magic link and holds full admin access.

**Fix:** add `sanitizeSeedUser`. It returns `undefined` off local development (`IS_DEV === false`), so production and preview never honor `seedUser`: no session bypass and no field spread. In local development it allow-lists only `createdAt`, `onboarded`, `allowProductUpdates` and `allowPetitionUpdates` — never `isSuperAdmin` or identity fields. Both actions run through it. New Zod schemas (`src/lib/zod-schemas/onboarding.ts`) validate the two action inputs; they use `passthrough` so the dev seed route keeps its seed fields, which `sanitizeSeedUser` neutralizes.

The dev seed route (`src/app/api/dev/seed-users/route.ts`, superadmin plus `IS_DEV` gated) still works: its seed fields all survive the allow-list.

## Files changed
- `src/app/[locale]/(city)/[cityId]/consultation/[id]/comments/page.tsx` — sanitize both comment render sites.
- `src/lib/db/notifications.ts` — `sanitizeSeedUser`, route both actions through it, input validation.
- `src/lib/zod-schemas/onboarding.ts` — new input schemas for the two actions.

## Verification
- ESLint passes on the three changed files.
- `sanitizeSeedUser` is a strict narrowing of the pre-existing `Partial<User>` spread, so it adds no new type surface.
- Manual XSS check: post a comment with ``'&lt;img src=x onerror="window.__xss=1"&gt;'`` on an active consultation, open the summary page, confirm the `onerror` attribute is stripped.
- Manual privesc check: replay the `saveNotificationPreferences` Server Action with `seedUser.isSuperAdmin = true`; confirm no user row is created with `isSuperAdmin = true`. Confirm the normal onboarding flow still creates a user and sends a magic link, and the dev seed route still works.

## Notes
- These are two of several findings from the review. Other findings (the RSC admin-layout auth bypass, preview dev-tools, `/api/notifications/{id}` field selection, denial-of-wallet on `/api/search`) are out of scope for this PR and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvP1W9vE752xZknkspeDGK)_





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR sanitizes stored consultation-comment HTML at the remaining unsafe render sites and narrows the development-only seed-user input before it can affect authentication or user creation.
- Applies the shared HTML allow-list to document and location comments.
- Disables `seedUser` outside local development and allow-lists only benign development seed fields.
- Adds runtime validation for both public onboarding actions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/(city)/[cityId]/consultation/[id]/comments/page.tsx | Both stored-comment HTML render sites now use the established sanitizer, which strips executable tags, event handlers, and unsafe URL schemes. |
| src/lib/db/notifications.ts | Both onboarding actions validate their inputs and sanitize the development seed payload before it can alter session handling or user creation. |
| src/lib/zod-schemas/onboarding.ts | The new passthrough schemas validate public onboarding fields while preserving the development seed payload for explicit downstream narrowing. |

<sub>Reviews (3): Last reviewed commit: ["fix(notifications): block seedUser privi..."](https://github.com/schemalabz/opencouncil/commit/f3d18044d70673b1f629981e8eb4384c645d6805) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55818563)</sub>

<!-- /greptile_comment -->