### PR TITLE
Keep the Nix Node in step with engines.node, and align @types/node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,14 @@ updates:
           - "patch"
     # Major bumps (e.g. Next.js 14 -> 16) are intentionally left as
     # individual, ungrouped PRs so they can be reviewed and tested on their own.
+    ignore:
+      # @types/node describes the runtime, so its major is set by
+      # engines.node — not by what npm has published. Dependabot cannot see
+      # that coupling and will always offer the newest major, which is wrong
+      # whenever it differs from the Node we run. Move this deliberately,
+      # together with engines.node and the nixpkgs input.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions used in workflows
   - package-ecosystem: "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,11 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          # Derived from engines.node rather than repeated here: setup-node
+          # reads volta.node, then devEngines.runtime, then engines.node from
+          # the manifest, and this repo declares only the last. One fewer place
+          # for the Node version to drift.
+          node-version-file: package.json
           cache: npm
 
       # Workspace install at the root covers packages/ui and services/notis.

--- a/flake.nix
+++ b/flake.nix
@@ -41,16 +41,108 @@
         prisma = prismaPkgs.nodePackages.prisma;
       };
 
+      # package.json's engines.node is the single source of truth for the Node
+      # major: DO App Platform's Node buildpack selects the production runtime
+      # from it. Nothing reconciled it with the Nix toolchain, so the two drifted
+      # for a month — CI tested on EOL Node 20 while production ran Node 24 (see
+      # issue #547). Fail the build instead of drifting again.
+      # Node version consistency. package.json's engines.node is the source of
+      # truth: DO App Platform's Node buildpack selects production's runtime
+      # from it. Nothing reconciled it with the Nix toolchain, so the two
+      # drifted for a month — CI tested on EOL Node 20 while production ran
+      # Node 24 (see issue #547).
+      #
+      # Workspaces share one lockfile and one runtime, so every manifest that
+      # declares engines.node must declare the SAME range; a workspace cannot
+      # actually run a different Node. Checking only "nixpkgs satisfies each"
+      # would let root ">=24 <25" and a workspace ">=22 <23" both pass while
+      # disagreeing. The workspace list comes from the root's workspaces globs,
+      # so a new workspace is covered without editing this file.
+      nodeConsistency =
+        let
+          inherit (nixpkgs) lib;
+          rootPkg = lib.importJSON ./package.json;
+          dirsOf = glob:
+            let
+              base = lib.removeSuffix "/*" glob;
+              dir = ./. + "/${base}";
+            in
+            if lib.hasSuffix "/*" glob && builtins.pathExists dir then
+              map (n: "${base}/${n}")
+                (builtins.attrNames
+                  (lib.filterAttrs (_: t: t == "directory") (builtins.readDir dir)))
+            else [ glob ];
+          candidates = [ "." ] ++ lib.concatMap dirsOf (rootPkg.workspaces or [ ]);
+          present = lib.filter (d: builtins.pathExists (./. + "/${d}/package.json")) candidates;
+          declaring = lib.filter
+            (d: ((lib.importJSON (./. + "/${d}/package.json")).engines or { }) ? node)
+            present;
+          rangeOf = d: (lib.importJSON (./. + "/${d}/package.json")).engines.node;
+          nameOf = d: if d == "." then "package.json" else "${d}/package.json";
+          ranges = map (d: { manifest = nameOf d; range = rangeOf d; }) declaring;
+          rootRange = rootPkg.engines.node or null;
+          disagreeing = lib.filter (r: r.range != rootRange) ranges;
+          # builtins.match anchors to the whole string, so this accepts only a
+          # bare ">=X <Y". A compound range does not match and falls through to
+          # the parse error, rather than being compared against whichever bound
+          # happened to be captured.
+          parsed = builtins.match " *>=([0-9]+(\\.[0-9]+)*) +<([0-9]+(\\.[0-9]+)*) *" rootRange;
+        in
+        { inherit disagreeing rootRange parsed; };
+
+      assertNodeSatisfiesEngines = pkgs:
+        let
+          inherit (nixpkgs) lib;
+          inherit (nodeConsistency) disagreeing rootRange parsed;
+          have = pkgs.nodejs.version;
+        in
+        if rootRange == null then
+          throw ''
+            flake.nix: package.json declares no engines.node.
+
+            It is the source of truth for the Node major — DO App Platform's
+            buildpack selects the runtime from it, and the notis CI job derives
+            its version from it. Restore it, or remove this check deliberately.
+          ''
+        else if disagreeing != [ ] then
+          throw ''
+            flake.nix: engines.node disagrees across workspaces.
+
+            package.json declares "${rootRange}", but:
+            ${lib.concatMapStringsSep "\n" (r: "  ${r.manifest} declares \"${r.range}\"") disagreeing}
+
+            Workspaces share one lockfile and one Node runtime, so these cannot
+            legitimately differ. Make them identical.
+          ''
+        else if parsed == null then
+          throw ''
+            flake.nix: cannot parse engines.node ("${rootRange}") from package.json.
+            This check understands ranges shaped ">=X <Y". Update
+            assertNodeSatisfiesEngines in flake.nix alongside the new range.
+          ''
+        else if !(lib.versionAtLeast have (builtins.elemAt parsed 0))
+             || !(lib.versionOlder have (builtins.elemAt parsed 2)) then
+          throw ''
+            flake.nix: nixpkgs provides Node ${have}, which does not satisfy
+            engines.node ("${rootRange}") in package.json.
+
+            The buildpack picks production's runtime from engines.node, so a
+            mismatch means CI and previews test a runtime production does not use.
+            Fix by moving the nixpkgs input, or by changing engines.node if the
+            supported range genuinely changed.
+          ''
+        else pkgs;
+
       forAllSystems =
         f: nixpkgs.lib.genAttrs systems (system:
           let
             prismaPkgs = import nixpkgs-pinned { inherit system; };
           in
           f system
-            (import nixpkgs {
+            (assertNodeSatisfiesEngines (import nixpkgs {
               inherit system;
               overlays = [ (prismaOverlay prismaPkgs) ];
-            })
+            }))
             (import nixpkgs-unstable {
               inherit system;
               config.allowUnfreePredicate = pkg:

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,7 +140,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/jest": "^29.5.14",
         "@types/js-yaml": "^4.0.9",
-        "@types/node": "^20",
+        "@types/node": "^24.13.3",
         "@types/pdf-parse": "^1.1.5",
         "@types/pg": "^8.11.10",
         "@types/proj4": "^2.19.0",
@@ -4104,22 +4104,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@posthog/cli/node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
-      "extraneous": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@posthog/core": {
@@ -9199,11 +9183,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.16.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.2.tgz",
-      "integrity": "sha512-91s/n4qUPV/wg8eE9KHYW1kouTfDk2FPGjXbBMfRWP/2vg1rCXNQL1OCabwGs0XSdukuK+MwCDXE30QpSeMUhQ==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/pbf": {
@@ -10434,6 +10420,21 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/apg-lite": {
       "version": "1.0.5",
@@ -24660,9 +24661,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicode-properties": {
       "version": "1.4.1",
@@ -25792,7 +25795,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
-        "@types/node": "^20",
+        "@types/node": "^24.13.3",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "autoprefixer": "^10.4.20",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^29.5.14",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^20",
+    "@types/node": "^24.13.3",
     "@types/pdf-parse": "^1.1.5",
     "@types/pg": "^8.11.10",
     "@types/proj4": "^2.19.0",

--- a/services/notis/package.json
+++ b/services/notis/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/node": "^20",
+    "@types/node": "^24.13.3",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
## Why

Four places declare a Node version, and nothing reconciles them:

| Where | Value | Who reads it |
|---|---|---|
| `package.json` → `engines.node` | `>=24.15.0 <25` | DO App Platform's Node buildpack — this selects production's runtime |
| `flake.nix` → `pkgs.nodejs` | 24.19.0 | Nix CI, dev shell, preview runtime |
| `Dockerfile` / `Dockerfile.dev` | `node:24-alpine` | local Docker development only |
| `ci.yml` notis job | `node-version: '24'` | that job |

`engines.node` is the one that decides production. The Nix side drifted from it for a month — `a6f55ac0` raised the range without touching `flake.nix`, so CI kept testing on EOL Node 20. Nothing failed, because npm only warns on an engine mismatch and this repository does not set `engine-strict`. See #547.

## What changes

**`build(nix): assert nodejs satisfies engines.node`**

`flake.nix` now reads `engines.node` from `package.json` and throws when the nixpkgs Node does not satisfy it. The check runs inside `forAllSystems`, so it guards the `pkgs` that every devShell, package, check and app receives.

Two failure paths, both verified to fire:
- Node outside the range names both versions and says which to move.
- A range the check cannot parse throws a distinct error naming `assertNodeSatisfiesEngines`, so a change of range shape fails loudly instead of passing silently.

The check understands ranges shaped `>=X <Y`, which is the shape the range has today. A different shape (for example `^24`) throws the parse error rather than being ignored.

**`build(deps): align @types/node with the Node runtime`**

`@types/node` describes the runtime, so its major belongs to `engines.node`. It sat at `^20` while the runtime moved to Node 24, so the types described a runtime we no longer run. Dependabot then offered `^26` in #666, which overshoots the other way: `tsc` would accept Node 26 APIs that do not exist in production.

This sets `^24.13.3` to match `engines.node`, and adds a Dependabot `ignore` for `@types/node` **major** bumps. Dependabot cannot see the coupling — no metadata links a types package to a runtime, and it does not read `engines.node` ([dependabot-core#7426](https://github.com/dependabot/dependabot-core/issues/7426)). It only ever offers the newest major, so no configuration of it produces the right answer. Security updates bypass `ignore` rules.

The lockfile also drops a stale `@posthog/cli/node_modules/prettier` entry that npm had marked `extraneous`. npm removed it while regenerating; it is cruft, not a version change.

## Scope

This does not touch the `Dockerfile` or `setup-node` declarations, which remain unreconciled — a four-way consistency check is a separate change. It adds no `ignore` rule for `prisma` or `@elastic/elasticsearch`: Prisma bumps stay visible deliberately, and the Elasticsearch coupling is to the deployed cluster, which needs a decision this PR should not presume.

## Verification

`nix flake check` passes: lint, types, and the full test suite. `@types/node@^24.13.3` typechecks clean. Both throw paths in the new check were exercised by temporarily setting an unsatisfiable range and an unparseable one.

Supersedes #666.













<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR establishes `engines.node` as the shared Node-version source for Nix and the Notis CI job, while aligning Node type declarations with the Node 24 runtime.
- Adds Nix checks for parseable, identical workspace engine ranges and compatibility with nixpkgs.
- Makes the Notis CI job read its Node version from `package.json`.
- Updates root and Notis `@types/node` dependencies and lockfile entries to Node 24.
- Prevents Dependabot from independently proposing major `@types/node` upgrades.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the current changes address both previously reported issues.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| flake.nix | Adds an anchored range parser, workspace engine-consistency validation, and a nixpkgs Node compatibility assertion; the previously reported compound-range bypass is closed. |
| services/notis/package.json | Aligns the Notis workspace’s Node declarations with its declared Node 24 runtime, resolving the prior nested Node 20 type selection. |
| package-lock.json | Resolves the root and Notis workspace declarations to `@types/node` 24.13.3 while retaining dependency-specific Node 20 declarations only under `apache-arrow`. |
| .github/workflows/ci.yml | Replaces the duplicated Node major with `node-version-file: package.json` for the Notis job. |
| .github/dependabot.yml | Ignores independent major updates for `@types/node` so its major remains coupled to the runtime declaration. |
| package.json | Updates the root Node type declarations from major 20 to major 24. |

<sub>Reviews (7): Last reviewed commit: ["ci: derive the notis job&#39;s Node from eng..."](https://github.com/schemalabz/opencouncil/commit/c60545f507382e437afb805cfc8935534abc0b99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55867301)</sub>

<!-- /greptile_comment -->