### PR TITLE
Align the Nix toolchain with the deployed runtime and automate flake.lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,23 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # Nix flake inputs (flake.lock). Without this, package-lock.json is automated
+  # and flake.lock is not, so the two halves of the toolchain drift apart — that
+  # is how the Nix build ended up on EOL Node 20 while package.json required
+  # Node 24. Version updates only; Dependabot does not do Nix security updates.
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "nix"
+    ignore:
+      # nixpkgs-pinned is pinned to one rev on purpose. It supplies
+      # prisma-engines 5.22.0 (must match package.json) and the PostGIS 3.3.5
+      # Postgres stack (PostGIS 3.3.5 cannot build against current GEOS).
+      # Dependabot's Nix support does no version comparison — it moves an input
+      # to the newest upstream commit — so left alone it would silently swap
+      # both. Bump it only alongside the matching upgrade. See flake.nix.
+      - dependency-name: "nixpkgs-pinned"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -29,7 +29,14 @@ jobs:
   # with write access deploy automatically via 'preview-auto', everyone
   # else (forks, dependabot) goes through the reviewer-gated 'preview'.
   gate:
-    if: github.event.action != 'labeled' || github.event.label.name == 'preview-notis'
+    # Skip bot-authored PRs (Dependabot, Renovate). Two reasons: a lockfile
+    # bump has nothing to preview, and pull_request_target grants secrets — a
+    # dependency-bump PR must not be built with them. `user.type` catches every
+    # app-authored PR, unlike a list of bot login names. Bots push branches to
+    # this repo, so a same-repo/fork check does not exclude them.
+    if: >-
+      (github.event.action != 'labeled' || github.event.label.name == 'preview-notis')
+      && github.event.pull_request.user.type != 'Bot'
     name: Determine Deploy Environment
     runs-on: ubuntu-latest
     outputs:
@@ -60,7 +67,14 @@ jobs:
 
   # Pre-flight checks (fast, run before expensive nix build)
   preflight:
-    if: github.event.action != 'labeled' || github.event.label.name == 'preview-notis'
+    # Skip bot-authored PRs (Dependabot, Renovate). Two reasons: a lockfile
+    # bump has nothing to preview, and pull_request_target grants secrets — a
+    # dependency-bump PR must not be built with them. `user.type` catches every
+    # app-authored PR, unlike a list of bot login names. Bots push branches to
+    # this repo, so a same-repo/fork check does not exclude them.
+    if: >-
+      (github.event.action != 'labeled' || github.event.label.name == 'preview-notis')
+      && github.event.pull_request.user.type != 'Bot'
     name: Pre-flight Checks
     runs-on: ubuntu-latest
     outputs:

--- a/flake.lock
+++ b/flake.lock
@@ -2,27 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751274312,
-        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "lastModified": 1787209939,
+        "narHash": "sha256-WvvHR4kSQLAbtouMC/ruZ5UpLwlUcY3K4FAllMN+yGk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1771207753,
-        "narHash": "sha256-b9uG8yN50DRQ6A7JdZBfzq718ryYrlmGgqkRm9OOwCE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d1c15b7d5806069da59e819999d70e1cec0760bf",
+        "rev": "391b592eb44808b3bd0cb80bb71b63a5a118b8bb",
         "type": "github"
       },
       "original": {
@@ -32,10 +16,29 @@
         "type": "github"
       }
     },
+    "nixpkgs-pinned": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable"
+        "nixpkgs-pinned": "nixpkgs-pinned",
+        "nixpkgs-unstable": [
+          "nixpkgs"
+        ]
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,13 +3,28 @@
 
   inputs = {
     # Version pinning is handled by flake.lock (single source of truth).
-    # We pin via flake.lock, but choose a channel that contains Prisma 5.22.x
-    # so NixOS can use nixpkgs-provided Prisma engines without version mismatches.
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
-    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    # `nixpkgs-unstable` is kept as a name so the many call sites that take a
+    # third `pkgs-unstable` argument keep working. It resolves to the same
+    # node as `nixpkgs`; the only reason it stays a separate instantiation is
+    # the unfree predicate below.
+    nixpkgs-unstable.follows = "nixpkgs";
+
+    # The previous nixos-24.11 pin, kept for the two things that must not move
+    # with the channel. Dependabot must not advance it (see dependabot.yml):
+    #
+    #   prisma-engines / prisma  5.22.0 — must correspond to `prisma` and
+    #     `@prisma/client` 5.22.x in package.json. Current nixpkgs carries only
+    #     6.x/7.x. Bump only together with a Prisma upgrade.
+    #   postgresql_16 + postgis  3.3.5 — matches production. PostGIS 3.3.5
+    #     cannot build against the current channel's GEOS 3.14, whose configure
+    #     no longer installs geos-config. Postgres comes from here too, because
+    #     an extension must be built against the server it loads into.
+    nixpkgs-pinned.url = "github:NixOS/nixpkgs/50ab793786d9de88ee30ec4e4c24fb4236fc2674";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, nixpkgs-pinned }:
     let
       systems = [
         "x86_64-linux"
@@ -18,27 +33,53 @@
         "aarch64-darwin"
       ];
 
