### PR TITLE
Run the integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,23 @@ jobs:
       - run: npm test -w notis
 
       - run: SKIP_ENV_VALIDATION=1 npm run build -w notis
+
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    # Testcontainers starts a PostgreSQL container per worker; a hung container
+    # would otherwise burn the 6-hour default.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: package.json
+          cache: npm
+
+      - run: npm ci
+
+      # These cannot run inside `nix flake check`: the Nix sandbox has no
+      # Docker, which testcontainers needs. Runners provide it, so they run here.
+      - run: npm run test:integration

--- a/flake.nix
+++ b/flake.nix
@@ -1655,7 +1655,8 @@ EOF
           };
           tests = mkCheck {
             name = "tests";
-            # Exclude integration tests (they need Docker/testcontainers).
+            # Exclude integration tests: the sandbox has no Docker, which
+            # testcontainers needs. They run in the integration job in ci.yml.
             # Limit workers to avoid exhausting memory in the nix sandbox.
             checkScript = "npm test -- --testPathIgnorePatterns='tests/integration' --maxWorkers=2";
           };

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -8,6 +8,10 @@ module.exports = {
     modulePathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
     testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
     moduleNameMapper: {
+        // Next.js bundler marker modules with no runtime content — same
+        // mapping as jest.config.js.
+        '^server-only$': '<rootDir>/__mocks__/empty.js',
+        '^client-only$': '<rootDir>/__mocks__/empty.js',
         '^@/auth$': '<rootDir>/tests/mocks/auth.ts',
         '^@/env.mjs$': '<rootDir>/tests/mocks/env.ts',
         '^@/lib/notifications/content$': '<rootDir>/tests/mocks/notificationsContent.ts',

--- a/tests/integration/notifications.admin-queries.test.ts
+++ b/tests/integration/notifications.admin-queries.test.ts
@@ -1,4 +1,13 @@
 /** @jest-environment node */
+
+// The query layer guards with withUserAuthorizedToEdit, which resolves a real
+// session. These tests exercise data shaping, not authorization, so stub the
+// guard — same pattern as task-handlers and the speaker-segment suites.
+jest.mock('@/lib/auth', () => ({
+    withUserAuthorizedToEdit: jest.fn(),
+    isUserAuthorizedToEdit: jest.fn().mockResolvedValue(true),
+}))
+
 import prisma from '@/lib/db/prisma'
 import { getNotificationsGroupedByMeeting, deleteNotificationsForMeetings } from '@/lib/db/notifications'
 import { ensureTestDb, resetDatabase } from '../helpers/test-db'


### PR DESCRIPTION
## Why

Seven integration suites exist under `tests/integration/` — notifications, subjects, speaker segments, task handlers — and they run nowhere.

`nix flake check` excludes them, correctly: the Nix sandbox has no Docker, which testcontainers needs. No workflow invokes `npm run test:integration`. So the suite has never been exercised automatically, and two defects sat in it undetected:

- Five suites failed to load at all with `Cannot find module 'server-only'`.
- `notifications.admin-queries` threw `Not authorized` on all 17 tests.

Neither is a regression. Both suites **could never have passed** — the auth guard has been on that code path since bb1eebea. Nothing ran them, so nobody found out.

The Node 24 move in #662 is what made this fixable: testcontainers' bundled undici calls `worker_threads.markAsUncloneable`, which does not exist on Node 20. On Node 24 it does, and the containers start.

## What changes

**`test(integration): map server-only and client-only marker modules`** — the suites reach `src/lib/db/*`, which imports Next.js bundler marker modules that have no runtime package for jest to resolve. `jest.config.js` already maps both to `__mocks__/empty.js`; the integration config never got the same treatment.

**`test(integration): stub the auth guard in the admin-queries suite`** — `getNotificationsGroupedByMeeting` calls `withUserAuthorizedToEdit`, which resolves a real session. Stub `@/lib/auth` the way `task-handlers`, `extract-speaker-segment` and `update-speaker-segment` already do. These tests cover query shaping, not authorization.

**`ci: run integration tests`** — a job that runs them where Docker exists. Node comes from `engines.node`, consistent with the notis job. `timeout-minutes` caps a hung container.

## Overlap with #632

The `server-only` / `client-only` mapping already exists in #632. I did not want a competing change, but the CI job is useless without it — five suites fail at import — so it has to be in this PR.

To make that painless, **this hunk is byte-identical to #632's, in the same position**. `git apply --check` of that PR's patch against this branch reports `patch does not apply`, because the lines are already present; on rebase git's three-way merge will drop the hunk cleanly. @christosporios — after this merges, a rebase should discard your version with no manual resolution.

## Verification

The suite passes **66/66, twice in a row** locally, on Node 24 with real Postgres containers:

```
Test Suites: 7 passed, 7 total
Tests:       66 passed, 66 total
```

Before this PR the same command produced `7 failed, 0 tests`.

`nix flake check` passes, so the unit checks are unaffected by the config change.

## Blocking from the start

Two clean consecutive runs and no flakiness, so the job blocks rather than warning. A non-blocking job nobody watches is how this suite decayed in the first place.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the existing integration suites runnable and adds them as a blocking GitHub Actions job.
- Maps Next.js marker modules to empty Jest mocks in the integration configuration.
- Stubs the authorization guard in the notification query suite so it tests data shaping without a real session.
- Runs integration tests on a Docker-capable CI runner while retaining their exclusion from the Nix sandbox.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking import-organization issue in the updated notification integration test.

The CI setup and test mocks align with the integration harness and guarded query behavior; the only accepted concern is that the new mock precedes the file's imports.

**Files Needing Attention:** tests/integration/notifications.admin-queries.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds a bounded integration-test job using the repository's declared Node version and GitHub-hosted Docker. |
| flake.nix | Clarifies why integration tests remain excluded from the Nix sandbox check. |
| jest.integration.config.js | Maps server-only and client-only marker modules so integration suites can import database code under Jest. |
| tests/integration/notifications.admin-queries.test.ts | Correctly stubs the throw-on-failure authorization guard, but places the mock before imports contrary to repository import-order guidance. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/integration/notifications.admin-queries.test.ts`, line 3-21 ([link](https://github.com/schemalabz/opencouncil/blob/60e27967429e3c7fc53f603e4accdf5a7204a00c/tests/integration/notifications.admin-queries.test.ts#L3-L21)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Mock precedes module imports**

   The new `jest.mock` call appears before the file's static imports, contrary to the repository's required import structure and making module dependencies less consistently organized.

   **Context Used:** CLAUDE.md ([source](https://github.com/schemalabz/opencouncil/blob/main/CLAUDE.md))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: tests/integration/notifications.admin-queries.test.ts
   Line: 3-21
   
   Comment:
   **Mock precedes module imports**
   
   The new `jest.mock` call appears before the file's static imports, contrary to the repository's required import structure and making module dependencies less consistently organized.
   
   
   
   **Context Used:** CLAUDE.md ([source](https://github.com/schemalabz/opencouncil/blob/main/CLAUDE.md))
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fintegration%2Fnotifications.admin-queries.test.ts%0ALine%3A%203-21%0A%0AComment%3A%0A**Mock%20precedes%20module%20imports**%0A%0AThe%20new%20%60jest.mock%60%20call%20appears%20before%20the%20file's%20static%20imports%2C%20contrary%20to%20the%20repository's%20required%20import%20structure%20and%20making%20module%20dependencies%20less%20consistently%20organized.%0A%0A%60%60%60suggestion%0Aimport%20prisma%20from%20'%40%2Flib%2Fdb%2Fprisma'%0Aimport%20%7B%20getNotificationsGroupedByMeeting%2C%20deleteNotificationsForMeetings%20%7D%20from%20'%40%2Flib%2Fdb%2Fnotifications'%0Aimport%20%7B%20ensureTestDb%2C%20resetDatabase%20%7D%20from%20'..%2Fhelpers%2Ftest-db'%0Aimport%20%7B%0A%20%20%20%20createAdministrativeBody%2C%0A%20%20%20%20createCity%2C%0A%20%20%20%20createMeeting%2C%0A%20%20%20%20createNotificationPreference%2C%0A%20%20%20%20createSubject%2C%0A%20%20%20%20createUser%2C%0A%7D%20from%20'..%2Fhelpers%2Ffactories'%0A%0A%2F%2F%20The%20query%20layer%20guards%20with%20withUserAuthorizedToEdit%2C%20which%20resolves%20a%20real%0A%2F%2F%20session.%20These%20tests%20exercise%20data%20shaping%2C%20not%20authorization%2C%20so%20stub%20the%0A%2F%2F%20guard%20%E2%80%94%20same%20pattern%20as%20task-handlers%20and%20the%20speaker-segment%20suites.%0Ajest.mock%28'%40%2Flib%2Fauth'%2C%20%28%29%20%3D%3E%20%28%7B%0A%20%20%20%20withUserAuthorizedToEdit%3A%20jest.fn%28%29%2C%0A%20%20%20%20isUserAuthorizedToEdit%3A%20jest.fn%28%29.mockResolvedValue%28true%29%2C%0A%7D%29%29%0A%60%60%60%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fgithub.com%2Fschemalabz%2Fopencouncil%2Fblob%2Fmain%2FCLAUDE.md%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=schemalabz%2Fopencouncil&pr=672&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20schemalabz%2Fopencouncil%20PR%20%23672%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=schemalabz%2Fopencouncil&pr=672&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atests%2Fintegration%2Fnotifications.admin-queries.test.ts%3A3-21%0A**Mock%20precedes%20module%20imports**%0A%0AThe%20new%20%60jest.mock%60%20call%20appears%20before%20the%20file's%20static%20imports%2C%20contrary%20to%20the%20repository's%20required%20import%20structure%20and%20making%20module%20dependencies%20less%20consistently%20organized.%0A%0A%60%60%60suggestion%0Aimport%20prisma%20from%20'%40%2Flib%2Fdb%2Fprisma'%0Aimport%20%7B%20getNotificationsGroupedByMeeting%2C%20deleteNotificationsForMeetings%20%7D%20from%20'%40%2Flib%2Fdb%2Fnotifications'%0Aimport%20%7B%20ensureTestDb%2C%20resetDatabase%20%7D%20from%20'..%2Fhelpers%2Ftest-db'%0Aimport%20%7B%0A%20%20%20%20createAdministrativeBody%2C%0A%20%20%20%20createCity%2C%0A%20%20%20%20createMeeting%2C%0A%20%20%20%20createNotificationPreference%2C%0A%20%20%20%20createSubject%2C%0A%20%20%20%20createUser%2C%0A%7D%20from%20'..%2Fhelpers%2Ffactories'%0A%0A%2F%2F%20The%20query%20layer%20guards%20with%20withUserAuthorizedToEdit%2C%20which%20resolves%20a%20real%0A%2F%2F%20session.%20These%20tests%20exercise%20data%20shaping%2C%20not%20authorization%2C%20so%20stub%20the%0A%2F%2F%20guard%20%E2%80%94%20same%20pattern%20as%20task-handlers%20and%20the%20speaker-segment%20suites.%0Ajest.mock%28'%40%2Flib%2Fauth'%2C%20%28%29%20%3D%3E%20%28%7B%0A%20%20%20%20withUserAuthorizedToEdit%3A%20jest.fn%28%29%2C%0A%20%20%20%20isUserAuthorizedToEdit%3A%20jest.fn%28%29.mockResolvedValue%28true%29%2C%0A%7D%29%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=schemalabz%2Fopencouncil&pr=672&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tests/integration/notifications.admin-queries.test.ts:3-21
**Mock precedes module imports**

The new `jest.mock` call appears before the file's static imports, contrary to the repository's required import structure and making module dependencies less consistently organized.

```suggestion
import prisma from '@/lib/db/prisma'
import { getNotificationsGroupedByMeeting, deleteNotificationsForMeetings } from '@/lib/db/notifications'
import { ensureTestDb, resetDatabase } from '../helpers/test-db'
import {
    createAdministrativeBody,
    createCity,
    createMeeting,
    createNotificationPreference,
    createSubject,
    createUser,
} from '../helpers/factories'

// The query layer guards with withUserAuthorizedToEdit, which resolves a real
// session. These tests exercise data shaping, not authorization, so stub the
// guard — same pattern as task-handlers and the speaker-segment suites.
jest.mock('@/lib/auth', () => ({
    withUserAuthorizedToEdit: jest.fn(),
    isUserAuthorizedToEdit: jest.fn().mockResolvedValue(true),
}))
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: run integration tests"](https://github.com/schemalabz/opencouncil/commit/60e27967429e3c7fc53f603e4accdf5a7204a00c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56022171)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/schemalabz/opencouncil/blob/main/CLAUDE.md))

<!-- /greptile_comment -->