+      # nixpkgs removed the `nodePackages` set and moved the Prisma CLI to a
+      # top-level `prisma` attribute. Both it and prisma-engines come from the
+      # pinned rev instead — see the nixpkgs-pinned comment above.
+      prismaOverlay = prismaPkgs: _final: _prev: {
+        inherit (prismaPkgs) prisma-engines;
+        prisma = prismaPkgs.nodePackages.prisma;
+      };
+
       forAllSystems =
-        f: nixpkgs.lib.genAttrs systems (system: f system
-          (import nixpkgs { inherit system; })
-          (import nixpkgs-unstable {
-            inherit system;
-            config.allowUnfreePredicate = pkg:
-              builtins.elem (nixpkgs-unstable.lib.getName pkg) [ "ngrok" ];
-          }));
+        f: nixpkgs.lib.genAttrs systems (system:
+          let
+            prismaPkgs = import nixpkgs-pinned { inherit system; };
+          in
+          f system
+            (import nixpkgs {
+              inherit system;
+              overlays = [ (prismaOverlay prismaPkgs) ];
+            })
+            (import nixpkgs-unstable {
+              inherit system;
+              config.allowUnfreePredicate = pkg:
+                builtins.elem (nixpkgs-unstable.lib.getName pkg) [ "ngrok" ];
+            }));
 
       # Shared PostGIS 3.3.5 builder - used by dev packages and preview module
       # This ensures both use the same locked version matching production
-      mkPostgis335 = pkgs: pkgs.postgresql_16.pkgs.postgis.overrideAttrs (old: rec {
-        version = "3.3.5";
-        src = pkgs.fetchurl {
-          url = "https://download.osgeo.org/postgis/source/postgis-${version}.tar.gz";
-          sha256 = "sha256-1w73FkGIHCIr55r32pbdpDI8T1+TWewbnBCFU53YQX8=";
-        };
-        doCheck = false;
-      });
+      # `pkgs` supplies only the system: the Postgres stack itself comes from
+      # nixpkgs-pinned, so callers get the same build whatever channel they are
+      # on. See the nixpkgs-pinned comment above for why it cannot follow the
+      # channel.
+      pinnedFor = pkgs: import nixpkgs-pinned {
+        inherit (pkgs.stdenv.hostPlatform) system;
+      };
 
-      mkPostgresCompat = pkgs: pkgs.postgresql_16.withPackages (_: [ (mkPostgis335 pkgs) ]);
+      mkPostgis335 = pkgs:
+        let pinned = pinnedFor pkgs; in
+        pinned.postgresql_16.pkgs.postgis.overrideAttrs (old: rec {
+          version = "3.3.5";
+          src = pinned.fetchurl {
+            url = "https://download.osgeo.org/postgis/source/postgis-${version}.tar.gz";
+            sha256 = "sha256-1w73FkGIHCIr55r32pbdpDI8T1+TWewbnBCFU53YQX8=";
+          };
+          doCheck = false;
+        });
+
+      mkPostgresCompat = pkgs:
+        (pinnedFor pkgs).postgresql_16.withPackages (_: [ (mkPostgis335 pkgs) ]);
 
       # Shared Prisma environment setup (used by devShell, builds, and preview module)
       # Returns a string of export statements for shell scripts
@@ -87,8 +128,7 @@
       # so their environments can't drift.
       mkPrismaToolchain = pkgs: with pkgs; [
         nodejs
-        nodePackages.npm
-        nodePackages.prisma
+        prisma
         openssl
       ];
 
@@ -165,7 +205,7 @@
         cairo pango libjpeg giflib pixman libpng glib librsvg
       ];
       mkNpmNativeBuildInputs = pkgs: with pkgs; [
-        nodejs nodePackages.prisma prisma-engines openssl pkg-config python3
+        nodejs prisma prisma-engines openssl pkg-config python3
         cairo pango libjpeg giflib librsvg pixman libpng glib
       ] ++ (pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.util-linux ]);
     in {
@@ -1329,7 +1369,7 @@ EOF
 
               export PRISMA_QUERY_ENGINE_LIBRARY="$WORK_DIR/prisma/libquery_engine.node"
               cd "$WORK_DIR"
-              exec ${pkgs.nodejs}/bin/node server.js
+              exec ${pkgs-unstable.nodejs_24}/bin/node server.js
               STARTEOF
               chmod +x $out/start.sh
             '';
@@ -1465,7 +1505,7 @@ EOF
                 [ "\$name" = cache ] || ln -sfn "\$item" "\$RUN/services/notis/.next/\$name"
               done
               cd "\$RUN/services/notis"
-              exec ${pkgs-unstable.nodejs_24}/bin/node server.js
+              exec ${pkgs.nodejs}/bin/node server.js
               EOF
               chmod +x $out/start.sh
               runHook postInstall
@@ -1762,7 +1802,7 @@ EOF
             export PATH="${pkgs.nodejs}/bin:$PATH"
 
             echo "Running migrations..."
-            ${pkgs.nodePackages.prisma}/bin/prisma migrate deploy
+            ${pkgs.prisma}/bin/prisma migrate deploy
 
             echo "Seeding database..."
             SEED_DATA_URL="https://raw.githubusercontent.com/schemalabz/opencouncil-seed-data/refs/heads/main/seed_data.json"

--- a/flake.nix
+++ b/flake.nix
@@ -1369,7 +1369,7 @@ EOF
 
               export PRISMA_QUERY_ENGINE_LIBRARY="$WORK_DIR/prisma/libquery_engine.node"
               cd "$WORK_DIR"
-              exec ${pkgs-unstable.nodejs_24}/bin/node server.js
+              exec ${pkgs.nodejs}/bin/node server.js
               STARTEOF
               chmod +x $out/start.sh
             '';
@@ -1431,10 +1431,9 @@ EOF
             '';
           };
           # Notis production build (services/notis workspace). Standalone Next
-          # server; runtime pinned to Node 24 per its engines requirement —
-          # the preview execs $out/start.sh so it always runs on this toolchain
-          # (runtime-ownership rule, see pr-previews README).
-          notis-prod = (pkgs.buildNpmPackage.override { nodejs = pkgs-unstable.nodejs_24; }) {
+          # server; the preview execs $out/start.sh so it always runs on this
+          # toolchain (runtime-ownership rule, see pr-previews README).
+          notis-prod = pkgs.buildNpmPackage {
             pname = "notis-prod";
             version = "0.1.0";
             src = ./.;


### PR DESCRIPTION
## Why

Three problems made the Dependabot backlog impossible to triage.

**The Nix toolchain had drifted from `package.json`.** `a6f55ac0` raised `engines.node`, because production hit a TransformStream race that Node 24.15.0 fixes. It changed `Dockerfile`, `Dockerfile.dev` and `package.json`, but not `flake.nix`. App Platform does not read the Dockerfile, so the only change that reached a deployment was `engines.node`. Meanwhile `nix flake check` kept testing on Node 20.19.1 — a runtime the application declares it does not support. See #547.

**Every Dependabot pull request carried a red check that meant nothing.** The preview deploy routes bots to the reviewer-gated `preview` environment. Nobody approves it, and GitHub marks the request failed after 30 days. The failure says nothing about the dependency.

**`flake.lock` had no owner.** `package-lock.json` was automated and `flake.lock` was not, so the two halves of the toolchain drift apart by construction. The Node gap is the first symptom, not the last.

## What changes

`build(nix): track nixpkgs-unstable, pin Prisma and Postgres separately`

The `nixos-24.11` pin existed only to hold two packages back. Invert it: track `nixpkgs-unstable` for the toolchain, and keep one input, `nixpkgs-pinned`, on the old rev for those packages alone.

`nixpkgs-pinned` supplies:
- `prisma-engines` / `prisma` 5.22.0, which must correspond to `@prisma/client` 5.22.x. Current nixpkgs carries only 6.x/7.x.
- The `postgresql_16` + PostGIS 3.3.5 stack. PostGIS 3.3.5 cannot build against the channel's GEOS 3.14, whose configure no longer installs `geos-config`. Postgres comes from the same rev, because an extension must be built against the server it loads into.

Current nixpkgs removed the `nodePackages` set and dropped top-level `npm`. The Prisma CLI now comes from the pinned rev as top-level `prisma`. `nodePackages.npm` is gone, because Node 24 ships npm itself.

`build(nix): drop notis Node 24 override`

`notis` pinned its own runtime because the main toolchain was on Node 20. The channel move makes that redundant. Both attributes resolve to the same store path, so the output does not change.

`ci(preview): skip bot-authored pull requests`

A lockfile bump has nothing to preview, and `pull_request_target` grants secrets — a dependency bump must not be built with them. The gate uses `pull_request.user.type`, not a list of bot names and not `github.actor`. `github.actor` becomes the maintainer when a maintainer pushes to a bot branch, and bots push branches to this repository, so a same-repo check does not exclude them either.

`build(deps): let Dependabot maintain flake.lock`

Dependabot has supported the Nix ecosystem since April 2026. `nixpkgs-pinned` is ignored, because its purpose is to stay still. Dependabot does no version comparison for Nix inputs; it moves an input to the newest upstream commit, which would silently swap both the Prisma engine and the Postgres stack.

## Effect

| | before | after |
|---|---|---|
| Node in Nix CI and dev shell | 20.19.1 (EOL) | 24.19.0 |
| npm | 10.x | 11.17.0 |
| Prisma CLI / engines | 5.22.0 | 5.22.0 (unchanged) |
| PostGIS / Postgres | 3.3.5 / 16.9 | 3.3.5 / 16.9 (unchanged) |

The npm generation matters beyond version numbers. npm 11 enforces the platform-package lockfile check that npm 10 skips — the check that let a malformed lockfile reach production in #547. Dependabot pull requests are lockfile changes, so the gate that judges them can now detect that class of defect.

## Verification

`nix flake check` passes on the committed tree: lint, types, and 110 suites / 3075 tests.

`nix flake check` builds only 3 of the 14 flake outputs, so every package was built separately. That found the PostGIS failure, which CI would not have caught — the gate would have passed and `nix run .#dev-db` would have failed for every developer. All 11 packages build after the fix.

The Postgres change is byte-identical, not merely equivalent: `mkPostgresCompat` resolves to the same store path on `main` and on this branch.

`opencouncil-prod` builds, and its `start.sh` references `nodejs-24.19.0`, so previews run the application on this toolchain. The built server starts Next.js 16.2.12 on Node 24 and loads every native module.

## After merge

Two things need watching, because neither can be proven before merge.

- The first `nix` Dependabot pull request. If it proposes moving `nixpkgs-pinned`, the `ignore` key needs a different form for this ecosystem, and the fallback is to fetch that nixpkgs inside `flake.nix` so it never enters `flake.lock`.
- The bot skip. It should show as skipped rather than waiting on the next Dependabot pull request.

Relates to #547. That issue asks to stay open until the alerts are confirmed quiet, so this does not close it.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns the Nix development and build toolchain with Node 24 while retaining pinned Prisma and PostgreSQL/PostGIS packages.
- Tracks `nixpkgs-unstable` and preserves compatibility-sensitive packages through `nixpkgs-pinned`.
- Adds weekly Dependabot maintenance for Nix inputs while excluding the compatibility pin.
- Skips secret-bearing preview workflows for bot-authored pull requests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| flake.nix | Moves the main toolchain to unstable nixpkgs, overlays pinned Prisma packages, preserves the compatible PostgreSQL/PostGIS stack, and removes the redundant Notis Node override. |
| flake.lock | Locks the unstable toolchain revision and records the separate compatibility pin. |
| .github/dependabot.yml | Adds weekly Nix input updates while excluding the intentionally fixed `nixpkgs-pinned` input. |
| .github/workflows/preview-deploy.yml | Prevents bot-authored pull requests from entering the secret-bearing preview workflow. |

<sub>Reviews (2): Last reviewed commit: ["build(deps): let Dependabot maintain fla..."](https://github.com/schemalabz/opencouncil/commit/2edc4692b1f135acf1ad91536ce96e10608fd124) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55831709)</sub>

<!-- /greptile_comment -->