### PR TITLE
notis: launch-week — incremental delivery, message supersede, SMS channel, review fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,29 @@ jobs:
       - run: npm test -w notis
 
       - run: SKIP_ENV_VALIDATION=1 npm run build -w notis
+
+  integration:
+    name: Integration (testcontainers)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: package.json
+          cache: npm
+
+      - run: npm ci
+
+      # Both generated clients: the contract suites exercise the main views
+      # AND the notis queue against real PostgreSQL containers.
+      - run: npm run prisma:generate
+      - run: npm run prisma:generate -w notis
+
+      # The suites CI could not previously see: view/grant contracts
+      # (notis-views, notis-rollout, notis-exclusion), queue claims
+      # (notis-queue), migration replay, and the notification paths.
+      # Serially: parallel testcontainers flake under contention (observed
+      # locally — 9 spurious failures hot, 0 after warmup); CI runners are
+      # slower still, and a deterministic 2-minute job beats a fast red one.
+      - run: npm run test:integration -- --runInBand

--- a/prisma/migrations/20260823214500_notis_perf_indexes/migration.sql
+++ b/prisma/migrations/20260823214500_notis_perf_indexes/migration.sql
@@ -1,0 +1,14 @@
+-- Perf indexes for the notis integration paths (cross-session review,
+-- finding 13). Replay-safe: IF NOT EXISTS throughout.
+
+-- Every WhatsApp webhook event resolves its sender by phone on BOTH apps'
+-- gates (the main app's notis-served check and notis's own lookup) —
+-- without an index each event seq-scans "User".
+CREATE INDEX IF NOT EXISTS "User_phone_idx" ON "User"("phone");
+
+-- The notis poller's meeting-event feed reads succeeded pipeline tasks by
+-- recency through the notis_meeting_events view; the partial keeps the
+-- per-tick scan off the full TaskStatus history.
+CREATE INDEX IF NOT EXISTS "TaskStatus_notis_events_idx"
+  ON "TaskStatus" ("updatedAt")
+  WHERE type IN ('processAgenda', 'summarize') AND status = 'succeeded';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -848,6 +848,9 @@ model User {
   serviceApiKeys ServiceApiKey[]
   mcpTokens UserMcpToken[]
   searchQueries SearchQuery[]
+
+  // Webhook gates resolve senders by phone on every WhatsApp event.
+  @@index([phone])
 }
  
 model Account {

--- a/services/notis/prisma/migrations/20260823210000_railed_flag/migration.sql
+++ b/services/notis/prisma/migrations/20260823210000_railed_flag/migration.sql
@@ -1,0 +1,6 @@
+-- The delivery-instant rail flag, stamped per row instead of derived per
+-- call site. Backfill approximates history: every proactive or template
+-- row was railed; reply-continuation freeform rows before this flag are
+-- all delivered already, so their value no longer matters.
+ALTER TABLE "NotisMessage" ADD COLUMN IF NOT EXISTS "railed" BOOLEAN NOT NULL DEFAULT false;
+UPDATE "NotisMessage" SET "railed" = true WHERE "proactive" = true OR "deliveryMode" = 'template';

--- a/services/notis/prisma/migrations/20260823214600_perf_indexes/migration.sql
+++ b/services/notis/prisma/migrations/20260823214600_perf_indexes/migration.sql
@@ -1,0 +1,23 @@
+-- Perf indexes (cross-session review, finding 13). Replay-safe: the
+-- integration harness applies migrations twice.
+
+-- Panel aggregates, the overview series, and cap counting all scan
+-- messages by time across subscriptions.
+CREATE INDEX IF NOT EXISTS "NotisMessage_createdAt_idx" ON "NotisMessage"("createdAt");
+
+-- The sweeper polls for stale pending outbound every minute. The partial
+-- stays tiny (pending rows drain within seconds) while the table grows
+-- with every message ever sent.
+CREATE INDEX IF NOT EXISTS "NotisMessage_pending_outbound_idx"
+  ON "NotisMessage" ("createdAt")
+  WHERE status = 'pending'::"MessageStatus" AND direction = 'outbound'::"MessageDirection";
+
+-- The poller fires due scheduled wakes each tick; un-fired rows are the
+-- entire working set.
+CREATE INDEX IF NOT EXISTS "NotisScheduledWake_unfired_idx"
+  ON "NotisScheduledWake" ("runAfter")
+  WHERE "firedAt" IS NULL;
+
+-- The system page counts wakes per meeting through event->>'meetingId'.
+CREATE INDEX IF NOT EXISTS "NotisWake_event_meeting_idx"
+  ON "NotisWake" ((event->>'meetingId'));

--- a/services/notis/prisma/migrations/20260823230000_live_lane_coalescing/migration.sql
+++ b/services/notis/prisma/migrations/20260823230000_live_lane_coalescing/migration.sql
@@ -1,0 +1,43 @@
+-- Live-lane coalescing: one pending live row per subscription, so a second
+-- inbound appends to the waiting wake instead of queueing a second answer.
+-- Replay-safe: the dedupe CTE is empty once the index exists.
+
+-- Merge any existing duplicate pending live rows (oldest wins, events
+-- concatenated in arrival order) before the unique index can be created.
+WITH dupes AS (
+  SELECT "subscriptionId",
+         (array_agg(id ORDER BY "createdAt", id))[1] AS keep_id,
+         array_agg(id ORDER BY "createdAt", id) AS ids
+  FROM "NotisWakeQueue"
+  WHERE status = 'pending'::"QueueItemStatus" AND lane = 'live'::"QueueLane"
+  GROUP BY "subscriptionId"
+  HAVING count(*) > 1
+),
+merged AS (
+  SELECT d.keep_id, jsonb_agg(e.elem ORDER BY q."createdAt", q.id, e.ord) AS extra
+  FROM dupes d
+  JOIN "NotisWakeQueue" q ON q.id = ANY(d.ids) AND q.id <> d.keep_id
+  CROSS JOIN LATERAL jsonb_array_elements(q.events) WITH ORDINALITY AS e(elem, ord)
+  GROUP BY d.keep_id
+)
+UPDATE "NotisWakeQueue" q
+SET events = q.events || m.extra
+FROM merged m
+WHERE q.id = m.keep_id;
+
+DELETE FROM "NotisWakeQueue" q
+USING (
+  SELECT unnest(ids[2:]) AS drop_id
+  FROM (
+    SELECT array_agg(id ORDER BY "createdAt", id) AS ids
+    FROM "NotisWakeQueue"
+    WHERE status = 'pending'::"QueueItemStatus" AND lane = 'live'::"QueueLane"
+    GROUP BY "subscriptionId"
+    HAVING count(*) > 1
+  ) g
+) d
+WHERE q.id = d.drop_id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "NotisWakeQueue_one_pending_live_per_sub"
+  ON "NotisWakeQueue" ("subscriptionId")
+  WHERE status = 'pending'::"QueueItemStatus" AND lane = 'live'::"QueueLane";

--- a/services/notis/prisma/schema.prisma
+++ b/services/notis/prisma/schema.prisma
@@ -200,6 +200,7 @@ model NotisMessage {
   createdAt DateTime @default(now())
 
   @@index([subscriptionId, createdAt])
+  @@index([createdAt])
 }
 
 // Why the schedule exists decides the template shell when it fires outside

--- a/services/notis/prisma/schema.prisma
+++ b/services/notis/prisma/schema.prisma
@@ -169,6 +169,13 @@ model NotisMessage {
   // deliveryMode=template — a scheduled wake inside the 24h window sends
   // freeform yet is unprompted.
   proactive Boolean          @default(false)
+  // The delivery-instant rails (unsubscribed / paused / shadow) apply to
+  // this row. Distinct from `proactive`: a reply-continuation follow-up is
+  // railed but cap-exempt, and a reactive reply (including the ΣΤΟΠ
+  // confirmation) is neither. Stamped at creation from the wake class, so
+  // every delivery path — boundary, sweeper, incremental — asks one flag
+  // instead of re-deriving the class per call site.
+  railed    Boolean          @default(false)
   // The failed WhatsApp message this SMS replaces. Unique: a replayed
   // failure webhook cannot fire a second SMS.
   fallbackForId String? @unique

--- a/services/notis/prompts/system.md
+++ b/services/notis/prompts/system.md
@@ -199,6 +199,11 @@ You have a profile of who they are, the conversation — what you sent, what
 they answered — and a decision log of what you did and why. Pick up a past
 exchange when it is natural. Never recite what you know about them.
 
+A stated interest is a center, not a fence. Someone who cares about parking
+pricing also cares about the zone expansions and permit schemes around it —
+read interests one notch wider than their words, unless the reader has drawn
+the line themselves.
+
 Read the engagement evidence. Someone who replies wants to hear from you more
 often. Someone who has had four messages and answered none wants to hear from
 you rarely — go quiet and surface only the big things. Nobody gave you a number;

--- a/services/notis/prompts/system.md
+++ b/services/notis/prompts/system.md
@@ -86,6 +86,8 @@ parties and hold roles.
 - Every message carries one opencouncil.gr link, always taken from a url field
   a tool returned. Match the link to the claim: subjects, meetings, people
   (/{city}/people/{id}) and parties (/{city}/parties/{id}) all have pages.
+- Write every link with its https:// prefix — WhatsApp does not reliably make
+  bare domains tappable.
 - A verbatim quote links its moment: utterances in get_subject_transcript
   carry urls ending in ?t=seconds that start the video at that exact second.
   Fetch the transcript before quoting — the moment url is the receipt, and it
@@ -100,7 +102,7 @@ just theirs. (Your archive is the Greek one; other countries live on their
 own OpenCouncil sites — if asked, say so and point there.)
 The one thing you cannot change is which cities you watch for them: city
 subscriptions live in their OpenCouncil account. If they ask to add or remove
-a city, warmly point them to their profile at opencouncil.gr — one minute of
+a city, warmly point them to their profile at https://opencouncil.gr — one minute of
 work — and note it in their taste profile so you remember they care.
 
 Everything else about their attention is yours to grant on the spot. The
@@ -117,7 +119,7 @@ For how municipalities and councils work — δημοτικό συμβούλιο
 επιτροπή, κοινότητες, προϋπολογισμοί, Διαύγεια — and for what OpenCouncil
 itself offers (search, notifications, petitions for uncovered cities), rely on
 the background material you have been given. Explain plainly when asked; link
-to opencouncil.gr/explain for the full picture.
+to https://opencouncil.gr/explain for the full picture.
 
 ## Links the reader shares
 

--- a/services/notis/src/agent/__tests__/runWake.test.ts
+++ b/services/notis/src/agent/__tests__/runWake.test.ts
@@ -379,3 +379,95 @@ describe("runWake", () => {
   });
 
 });
+
+describe("runWake incremental delivery (deps.deliver)", () => {
+  const userEvent = {
+    type: "user_message" as const,
+    at: "2026-03-10T10:00:00.000Z",
+    text: "Τι ψηφίστηκε;",
+  };
+  const sendFinishTurn = [
+    {
+      content: [
+        toolUse("t1", "send_message", { text: "Η απάντηση." }),
+        toolUse("t2", "finish_wake", { rationale: "Απάντησα." }),
+      ],
+      stop_reason: "tool_use" as const,
+    },
+  ];
+
+  it("hands each send to deliver the moment it is emitted", async () => {
+    const fake = new FakeAnthropic(sendFinishTurn);
+    const delivered: string[] = [];
+    const { outcome } = await runWake(makeState(), [userEvent], {
+      ...makeDeps(fake),
+      deliver: async (t) => {
+        delivered.push(t);
+        return { ok: true };
+      },
+    });
+
+    expect(delivered).toEqual(["Η απάντηση."]);
+    expect(outcome.decision).toBe("send");
+    expect(outcome.partialDeliveryError).toBeUndefined();
+  });
+
+  it("a failed delivery reaches the model in the tool_result", async () => {
+    const fake = new FakeAnthropic([
+      {
+        content: [toolUse("t1", "send_message", { text: "Χάθηκε." })],
+        stop_reason: "tool_use" as const,
+      },
+      {
+        content: [toolUse("t2", "finish_wake", { rationale: "Δεν βγήκε." })],
+        stop_reason: "tool_use" as const,
+      },
+    ]);
+    await runWake(makeState(), [userEvent], {
+      ...makeDeps(fake),
+      deliver: async () => ({ ok: false, detail: "503 from Bird" }),
+    });
+
+    // requests[] aliases the live messages array, so find t1's tool_result
+    // by id instead of by position.
+    const blocks = (
+      fake.requests[1].messages as Array<{ content: unknown }>
+    ).flatMap((m) => (Array.isArray(m.content) ? m.content : [])) as Array<{
+      type: string;
+      tool_use_id?: string;
+      content?: string;
+    }>;
+    const toolResult = blocks.find((b) => b.type === "tool_result" && b.tool_use_id === "t1");
+    expect(toolResult?.content).toContain("delivery failed: 503 from Bird");
+  });
+
+  it("fail-forward: an error after a delivery attempt finalizes instead of throwing", async () => {
+    // One send turn without finish_wake; the second model call throws.
+    const fake = new FakeAnthropic([
+      {
+        content: [toolUse("t1", "send_message", { text: "Πρώτο μισό." })],
+        stop_reason: "tool_use" as const,
+      },
+    ]);
+    const { outcome } = await runWake(makeState(), [userEvent], {
+      ...makeDeps(fake),
+      deliver: async () => ({ ok: true }),
+    });
+
+    expect(outcome.decision).toBe("send");
+    expect(outcome.partialDeliveryError).toContain("exhausted");
+    expect(outcome.rationale).toContain("διακόπηκε");
+    // The breach is explained by the error, not the finish_wake contract.
+    expect(outcome.finishWakeMissing).toBeUndefined();
+  });
+
+  it("an error before any delivery attempt still throws — the queue retries", async () => {
+    const fake = new FakeAnthropic([]);
+    await expect(
+      runWake(makeState(), [userEvent], {
+        ...makeDeps(fake),
+        deliver: async () => ({ ok: true }),
+      }),
+    ).rejects.toThrow("exhausted");
+  });
+});

--- a/services/notis/src/agent/__tests__/runWake.test.ts
+++ b/services/notis/src/agent/__tests__/runWake.test.ts
@@ -386,6 +386,96 @@ describe("runWake", () => {
 
 });
 
+describe("mid-run absorption (deps.absorb)", () => {
+  const userEvent = {
+    type: "user_message" as const,
+    at: "2026-03-10T10:00:00.000Z",
+    text: "Τι γίνεται με το μετρό στα Εξάρχεια;",
+  };
+  const correction = {
+    type: "user_message" as const,
+    at: "2026-03-10T10:00:20.000Z",
+    text: "Σόρρυ άκυρο — στην Κυψέλη εννοούσα",
+  };
+
+  it("injects a turn-start update into the conversation and returns it", async () => {
+    const fake = new FakeAnthropic([
+      {
+        content: [
+          toolUse("t1", "send_message", { text: "Για την Κυψέλη λοιπόν..." }),
+          toolUse("t2", "finish_wake", { rationale: "Απάντησα στη διόρθωση." }),
+        ],
+        stop_reason: "tool_use",
+      },
+    ]);
+    let calls = 0;
+    const { absorbed, outcome } = await runWake(makeState(), [userEvent], {
+      ...makeDeps(fake),
+      absorb: async () => (++calls === 1 ? [correction] : []),
+    });
+
+    expect(absorbed).toEqual([correction]);
+    expect(outcome.messages).toEqual(["Για την Κυψέλη λοιπόν..."]);
+    // The note rides in the FIRST request, appended to the user turn.
+    const first = fake.requests[0].messages as Array<{ content: Array<{ text?: string }> }>;
+    const blocks = first[0].content;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[1].text).toContain("Κυψέλη εννοούσα");
+    expect(blocks[1].text).toContain("reader update");
+  });
+
+  it("holds a turn's sends when the reader wrote during it, then delivers the corrected answer", async () => {
+    const fake = new FakeAnthropic([
+      {
+        content: [
+          toolUse("t1", "send_message", { text: "Για τα Εξάρχεια: ..." }),
+          toolUse("t2", "finish_wake", { rationale: "Απάντησα." }),
+        ],
+        stop_reason: "tool_use",
+      },
+      {
+        content: [
+          toolUse("t3", "send_message", { text: "Για την Κυψέλη: ..." }),
+          toolUse("t4", "finish_wake", { rationale: "Απάντησα στη διόρθωση." }),
+        ],
+        stop_reason: "tool_use",
+      },
+    ]);
+    const delivered: string[] = [];
+    let calls = 0;
+    const { outcome, absorbed } = await runWake(makeState(), [userEvent], {
+      ...makeDeps(fake),
+      deliver: async (t) => {
+        delivered.push(t);
+        return { ok: true };
+      },
+      // Turn-0 start: nothing. Pre-send probe of turn 1: the correction.
+      // Everything after: nothing.
+      absorb: async () => (++calls === 2 ? [correction] : []),
+    });
+
+    // The stale Εξάρχεια answer never left; only the corrected one did.
+    expect(delivered).toEqual(["Για την Κυψέλη: ..."]);
+    expect(outcome.messages).toEqual(["Για την Κυψέλη: ..."]);
+    expect(outcome.repairs).toContain("reader-update/held-sends");
+    expect(absorbed).toEqual([correction]);
+    // The held turn's tool_results tell the model exactly what happened.
+    const second = fake.requests[1].messages as Array<{ content: unknown }>;
+    const resultBlocks = second
+      .flatMap((m) => (Array.isArray(m.content) ? m.content : []))
+      .filter(
+        (b): b is { type: string; content?: string; text?: string } =>
+          typeof b === "object" && b !== null,
+      );
+    expect(
+      resultBlocks.some((b) => b.type === "tool_result" && b.content?.includes("held")),
+    ).toBe(true);
+    expect(resultBlocks.some((b) => b.type === "text" && b.text?.includes("reader update"))).toBe(
+      true,
+    );
+  });
+});
+
 describe("unsubscribe guard", () => {
   it("ignores unsubscribe_user on a wake without a reader message", async () => {
     const fake = new FakeAnthropic([

--- a/services/notis/src/agent/__tests__/runWake.test.ts
+++ b/services/notis/src/agent/__tests__/runWake.test.ts
@@ -243,7 +243,13 @@ describe("runWake", () => {
       },
       { content: [text("They wanted out; let them go warmly.")], stop_reason: "end_turn" },
     ]);
-    const { outcome } = await runWake(makeState(), [meetingEvent()], makeDeps(fake));
+    // A user_message event: only the reader can unsubscribe the reader, and
+    // the guard ignores the tool on wakes without one.
+    const { outcome } = await runWake(
+      makeState(),
+      [{ type: "user_message", at: FIXED_NOW.toISOString(), text: "σταμάτα να μου στέλνεις" }],
+      makeDeps(fake),
+    );
     expect(outcome.unsubscribe).toEqual({ reason: "asked to stop" });
     expect(outcome.messages).toHaveLength(1);
   });
@@ -378,6 +384,23 @@ describe("runWake", () => {
     expect(markers).toBe(2);
   });
 
+});
+
+describe("unsubscribe guard", () => {
+  it("ignores unsubscribe_user on a wake without a reader message", async () => {
+    const fake = new FakeAnthropic([
+      {
+        content: [
+          toolUse("t1", "unsubscribe_user", { reason: "hallucinated" }),
+          toolUse("t2", "finish_wake", { rationale: "Τίποτα σχετικό." }),
+        ],
+        stop_reason: "tool_use",
+      },
+    ]);
+    const { outcome } = await runWake(makeState(), [meetingEvent()], makeDeps(fake));
+
+    expect(outcome.unsubscribe).toBeUndefined();
+  });
 });
 
 describe("runWake incremental delivery (deps.deliver)", () => {

--- a/services/notis/src/agent/__tests__/runWake.test.ts
+++ b/services/notis/src/agent/__tests__/runWake.test.ts
@@ -476,6 +476,91 @@ describe("mid-run absorption (deps.absorb)", () => {
   });
 });
 
+describe("held turns and superseded decisions", () => {
+  const userEvent = {
+    type: "user_message" as const,
+    at: "2026-03-10T10:00:00.000Z",
+    text: "Σταμάτα να μου στέλνεις.",
+  };
+  const retraction = {
+    type: "user_message" as const,
+    at: "2026-03-10T10:00:30.000Z",
+    text: "Όχι τελικά — συνέχισε!",
+  };
+
+  it("a held turn commits neither the schedule nor the unsubscribe", async () => {
+    const fake = new FakeAnthropic([
+      {
+        content: [
+          toolUse("t1", "send_message", { text: "Εντάξει, σταματώ. Γεια!" }),
+          toolUse("t2", "schedule_wakeup", {
+            at: "2026-03-12T10:00:00.000Z",
+            reason: "τελευταία υπενθύμιση",
+          }),
+          toolUse("t3", "unsubscribe_user", { reason: "το ζήτησε" }),
+          toolUse("t4", "finish_wake", { rationale: "Απεγγραφή." }),
+        ],
+        stop_reason: "tool_use",
+      },
+      {
+        content: [
+          toolUse("t5", "send_message", { text: "Χαίρομαι! Συνεχίζω κανονικά." }),
+          toolUse("t6", "finish_wake", { rationale: "Ανακάλεσε την απεγγραφή." }),
+        ],
+        stop_reason: "tool_use",
+      },
+    ]);
+    const delivered: string[] = [];
+    let calls = 0;
+    const { outcome } = await runWake(makeState(), [userEvent], {
+      ...makeDeps(fake),
+      deliver: async (t) => {
+        delivered.push(t);
+        return { ok: true };
+      },
+      // The retraction lands in the pre-send probe of the goodbye turn.
+      absorb: async () => (++calls === 2 ? [retraction] : []),
+    });
+
+    expect(outcome.unsubscribe).toBeUndefined();
+    expect(outcome.scheduledWakes).toEqual([]);
+    expect(delivered).toEqual(["Χαίρομαι! Συνεχίζω κανονικά."]);
+    expect(outcome.messages).toEqual(["Χαίρομαι! Συνεχίζω κανονικά."]);
+  });
+
+  it("a turn-start update clears a latched unsubscribe and tells the model", async () => {
+    const fake = new FakeAnthropic([
+      {
+        content: [toolUse("t1", "unsubscribe_user", { reason: "το ζήτησε" })],
+        stop_reason: "tool_use",
+      },
+      {
+        content: [
+          toolUse("t2", "send_message", { text: "Μένουμε λοιπόν!" }),
+          toolUse("t3", "finish_wake", { rationale: "Ανακλήθηκε." }),
+        ],
+        stop_reason: "tool_use",
+      },
+    ]);
+    let calls = 0;
+    const { outcome, trace } = await runWake(makeState(), [userEvent], {
+      ...makeDeps(fake),
+      deliver: async () => ({ ok: true }),
+      // Turn-0 start: nothing. Turn-1 start: the retraction (no sends in
+      // turn 0's response, so no pre-send probe fires).
+      absorb: async () => (++calls === 2 ? [retraction] : []),
+    });
+
+    expect(outcome.unsubscribe).toBeUndefined();
+    const injected = trace.turns.filter((t) => t.role === "injected");
+    expect(
+      injected.some((t) =>
+        String((t.content[0] as { text?: string }).text).includes("cancelled pending"),
+      ),
+    ).toBe(true);
+  });
+});
+
 describe("unsubscribe guard", () => {
   it("ignores unsubscribe_user on a wake without a reader message", async () => {
     const fake = new FakeAnthropic([

--- a/services/notis/src/agent/runWake.ts
+++ b/services/notis/src/agent/runWake.ts
@@ -193,6 +193,16 @@ export async function runWake(
             });
             break;
           case "unsubscribe_user":
+            // Only the reader can unsubscribe the reader. On a wake without
+            // a user_message there is no reader request to honor — prompt
+            // guidance alone must not be the only thing standing between a
+            // hallucinated call and a silent permanent opt-out.
+            if (!hasUserMessage) {
+              ack =
+                "ignored: unsubscribe is only available while replying to the reader; " +
+                "this wake has no reader message";
+              break;
+            }
             unsubscribe = { reason: String(block.input.reason ?? "") };
             break;
           case "finish_wake":

--- a/services/notis/src/agent/runWake.ts
+++ b/services/notis/src/agent/runWake.ts
@@ -30,9 +30,11 @@ function textOf(content: unknown[]): string {
  * time, defensively), all consumed in a single invocation so the reader gets
  * one considered response instead of a burst.
  *
- * Pure over Deps: never mutates `state`, performs no side effects — client
- * tool calls are recorded into the outcome and answered with synthetic
- * tool_results; MCP research runs server-side inside the API call.
+ * Pure over Deps: never mutates `state` — client tool calls are recorded
+ * into the outcome and answered with synthetic tool_results; MCP research
+ * runs server-side inside the API call. The one deliberate side-effect
+ * channel is deps.deliver (incremental delivery): when present, each
+ * send_message is handed to the shell the moment it is emitted.
  */
 export async function runWake(
   state: WakeState,
@@ -84,6 +86,11 @@ export async function runWake(
   };
 
   const sent: string[] = [];
+  // How many times deps.deliver was invoked — attempted, not succeeded: a
+  // transiently-failed row stays pending and the sweeper may still deliver
+  // it, so any attempt at all makes a model re-run a duplicate risk.
+  let deliveryAttempts = 0;
+  let partialDeliveryError: string | undefined;
   let profileRewrite: string | undefined;
   const scheduledWakes: Array<{ at: string; reason: string }> = [];
   let unsubscribe: { reason: string } | undefined;
@@ -116,6 +123,12 @@ export async function runWake(
   let preNudgeRationale: string | undefined;
   let sentAtNudge = -1;
 
+  // Fail-forward fence: once a delivery attempt has been made, an error can
+  // no longer roll this wake back — a retry would re-run the model after the
+  // reader already received (or may yet receive) messages, and a duplicate
+  // answer is worse than a truncated one. The loop finalizes with what it
+  // has; before the first attempt, errors propagate and the queue retries.
+  try {
   for (let turn = 0; turn < deps.config.maxTurns; turn++) {
     const response = await deps.anthropic.create({
       model: deps.config.model,
@@ -153,8 +166,21 @@ export async function runWake(
         switch (block.name) {
           case "send_message": {
             const t = String(block.input.text ?? "");
-            if (t) sent.push(t);
-            ack = "delivered";
+            if (t) {
+              sent.push(t);
+              if (deps.deliver) {
+                deliveryAttempts++;
+                const result = await deps.deliver(t);
+                ack = result.ok
+                  ? "delivered"
+                  : `delivery failed: ${result.detail ?? "unknown error"} — the message ` +
+                    "did not reach the reader now; do not repeat it verbatim";
+              } else {
+                ack = "delivered";
+              }
+            } else {
+              ack = "delivered";
+            }
             break;
           }
           case "update_taste_profile":
@@ -307,6 +333,10 @@ export async function runWake(
     // end_turn, max_tokens, or anything else: stop.
     break;
   }
+  } catch (error) {
+    if (deliveryAttempts === 0) throw error;
+    partialDeliveryError = error instanceof Error ? error.message : String(error);
+  }
 
   if (preNudgeRationale && sent.length === sentAtNudge) {
     rationale = preNudgeRationale;
@@ -319,13 +349,20 @@ export async function runWake(
   if (truncated && !rationale) {
     rationale = "(cut at the token ceiling — no decision was made)";
   }
+  if (partialDeliveryError) {
+    // The error is the story now — whatever rationale the model had written
+    // describes a wake that did not finish the way it thought it would.
+    rationale =
+      `Το wake διακόπηκε από σφάλμα μετά από ${deliveryAttempts} απόπειρες παράδοσης: ` +
+      partialDeliveryError;
+  }
   if (!rationale) {
     rationale = "(no rationale emitted)";
   }
 
   // finish_wake is REQUIRED by the prompt; when the loop ends without it (and
   // without a terminal anomaly explaining why), record the contract breach.
-  const finishWakeMissing = !finished && !refused && !truncated;
+  const finishWakeMissing = !finished && !refused && !truncated && !partialDeliveryError;
 
   const outcome: WakeOutcome = {
     decision,
@@ -337,6 +374,7 @@ export async function runWake(
     ...(profileRewrite !== undefined ? { profileRewrite } : {}),
     scheduledWakes,
     ...(unsubscribe ? { unsubscribe } : {}),
+    ...(partialDeliveryError !== undefined ? { partialDeliveryError } : {}),
   };
 
   const trace: WakeTrace = {

--- a/services/notis/src/agent/runWake.ts
+++ b/services/notis/src/agent/runWake.ts
@@ -108,7 +108,16 @@ export async function runWake(
     const news = await deps.absorb();
     if (news.length === 0) return;
     absorbedAll.push(...news);
-    const note = absorbNote(news);
+    let note = absorbNote(news);
+    if (unsubscribe) {
+      // A newer message supersedes the latched opt-out too: clear it and
+      // make the model re-decide with the update in hand — otherwise a
+      // retraction («όχι τελικά») could not stop the unsubscribe.
+      unsubscribe = undefined;
+      note +=
+        "\n(Your earlier unsubscribe_user call was cancelled pending this " +
+        "update — call it again if the reader still wants to stop.)";
+    }
     recordInjected(note);
     // Merge into the trailing user message when one exists; the API's
     // message list stays well-formed either way.
@@ -161,8 +170,19 @@ export async function runWake(
   // reader already received (or may yet receive) messages, and a duplicate
   // answer is worse than a truncated one. The loop finalizes with what it
   // has; before the first attempt, errors propagate and the queue retries.
+  // A held turn consumes its slot without producing anything the reader
+  // sees; without a granted extra turn a hold on the FINAL turn strands the
+  // wake (sends discarded, absorbed rows consumed, nothing pending). Two
+  // grants bound the extension.
+  let bonusTurns = 0;
   try {
-  for (let turn = 0; turn < deps.config.maxTurns; turn++) {
+  for (let turn = 0; turn < deps.config.maxTurns + bonusTurns; turn++) {
+    if (deps.heartbeat && !(await deps.heartbeat())) {
+      // The claim is no longer ours: a reclaimer is (or will be) running
+      // this wake. Stop immediately — before the first delivery this is a
+      // clean abort into the retry path; after it, fail-forward finalizes.
+      throw new Error("claim lost mid-wake — another worker owns this item now");
+    }
     await absorbAtTurnStart();
     const response = await deps.anthropic.create({
       model: deps.config.model,
@@ -208,6 +228,7 @@ export async function runWake(
           holdNote = absorbNote(news);
           repairs.push("reader-update/held-sends");
           recordInjected(holdNote);
+          if (bonusTurns < 2) bonusTurns++;
         }
       }
       const results: unknown[] = [];
@@ -241,15 +262,33 @@ export async function runWake(
             break;
           }
           case "update_taste_profile":
+            if (holdNote) {
+              ack = "held: re-decide after the reader update below";
+              break;
+            }
             profileRewrite = String(block.input.profile ?? "");
             break;
           case "schedule_wakeup":
+            // A held turn's schedule must not survive it: a follow-up
+            // planned for a request the reader just changed would fire
+            // days later about the cancelled topic.
+            if (holdNote) {
+              ack = "held: re-decide after the reader update below";
+              break;
+            }
             scheduledWakes.push({
               at: String(block.input.at ?? ""),
               reason: String(block.input.reason ?? ""),
             });
             break;
           case "unsubscribe_user":
+            if (holdNote) {
+              ack =
+                "held: the reader just sent a new message — re-decide the " +
+                "unsubscribe against it, and call unsubscribe_user again if " +
+                "they still want to stop";
+              break;
+            }
             // Only the reader can unsubscribe the reader. On a wake without
             // a user_message there is no reader request to honor — prompt
             // guidance alone must not be the only thing standing between a

--- a/services/notis/src/agent/runWake.ts
+++ b/services/notis/src/agent/runWake.ts
@@ -1,6 +1,6 @@
 import { buildDecisionEntry } from "./decisions";
 import { addUsage, emptyUsage, normalizeUsage, usageToCost } from "./pricing";
-import { assembleSystem, assembleUserTurn } from "./prompt";
+import { assembleSystem, assembleUserTurn, neutralizeFences } from "./prompt";
 import { buildMcpServers, buildTools } from "./tools";
 import {
   Deps,
@@ -41,7 +41,7 @@ export async function runWake(
   eventsInput: WakeEvent[],
   deps: Deps,
   opts: { now?: Date } = {},
-): Promise<{ outcome: WakeOutcome; trace: WakeTrace }> {
+): Promise<{ outcome: WakeOutcome; trace: WakeTrace; absorbed: WakeEvent[] }> {
   if (eventsInput.length === 0) throw new Error("runWake: no events");
   const events = [...eventsInput].sort((a, b) => a.at.localeCompare(b.at));
   const hasUserMessage = events.some((e) => e.type === "user_message");
@@ -86,6 +86,39 @@ export async function runWake(
   };
 
   const sent: string[] = [];
+  // Reader messages that arrived mid-run and were absorbed into this wake —
+  // their own queued wakes are consumed by deps.absorb, so answering them
+  // here is not optional: nobody else will.
+  const absorbedAll: WakeEvent[] = [];
+  const absorbNote = (events: WakeEvent[]): string => {
+    const texts = events
+      .filter((e): e is Extract<WakeEvent, { type: "user_message" }> => e.type === "user_message")
+      .map((e) => `«${neutralizeFences(e.text)}»`);
+    const count = texts.length === 1 ? "a new message" : `${texts.length} new messages`;
+    return (
+      `(reader update) The reader sent ${count} while you were working:\n` +
+      texts.join("\n") +
+      "\nThese are part of the conversation now. Respond to the reader's CURRENT " +
+      "request: if the new message changes or cancels the earlier one, do not send " +
+      "anything that no longer applies; if it adds a question, cover it too."
+    );
+  };
+  const absorbAtTurnStart = async (): Promise<void> => {
+    if (!deps.absorb) return;
+    const news = await deps.absorb();
+    if (news.length === 0) return;
+    absorbedAll.push(...news);
+    const note = absorbNote(news);
+    recordInjected(note);
+    // Merge into the trailing user message when one exists; the API's
+    // message list stays well-formed either way.
+    const last = messages[messages.length - 1] as { role?: string; content?: unknown };
+    if (last?.role === "user" && Array.isArray(last.content)) {
+      last.content.push({ type: "text", text: note });
+    } else {
+      messages.push({ role: "user", content: [{ type: "text", text: note }] });
+    }
+  };
   // How many times deps.deliver was invoked — attempted, not succeeded: a
   // transiently-failed row stays pending and the sweeper may still deliver
   // it, so any attempt at all makes a model re-run a duplicate risk.
@@ -130,6 +163,7 @@ export async function runWake(
   // has; before the first attempt, errors propagate and the queue retries.
   try {
   for (let turn = 0; turn < deps.config.maxTurns; turn++) {
+    await absorbAtTurnStart();
     const response = await deps.anthropic.create({
       model: deps.config.model,
       max_tokens: MAX_TOKENS,
@@ -159,6 +193,23 @@ export async function runWake(
     }
 
     if (response.stop_reason === "tool_use") {
+      // Last look before bytes leave: if the reader wrote again while this
+      // turn was streaming, hold its sends — the model re-decides with the
+      // new message in hand instead of delivering a superseded answer.
+      let holdNote: string | undefined;
+      if (
+        deps.absorb &&
+        deps.deliver &&
+        response.content.some((b) => isToolUseBlock(b) && b.name === "send_message")
+      ) {
+        const news = await deps.absorb();
+        if (news.length > 0) {
+          absorbedAll.push(...news);
+          holdNote = absorbNote(news);
+          repairs.push("reader-update/held-sends");
+          recordInjected(holdNote);
+        }
+      }
       const results: unknown[] = [];
       for (const block of response.content) {
         if (!isToolUseBlock(block)) continue;
@@ -166,6 +217,12 @@ export async function runWake(
         switch (block.name) {
           case "send_message": {
             const t = String(block.input.text ?? "");
+            if (holdNote) {
+              ack =
+                "held: the reader sent a new message before delivery (see the reader " +
+                "update below) — nothing was sent; decide again what to send now";
+              break;
+            }
             if (t) {
               sent.push(t);
               if (deps.deliver) {
@@ -206,6 +263,10 @@ export async function runWake(
             unsubscribe = { reason: String(block.input.reason ?? "") };
             break;
           case "finish_wake":
+            if (holdNote) {
+              ack = "not finished: address the reader's newest message first";
+              break;
+            }
             rationale = String(block.input.rationale ?? "") || rationale;
             finished = true;
             ack = "wake recorded";
@@ -273,8 +334,12 @@ export async function runWake(
       // A tool_use stop with no client tool calls happens when the turn holds
       // only server-side (MCP) blocks. There is nothing for us to answer —
       // an empty user message is an API error — so continue like pause_turn.
-      if (results.length > 0 || nudge) {
-        const content = nudge ? [...results, { type: "text", text: nudge }] : results;
+      if (results.length > 0 || nudge || holdNote) {
+        const extras = [
+          ...(holdNote ? [{ type: "text", text: holdNote }] : []),
+          ...(nudge ? [{ type: "text", text: nudge }] : []),
+        ];
+        const content = extras.length > 0 ? [...results, ...extras] : results;
         if (!finished) markLatest(content);
         messages.push({ role: "user", content });
       }
@@ -396,7 +461,7 @@ export async function runWake(
     durationMs: deps.now().getTime() - started,
   };
 
-  return { outcome, trace };
+  return { outcome, trace, absorbed: absorbedAll };
 }
 
 /**

--- a/services/notis/src/agent/schemas.ts
+++ b/services/notis/src/agent/schemas.ts
@@ -163,6 +163,10 @@ export const wakeEventSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("heartbeat"), at: z.string() }),
 ]);
 
+/** The wake-events array, everywhere one is parsed (queue items, absorb,
+ *  panel projections) — one schema so a refinement lands once. */
+export const wakeEventsSchema = z.array(wakeEventSchema);
+
 /**
  * Which of a coalesced wake's events leads: the meatiest content wins the
  * template shell and the decision-log label, and user_message dominating keeps

--- a/services/notis/src/agent/types.ts
+++ b/services/notis/src/agent/types.ts
@@ -43,6 +43,13 @@ export interface WakeOutcome {
   profileRewrite?: string;
   scheduledWakes: Array<{ at: string; reason: string }>;
   unsubscribe?: { reason: string };
+  /**
+   * The wake errored AFTER at least one incremental delivery reached (or
+   * may still reach) the reader. The loop was finalized instead of retried:
+   * re-running the model after real delivery risks duplicate messages,
+   * which is worse than a truncated answer.
+   */
+  partialDeliveryError?: string;
 }
 
 export interface Usage {
@@ -160,6 +167,19 @@ export interface Deps {
   prompts: Prompts;
   config: DepsConfig;
   mcp: McpLike;
+  /**
+   * Incremental delivery: hand each send_message to the reader the moment
+   * the model emits it, instead of batching at wake persistence. The shell
+   * injects this for reactive wakes only (someone is waiting; no rail
+   * applies to a reply). Absent — playground, dry-run, batch lane — the
+   * loop only records sends, exactly as before.
+   *
+   * `ok: false` means the text did not reach the reader NOW (the row may
+   * still be swept later); the tool_result tells the model so it can react.
+   * Once called at all, the wake becomes fail-forward: see
+   * WakeOutcome.partialDeliveryError.
+   */
+  deliver?(text: string): Promise<{ ok: boolean; detail?: string }>;
 }
 
 export const DEFAULT_CONFIG: DepsConfig = {

--- a/services/notis/src/agent/types.ts
+++ b/services/notis/src/agent/types.ts
@@ -191,6 +191,12 @@ export interface Deps {
    * draws two answers.
    */
   absorb?(): Promise<WakeEvent[]>;
+  /**
+   * Claim heartbeat, called once per model turn. Returns false when the
+   * queue item's claim is no longer this worker's (stale reclaim) — the
+   * loop must stop instead of racing the reclaimer's second run.
+   */
+  heartbeat?(): Promise<boolean>;
 }
 
 export const DEFAULT_CONFIG: DepsConfig = {

--- a/services/notis/src/agent/types.ts
+++ b/services/notis/src/agent/types.ts
@@ -180,6 +180,17 @@ export interface Deps {
    * WakeOutcome.partialDeliveryError.
    */
   deliver?(text: string): Promise<{ ok: boolean; detail?: string }>;
+  /**
+   * Mid-run absorption: return (and consume) reader messages that arrived
+   * AFTER this wake started, so the model answers the reader's CURRENT
+   * request instead of a superseded one. The loop calls it at each turn
+   * start and again before delivering a turn's sends; returned events are
+   * injected into the conversation and become part of this wake. The shell
+   * wires it for reactive wakes only, backed by consumePendingLiveEvents —
+   * consuming closes the messages' own queued wakes, so one message never
+   * draws two answers.
+   */
+  absorb?(): Promise<WakeEvent[]>;
 }
 
 export const DEFAULT_CONFIG: DepsConfig = {

--- a/services/notis/src/app/admin/(panel)/_components/MetricCard.tsx
+++ b/services/notis/src/app/admin/(panel)/_components/MetricCard.tsx
@@ -13,6 +13,12 @@ import { DeltaChip } from "./DeltaChip";
  */
 
 export interface MetricPoint {
+  /** Unique x value (the bucket key). The tooltip matches points by the x
+   *  axis dataKey, and labels repeat — a 24h window starts and ends inside
+   *  the same wall-clock hour, so two points share «22:00–23:00» and the
+   *  lookup lands on the first one (yesterday's), showing 0 for an hour
+   *  that has traffic. */
+  key: string;
   /** Tooltip label, e.g. «Σαβ 16/8». */
   label: string;
   value: number;
@@ -84,7 +90,7 @@ export function MetricCard({
                 <stop offset="100%" stopColor={colors.fillFrom} stopOpacity={0.02} />
               </linearGradient>
             </defs>
-            <XAxis dataKey="label" hide />
+            <XAxis dataKey="key" hide />
             <YAxis hide domain={[0, "dataMax"]} allowDecimals={false} />
             <Tooltip
               content={<MiniTooltip />}

--- a/services/notis/src/app/admin/(panel)/_components/Timeline.tsx
+++ b/services/notis/src/app/admin/(panel)/_components/Timeline.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { AlarmClock, FileText, ListTodo, MessageCircle, Moon } from "lucide-react";
+import { AlarmClock, FileText, ListTodo, MessageCircle, Moon, OctagonAlert } from "lucide-react";
 import { MeetingDetails, fetchMeetingDetails } from "../_lib/meetings";
 import { CityMeta, WakeRecord } from "../_lib/records";
 import { fmtLongDate } from "../_lib/format";
@@ -33,6 +33,10 @@ function icon(item: WakeRecord) {
       return <AlarmClock className="h-4 w-4" />;
     case "heartbeat":
       return <Moon className="h-4 w-4" />;
+    case "system":
+      // Shell-side decisions without a wake event behind them (ΣΤΟΠ
+      // pre-step, cap skip, phone-gone unsubscribe).
+      return <OctagonAlert className="h-4 w-4" />;
   }
 }
 
@@ -309,7 +313,9 @@ function HoverCard({
               ? "Μήνυμα χρήστη"
               : e.type === "scheduled"
                 ? "Προγραμματισμένο follow-up"
-                : "Heartbeat"}
+                : e.type === "system"
+                  ? "Απόφαση συστήματος"
+                  : "Heartbeat"}
           </p>
           <p className="text-xs text-muted-foreground">{when}</p>
           {e.type === "user_message" && (

--- a/services/notis/src/app/admin/(panel)/_components/Timeline.tsx
+++ b/services/notis/src/app/admin/(panel)/_components/Timeline.tsx
@@ -61,6 +61,7 @@ function circleClasses(item: WakeRecord, isNext: boolean, isSelected: boolean, i
     "flex h-14 w-14 items-center justify-center overflow-hidden rounded-full border-2 bg-background transition-all";
   const ring = isSelected ? " ring-2 ring-orange ring-offset-2 ring-offset-background" : "";
   if (isBusy) return `${base} animate-pulse border-orange${ring}`;
+  if (item.status === "failed") return `${base} border-red-600/60${ring}`;
   if (item.status === "skipped") return `${base} border-dashed border-muted-foreground/40${ring}`;
   if (item.status === "done" && item.outcome?.decision === "send")
     return `${base} border-orange${ring}`;

--- a/services/notis/src/app/admin/(panel)/_components/WhatsAppChat.tsx
+++ b/services/notis/src/app/admin/(panel)/_components/WhatsAppChat.tsx
@@ -65,7 +65,10 @@ function eventCaption(item: WakeRecord): string {
       caption = `πριν τη συνεδρίαση · ${e.meetingName}`;
       break;
     case "meeting_summarized":
-      caption = `${e.meetingName}`;
+      // Labeled like the agenda wake: without the prefix, a silence chip for
+      // a published record reads identically to any other meeting mention
+      // and the thread looks all pre-meeting.
+      caption = `απολογισμός · ${e.meetingName}`;
       break;
     case "scheduled":
       // A promised answer to the reader is a follow-up; the agent's own

--- a/services/notis/src/app/admin/(panel)/_components/WhatsAppChat.tsx
+++ b/services/notis/src/app/admin/(panel)/_components/WhatsAppChat.tsx
@@ -576,7 +576,8 @@ export function WhatsAppChat({
                     {item.queue.state === "failed" ? (
                       <>
                         <AlertTriangle className="h-3 w-3 shrink-0" />
-                        η επεξεργασία απέτυχε οριστικά μετά από {item.queue.attempts} προσπάθειες
+                        η επεξεργασία απέτυχε οριστικά μετά από{" "}
+                        {Math.min(item.queue.attempts, item.queue.maxAttempts)} προσπάθειες
                       </>
                     ) : item.queue.state === "running" ? (
                       <>

--- a/services/notis/src/app/admin/(panel)/_components/WhatsAppChat.tsx
+++ b/services/notis/src/app/admin/(panel)/_components/WhatsAppChat.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import {
   AlarmClock,
   AlertCircle,
+  AlertTriangle,
   Check,
   CheckCheck,
   Clock3,
@@ -11,6 +12,7 @@ import {
   ExternalLink,
   EyeOff,
   FastForward,
+  Loader2,
   Send,
   SkipForward,
   Square,
@@ -448,7 +450,11 @@ export function WhatsAppChat({
   // Pending records are invisible except the one actively running — that
   // keeps a just-sent user message visible instantly, while a rewind (which
   // returns records to pending without running them) clears their bubbles.
-  const visible = records.filter((q) => q.status !== "pending" || q.id === busyItemId);
+  // Queue-backed records (live viewer) are the opposite case: they exist
+  // BECAUSE the wake has not run, and hiding them hides the reader's message.
+  const visible = records.filter(
+    (q) => q.status !== "pending" || q.queue !== undefined || q.id === busyItemId,
+  );
   // Mirror the page's ΣΤΟΠ gate: once a wake unsubscribed the reader, the
   // remaining proactive items are dead — the buttons must look it, not just
   // silently no-op. The composer stays live (inbound survives a ΣΤΟΠ).
@@ -555,6 +561,52 @@ export function WhatsAppChat({
                   <span className="rounded-md bg-[#ffffff99] px-3 py-1 text-[11px] text-[#8696a0] shadow-sm">
                     {eventCaption(item)} — παραλείφθηκε
                   </span>
+                </div>
+              )}
+              {item.queue && (
+                <div className="flex flex-col items-center gap-1 px-4">
+                  <span
+                    className={`flex items-center gap-1.5 rounded-md px-3 py-1 text-[11px] shadow-sm ${
+                      item.queue.state === "failed"
+                        ? "bg-[#ffffffcc] font-medium text-red-700"
+                        : "bg-[#ffffff99] text-[#8696a0]"
+                    }`}
+                  >
+                    {item.event.type !== "user_message" && <>{eventCaption(item)} — </>}
+                    {item.queue.state === "failed" ? (
+                      <>
+                        <AlertTriangle className="h-3 w-3 shrink-0" />
+                        η επεξεργασία απέτυχε οριστικά μετά από {item.queue.attempts} προσπάθειες
+                      </>
+                    ) : item.queue.state === "running" ? (
+                      <>
+                        <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+                        επεξεργάζεται τώρα
+                      </>
+                    ) : item.queue.attempts > 0 ? (
+                      <>
+                        <AlertTriangle className="h-3 w-3 shrink-0 text-amber-600" />
+                        απέτυχε {item.queue.attempts}
+                        {item.queue.attempts === 1 ? " φορά" : " φορές"}
+                        {item.queue.nextTryAt
+                          ? ` · ξαναδοκιμάζει ${fmtTime(item.queue.nextTryAt)}`
+                          : ""}
+                      </>
+                    ) : (
+                      <>
+                        <Clock className="h-3 w-3 shrink-0" />
+                        σε αναμονή επεξεργασίας
+                      </>
+                    )}
+                  </span>
+                  {item.queue.lastError && item.queue.attempts > 0 && (
+                    <span
+                      className="max-w-[420px] truncate rounded-md bg-[#ffffff99] px-3 py-1 font-mono text-[10px] text-red-700/80 shadow-sm"
+                      title={item.queue.lastError}
+                    >
+                      {item.queue.lastError}
+                    </span>
+                  )}
                 </div>
               )}
               {item.outcome?.decision === "silence" && (

--- a/services/notis/src/app/admin/(panel)/_components/WhatsAppChat.tsx
+++ b/services/notis/src/app/admin/(panel)/_components/WhatsAppChat.tsx
@@ -536,6 +536,32 @@ export function WhatsAppChat({
           const chip = day !== lastDay;
           lastDay = day;
           const selected = selectedId === item.id;
+          // One chronological stream per record: an absorbed conversation
+          // really went reader → answer → correction → answer, and the
+          // thread must show that order, not all readers first.
+          const readerBubbles =
+            item.readerMessages ??
+            (item.event.type === "user_message"
+              ? [{ at: item.event.at, text: item.event.text }]
+              : []);
+          const timeline = [
+            ...readerBubbles.map((r) => ({
+              kind: "reader" as const,
+              at: r.at,
+              text: r.text,
+              i: -1,
+            })),
+            ...(item.outcome?.messages ?? []).map((text, i) => ({
+              kind: "send" as const,
+              at: item.deliveries?.[i]?.at ?? item.event.at,
+              text,
+              i,
+            })),
+          ].sort(
+            (a, b) =>
+              a.at.localeCompare(b.at) ||
+              (a.kind === b.kind ? 0 : a.kind === "reader" ? -1 : 1),
+          );
           return (
             <div key={item.id} className="space-y-1.5">
               {chip && (
@@ -545,23 +571,43 @@ export function WhatsAppChat({
                   </span>
                 </div>
               )}
-              {(
-                item.readerMessages ??
-                (item.event.type === "user_message"
-                  ? [{ at: item.event.at, text: item.event.text }]
-                  : [])
-              ).map((reader, readerIdx) => (
-                <Bubble
-                  key={readerIdx}
-                  side="out"
-                  first
-                  time={fmtTime(reader.at)}
-                  selected={selected}
-                  onClick={() => onSelect(item.id)}
-                  text={reader.text}
-                  ticks={item.id === busyItemId ? "live" : "read"}
-                />
-              ))}
+              {timeline.map((entry, k) =>
+                entry.kind === "reader" ? (
+                  <Bubble
+                    key={`r${k}`}
+                    side="out"
+                    first
+                    time={fmtTime(entry.at)}
+                    selected={selected}
+                    onClick={() => onSelect(item.id)}
+                    text={entry.text}
+                    ticks={item.id === busyItemId ? "live" : "read"}
+                  />
+                ) : item.delivery?.mode === "template" ? (
+                  <TemplateBubble
+                    key={`s${entry.i}`}
+                    rendered={renderTemplate(item.delivery.template, entry.text)}
+                    time={fmtTime(entry.at)}
+                    first={entry.i === 0}
+                    selected={selected}
+                    busy={busy || autoRun}
+                    onClick={() => onSelect(item.id)}
+                    onQuickReply={sim?.onUserMessage}
+                  />
+                ) : (
+                  <Bubble
+                    key={`s${entry.i}`}
+                    side="in"
+                    first={entry.i === 0}
+                    time={fmtTime(entry.at)}
+                    caption={entry.i === 0 ? eventCaption(item) || undefined : undefined}
+                    selected={selected}
+                    onClick={() => onSelect(item.id)}
+                    text={entry.text}
+                    delivery={item.deliveries?.[entry.i]}
+                  />
+                ),
+              )}
               {item.status === "skipped" && (
                 <div className="flex justify-center px-4">
                   <span className="rounded-md bg-[#ffffff99] px-3 py-1 text-[11px] text-[#8696a0] shadow-sm">
@@ -631,32 +677,6 @@ export function WhatsAppChat({
                     Ο Νότης σταμάτησε τις ειδοποιήσεις (unsubscribe)
                   </button>
                 </div>
-              )}
-              {item.outcome?.messages.map((m, i) =>
-                item.delivery?.mode === "template" ? (
-                  <TemplateBubble
-                    key={i}
-                    rendered={renderTemplate(item.delivery.template, m)}
-                    time={fmtTime(item.deliveries?.[i]?.at ?? item.event.at)}
-                    first={i === 0}
-                    selected={selected}
-                    busy={busy || autoRun}
-                    onClick={() => onSelect(item.id)}
-                    onQuickReply={sim?.onUserMessage}
-                  />
-                ) : (
-                  <Bubble
-                    key={i}
-                    side="in"
-                    first={i === 0}
-                    time={fmtTime(item.deliveries?.[i]?.at ?? item.event.at)}
-                    caption={i === 0 ? eventCaption(item) || undefined : undefined}
-                    selected={selected}
-                    onClick={() => onSelect(item.id)}
-                    text={m}
-                    delivery={item.deliveries?.[i]}
-                  />
-                ),
               )}
             </div>
           );

--- a/services/notis/src/app/admin/(panel)/_components/WhatsAppChat.tsx
+++ b/services/notis/src/app/admin/(panel)/_components/WhatsAppChat.tsx
@@ -545,17 +545,23 @@ export function WhatsAppChat({
                   </span>
                 </div>
               )}
-              {item.event.type === "user_message" && (
+              {(
+                item.readerMessages ??
+                (item.event.type === "user_message"
+                  ? [{ at: item.event.at, text: item.event.text }]
+                  : [])
+              ).map((reader, readerIdx) => (
                 <Bubble
+                  key={readerIdx}
                   side="out"
                   first
-                  time={fmtTime(item.event.at)}
+                  time={fmtTime(reader.at)}
                   selected={selected}
                   onClick={() => onSelect(item.id)}
-                  text={item.event.text}
+                  text={reader.text}
                   ticks={item.id === busyItemId ? "live" : "read"}
                 />
-              )}
+              ))}
               {item.status === "skipped" && (
                 <div className="flex justify-center px-4">
                   <span className="rounded-md bg-[#ffffff99] px-3 py-1 text-[11px] text-[#8696a0] shadow-sm">

--- a/services/notis/src/app/admin/(panel)/_lib/__tests__/records.test.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/__tests__/records.test.ts
@@ -1,0 +1,104 @@
+import { queueBackedRecords } from "../records";
+
+/**
+ * The thread synthesizes records for wakes still in the queue — the reader's
+ * message exists before its NotisWake row does, and it must stay visible
+ * while the wake is pending, retrying, or terminally failed (the exact
+ * moments an operator is looking). These tests pin the projection.
+ */
+
+const MAX = 3;
+
+function row(overrides: Partial<Parameters<typeof queueBackedRecords>[0][number]> = {}) {
+  return {
+    id: "q1",
+    status: "pending",
+    events: [{ type: "user_message", at: "2026-08-23T17:25:24.000Z", text: "Ας γνωριστούμε" }],
+    attempts: 0,
+    lastError: null,
+    runAfter: new Date("2026-08-23T17:40:44.000Z"),
+    ...overrides,
+  };
+}
+
+describe("queueBackedRecords", () => {
+  it("projects a fresh pending row: reader message visible, no retry hint", () => {
+    const [rec] = queueBackedRecords([row()], MAX);
+    expect(rec).toMatchObject({
+      id: "queue:q1",
+      status: "pending",
+      event: { type: "user_message", text: "Ας γνωριστούμε" },
+      queue: { state: "pending", attempts: 0, maxAttempts: MAX, lastError: null },
+    });
+    expect(rec.queue?.nextTryAt).toBeUndefined();
+    expect(rec.outcome).toBeUndefined();
+  });
+
+  it("a retrying row carries its error and the next attempt instant", () => {
+    const [rec] = queueBackedRecords(
+      [row({ attempts: 2, lastError: "Cannot convert argument to a ByteString" })],
+      MAX,
+    );
+    expect(rec.status).toBe("pending");
+    expect(rec.queue).toMatchObject({
+      state: "pending",
+      attempts: 2,
+      lastError: "Cannot convert argument to a ByteString",
+      nextTryAt: "2026-08-23T17:40:44.000Z",
+    });
+  });
+
+  it("a terminally failed row surfaces as a failed record without a retry", () => {
+    const [rec] = queueBackedRecords(
+      [row({ status: "failed", attempts: 4, lastError: "gave up after 3 attempts" })],
+      MAX,
+    );
+    expect(rec.status).toBe("failed");
+    expect(rec.queue).toMatchObject({ state: "failed", attempts: 4 });
+    expect(rec.queue?.nextTryAt).toBeUndefined();
+  });
+
+  it("a running row stays a pending record with the running state", () => {
+    const [rec] = queueBackedRecords([row({ status: "running", attempts: 1 })], MAX);
+    expect(rec.status).toBe("pending");
+    expect(rec.queue?.state).toBe("running");
+    expect(rec.queue?.nextTryAt).toBeUndefined();
+  });
+
+  it("a coalesced batch row keeps its primary event and count", () => {
+    const [rec] = queueBackedRecords(
+      [
+        row({
+          events: [
+            {
+              type: "agenda_processed",
+              at: "2026-08-23T15:30:00.000Z",
+              cityId: "athens",
+              meetingId: "m1",
+              meetingName: "Συνεδρίαση",
+              meetingDate: "2026-08-25",
+              brief: {
+                cityId: "athens",
+                meetingId: "m1",
+                generatedAt: "2026-08-23T15:30:00.000Z",
+                headline: "Δοκιμαστική ατζέντα",
+                meetingUrl: "https://opencouncil.gr/athens/m1",
+                subjects: [],
+              },
+            },
+            { type: "user_message", at: "2026-08-23T15:31:00.000Z", text: "τι λέει;" },
+          ],
+        }),
+      ],
+      MAX,
+    );
+    // user_message outranks meeting events in primaryEvent's ordering.
+    expect(rec.event.type).toBe("user_message");
+    expect(rec.coalesced).toBe(2);
+  });
+
+  it("drops rows whose events no longer parse instead of throwing", () => {
+    const rows = [row({ events: [{ nonsense: true }] }), row({ id: "q2", events: null })];
+    expect(queueBackedRecords(rows, MAX)).toEqual([]);
+  });
+});

--- a/services/notis/src/app/admin/(panel)/_lib/conversations.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/conversations.ts
@@ -254,7 +254,15 @@ export async function getConversation(id: string): Promise<ConversationDetail | 
       // tiebreaker (cuids are monotonic per process) pins insertion order,
       // which is what the index-alignment with outcome.messages needs.
       orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-      select: { id: true, wakeId: true, status: true, failureReason: true, createdAt: true },
+      select: {
+        id: true,
+        wakeId: true,
+        status: true,
+        failureReason: true,
+        createdAt: true,
+        body: true,
+        deliveryMode: true,
+      },
     }),
   ]);
 
@@ -314,6 +322,34 @@ export async function getConversation(id: string): Promise<ConversationDetail | 
     ...(Array.isArray(wake.events) ? { coalesced: (wake.events as unknown[]).length } : {}),
     };
   });
+
+  // Orphaned deliveries: freeform outbound rows with no wake — a claim
+  // lost or a persist failure after an incremental send. The reader
+  // received these, so the audit view must show them; the enrollment intro
+  // is the one legitimate wakeId-less row (template mode) and renders from
+  // the subscription's origin instead.
+  for (const message of outbound) {
+    if (message.wakeId !== null || message.deliveryMode === "template") continue;
+    records.push({
+      id: `orphan:${message.id}`,
+      event: { type: "system", at: message.createdAt.toISOString() },
+      status: "done",
+      outcome: {
+        decision: "send",
+        rationale:
+          "(σύστημα) Ορφανή αποστολή: το μήνυμα στάλθηκε, αλλά το wake του δεν καταγράφηκε — χαμένο claim ή αποτυχία εγγραφής.",
+        messages: [message.body],
+        scheduledWakes: [],
+      },
+      deliveries: [
+        {
+          at: message.createdAt.toISOString(),
+          status: message.status,
+          failureReason: message.failureReason,
+        },
+      ],
+    });
+  }
 
   // Wakes still in the queue — pending, running, or terminally failed. The
   // reader's message exists before its wake does, and the thread must show

--- a/services/notis/src/app/admin/(panel)/_lib/conversations.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/conversations.ts
@@ -258,8 +258,15 @@ export async function getConversation(id: string): Promise<ConversationDetail | 
   ]);
 
   // SMS fallbacks mark the failed WhatsApp send they replaced.
+  // Only fallbacks that reached (or verifiably left for) the reader earn the
+  // «εστάλη SMS» marker — a failed or still-held SMS did not rescue anything.
   const smsFallbacks = await db.notisMessage.findMany({
-    where: { subscriptionId: id, channel: "sms", fallbackForId: { not: null } },
+    where: {
+      subscriptionId: id,
+      channel: "sms",
+      fallbackForId: { not: null },
+      status: { in: ["sent", "delivered", "read"] },
+    },
     select: { fallbackForId: true },
   });
   const fallbackFor = new Set(smsFallbacks.map((m) => m.fallbackForId));

--- a/services/notis/src/app/admin/(panel)/_lib/conversations.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/conversations.ts
@@ -8,7 +8,15 @@ import { TemplateName } from "@/agent/templates";
 import { hasNotisDb, notisDb } from "@/lib/db";
 import { citiesForUsers } from "@/lib/fanout";
 import { hasMainDb } from "@/lib/main-db";
-import { CityMeta, MessageDelivery, Origin, RecordEvent, WakeRecord } from "./records";
+import { MAX_ATTEMPTS } from "@/lib/queue-core";
+import {
+  CityMeta,
+  MessageDelivery,
+  Origin,
+  RecordEvent,
+  WakeRecord,
+  queueBackedRecords,
+} from "./records";
 
 /**
  * Conversation listing + loading, straight from the Notis database. A stored
@@ -294,6 +302,23 @@ export async function getConversation(id: string): Promise<ConversationDetail | 
     ...(deliveriesByWake.has(wake.id) ? { deliveries: deliveriesByWake.get(wake.id) } : {}),
     ...(Array.isArray(wake.events) ? { coalesced: (wake.events as unknown[]).length } : {}),
   }));
+
+  // Wakes still in the queue — pending, running, or terminally failed. The
+  // reader's message exists before its wake does, and the thread must show
+  // it (with the failure, if any) rather than go blank until the wake lands.
+  const queueRows = await db.notisWakeQueue.findMany({
+    where: { subscriptionId: id, status: { in: ["pending", "running", "failed"] } },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      status: true,
+      events: true,
+      attempts: true,
+      lastError: true,
+      runAfter: true,
+    },
+  });
+  records.push(...queueBackedRecords(queueRows, MAX_ATTEMPTS));
 
   // Sort on when each record's messages actually went out, falling back to
   // the trigger for records that sent nothing. Sorting on event.at alone

--- a/services/notis/src/app/admin/(panel)/_lib/conversations.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/conversations.ts
@@ -8,7 +8,7 @@ import { TemplateName } from "@/agent/templates";
 import { hasNotisDb, notisDb } from "@/lib/db";
 import { citiesForUsers } from "@/lib/fanout";
 import { hasMainDb } from "@/lib/main-db";
-import { MAX_ATTEMPTS } from "@/lib/queue-core";
+import { LIVE_QUEUE_STATUSES, MAX_ATTEMPTS } from "@/lib/queue-core";
 import {
   CityMeta,
   MessageDelivery,
@@ -355,7 +355,7 @@ export async function getConversation(id: string): Promise<ConversationDetail | 
   // reader's message exists before its wake does, and the thread must show
   // it (with the failure, if any) rather than go blank until the wake lands.
   const queueRows = await db.notisWakeQueue.findMany({
-    where: { subscriptionId: id, status: { in: ["pending", "running", "failed"] } },
+    where: { subscriptionId: id, status: { in: [...LIVE_QUEUE_STATUSES] } },
     orderBy: { createdAt: "asc" },
     select: {
       id: true,

--- a/services/notis/src/app/admin/(panel)/_lib/conversations.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/conversations.ts
@@ -16,6 +16,7 @@ import {
   RecordEvent,
   WakeRecord,
   queueBackedRecords,
+  readerMessagesOf,
 } from "./records";
 
 /**
@@ -292,10 +293,13 @@ export async function getConversation(id: string): Promise<ConversationDetail | 
     ]);
   }
 
-  const records: WakeRecord[] = sub.wakes.map((wake) => ({
+  const records: WakeRecord[] = sub.wakes.map((wake) => {
+    const readers = Array.isArray(wake.events) ? readerMessagesOf(wake.events as unknown[]) : [];
+    return {
     id: wake.id,
     event: wake.event as unknown as RecordEvent,
-    status: "done",
+    status: "done" as const,
+    ...(readers.length > 1 ? { readerMessages: readers } : {}),
     outcome: wake.outcome as unknown as WakeOutcome,
     ...(wake.model !== null ? { traceRef: wake.id } : {}),
     ...(wake.deliveryMode
@@ -308,7 +312,8 @@ export async function getConversation(id: string): Promise<ConversationDetail | 
       : {}),
     ...(deliveriesByWake.has(wake.id) ? { deliveries: deliveriesByWake.get(wake.id) } : {}),
     ...(Array.isArray(wake.events) ? { coalesced: (wake.events as unknown[]).length } : {}),
-  }));
+    };
+  });
 
   // Wakes still in the queue — pending, running, or terminally failed. The
   // reader's message exists before its wake does, and the thread must show

--- a/services/notis/src/app/admin/(panel)/_lib/metrics.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/metrics.ts
@@ -343,6 +343,9 @@ async function periodStats(db: Db, from: Date, to: Date): Promise<PeriodStats> {
   );
   const outboundTotal = Object.values(outboundByStatus).reduce((a, b) => a + b, 0);
   const failed = outboundByStatus.failed ?? 0;
+  // Suppressed rows were never given to Bird — counting them in the fail
+  // rate's denominator dilutes it with sends that could not fail.
+  const sendable = outboundTotal - (outboundByStatus.suppressed ?? 0);
 
   const decisionCount = (d: string) =>
     wakesByDecision.find((r) => r.decision === d)?._count._all ?? 0;
@@ -364,7 +367,7 @@ async function periodStats(db: Db, from: Date, to: Date): Promise<PeriodStats> {
     messagesReceived: directionCount("inbound"),
     unsubscribes,
     outboundByStatus,
-    failRate: outboundTotal > 0 ? failed / outboundTotal : null,
+    failRate: sendable > 0 ? failed / sendable : null,
     failureReasons: failures.map((r) => ({
       reason: r.failureReason ?? "άγνωστος λόγος",
       count: r._count._all,

--- a/services/notis/src/app/admin/(panel)/_lib/metrics.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/metrics.ts
@@ -415,19 +415,33 @@ export async function getOverviewStats(range: RangeKey): Promise<OverviewStats> 
     periodStats(db, currentFrom, now),
     periodStats(db, previousFrom, currentFrom),
     bucketedSeries(db, currentFrom, now, bucket),
-    db.notisMessage.findMany({
-      // Ranged like everything else on the page: an unfiltered list sat under
-      // a received-counter reading 0 for the same window.
-      where: { direction: "inbound", createdAt: { gte: currentFrom, lte: now } },
-      orderBy: { createdAt: "desc" },
-      take: 5,
-      select: {
-        id: true,
-        body: true,
-        createdAt: true,
-        subscription: { select: { id: true, userId: true, userName: true } },
-      },
-    }),
+    // Ranged like everything else on the page, and DISTINCT ON the
+    // subscription: one active reader must not fill all five rows with
+    // their own back-and-forth — the list answers «ποιοι μιλάνε», not
+    // «τι ειπώθηκε τελευταίο».
+    db.$queryRaw<
+      Array<{
+        id: string;
+        body: string;
+        createdAt: Date;
+        subscriptionId: string;
+        userId: string;
+        userName: string | null;
+      }>
+    >`
+      SELECT m.id, m.body, m."createdAt", s.id AS "subscriptionId",
+             s."userId", s."userName"
+      FROM (
+        SELECT DISTINCT ON ("subscriptionId") id, body, "createdAt", "subscriptionId"
+        FROM "NotisMessage"
+        WHERE direction = 'inbound'::"MessageDirection"
+          AND "createdAt" >= ${currentFrom} AND "createdAt" <= ${now}
+        ORDER BY "subscriptionId", "createdAt" DESC, id DESC
+      ) m
+      JOIN "NotisSubscription" s ON s.id = m."subscriptionId"
+      ORDER BY m."createdAt" DESC
+      LIMIT 5
+    `,
     db.notisSubscription.count(),
     db.notisSubscription.count({ where: { status: "unsubscribed" } }),
   ]);
@@ -439,9 +453,9 @@ export async function getOverviewStats(range: RangeKey): Promise<OverviewStats> 
     series,
     recentInbound: recent.map((m) => ({
       id: m.id,
-      subscriptionId: m.subscription.id,
-      userId: m.subscription.userId,
-      userName: m.subscription.userName ?? "—",
+      subscriptionId: m.subscriptionId,
+      userId: m.userId,
+      userName: m.userName ?? "—",
       body: m.body,
       at: m.createdAt.toISOString(),
     })),

--- a/services/notis/src/app/admin/(panel)/_lib/records.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/records.ts
@@ -1,5 +1,4 @@
-import { z } from "zod";
-import { primaryEvent, wakeEventSchema } from "@/agent/schemas";
+import { primaryEvent, wakeEventsSchema } from "@/agent/schemas";
 import { TemplateName } from "@/agent/templates";
 import { WakeEvent, WakeOutcome } from "@/agent/types";
 
@@ -113,8 +112,6 @@ export function readerMessagesOf(events: unknown[]): Array<{ at: string; text: s
     .map((e) => ({ at: e.at, text: e.text }));
 }
 
-const queueEventsSchema = z.array(wakeEventSchema);
-
 /** The queue-row slice the synthesis needs; matches NotisWakeQueue columns. */
 export interface QueueRowLike {
   id: string;
@@ -136,7 +133,7 @@ export interface QueueRowLike {
 export function queueBackedRecords(rows: QueueRowLike[], maxAttempts: number): WakeRecord[] {
   const out: WakeRecord[] = [];
   for (const row of rows) {
-    const parsed = queueEventsSchema.safeParse(row.events);
+    const parsed = wakeEventsSchema.safeParse(row.events);
     if (!parsed.success || parsed.data.length === 0) continue;
     const events = parsed.data;
     const state =

--- a/services/notis/src/app/admin/(panel)/_lib/records.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/records.ts
@@ -90,6 +90,27 @@ export interface WakeRecord {
   /** Present only on records synthesized from a live queue row — the wake
    *  has not completed (or never will), so there is no NotisWake behind it. */
   queue?: QueueState;
+  /**
+   * Every reader message this wake carries, in order — a coalesced or
+   * absorbing wake holds several, and the thread must render each as its
+   * own bubble (the primary event alone would hide the correction the wake
+   * exists to honor). Absent = derive from the primary event.
+   */
+  readerMessages?: Array<{ at: string; text: string }>;
+}
+
+/** All user_message events of a wake, in order, for the thread's bubbles. */
+export function readerMessagesOf(events: unknown[]): Array<{ at: string; text: string }> {
+  return events
+    .filter(
+      (e): e is { type: "user_message"; at: string; text: string } =>
+        typeof e === "object" &&
+        e !== null &&
+        (e as { type?: unknown }).type === "user_message" &&
+        typeof (e as { text?: unknown }).text === "string" &&
+        typeof (e as { at?: unknown }).at === "string",
+    )
+    .map((e) => ({ at: e.at, text: e.text }));
 }
 
 const queueEventsSchema = z.array(wakeEventSchema);
@@ -120,10 +141,12 @@ export function queueBackedRecords(rows: QueueRowLike[], maxAttempts: number): W
     const events = parsed.data;
     const state =
       row.status === "failed" ? "failed" : row.status === "running" ? "running" : "pending";
+    const readers = readerMessagesOf(events);
     out.push({
       id: `queue:${row.id}`,
       event: primaryEvent(events),
       status: state === "failed" ? "failed" : "pending",
+      ...(readers.length > 1 ? { readerMessages: readers } : {}),
       queue: {
         state,
         attempts: row.attempts,

--- a/services/notis/src/app/admin/(panel)/_lib/records.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/records.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+import { primaryEvent, wakeEventSchema } from "@/agent/schemas";
 import { TemplateName } from "@/agent/templates";
 import { WakeEvent, WakeOutcome } from "@/agent/types";
 
@@ -51,10 +53,24 @@ export interface MessageDelivery {
   smsFallback?: boolean;
 }
 
+/**
+ * Live queue state carried by a synthesized record (see queueBackedRecords).
+ * `attempts` counts claims so far: on a pending row every claim ended in a
+ * retryable failure; on a running row the current claim is the attempts-th.
+ */
+export interface QueueState {
+  state: "pending" | "running" | "failed";
+  attempts: number;
+  maxAttempts: number;
+  lastError: string | null;
+  /** Next retry instant — present only on a pending row that failed before. */
+  nextTryAt?: string;
+}
+
 export interface WakeRecord {
   id: string;
   event: RecordEvent;
-  status: "pending" | "done" | "skipped";
+  status: "pending" | "done" | "skipped" | "failed";
   outcome?: WakeOutcome;
   traceRef?: string;
   /**
@@ -71,6 +87,56 @@ export interface WakeRecord {
   /** Number of events this wake consumed at once; absent for the common
    *  single-event wake. */
   coalesced?: number;
+  /** Present only on records synthesized from a live queue row — the wake
+   *  has not completed (or never will), so there is no NotisWake behind it. */
+  queue?: QueueState;
+}
+
+const queueEventsSchema = z.array(wakeEventSchema);
+
+/** The queue-row slice the synthesis needs; matches NotisWakeQueue columns. */
+export interface QueueRowLike {
+  id: string;
+  status: string;
+  events: unknown;
+  attempts: number;
+  lastError: string | null;
+  runAfter: Date;
+}
+
+/**
+ * A wake still sitting in the queue has no NotisWake row, so a thread built
+ * from wake records alone hides the reader's message exactly while it is
+ * pending or failing — the moment an operator is looking. The queue row
+ * itself carries the unconsumed events, so the thread synthesizes a record
+ * from it; once the wake completes, the row leaves the queue and the real
+ * record takes over.
+ */
+export function queueBackedRecords(rows: QueueRowLike[], maxAttempts: number): WakeRecord[] {
+  const out: WakeRecord[] = [];
+  for (const row of rows) {
+    const parsed = queueEventsSchema.safeParse(row.events);
+    if (!parsed.success || parsed.data.length === 0) continue;
+    const events = parsed.data;
+    const state =
+      row.status === "failed" ? "failed" : row.status === "running" ? "running" : "pending";
+    out.push({
+      id: `queue:${row.id}`,
+      event: primaryEvent(events),
+      status: state === "failed" ? "failed" : "pending",
+      queue: {
+        state,
+        attempts: row.attempts,
+        maxAttempts,
+        lastError: row.lastError,
+        ...(state === "pending" && row.attempts > 0
+          ? { nextTryAt: row.runAfter.toISOString() }
+          : {}),
+      },
+      ...(events.length > 1 ? { coalesced: events.length } : {}),
+    });
+  }
+  return out;
 }
 
 export function hasPendingBrief(

--- a/services/notis/src/app/admin/(panel)/_lib/system.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/system.ts
@@ -150,22 +150,29 @@ export async function getRailsNow(): Promise<RailsNow | null> {
   const now = new Date();
   const phase = activePhase(now);
   const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60_000);
-  const [settings, heldUntilRelease, capped, failed, retryPending, retryRunning] =
-    await Promise.all([
-      getProactiveSettings(db),
-      // attempts: 0 — a retry-backoff row also has runAfter in the future,
-      // and it belongs to «ξαναδοκιμάζει», not «σε αναμονή»; without the
-      // filter one row shows up in both cells.
-      db.notisWakeQueue.count({
-        where: { status: "pending", runAfter: { gt: now }, attempts: 0 },
-      }),
-      usersAtCap(db),
-      db.notisWakeQueue.count({ where: { status: "failed", updatedAt: { gte: weekAgo } } }),
-      db.notisWakeQueue.count({ where: { status: "pending", attempts: { gt: 0 } } }),
-      // attempts counts claims, and a first run holds claim #1 — only a
-      // second-or-later claim means an earlier attempt failed.
-      db.notisWakeQueue.count({ where: { status: "running", attempts: { gt: 1 } } }),
-    ]);
+  const [settings, capped, queueCounts] = await Promise.all([
+    getProactiveSettings(db),
+    usersAtCap(db),
+    // One scan for all four queue cells. held excludes retry-backoff rows
+    // (attempts > 0 belongs to «ξαναδοκιμάζει», not «σε αναμονή»), and
+    // running counts a retry only from the second claim — the first run
+    // holds claim #1.
+    db.$queryRaw<
+      Array<{ held: number; failed7d: number; retry_pending: number; retry_running: number }>
+    >`
+      SELECT
+        count(*) FILTER (
+          WHERE status = 'pending' AND "runAfter" > ${now} AND attempts = 0
+        )::int AS held,
+        count(*) FILTER (
+          WHERE status = 'failed' AND "updatedAt" >= ${weekAgo}
+        )::int AS failed7d,
+        count(*) FILTER (WHERE status = 'pending' AND attempts > 0)::int AS retry_pending,
+        count(*) FILTER (WHERE status = 'running' AND attempts > 1)::int AS retry_running
+      FROM "NotisWakeQueue"
+    `,
+  ]);
+  const q = queueCounts[0] ?? { held: 0, failed7d: 0, retry_pending: 0, retry_running: 0 };
   return {
     phase: {
       kind: phase.phase,
@@ -173,9 +180,9 @@ export async function getRailsNow(): Promise<RailsNow | null> {
       until: phase.until.toISOString(),
     },
     settings,
-    heldUntilRelease,
+    heldUntilRelease: q.held,
     atCapCount: capped.length,
-    queueTrouble: { failed, retrying: retryPending + retryRunning },
+    queueTrouble: { failed: q.failed7d, retrying: q.retry_pending + q.retry_running },
   };
 }
 
@@ -185,7 +192,8 @@ export async function getSystemSnapshot(digestedPage = 1): Promise<SystemSnapsho
   const now = new Date();
   const phase = activePhase(now);
 
-  const [settings, pollerRow, statusCounts, laneStatusCounts, heldUntilRelease] =
+  const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60_000);
+  const [settings, pollerRow, statusCounts, laneStatusCounts, heldUntilRelease, failuresAgg] =
     await Promise.all([
       getProactiveSettings(db),
       db.notisSetting.findUnique({ where: { key: POLLER_STATUS_KEY } }),
@@ -197,6 +205,11 @@ export async function getSystemSnapshot(digestedPage = 1): Promise<SystemSnapsho
       }),
       db.notisWakeQueue.count({
         where: { status: "pending", runAfter: { gt: now }, attempts: 0 },
+      }),
+      db.notisWakeQueue.aggregate({
+        where: { status: "failed", updatedAt: { gte: weekAgo } },
+        _count: { _all: true },
+        _max: { updatedAt: true },
       }),
     ]);
 
@@ -239,13 +252,6 @@ export async function getSystemSnapshot(digestedPage = 1): Promise<SystemSnapsho
       },
     }),
   ]);
-
-  const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60_000);
-  const failuresAgg = await db.notisWakeQueue.aggregate({
-    where: { status: "failed", updatedAt: { gte: weekAgo } },
-    _count: { _all: true },
-    _max: { updatedAt: true },
-  });
 
   // Count first: the page is clamped into range, so a stale ?digested=99
   // link lands on the last page instead of an empty list.

--- a/services/notis/src/app/admin/(panel)/_lib/system.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/system.ts
@@ -79,7 +79,13 @@ export interface SystemSnapshot {
     /** Terminal failures in the last 7 days. Failed rows are history, not
      *  queue state — the table shows live work and this line shows the
      *  toll, until the janitor removes the rows entirely (30 days). */
-    failures: { count: number; latestAt: string | null };
+    failures: {
+      count: number;
+      latestAt: string | null;
+      /** Failed rows older than the 7-day window but not yet janitored
+       *  (up to 30 days) — otherwise invisible anywhere. */
+      older: number;
+    };
   };
   scheduled: { items: ScheduledView[]; more: number; total: number };
   digested: { items: DigestedMeetingView[]; total: number };
@@ -91,7 +97,7 @@ const EMPTY: SystemSnapshot = {
   phase: { kind: "active", since: new Date(0).toISOString(), until: new Date(0).toISOString() },
   settings: { paused: true },
   poller: { lastTickAt: null, nextTickAt: null },
-  queue: { counts: {}, laneCounts: {}, heldUntilRelease: 0, items: [], more: 0, failures: { count: 0, latestAt: null } },
+  queue: { counts: {}, laneCounts: {}, heldUntilRelease: 0, items: [], more: 0, failures: { count: 0, latestAt: null, older: 0 } },
   scheduled: { items: [], more: 0, total: 0 },
   digested: { items: [], total: 0 },
   atCap: [],
@@ -147,7 +153,12 @@ export async function getRailsNow(): Promise<RailsNow | null> {
   const [settings, heldUntilRelease, capped, failed, retryPending, retryRunning] =
     await Promise.all([
       getProactiveSettings(db),
-      db.notisWakeQueue.count({ where: { status: "pending", runAfter: { gt: now } } }),
+      // attempts: 0 — a retry-backoff row also has runAfter in the future,
+      // and it belongs to «ξαναδοκιμάζει», not «σε αναμονή»; without the
+      // filter one row shows up in both cells.
+      db.notisWakeQueue.count({
+        where: { status: "pending", runAfter: { gt: now }, attempts: 0 },
+      }),
       usersAtCap(db),
       db.notisWakeQueue.count({ where: { status: "failed", updatedAt: { gte: weekAgo } } }),
       db.notisWakeQueue.count({ where: { status: "pending", attempts: { gt: 0 } } }),
@@ -184,7 +195,9 @@ export async function getSystemSnapshot(): Promise<SystemSnapshot> {
         where: { status: { in: ["pending", "running"] } },
         _count: { _all: true },
       }),
-      db.notisWakeQueue.count({ where: { status: "pending", runAfter: { gt: now } } }),
+      db.notisWakeQueue.count({
+        where: { status: "pending", runAfter: { gt: now }, attempts: 0 },
+      }),
     ]);
 
   // Live work only, worst first: running (possibly stuck), then pending by
@@ -294,10 +307,16 @@ export async function getSystemSnapshot(): Promise<SystemSnapshot> {
       laneCounts: Object.fromEntries(laneStatusCounts.map((r) => [r.lane, r._count._all])),
       heldUntilRelease,
       items: queueItems,
-      more: Math.max(0, activeItems.length - QUEUE_LIST_LIMIT),
+      // From the full counts, not the LIMIT+1 fetch — that could only ever
+      // say «+1 ακόμη» no matter how deep the queue.
+      more: Math.max(
+        0,
+        (statusMap.pending ?? 0) + (statusMap.running ?? 0) - queueItems.length,
+      ),
       failures: {
         count: failuresAgg._count._all,
         latestAt: failuresAgg._max.updatedAt?.toISOString() ?? null,
+        older: Math.max(0, (statusMap.failed ?? 0) - failuresAgg._count._all),
       },
     },
     scheduled: {

--- a/services/notis/src/app/admin/(panel)/_lib/system.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/system.ts
@@ -15,7 +15,7 @@ import { WEEKLY_CAP } from "@/lib/queue";
 export const POLLER_INTERVAL_MS = 5 * 60_000;
 const QUEUE_LIST_LIMIT = 30;
 const SCHEDULE_LIST_LIMIT = 30;
-const BRIEF_LIST_LIMIT = 20;
+export const DIGESTED_PAGE_SIZE = 20;
 
 export interface QueueItemView {
   id: string;
@@ -88,7 +88,7 @@ export interface SystemSnapshot {
     };
   };
   scheduled: { items: ScheduledView[]; more: number; total: number };
-  digested: { items: DigestedMeetingView[]; total: number };
+  digested: { items: DigestedMeetingView[]; total: number; page: number; pages: number };
   atCap: Array<{ subscriptionId: string; userId: string; userName: string; count: number }>;
 }
 
@@ -99,7 +99,7 @@ const EMPTY: SystemSnapshot = {
   poller: { lastTickAt: null, nextTickAt: null },
   queue: { counts: {}, laneCounts: {}, heldUntilRelease: 0, items: [], more: 0, failures: { count: 0, latestAt: null, older: 0 } },
   scheduled: { items: [], more: 0, total: 0 },
-  digested: { items: [], total: 0 },
+  digested: { items: [], total: 0, page: 1, pages: 1 },
   atCap: [],
 };
 
@@ -179,7 +179,7 @@ export async function getRailsNow(): Promise<RailsNow | null> {
   };
 }
 
-export async function getSystemSnapshot(): Promise<SystemSnapshot> {
+export async function getSystemSnapshot(digestedPage = 1): Promise<SystemSnapshot> {
   if (!hasNotisDb()) return EMPTY;
   const db = notisDb();
   const now = new Date();
@@ -247,13 +247,16 @@ export async function getSystemSnapshot(): Promise<SystemSnapshot> {
     _max: { updatedAt: true },
   });
 
-  const [digestedTotal, digestedRows] = await Promise.all([
-    db.notisProcessedEvent.count(),
-    db.notisProcessedEvent.findMany({
-      orderBy: { processedAt: "desc" },
-      take: BRIEF_LIST_LIMIT,
-    }),
-  ]);
+  // Count first: the page is clamped into range, so a stale ?digested=99
+  // link lands on the last page instead of an empty list.
+  const digestedTotal = await db.notisProcessedEvent.count();
+  const digestedPages = Math.max(1, Math.ceil(digestedTotal / DIGESTED_PAGE_SIZE));
+  const digestedCurrent = Math.min(Math.max(1, digestedPage), digestedPages);
+  const digestedRows = await db.notisProcessedEvent.findMany({
+    orderBy: { processedAt: "desc" },
+    skip: (digestedCurrent - 1) * DIGESTED_PAGE_SIZE,
+    take: DIGESTED_PAGE_SIZE,
+  });
 
   // Fan-out width per digested meeting: wakes whose primary event named it.
   const meetingIds = [...new Set(digestedRows.map((r) => r.meetingId))];
@@ -338,6 +341,8 @@ export async function getSystemSnapshot(): Promise<SystemSnapshot> {
       total: scheduledTotal,
     },
     digested: {
+      page: digestedCurrent,
+      pages: digestedPages,
       items: digestedRows.map((row) => {
         const brief = (row.brief as unknown as EditorialBrief | null) ?? null;
         return {

--- a/services/notis/src/app/admin/(panel)/_lib/system.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/system.ts
@@ -76,6 +76,10 @@ export interface SystemSnapshot {
     heldUntilRelease: number;
     items: QueueItemView[];
     more: number;
+    /** Terminal failures in the last 7 days. Failed rows are history, not
+     *  queue state — the table shows live work and this line shows the
+     *  toll, until the janitor removes the rows entirely (30 days). */
+    failures: { count: number; latestAt: string | null };
   };
   scheduled: { items: ScheduledView[]; more: number; total: number };
   digested: { items: DigestedMeetingView[]; total: number };
@@ -87,7 +91,7 @@ const EMPTY: SystemSnapshot = {
   phase: { kind: "active", since: new Date(0).toISOString(), until: new Date(0).toISOString() },
   settings: { paused: true },
   poller: { lastTickAt: null, nextTickAt: null },
-  queue: { counts: {}, laneCounts: {}, heldUntilRelease: 0, items: [], more: 0 },
+  queue: { counts: {}, laneCounts: {}, heldUntilRelease: 0, items: [], more: 0, failures: { count: 0, latestAt: null } },
   scheduled: { items: [], more: 0, total: 0 },
   digested: { items: [], total: 0 },
   atCap: [],
@@ -127,6 +131,10 @@ export interface RailsNow {
   settings: { paused: boolean };
   heldUntilRelease: number;
   atCapCount: number;
+  /** Wakes in trouble: terminal failures in the last 7 days, and live items
+   *  that have failed at least once and are waiting to retry. Zero on a
+   *  healthy system, so the overview can shout when it is not. */
+  queueTrouble: { failed: number; retrying: number };
 }
 
 /** The lightweight "now" slice the overview strip needs. */
@@ -135,11 +143,18 @@ export async function getRailsNow(): Promise<RailsNow | null> {
   const db = notisDb();
   const now = new Date();
   const phase = activePhase(now);
-  const [settings, heldUntilRelease, capped] = await Promise.all([
-    getProactiveSettings(db),
-    db.notisWakeQueue.count({ where: { status: "pending", runAfter: { gt: now } } }),
-    usersAtCap(db),
-  ]);
+  const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60_000);
+  const [settings, heldUntilRelease, capped, failed, retryPending, retryRunning] =
+    await Promise.all([
+      getProactiveSettings(db),
+      db.notisWakeQueue.count({ where: { status: "pending", runAfter: { gt: now } } }),
+      usersAtCap(db),
+      db.notisWakeQueue.count({ where: { status: "failed", updatedAt: { gte: weekAgo } } }),
+      db.notisWakeQueue.count({ where: { status: "pending", attempts: { gt: 0 } } }),
+      // attempts counts claims, and a first run holds claim #1 — only a
+      // second-or-later claim means an earlier attempt failed.
+      db.notisWakeQueue.count({ where: { status: "running", attempts: { gt: 1 } } }),
+    ]);
   return {
     phase: {
       kind: phase.phase,
@@ -149,6 +164,7 @@ export async function getRailsNow(): Promise<RailsNow | null> {
     settings,
     heldUntilRelease,
     atCapCount: capped.length,
+    queueTrouble: { failed, retrying: retryPending + retryRunning },
   };
 }
 
@@ -171,10 +187,11 @@ export async function getSystemSnapshot(): Promise<SystemSnapshot> {
       db.notisWakeQueue.count({ where: { status: "pending", runAfter: { gt: now } } }),
     ]);
 
-  // Worst first: running (possibly stuck), then failed (needs eyes), then
-  // pending by due time. Done rows are history, not state.
+  // Live work only, worst first: running (possibly stuck), then pending by
+  // due time. Done and failed rows are history, not state — failures roll
+  // up into the `failures` line instead of squatting in the table.
   const activeItems = await db.notisWakeQueue.findMany({
-    where: { status: { in: ["running", "pending", "failed"] } },
+    where: { status: { in: ["running", "pending"] } },
     orderBy: [{ status: "desc" }, { runAfter: "asc" }],
     take: QUEUE_LIST_LIMIT + 1,
     select: {
@@ -209,6 +226,13 @@ export async function getSystemSnapshot(): Promise<SystemSnapshot> {
       },
     }),
   ]);
+
+  const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60_000);
+  const failuresAgg = await db.notisWakeQueue.aggregate({
+    where: { status: "failed", updatedAt: { gte: weekAgo } },
+    _count: { _all: true },
+    _max: { updatedAt: true },
+  });
 
   const [digestedTotal, digestedRows] = await Promise.all([
     db.notisProcessedEvent.count(),
@@ -271,6 +295,10 @@ export async function getSystemSnapshot(): Promise<SystemSnapshot> {
       heldUntilRelease,
       items: queueItems,
       more: Math.max(0, activeItems.length - QUEUE_LIST_LIMIT),
+      failures: {
+        count: failuresAgg._count._all,
+        latestAt: failuresAgg._max.updatedAt?.toISOString() ?? null,
+      },
     },
     scheduled: {
       items: scheduledRows.slice(0, SCHEDULE_LIST_LIMIT).map((row) => ({

--- a/services/notis/src/app/admin/(panel)/_lib/wakes.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/wakes.ts
@@ -6,14 +6,17 @@ import { hasNotisDb, notisDb } from "@/lib/db";
 /** The cross-user wake feed. Empty without NOTIS_DATABASE_URL. */
 
 export type DecisionFilter = "all" | "send" | "silence" | "error";
-export type EventFilter = "all" | (typeof WAKE_EVENT_TYPES)[number];
+// "system" is a real eventType on shell-side wakes (ΣΤΟΠ pre-step, cap skip,
+// phone-gone) even though it is not a WakeEvent — the filter must accept it
+// or the panel's own chip silently resets to «όλα».
+export type EventFilter = "all" | (typeof WAKE_EVENT_TYPES)[number] | "system";
 
 export function parseDecisionFilter(value: string | undefined): DecisionFilter {
   return value === "send" || value === "silence" || value === "error" ? value : "all";
 }
 
 export function parseEventFilter(value: string | undefined): EventFilter {
-  return value && (WAKE_EVENT_TYPES as readonly string[]).includes(value)
+  return value && ([...WAKE_EVENT_TYPES, "system"] as readonly string[]).includes(value)
     ? (value as EventFilter)
     : "all";
 }

--- a/services/notis/src/app/admin/(panel)/conversations/[id]/view.tsx
+++ b/services/notis/src/app/admin/(panel)/conversations/[id]/view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { Download } from "lucide-react";
 import { WakeTrace } from "@/agent/types";
 import { ConversationView } from "../../_components/ConversationView";
 import { fmtDate } from "../../_lib/format";
@@ -38,6 +39,15 @@ export function ConversationDetailView({ detail }: { detail: ConversationDetail 
           {s.phone} · {s.cityNames.join(", ")} · από {fmtDate(s.startedAt)}
         </span>
         {s.unsubscribedAt && <StopBadge at={s.unsubscribedAt} />}
+        <a
+          href={`/api/admin/conversations/${s.id}/export`}
+          download
+          className="ml-auto flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          title="Όλα τα δεδομένα της συνομιλίας (μηνύματα, wakes, traces) σε ένα JSON — για αξιολόγηση"
+        >
+          <Download className="h-3.5 w-3.5" />
+          Εξαγωγή JSON
+        </a>
       </PageHeader>
       <ConversationView
         records={detail.records}

--- a/services/notis/src/app/admin/(panel)/page.tsx
+++ b/services/notis/src/app/admin/(panel)/page.tsx
@@ -1,7 +1,7 @@
 import { getAdminSession } from "@/lib/session-auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
-import { CalendarClock, EyeOff, Gauge, Moon, OctagonAlert, Sun } from "lucide-react";
+import { CalendarClock, EyeOff, Gauge, Moon, OctagonAlert, Sun, TriangleAlert } from "lucide-react";
 import { EVENT_LABELS } from "./_lib/records";
 import { getRailsNow } from "./_lib/system";
 import { Countdown } from "./_components/Countdown";
@@ -410,6 +410,29 @@ async function RailsStrip({ suppressions }: { suppressions: Array<{ reason: stri
           />
         </div>
       </div>
+
+      {(rails.queueTrouble.failed > 0 || rails.queueTrouble.retrying > 0) && (
+        <div className={cell}>
+          <TriangleAlert className="h-4 w-4 shrink-0 text-destructive" />
+          <div className="leading-tight">
+            <p className="text-sm font-semibold tabular-nums text-destructive">
+              {rails.queueTrouble.failed + rails.queueTrouble.retrying}
+            </p>
+            <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
+              {[
+                rails.queueTrouble.failed > 0
+                  ? `απέτυχαν ${rails.queueTrouble.failed} (7ημ)`
+                  : "",
+                rails.queueTrouble.retrying > 0
+                  ? `ξαναδοκιμάζει ${rails.queueTrouble.retrying}`
+                  : "",
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </p>
+          </div>
+        </div>
+      )}
 
       {rails.heldUntilRelease > 0 && (
         <div className={cell}>

--- a/services/notis/src/app/admin/(panel)/page.tsx
+++ b/services/notis/src/app/admin/(panel)/page.tsx
@@ -77,7 +77,11 @@ function seriesFor(
   key: "activeUsers" | "sent" | "received" | "unsubscribes",
   bucket: BucketUnit,
 ): MetricPoint[] {
-  return series.map((point) => ({ label: fmtBucketLabel(point.key, bucket), value: point[key] }));
+  return series.map((point) => ({
+    key: point.key,
+    label: fmtBucketLabel(point.key, bucket),
+    value: point[key],
+  }));
 }
 
 function StackedBar({

--- a/services/notis/src/app/admin/(panel)/page.tsx
+++ b/services/notis/src/app/admin/(panel)/page.tsx
@@ -44,6 +44,7 @@ const STATUS_BAR: Record<string, string> = {
   delivered: "bg-stone-400",
   read: "bg-[#53bdeb]",
   failed: "bg-red-500",
+  suppressed: "bg-stone-400/60",
 };
 
 function fmtPct(fraction: number): string {

--- a/services/notis/src/app/admin/(panel)/page.tsx
+++ b/services/notis/src/app/admin/(panel)/page.tsx
@@ -35,6 +35,7 @@ const STATUS_LABELS: Record<string, string> = {
   delivered: "παραδόθηκαν",
   read: "διαβάστηκαν",
   failed: "απέτυχαν",
+  suppressed: "κατεστάλησαν",
 };
 
 const STATUS_BAR: Record<string, string> = {

--- a/services/notis/src/app/admin/(panel)/settings/page.tsx
+++ b/services/notis/src/app/admin/(panel)/settings/page.tsx
@@ -190,13 +190,6 @@ export default async function SettingsPage() {
             </ul>
           </section>
 
-          <section className="rounded-lg border bg-background p-4">
-            <p className="text-sm font-medium">Έρχονται στα επόμενα PRs</p>
-            <ul className="mt-2 list-inside list-disc space-y-1 text-sm text-muted-foreground">
-              <li>Review queue απεσταλμένων μηνυμάτων με τα σκεπτικά τους (PR 5)</li>
-              <li>Ενότητα Νότη στο /profile — εγγραφή/απεγγραφή από τον ίδιο τον χρήστη (PR 5)</li>
-            </ul>
-          </section>
         </div>
       </div>
     </>

--- a/services/notis/src/app/admin/(panel)/system/page.tsx
+++ b/services/notis/src/app/admin/(panel)/system/page.tsx
@@ -291,7 +291,12 @@ export default async function SystemPage() {
                       {item.eventTypes
                         .map((t) => EVENT_LABELS[t as keyof typeof EVENT_LABELS] ?? t)
                         .join(" + ")}
-                      {item.attempts > 1 ? ` · ${item.attempts}η προσπάθεια` : ""}
+                      {item.status === "running" && item.attempts > 1
+                        ? ` · ${item.attempts}η προσπάθεια`
+                        : ""}
+                      {item.status === "pending" && item.attempts > 0
+                        ? ` · απέτυχε ${item.attempts} ${item.attempts === 1 ? "φορά" : "φορές"}`
+                        : ""}
                       {item.status === "failed" && item.lastError ? (
                         <span className="text-destructive"> · {item.lastError}</span>
                       ) : null}
@@ -329,6 +334,9 @@ export default async function SystemPage() {
                 τις τελευταίες 7 ημέρες
                 {snap.queue.failures.latestAt
                   ? ` · τελευταία ${timeAgo(snap.queue.failures.latestAt, now)}`
+                  : ""}
+                {snap.queue.failures.older > 0
+                  ? ` · +${snap.queue.failures.older} παλαιότερες`
                   : ""}
               </p>
             )}

--- a/services/notis/src/app/admin/(panel)/system/page.tsx
+++ b/services/notis/src/app/admin/(panel)/system/page.tsx
@@ -11,6 +11,7 @@ import {
   Moon,
   OctagonAlert,
   Sun,
+  TriangleAlert,
 } from "lucide-react";
 import { env } from "@/env.mjs";
 import { EVENT_LABELS } from "../_lib/records";
@@ -317,6 +318,19 @@ export default async function SystemPage() {
                   </li>
                 ))}
               </ul>
+            )}
+            {snap.queue.failures.count > 0 && (
+              <p className="flex items-center gap-1.5 border-t px-4 py-2.5 text-xs text-destructive">
+                <TriangleAlert className="h-3.5 w-3.5 shrink-0" />
+                {snap.queue.failures.count}{" "}
+                {snap.queue.failures.count === 1
+                  ? "οριστική αποτυχία"
+                  : "οριστικές αποτυχίες"}{" "}
+                τις τελευταίες 7 ημέρες
+                {snap.queue.failures.latestAt
+                  ? ` · τελευταία ${timeAgo(snap.queue.failures.latestAt, now)}`
+                  : ""}
+              </p>
             )}
           </section>
 

--- a/services/notis/src/app/admin/(panel)/system/page.tsx
+++ b/services/notis/src/app/admin/(panel)/system/page.tsx
@@ -16,6 +16,8 @@ import {
 import { env } from "@/env.mjs";
 import { EVENT_LABELS } from "../_lib/records";
 import { getSystemSnapshot } from "../_lib/system";
+import { parsePage } from "../_lib/paging";
+import { Pager } from "../_components/Pager";
 import { AutoRefresh } from "../_components/AutoRefresh";
 import { Countdown } from "../_components/Countdown";
 import { PageHeader } from "../_components/PageHeader";
@@ -131,13 +133,16 @@ function ScoreBars({ scores }: { scores: Record<string, number> }) {
   );
 }
 
-export default async function SystemPage() {
+export default async function SystemPage(props: {
+  searchParams: Promise<{ digested?: string }>;
+}) {
   // Re-assert auth in the page body: the (panel) layout guard does not
   // re-run on an RSC soft-navigation, so a segment request can reach this
   // page without it (enforced by the admin-auth-guard test).
   const session = await getAdminSession();
   if (!session) redirect("/admin/login");
-  const snap = await getSystemSnapshot();
+  const searchParams = await props.searchParams;
+  const snap = await getSystemSnapshot(parsePage(searchParams.digested));
   const now = new Date(snap.now);
   const queueActive =
     (snap.queue.counts.pending ?? 0) + (snap.queue.counts.running ?? 0);
@@ -512,6 +517,16 @@ export default async function SystemPage() {
                   </li>
                 ))}
               </ul>
+            )}
+            {snap.digested.pages > 1 && (
+              <div className="px-4 pb-3">
+                <Pager
+                  page={snap.digested.page}
+                  pages={snap.digested.pages}
+                  total={snap.digested.total}
+                  hrefFor={(p) => (p === 1 ? "/admin/system" : `/admin/system?digested=${p}`)}
+                />
+              </div>
             )}
           </section>
         </div>

--- a/services/notis/src/app/api/admin/conversations/[id]/export/route.ts
+++ b/services/notis/src/app/api/admin/conversations/[id]/export/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { hasNotisDb, notisDb } from "@/lib/db";
+import { requireAdmin } from "@/lib/session-auth";
+
+/**
+ * Everything notis knows about one conversation, as a single JSON file — the
+ * subscription, every message, every wake with its full trace, live queue
+ * rows, and scheduled wakes. Built for offline evaluation: an operator
+ * downloads it from the conversation view and hands it to a person or a
+ * model to judge what the agent did and why. Raw rows on purpose — an
+ * evaluation wants the stored truth, not the panel's view model.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = await requireAdmin();
+  if (denied) return denied;
+  if (!hasNotisDb()) {
+    return NextResponse.json({ error: "no notis database" }, { status: 503 });
+  }
+
+  const { id } = await params;
+  const db = notisDb();
+
+  const subscription = await db.notisSubscription.findUnique({ where: { id } });
+  if (!subscription) {
+    return NextResponse.json({ error: "conversation not found" }, { status: 404 });
+  }
+
+  const [messages, wakes, queue, scheduledWakes] = await Promise.all([
+    db.notisMessage.findMany({
+      where: { subscriptionId: id },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    }),
+    db.notisWake.findMany({
+      where: { subscriptionId: id },
+      orderBy: { createdAt: "asc" },
+    }),
+    // Live rows only: done rows duplicate the wakes above, and failed rows
+    // older than the janitor window are gone anyway.
+    db.notisWakeQueue.findMany({
+      where: { subscriptionId: id, status: { in: ["pending", "running", "failed"] } },
+      orderBy: { createdAt: "asc" },
+    }),
+    db.notisScheduledWake.findMany({
+      where: { subscriptionId: id },
+      orderBy: { createdAt: "asc" },
+    }),
+  ]);
+
+  const body = {
+    exportedAt: new Date().toISOString(),
+    subscription,
+    messages,
+    wakes,
+    queue,
+    scheduledWakes,
+  };
+
+  const date = new Date().toISOString().slice(0, 10);
+  return new NextResponse(JSON.stringify(body, null, 2), {
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "content-disposition": `attachment; filename="notis-conversation-${id}-${date}.json"`,
+    },
+  });
+}

--- a/services/notis/src/app/api/admin/conversations/[id]/export/route.ts
+++ b/services/notis/src/app/api/admin/conversations/[id]/export/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { hasNotisDb, notisDb } from "@/lib/db";
 import { requireAdmin } from "@/lib/session-auth";
+import { LIVE_QUEUE_STATUSES } from "@/lib/queue-core";
 
 /**
  * Everything notis knows about one conversation, as a single JSON file — the
@@ -73,7 +74,7 @@ export async function GET(
     // Live rows only: done rows duplicate the wakes above, and failed rows
     // older than the janitor window are gone anyway.
     db.notisWakeQueue.findMany({
-      where: { subscriptionId: id, status: { in: ["pending", "running", "failed"] } },
+      where: { subscriptionId: id, status: { in: [...LIVE_QUEUE_STATUSES] } },
       orderBy: { createdAt: "asc" },
     }),
     db.notisScheduledWake.findMany({

--- a/services/notis/src/app/api/admin/conversations/[id]/export/route.ts
+++ b/services/notis/src/app/api/admin/conversations/[id]/export/route.ts
@@ -11,7 +11,7 @@ import { requireAdmin } from "@/lib/session-auth";
  * evaluation wants the stored truth, not the panel's view model.
  */
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const denied = await requireAdmin();
@@ -33,10 +33,43 @@ export async function GET(
       where: { subscriptionId: id },
       orderBy: [{ createdAt: "asc" }, { id: "asc" }],
     }),
-    db.notisWake.findMany({
-      where: { subscriptionId: id },
-      orderBy: { createdAt: "asc" },
-    }),
+    // Traces are the evaluation payload but also the weight — each embeds
+    // the full system prompt and every MCP turn. ?traces=0 exports the
+    // light version for big conversations.
+    request.nextUrl.searchParams.get("traces") === "0"
+      ? db.notisWake.findMany({
+          where: { subscriptionId: id },
+          orderBy: { createdAt: "asc" },
+          select: {
+            id: true,
+            subscriptionId: true,
+            eventType: true,
+            eventAt: true,
+            event: true,
+            events: true,
+            decision: true,
+            rationale: true,
+            outcome: true,
+            deliveryMode: true,
+            deliveryTemplate: true,
+            repairs: true,
+            truncated: true,
+            finishWakeMissing: true,
+            model: true,
+            inputTokens: true,
+            outputTokens: true,
+            cacheReadTokens: true,
+            cacheWriteTokens: true,
+            cacheWrite1hTokens: true,
+            costUsd: true,
+            durationMs: true,
+            createdAt: true,
+          },
+        })
+      : db.notisWake.findMany({
+          where: { subscriptionId: id },
+          orderBy: { createdAt: "asc" },
+        }),
     // Live rows only: done rows duplicate the wakes above, and failed rows
     // older than the janitor window are gone anyway.
     db.notisWakeQueue.findMany({
@@ -59,7 +92,9 @@ export async function GET(
   };
 
   const date = new Date().toISOString().slice(0, 10);
-  return new NextResponse(JSON.stringify(body, null, 2), {
+  // Compact on purpose: pretty-printing a trace-bearing export makes a
+  // second, ~30% larger copy of tens of MB for a machine-consumed file.
+  return new NextResponse(JSON.stringify(body), {
     headers: {
       "content-type": "application/json; charset=utf-8",
       "content-disposition": `attachment; filename="notis-conversation-${id}-${date}.json"`,

--- a/services/notis/src/app/api/webhooks/bird/__tests__/handlers.test.ts
+++ b/services/notis/src/app/api/webhooks/bird/__tests__/handlers.test.ts
@@ -395,6 +395,7 @@ describe("SMS fallback on failed proactive templates", () => {
         status: "sent",
         channel: "whatsapp",
         proactive: true,
+        railed: true,
         deliveryMode: "template",
         template: "demos_update_news",
         wakeId: "wake1",
@@ -460,22 +461,37 @@ describe("SMS fallback on failed proactive templates", () => {
     }
   });
 
-  it("no fallback while paused (the default), for freeform sends, or for reactive messages", async () => {
-    const cases: Array<{ settings?: Row[]; overrides: Row }> = [
-      { settings: undefined, overrides: {} }, // paused (the default)
-      { settings: LIVE, overrides: { deliveryMode: "freeform", template: null } },
-      { settings: LIVE, overrides: { proactive: false } },
-    ];
-    for (const [i, c] of cases.entries()) {
-      const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: c.settings });
-      await seedFailedCandidate(db, { ...c.overrides, birdMessageId: `bm-${i}` });
-      const bird = new FakeBird();
-      await handleOutboundStatus(
-        inbound({ birdMessageId: `bm-${i}`, direction: "outbound", status: "failed" }),
-        { db, bird },
-      );
-      expect(bird.smsSends).toHaveLength(0);
-    }
+  it("pause blocks only railed fallbacks — a reply's rides through, raw", async () => {
+    // Railed news while paused (the default): no fallback.
+    const db1 = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    await seedFailedCandidate(db1, { birdMessageId: "bm-r" });
+    const bird1 = new FakeBird();
+    await handleOutboundStatus(
+      inbound({ birdMessageId: "bm-r", direction: "outbound", status: "failed" }),
+      { db: db1, bird: bird1 },
+    );
+    expect(bird1.smsSends).toHaveLength(0);
+
+    // A freeform REPLY while paused: the conversation continues on its
+    // second leg — raw body, no template shell, no footer.
+    const db2 = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    await seedFailedCandidate(db2, {
+      birdMessageId: "bm-f",
+      deliveryMode: "freeform",
+      template: null,
+      proactive: false,
+      railed: false,
+    });
+    const bird2 = new FakeBird();
+    await handleOutboundStatus(
+      inbound({ birdMessageId: "bm-f", direction: "outbound", status: "failed" }),
+      { db: db2, bird: bird2 },
+    );
+    expect(bird2.smsSends).toHaveLength(1);
+    expect(bird2.smsSends[0].text).toBe("Νέα από τον δήμο.");
+    const fallback = db2.store.messages.find((m) => m.channel === "sms")!;
+    expect(fallback.status).toBe("sent");
+    expect(fallback.railed).toBe(false);
   });
 
   it("no fallback for an unsubscribed reader", async () => {

--- a/services/notis/src/app/api/webhooks/bird/__tests__/handlers.test.ts
+++ b/services/notis/src/app/api/webhooks/bird/__tests__/handlers.test.ts
@@ -2,7 +2,7 @@ import type { ExtractedMessageFields } from "@/lib/bird-extract";
 import { STOP_ALREADY_TEXT, STOP_CONFIRMATION_TEXT } from "@/lib/stop";
 import { type Row, makeFakeDb } from "../../../../../lib/__tests__/fake-db";
 import { FakeBird } from "../../../../../lib/__tests__/fake-bird";
-import { handleInbound, handleOutboundStatus, isForwardProgression } from "../handlers";
+import { handleInbound, handleOutboundStatus, isForwardProgression, handleSmsInbound } from "../handlers";
 import { SMS_HELD_FOR_QUIET_HOURS } from "../../../../../lib/queue";
 
 // Enrollment reads the main-DB views through these two modules; the fakes
@@ -270,6 +270,90 @@ describe("handleInbound", () => {
   });
 });
 
+describe("inbound SMS for served phones", () => {
+  it("a bare ΣΤΟΠ over SMS unsubscribes and confirms over SMS", async () => {
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    const bird = new FakeBird();
+
+    const result = await handleSmsInbound(inbound({ body: "ΣΤΟΠ", channel: "sms" }), {
+      db,
+      bird,
+      alert: async () => {},
+    });
+
+    expect(result).toEqual({ action: "stopped" });
+    expect(db.store.subscriptions.get("sub1")!.status).toBe("unsubscribed");
+    // Confirmation went out over SMS, not the WhatsApp conversation.
+    expect(bird.smsSends).toHaveLength(1);
+    expect(bird.smsSends[0].text).toBe(STOP_CONFIRMATION_TEXT);
+    expect(bird.sends).toHaveLength(0);
+    const reply = db.store.messages.find((m) => m.direction === "outbound")!;
+    expect(reply.channel).toBe("sms");
+    expect(reply.status).toBe("sent");
+  });
+
+  it("a normal SMS reply persists and wakes the agent", async () => {
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    const bird = new FakeBird();
+
+    const result = await handleSmsInbound(
+      inbound({ body: "Τι έγινε με το πάρκο;", channel: "sms" }),
+      { db, bird, alert: async () => {} },
+    );
+
+    expect(result.action).toBe("enqueued");
+    const stored = db.store.messages.find((m) => m.direction === "inbound")!;
+    expect(stored.channel).toBe("sms");
+    expect(db.store.queue.size).toBe(1);
+  });
+
+  it("ignores SMS from a phone notis does not serve — the main app owns it", async () => {
+    const db = makeFakeDb({ subscriptions: [] });
+    const bird = new FakeBird();
+
+    const result = await handleSmsInbound(
+      inbound({ body: "ΣΤΟΠ", channel: "sms", phone: "+306900000099" }),
+      { db, bird, alert: async () => {} },
+    );
+
+    expect(result).toEqual({ action: "ignored", reason: "sms from a phone notis does not serve" });
+    expect(db.store.messages).toHaveLength(0);
+    expect(bird.smsSends).toHaveLength(0);
+  });
+
+  it("a failed SMS delivery status alerts — there is no next channel", async () => {
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    await db.notisMessage.create({
+      data: {
+        subscriptionId: "sub1",
+        direction: "outbound",
+        channel: "sms",
+        body: "Νέα από τον δήμο.",
+        birdMessageId: "bm-sms",
+        status: "sent",
+        railed: true,
+      },
+    });
+    const bird = new FakeBird();
+    const alerts: string[] = [];
+
+    await handleOutboundStatus(
+      inbound({ birdMessageId: "bm-sms", direction: "outbound", status: "failed" }),
+      {
+        db,
+        bird,
+        alert: async (m) => {
+          alerts.push(m);
+        },
+      },
+    );
+
+    expect(alerts.some((m) => m.includes("SMS delivery failed"))).toBe(true);
+    // No cascade: an SMS failure must not try to fire another SMS.
+    expect(bird.smsSends).toHaveLength(0);
+  });
+});
+
 describe("SMS fallback on failed proactive templates", () => {
   const LIVE = [{ key: "proactivePaused", value: false }];
 
@@ -295,6 +379,10 @@ describe("SMS fallback on failed proactive templates", () => {
     inbound({ birdMessageId: "bm-out", direction: "outbound", status: "failed" });
 
   it("sends ONE SMS with the rendered shell when a live proactive template fails", async () => {
+    // Pin the clock inside active hours: the fallback holds through quiet
+    // hours, so on a real clock this test would fail every night.
+    jest.useFakeTimers({ doNotFake: ["nextTick", "setImmediate"] });
+    jest.setSystemTime(new Date("2026-03-11T10:00:00.000Z")); // 12:00 Athens
     const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: LIVE });
     await seedFailedCandidate(db);
     const bird = new FakeBird();
@@ -315,6 +403,7 @@ describe("SMS fallback on failed proactive templates", () => {
     await handleOutboundStatus(failedEvent(), { db, bird });
     expect(bird.smsSends).toHaveLength(1);
     expect(db.store.messages.filter((m) => m.channel === "sms")).toHaveLength(1);
+    jest.useRealTimers();
   });
 
   it("holds the SMS through quiet hours instead of ringing at 03:00", async () => {
@@ -376,6 +465,8 @@ describe("SMS fallback on failed proactive templates", () => {
   });
 
   it("an SMS send failure marks the row failed and alerts, and is never retried", async () => {
+    jest.useFakeTimers({ doNotFake: ["nextTick", "setImmediate"] });
+    jest.setSystemTime(new Date("2026-03-11T10:00:00.000Z")); // 12:00 Athens
     const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: LIVE });
     await seedFailedCandidate(db);
     const bird = new FakeBird({ success: false, error: "sms rejected" });
@@ -392,6 +483,7 @@ describe("SMS fallback on failed proactive templates", () => {
     const sms = db.store.messages.find((m) => m.channel === "sms")!;
     expect(sms.status).toBe("failed");
     expect(alerts.some((m) => m.includes("SMS fallback failed"))).toBe(true);
+    jest.useRealTimers();
   });
 });
 

--- a/services/notis/src/app/api/webhooks/bird/__tests__/handlers.test.ts
+++ b/services/notis/src/app/api/webhooks/bird/__tests__/handlers.test.ts
@@ -122,6 +122,30 @@ describe("handleInbound", () => {
     expect(String(sub.profileText)).toContain("Αθήνα");
   });
 
+  it("a second message before the wake starts coalesces into the pending live row", async () => {
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    const bird = new FakeBird();
+    const deps = { db, bird, alert: async () => {} };
+
+    const first = await handleInbound(inbound({ birdMessageId: "bm-a", body: "Τι γίνεται με το μετρό στα Εξάρχεια;" }), deps);
+    const second = await handleInbound(
+      inbound({ birdMessageId: "bm-b", body: "Σόρρυ άκυρο — στην Κυψέλη εννοούσα" }),
+      deps,
+    );
+
+    expect(first.action).toBe("enqueued");
+    expect(second.action).toBe("enqueued");
+    // ONE pending wake holding both messages — not a queue of two answers.
+    expect(db.store.queue.size).toBe(1);
+    const item = [...db.store.queue.values()][0];
+    expect((item.events as Array<{ text?: string }>).map((e) => e.text)).toEqual([
+      "Τι γίνεται με το μετρό στα Εξάρχεια;",
+      "Σόρρυ άκυρο — στην Κυψέλη εννοούσα",
+    ]);
+    // Both inbound rows persisted — the conversation loses nothing.
+    expect(db.store.messages.filter((m) => m.direction === "inbound")).toHaveLength(2);
+  });
+
   it("a bare ΣΤΟΠ unsubscribes deterministically — no wake, confirmation sent", async () => {
     const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
     const bird = new FakeBird();

--- a/services/notis/src/app/api/webhooks/bird/__tests__/handlers.test.ts
+++ b/services/notis/src/app/api/webhooks/bird/__tests__/handlers.test.ts
@@ -381,6 +381,10 @@ describe("inbound SMS for served phones", () => {
 describe("SMS fallback on failed proactive templates", () => {
   const LIVE = [{ key: "proactivePaused", value: false }];
 
+  // Fake timers restore in afterEach, not inline: an assertion failure must
+  // not leak a pinned clock into every later test in the file.
+  afterEach(() => jest.useRealTimers());
+
   async function seedFailedCandidate(db: ReturnType<typeof makeFakeDb>, overrides: Row = {}) {
     await db.notisMessage.create({
       data: {
@@ -427,7 +431,6 @@ describe("SMS fallback on failed proactive templates", () => {
     await handleOutboundStatus(failedEvent(), { db, bird });
     expect(bird.smsSends).toHaveLength(1);
     expect(db.store.messages.filter((m) => m.channel === "sms")).toHaveLength(1);
-    jest.useRealTimers();
   });
 
   it("holds the SMS through quiet hours instead of ringing at 03:00", async () => {
@@ -507,7 +510,6 @@ describe("SMS fallback on failed proactive templates", () => {
     const sms = db.store.messages.find((m) => m.channel === "sms")!;
     expect(sms.status).toBe("failed");
     expect(alerts.some((m) => m.includes("SMS fallback failed"))).toBe(true);
-    jest.useRealTimers();
   });
 });
 

--- a/services/notis/src/app/api/webhooks/bird/__tests__/handlers.test.ts
+++ b/services/notis/src/app/api/webhooks/bird/__tests__/handlers.test.ts
@@ -148,6 +148,30 @@ describe("handleInbound", () => {
     expect(bird.sends[0].idempotencyKey).toBe(reply.id);
   });
 
+  it("a ΣΤΟΠ suppresses queued outbound rows — only the confirmation survives", async () => {
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    // A pending row waiting on the sweeper: without the suppression it
+    // would deliver AFTER the reader said stop.
+    db.store.messages.push({
+      id: "held1",
+      subscriptionId: "sub1",
+      direction: "outbound",
+      body: "Κρατημένη είδηση.",
+      status: "pending",
+      createdAt: new Date(),
+    });
+    const bird = new FakeBird();
+
+    await handleInbound(inbound({ body: "ΣΤΟΠ" }), { db, bird, alert: async () => {} });
+
+    const held = db.store.messages.find((m) => m.id === "held1")!;
+    expect(held.status).toBe("suppressed");
+    expect(held.failureReason).toBe("unsubscribed");
+    // Exactly one send left the building: the confirmation.
+    expect(bird.sends).toHaveLength(1);
+    expect(bird.sends[0].text).toBe(STOP_CONFIRMATION_TEXT);
+  });
+
   it("a repeated ΣΤΟΠ gets the already-unsubscribed reminder without touching state", async () => {
     const db = makeFakeDb({
       subscriptions: [{ ...SUB, status: "unsubscribed", unsubscribedAt: new Date("2026-08-01") }],

--- a/services/notis/src/app/api/webhooks/bird/handlers.ts
+++ b/services/notis/src/app/api/webhooks/bird/handlers.ts
@@ -1,6 +1,5 @@
 import { seedProfileFromPreferences } from "@/agent/profileSeed";
 import type { WakeEvent } from "@/agent/types";
-import { isQuietHour } from "@/lib/active-hours";
 import { alert as sendAlert } from "@/lib/alert";
 import { BirdLike } from "@/lib/bird";
 import { ExtractedMessageFields } from "@/lib/bird-extract";
@@ -8,14 +7,13 @@ import { citiesForUser, findEnabledUserByPhone } from "@/lib/fanout";
 import { hasMainDb, mainDb } from "@/lib/main-db";
 import { normalizePhone } from "@/lib/phone";
 import {
-  SMS_HELD_FOR_QUIET_HOURS,
+  maybeSendSmsFallback,
   sendPendingMessages,
+  sendSmsAndRecord,
   suppressPendingOutbound,
 } from "@/lib/queue";
 import { enqueueLiveWake } from "@/lib/queue-core";
 import { STOP_ALREADY_TEXT, STOP_CONFIRMATION_TEXT, isBareStop } from "@/lib/stop";
-import { renderTemplate, type TemplateName } from "@/agent/templates";
-import { getProactiveSettings } from "@/lib/settings";
 import type {
   MessageStatus,
   NotisMessage,
@@ -38,6 +36,9 @@ export interface HandlerDeps {
   bird: BirdLike;
   alert?: (message: string) => Promise<void>;
 }
+
+const webhookAlert = (alert?: (message: string) => Promise<void>) =>
+  alert ?? ((message: string) => sendAlert("webhook", message));
 
 export type InboundResult =
   | { action: "ignored"; reason: string }
@@ -107,11 +108,13 @@ export async function handleOutboundStatus(
       if (existing.channel === "sms") {
         // The SMS WAS the fallback — there is no next channel. The reader
         // missed a notification; the operator hears about it.
-        await (deps.alert ?? ((m: string) => sendAlert("webhook", m)))(
+        await webhookAlert(deps.alert)(
           `SMS delivery failed for message ${existing.id}: ${fields.failureReason ?? "unknown error"}`,
         );
       } else {
-        await maybeSendSmsFallback(existing, deps);
+        // Any terminal WhatsApp failure — template news OR a freeform reply
+        // — continues over SMS: the conversation's second leg.
+        await maybeSendSmsFallback(deps.db, deps.bird, existing, webhookAlert(deps.alert));
       }
     }
     return { action: "status-updated" };
@@ -119,88 +122,6 @@ export async function handleOutboundStatus(
   return { action: "ignored", reason: "no forward progression" };
 }
 
-/**
- * The notify-only SMS fallback (PRD §6): when WhatsApp delivery of a
- * PROACTIVE template send fails, the same text goes out once as an SMS.
- * The sms row is inserted FIRST with fallbackForId unique on the failed
- * message — a replayed failure webhook loses the insert and stops, so one
- * failure can never fire two SMS. Skipped while paused; reactive replies
- * and freeform sends get no fallback (the reader is reachable on
- * WhatsApp — they just wrote to us there).
- *
- * Quiet hours hold it rather than drop it. Bird redelivers hours-old status
- * events and a handset can fail a message long after the send, so a template
- * that correctly went out at 22:40 can fail at 03:00 — and the fallback is
- * proactive, so it obeys the same 23:00-09:00 rail as everything else. The
- * row is written held; the sweeper releases it after the 09:00 boundary.
- */
-async function maybeSendSmsFallback(
-  failed: NotisMessage,
-  { db, bird, alert }: HandlerDeps,
-): Promise<void> {
-  if (
-    failed.channel !== "whatsapp" ||
-    failed.deliveryMode !== "template" ||
-    !failed.proactive ||
-    !failed.template
-  ) {
-    return;
-  }
-  const settings = await getProactiveSettings(db);
-  if (settings.paused) return;
-
-  const sub = await db.notisSubscription.findUnique({ where: { id: failed.subscriptionId } });
-  if (!sub?.phone || sub.status === "unsubscribed") return;
-
-  const rendered = renderTemplate(failed.template as TemplateName, failed.body);
-  const text = `${rendered.body}\n\n${rendered.footer}`;
-  const held = isQuietHour(new Date());
-
-  let smsId: string;
-  try {
-    const sms = await db.notisMessage.create({
-      data: {
-        subscriptionId: failed.subscriptionId,
-        wakeId: failed.wakeId,
-        direction: "outbound",
-        body: text,
-        channel: "sms",
-        proactive: failed.proactive,
-        // Replaces a proactive template send; the rails follow it.
-        railed: true,
-        fallbackForId: failed.id,
-        status: "pending",
-        ...(held ? { failureReason: SMS_HELD_FOR_QUIET_HOURS } : {}),
-      },
-      select: { id: true },
-    });
-    smsId = sms.id;
-  } catch (error) {
-    if ((error as { code?: string }).code === "P2002") return; // replayed webhook
-    throw error;
-  }
-
-  // Held rows leave here pending; the sweeper sends them at the release.
-  if (held) return;
-
-  const result = await bird.sendSms({ phone: sub.phone, text });
-  if (result.success) {
-    await db.notisMessage.update({
-      where: { id: smsId },
-      data: { status: "sent", birdMessageId: result.messageId },
-    });
-  } else {
-    // Never re-sent (the channels API has no idempotency key) — mark it
-    // and alert; the reader misses one notification, not a conversation.
-    await db.notisMessage.update({
-      where: { id: smsId },
-      data: { status: "failed", failureReason: (result.error ?? "unknown error").slice(0, 300) },
-    });
-    await (alert ?? ((m: string) => sendAlert("webhook", m)))(
-      `SMS fallback failed for message ${failed.id}: ${result.error ?? "unknown error"}`,
-    );
-  }
-}
 
 /**
  * Inbound SMS for a phone notis serves. SMS exists here because our own
@@ -436,7 +357,6 @@ async function handleBareStop(
     // The reader is talking to us over SMS — confirm there. Single attempt,
     // no idempotency key (the channels API has none); a lost confirmation
     // does not undo the unsubscribe, which committed above.
-    const notifyOps = alert ?? ((message: string) => sendAlert("webhook", message));
     if (!sub.phone) {
       await db.notisMessage.update({
         where: { id: replyId },
@@ -444,21 +364,15 @@ async function handleBareStop(
       });
       return { action: "stopped" };
     }
-    const result = await bird.sendSms({ phone: sub.phone, text: replyText });
-    await db.notisMessage.update({
-      where: { id: replyId },
-      data: result.success
-        ? { status: "sent", birdMessageId: result.messageId }
-        : {
-            status: "failed",
-            failureReason: (result.error ?? "unknown error").slice(0, 300),
-          },
-    });
-    if (!result.success) {
-      await notifyOps(
-        `ΣΤΟΠ confirmation SMS failed for ${sub.id}: ${result.error ?? "unknown error"}`,
-      );
-    }
+    await sendSmsAndRecord(
+      db,
+      bird,
+      replyId,
+      sub.phone,
+      replyText,
+      webhookAlert(alert),
+      `ΣΤΟΠ confirmation SMS failed for ${sub.id}`,
+    );
     return { action: "stopped" };
   }
 
@@ -467,7 +381,7 @@ async function handleBareStop(
     bird,
     [replyId],
     { id: sub.id, birdConversationId: fields.conversationId ?? sub.birdConversationId },
-    alert ?? ((message) => sendAlert("webhook", message)),
+    webhookAlert(alert),
   );
   return { action: "stopped" };
 }

--- a/services/notis/src/app/api/webhooks/bird/handlers.ts
+++ b/services/notis/src/app/api/webhooks/bird/handlers.ts
@@ -100,7 +100,15 @@ export async function handleOutboundStatus(
       },
     });
     if (fields.status === "failed") {
-      await maybeSendSmsFallback(existing, deps);
+      if (existing.channel === "sms") {
+        // The SMS WAS the fallback — there is no next channel. The reader
+        // missed a notification; the operator hears about it.
+        await (deps.alert ?? ((m: string) => sendAlert("webhook", m)))(
+          `SMS delivery failed for message ${existing.id}: ${fields.failureReason ?? "unknown error"}`,
+        );
+      } else {
+        await maybeSendSmsFallback(existing, deps);
+      }
     }
     return { action: "status-updated" };
   }
@@ -154,6 +162,8 @@ async function maybeSendSmsFallback(
         body: text,
         channel: "sms",
         proactive: failed.proactive,
+        // Replaces a proactive template send; the rails follow it.
+        railed: true,
         fallbackForId: failed.id,
         status: "pending",
         ...(held ? { failureReason: SMS_HELD_FOR_QUIET_HOURS } : {}),
@@ -186,6 +196,59 @@ async function maybeSendSmsFallback(
       `SMS fallback failed for message ${failed.id}: ${result.error ?? "unknown error"}`,
     );
   }
+}
+
+/**
+ * Inbound SMS for a phone notis serves. SMS exists here because our own
+ * fallback footer says «ΣΤΟΠ για διακοπή» — so ΣΤΟΠ must work over SMS,
+ * and any other reply deserves the agent, not a void. No enrollment on SMS
+ * contact: an eligible first message enrolls via WhatsApp, never here.
+ * Unknown phones stay ignored — the main app's webhook owns them.
+ */
+export async function handleSmsInbound(
+  fields: ExtractedMessageFields,
+  deps: HandlerDeps,
+): Promise<InboundResult> {
+  const { db } = deps;
+  if (!fields.birdMessageId || !fields.phone) {
+    return { action: "ignored", reason: "missing message id or phone" };
+  }
+  const duplicate = await db.notisMessage.findUnique({
+    where: { birdMessageId: fields.birdMessageId },
+    select: { id: true },
+  });
+  if (duplicate) return { action: "ignored", reason: "duplicate birdMessageId" };
+
+  const sub = await findSubscriptionByPhone(db, fields.phone);
+  if (!sub) return { action: "ignored", reason: "sms from a phone notis does not serve" };
+
+  if (isBareStop(fields.body)) {
+    return handleBareStop(sub, fields, deps);
+  }
+
+  const event: WakeEvent = {
+    type: "user_message",
+    at: new Date().toISOString(),
+    text: fields.body,
+  };
+  const queueItemId = await db.$transaction(async (tx) => {
+    await tx.notisMessage.create({
+      data: {
+        subscriptionId: sub.id,
+        direction: "inbound",
+        channel: "sms",
+        body: fields.body,
+        birdMessageId: fields.birdMessageId,
+      },
+    });
+    // Always touched: updatedAt is the conversation list's activity sort key.
+    await tx.notisSubscription.update({
+      where: { id: sub.id },
+      data: { updatedAt: new Date() },
+    });
+    return enqueueLiveWake(tx, { subscriptionId: sub.id, event });
+  });
+  return { action: "enqueued", queueItemId };
 }
 
 async function findSubscriptionByPhone(
@@ -256,6 +319,7 @@ async function handleBareStop(
       data: {
         subscriptionId: sub.id,
         direction: "inbound",
+        channel: fields.channel,
         body: fields.body,
         birdMessageId: fields.birdMessageId,
       },
@@ -309,6 +373,7 @@ async function handleBareStop(
         subscriptionId: sub.id,
         wakeId: wake.id,
         direction: "outbound",
+        channel: fields.channel,
         body: replyText,
         deliveryMode: "freeform",
         status: "pending",
@@ -317,6 +382,36 @@ async function handleBareStop(
     });
     return reply.id;
   });
+
+  if (fields.channel === "sms") {
+    // The reader is talking to us over SMS — confirm there. Single attempt,
+    // no idempotency key (the channels API has none); a lost confirmation
+    // does not undo the unsubscribe, which committed above.
+    const notifyOps = alert ?? ((message: string) => sendAlert("webhook", message));
+    if (!sub.phone) {
+      await db.notisMessage.update({
+        where: { id: replyId },
+        data: { status: "failed", failureReason: "no phone on subscription" },
+      });
+      return { action: "stopped" };
+    }
+    const result = await bird.sendSms({ phone: sub.phone, text: replyText });
+    await db.notisMessage.update({
+      where: { id: replyId },
+      data: result.success
+        ? { status: "sent", birdMessageId: result.messageId }
+        : {
+            status: "failed",
+            failureReason: (result.error ?? "unknown error").slice(0, 300),
+          },
+    });
+    if (!result.success) {
+      await notifyOps(
+        `ΣΤΟΠ confirmation SMS failed for ${sub.id}: ${result.error ?? "unknown error"}`,
+      );
+    }
+    return { action: "stopped" };
+  }
 
   await sendPendingMessages(
     db,

--- a/services/notis/src/app/api/webhooks/bird/handlers.ts
+++ b/services/notis/src/app/api/webhooks/bird/handlers.ts
@@ -7,7 +7,11 @@ import { ExtractedMessageFields } from "@/lib/bird-extract";
 import { citiesForUser, findEnabledUserByPhone } from "@/lib/fanout";
 import { hasMainDb, mainDb } from "@/lib/main-db";
 import { normalizePhone } from "@/lib/phone";
-import { SMS_HELD_FOR_QUIET_HOURS, sendPendingMessages } from "@/lib/queue";
+import {
+  SMS_HELD_FOR_QUIET_HOURS,
+  sendPendingMessages,
+  suppressPendingOutbound,
+} from "@/lib/queue";
 import { enqueueLiveWake } from "@/lib/queue-core";
 import { STOP_ALREADY_TEXT, STOP_CONFIRMATION_TEXT, isBareStop } from "@/lib/stop";
 import { renderTemplate, type TemplateName } from "@/agent/templates";
@@ -219,8 +223,15 @@ export async function handleSmsInbound(
   });
   if (duplicate) return { action: "ignored", reason: "duplicate birdMessageId" };
 
-  const sub = await findSubscriptionByPhone(db, fields.phone);
-  if (!sub) return { action: "ignored", reason: "sms from a phone notis does not serve" };
+  const found = await findSubscriptionByPhone(db, fields.phone);
+  if (!found) return { action: "ignored", reason: "sms from a phone notis does not serve" };
+  // The same gate as WhatsApp: a rolled-back user or a reassigned number
+  // must not be agent-served — or unsubscribed by a stranger — over SMS.
+  const gated = await gateExistingSubscription(db, found, fields.phone);
+  if ("ignored" in gated) {
+    return { action: "ignored", reason: gated.ignored };
+  }
+  const sub = gated.sub;
 
   if (isBareStop(fields.body)) {
     return handleBareStop(sub, fields, deps);
@@ -249,6 +260,48 @@ export async function handleSmsInbound(
     return enqueueLiveWake(tx, { subscriptionId: sub.id, event });
   });
   return { action: "enqueued", queueItemId };
+}
+
+/**
+ * The main-DB gate for an EXISTING subscription, channel-agnostic: a
+ * rolled-back user (notisEnabledAt cleared) is the main app's again, and a
+ * number the user no longer owns is not the user — on WhatsApp or SMS.
+ * Returns the (possibly phone-canonicalized) subscription or the ignore
+ * reason. Fails open when the main DB is unreachable: dropping a served
+ * reader's message is worse than a rare double answer during an outage.
+ */
+async function gateExistingSubscription(
+  db: PrismaClient,
+  sub: NotisSubscription,
+  phone: string,
+): Promise<{ sub: NotisSubscription } | { ignored: string }> {
+  if (!hasMainDb()) return { sub };
+  const user = await mainDb().notisUserRow.findUnique({
+    where: { id: sub.userId },
+    select: { notisEnabledAt: true, phone: true },
+  });
+  if (!user?.notisEnabledAt) {
+    return { ignored: "user rolled back to the old path" };
+  }
+  // A number this reader no longer owns is not this reader. After a phone
+  // change, the OLD number still matches the stored subscription here while
+  // the main app's gate (which looks up User.phone) misses — treat it like
+  // a rollback and stay silent; the new number self-heals through the
+  // enrollment upsert.
+  const current = normalizePhone(user.phone);
+  if (current && current !== normalizePhone(phone)) {
+    return { ignored: "message from a number the user no longer has" };
+  }
+  // Canonicalize a stored form that differs only by the leading "+": the
+  // lookup accepts both, and later sends address whatever is stored.
+  if (current && current !== sub.phone) {
+    const updated = await db.notisSubscription.update({
+      where: { id: sub.id },
+      data: { phone: current },
+    });
+    return { sub: updated };
+  }
+  return { sub };
 }
 
 async function findSubscriptionByPhone(
@@ -332,14 +385,10 @@ async function handleBareStop(
         ...(alreadyUnsubscribed ? {} : { status: "unsubscribed" as const, unsubscribedAt: at }),
       },
     });
-    // Nothing queued may outlive a ΣΤΟΠ: a pending row the sweeper would
-    // retry later must die with the subscription. The confirmation reply is
-    // created below, after this statement, so it is the one outbound row
-    // that survives.
-    await tx.notisMessage.updateMany({
-      where: { subscriptionId: sub.id, direction: "outbound", status: "pending" },
-      data: { status: "suppressed", failureReason: "unsubscribed" },
-    });
+    // Nothing queued may outlive a ΣΤΟΠ. The confirmation reply is created
+    // below, after this statement, so it is the one outbound row that
+    // survives.
+    await suppressPendingOutbound(tx, sub.id);
     // A model-less wake row records the decision (the reader's text lives on
     // the inbound message row, the reply on its own row below — this is only
     // the "what happened and why"). model/trace stay null: no model ran.
@@ -450,39 +499,13 @@ export async function handleInbound(
       return { action: "ignored", reason: "not a notis-served phone" };
     }
   } else {
-    // The gate holds for EXISTING subscriptions too: an admin rolling a
-    // user back (clearing notisEnabledAt) hands their inbound to the main
-    // app's webhook again — answering here as well would double-reply.
-    // Fail open when the main DB is unreachable: dropping a served user's
-    // message is worse than a rare double answer during an outage.
-    if (hasMainDb()) {
-      const user = await mainDb().notisUserRow.findUnique({
-        where: { id: sub.userId },
-        select: { notisEnabledAt: true, phone: true },
-      });
-      if (!user?.notisEnabledAt) {
-        return { action: "ignored", reason: "user rolled back to the old path" };
-      }
-      // A number this reader no longer owns is not this reader. After a phone
-      // change, the OLD number still matches the stored subscription here
-      // while the main app's gate (which looks up User.phone) misses and
-      // sends its unsupported-number reply — so the sender would get two
-      // answers that contradict each other, on every message. Treat it like a
-      // rollback and stay silent; the new number self-heals through the
-      // enrollment upsert.
-      const current = normalizePhone(user.phone);
-      if (current && current !== normalizePhone(fields.phone)) {
-        return { action: "ignored", reason: "message from a number the user no longer has" };
-      }
-      // Canonicalize a stored form that differs only by the leading "+": the
-      // lookup accepts both, and later sends address whatever is stored.
-      if (current && current !== sub.phone) {
-        sub = await db.notisSubscription.update({
-          where: { id: sub.id },
-          data: { phone: current },
-        });
-      }
+    // The gate holds for EXISTING subscriptions too: answering a
+    // rolled-back user here as well as in the main app would double-reply.
+    const gated = await gateExistingSubscription(db, sub, fields.phone);
+    if ("ignored" in gated) {
+      return { action: "ignored", reason: gated.ignored };
     }
+    sub = gated.sub;
     if (fields.conversationId && sub.birdConversationId !== fields.conversationId) {
       sub = await db.notisSubscription.update({
         where: { id: sub.id },

--- a/services/notis/src/app/api/webhooks/bird/handlers.ts
+++ b/services/notis/src/app/api/webhooks/bird/handlers.ts
@@ -268,6 +268,14 @@ async function handleBareStop(
         ...(alreadyUnsubscribed ? {} : { status: "unsubscribed" as const, unsubscribedAt: at }),
       },
     });
+    // Nothing queued may outlive a ΣΤΟΠ: a pending row the sweeper would
+    // retry later must die with the subscription. The confirmation reply is
+    // created below, after this statement, so it is the one outbound row
+    // that survives.
+    await tx.notisMessage.updateMany({
+      where: { subscriptionId: sub.id, direction: "outbound", status: "pending" },
+      data: { status: "suppressed", failureReason: "unsubscribed" },
+    });
     // A model-less wake row records the decision (the reader's text lives on
     // the inbound message row, the reply on its own row below — this is only
     // the "what happened and why"). model/trace stay null: no model ran.

--- a/services/notis/src/app/api/webhooks/bird/handlers.ts
+++ b/services/notis/src/app/api/webhooks/bird/handlers.ts
@@ -92,8 +92,11 @@ export async function handleOutboundStatus(
         status: fields.status,
         // Only keep a reason on failure; clear it otherwise (same rule as
         // the main app's webhook).
+        // `?? null` must come LAST: a `(x ?? null)?.slice()` on a missing
+        // reason yields undefined, which Prisma reads as "leave unchanged" —
+        // keeping a stale reason from an earlier failure.
         failureReason:
-          fields.status === "failed" ? (fields.failureReason ?? null)?.slice(0, 300) : null,
+          fields.status === "failed" ? (fields.failureReason?.slice(0, 300) ?? null) : null,
       },
     });
     if (fields.status === "failed") {

--- a/services/notis/src/app/api/webhooks/bird/route.ts
+++ b/services/notis/src/app/api/webhooks/bird/route.ts
@@ -6,7 +6,7 @@ import { realBird } from "@/lib/bird";
 import { hasNotisDb, notisDb } from "@/lib/db";
 import { drainQueue } from "@/lib/queue";
 import { SIGNATURE_HEADER, TIMESTAMP_HEADER, verifyBirdSignature } from "@/lib/webhook-signature";
-import { handleInbound, handleOutboundStatus } from "./handlers";
+import { handleInbound, handleOutboundStatus, handleSmsInbound } from "./handlers";
 
 /**
  * Notis's own Bird webhook subscription — a SECOND subscription beside the
@@ -65,18 +65,22 @@ export async function POST(request: Request) {
     // birdConversationId with an SMS thread.
     sms: env.BIRD_SMS_CHANNEL_ID,
   });
-  if (fields.channel !== "whatsapp") {
-    return NextResponse.json({ ok: true, ignored: "not whatsapp" });
-  }
-
   const deps = { db: notisDb(), bird: realBird };
   try {
     if (fields.direction === "outbound") {
+      // Both channels: the SMS fallback rows have delivery lifecycles too,
+      // and their failures must alert — there is no next channel after SMS.
       await handleOutboundStatus(fields, deps);
       return NextResponse.json({ ok: true });
     }
 
-    const result = await handleInbound(fields, deps);
+    // Inbound SMS gets its own, narrower handler: our fallback's footer
+    // invites ΣΤΟΠ, so served phones must be heard there — but nothing
+    // enrolls over SMS, and unknown phones stay the main app's.
+    const result =
+      fields.channel === "sms"
+        ? await handleSmsInbound(fields, deps)
+        : await handleInbound(fields, deps);
     if (result.action === "enqueued") {
       after(() => drainQueue());
     }

--- a/services/notis/src/lib/__tests__/fake-db.ts
+++ b/services/notis/src/lib/__tests__/fake-db.ts
@@ -240,11 +240,25 @@ export function makeFakeDb(seed: { subscriptions?: Row[]; settings?: Row[] } = {
     },
     notisWakeQueue: {
       create: async ({ data }: { data: Row }) => {
-        const row: Row = { id: id("q"), status: "pending", attempts: 0, ...data };
+        const row: Row = {
+          id: id("q"),
+          status: "pending",
+          attempts: 0,
+          updatedAt: new Date(),
+          ...data,
+        };
         store.queue.set(row.id as string, row);
         calls.push("queue-created");
         return row;
       },
+      findFirst: async ({ where }: { where?: Row } = {}) =>
+        [...store.queue.values()].find((q) =>
+          Object.entries(where ?? {}).every(([k, v]) => q[k] === v),
+        ) ?? null,
+      findMany: async ({ where }: { where?: Row } = {}) =>
+        [...store.queue.values()].filter((q) =>
+          Object.entries(where ?? {}).every(([k, v]) => q[k] === v),
+        ),
       // Fenced transitions: match id + optional status/attempts like the
       // real claim-ownership guards do, reporting the matched count.
       updateMany: async ({

--- a/services/notis/src/lib/__tests__/fake-db.ts
+++ b/services/notis/src/lib/__tests__/fake-db.ts
@@ -265,14 +265,19 @@ export function makeFakeDb(seed: { subscriptions?: Row[]; settings?: Row[] } = {
         where,
         data,
       }: {
-        where: { id: string; status?: string; attempts?: number };
+        where: { id: string; status?: string; attempts?: number; updatedAt?: Date };
         data: Row;
       }) => {
         const row = store.queue.get(where.id);
         const matches =
           row &&
           (where.status === undefined || row.status === where.status) &&
-          (where.attempts === undefined || row.attempts === where.attempts);
+          (where.attempts === undefined || row.attempts === where.attempts) &&
+          // The CAS fence: enqueueLiveWake's append fences on updatedAt —
+          // ignoring it here would let a broken fence pass every unit test.
+          (where.updatedAt === undefined ||
+            (row.updatedAt instanceof Date &&
+              row.updatedAt.getTime() === where.updatedAt.getTime()));
         if (!matches) return { count: 0 };
         Object.assign(row, data);
         calls.push(`queue:${data.status}`);

--- a/services/notis/src/lib/__tests__/queue-delivery.test.ts
+++ b/services/notis/src/lib/__tests__/queue-delivery.test.ts
@@ -66,15 +66,16 @@ describe("deliverPendingMessage — rails on the retry path", () => {
   afterEach(() => jest.useRealTimers());
 
   it("suppresses a reply-continuation template (proactive:false) when the reader unsubscribed", async () => {
-    // A promised follow-up is cap-exempt, so proactive is false — but it is a
-    // template send, so it is unprompted and must still respect a ΣΤΟΠ. The
-    // rail keys on proactive OR template for exactly this row.
+    // A promised follow-up is cap-exempt, so proactive is false — but it is
+    // unprompted at delivery, so it is stamped railed and must still respect
+    // a ΣΤΟΠ. The rail keys on the stamp, not on mode inference.
     const db = makeFakeDb({
       subscriptions: [{ ...SUB, status: "unsubscribed", unsubscribedAt: new Date() }],
       settings: liveSettings(),
     });
     const id = seedMessage(db, {
       proactive: false,
+      railed: true,
       deliveryMode: "template",
       template: "demos_followup",
     });
@@ -95,6 +96,7 @@ describe("deliverPendingMessage — rails on the retry path", () => {
     });
     const id = seedMessage(db, {
       proactive: true,
+      railed: true,
       deliveryMode: "template",
       template: "demos_update_news",
     });
@@ -170,6 +172,7 @@ describe("resendStalePendingMessages — held SMS release honors the rails", () 
       id: "sms1",
       channel: "sms",
       proactive: true,
+      railed: true,
       failureReason: SMS_HELD_FOR_QUIET_HOURS,
       createdAt: new Date(Date.now() - RESEND_STALE_AFTER_MS - 60_000),
     });

--- a/services/notis/src/lib/__tests__/queue-rails.test.ts
+++ b/services/notis/src/lib/__tests__/queue-rails.test.ts
@@ -396,10 +396,15 @@ describe("proactive rails", () => {
       alert: async () => {},
     });
 
-    const outbound = db.store.messages.find((m) => m.direction === "outbound")!;
-    expect(outbound.status).toBe("suppressed");
-    expect(outbound.failureReason).toBe("unsubscribed");
+    // Better than suppression-at-boundary: the wake is consumed BEFORE the
+    // model runs — no outbound row exists at all, no model cost is paid,
+    // and the decision log records the model-less skip.
+    expect(db.store.messages.filter((m) => m.direction === "outbound")).toHaveLength(0);
     expect(bird.templateSends).toHaveLength(0);
+    expect(db.store.wakes).toHaveLength(1);
+    expect(db.store.wakes[0].rationale).toContain("απεγγράφηκε");
+    expect(db.store.wakes[0].model ?? null).toBeNull();
+    expect(db.store.queue.get("q1")?.status).toBe("done");
   });
 
   it("a coalesced wake persists the primary event plus the full array and scheduled origin", async () => {

--- a/services/notis/src/lib/__tests__/queue.test.ts
+++ b/services/notis/src/lib/__tests__/queue.test.ts
@@ -6,9 +6,11 @@ import { FakeBird } from "./fake-bird";
 
 /**
  * processItem against an in-memory Prisma fake: the shell's ordering
- * invariants (wake committed before Bird, idempotency key = message id,
- * failure → pending retry with Bird untouched) are what's under test —
- * runWake itself has its own suite.
+ * invariants are what's under test — runWake itself has its own suite.
+ * Reactive wakes deliver INCREMENTALLY (each send goes out mid-loop, the
+ * wake row adopts the rows at persistence); everything else keeps the old
+ * order (wake committed before Bird, idempotency key = message id,
+ * failure → pending retry with Bird untouched).
  */
 
 
@@ -47,7 +49,7 @@ function seedClaim(db: ReturnType<typeof makeFakeDb>, attempts = 1) {
 }
 
 describe("processItem", () => {
-  it("persists the wake and message BEFORE calling Bird, keyed by the message id", async () => {
+  it("delivers the reply mid-wake, then persists the wake and adopts the rows", async () => {
     const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
     seedClaim(db);
     const bird = new FakeBird();
@@ -77,10 +79,52 @@ describe("processItem", () => {
     expect(outbound.birdMessageId).toBe("bird-1");
     expect(outbound.deliveryMode).toBe("freeform");
 
-    // Ordering: the wake row and the done-mark precede the send.
+    // Incremental ordering: the reader has the message BEFORE the wake row
+    // exists, and the wake adopts the row at persistence.
     const sendIndex = db.calls.indexOf("message-created:outbound");
-    expect(db.calls.indexOf("wake-created")).toBeLessThan(sendIndex);
+    expect(sendIndex).toBeLessThan(db.calls.indexOf("wake-created"));
+    expect(outbound.wakeId).toBe(db.store.wakes[0].id);
     expect(alerts).toHaveLength(0);
+  });
+
+  it("finalizes fail-forward when the model errors after a delivery", async () => {
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    seedClaim(db);
+    const bird = new FakeBird();
+    const alerts: string[] = [];
+
+    await processItem(ITEM, {
+      db,
+      bird,
+      // Turn 1 sends without finish_wake; turn 2 does not exist, so the
+      // model call throws mid-wake — after the reader already got a message.
+      deps: makeDeps(
+        new FakeAnthropic([
+          {
+            content: [toolUse("t1", "send_message", { text: "Πρώτο μισό." })],
+            stop_reason: "tool_use",
+          },
+        ]),
+      ),
+      alert: async (m) => {
+        alerts.push(m);
+      },
+    });
+
+    // Re-running the model after a real delivery risks a duplicate answer,
+    // so the error finalizes the wake with what it has instead of retrying.
+    expect(bird.sends).toHaveLength(1);
+    expect(db.store.wakes).toHaveLength(1);
+    const wake = db.store.wakes[0];
+    expect(wake.decision).toBe("send");
+    expect(
+      (wake.outcome as { partialDeliveryError?: string }).partialDeliveryError,
+    ).toContain("exhausted");
+    expect(db.store.queue.get("q1")?.status).toBe("done");
+    const outbound = db.store.messages.find((m) => m.direction === "outbound")!;
+    expect(outbound.status).toBe("sent");
+    expect(outbound.wakeId).toBe(wake.id);
+    expect(alerts.some((m) => m.includes("partial delivery"))).toBe(true);
   });
 
   it("returns the item to pending when the wake throws — Bird untouched, nothing persisted", async () => {
@@ -190,25 +234,35 @@ describe("processItem", () => {
     expect(alerts).toHaveLength(0);
   });
 
-  it("aborts without side effects when the claim was reclaimed mid-wake (fence)", async () => {
+  it("a lost claim aborts the record — delivered bytes stay delivered, with an alert", async () => {
     const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
     // The reclaimer bumped attempts: this worker's fence no longer matches.
     db.store.queue.set("q1", { id: "q1", status: "running", attempts: ITEM.attempts + 1 });
     const bird = new FakeBird();
+    const alerts: string[] = [];
 
     await processItem(ITEM, {
       db,
       bird,
       deps: makeDeps(new FakeAnthropic(sendTurn)),
-      alert: async () => {},
+      alert: async (m) => {
+        alerts.push(m);
+      },
     });
 
-    // The persist tx threw ClaimLostError: nothing landed, nothing sent,
-    // and the reclaimer's row was left untouched.
+    // The persist tx threw ClaimLostError: no wake row landed and the
+    // reclaimer's row was left untouched — it owns the item now.
     expect(db.store.wakes).toHaveLength(0);
-    expect(bird.sends).toHaveLength(0);
     expect(db.store.queue.get("q1")?.status).toBe("running");
     expect(db.store.queue.get("q1")?.attempts).toBe(ITEM.attempts + 1);
+    // But the incremental send went out mid-loop and cannot be recalled:
+    // the row stays wakeId-less, the reclaimer's run sees it in the
+    // conversation, and the alert is the operator's signal.
+    expect(bird.sends).toHaveLength(1);
+    const outbound = db.store.messages.find((m) => m.direction === "outbound")!;
+    expect(outbound.status).toBe("sent");
+    expect(outbound.wakeId ?? null).toBeNull();
+    expect(alerts.some((m) => m.includes("lost its claim"))).toBe(true);
   });
 });
 

--- a/services/notis/src/lib/__tests__/queue.test.ts
+++ b/services/notis/src/lib/__tests__/queue.test.ts
@@ -234,6 +234,47 @@ describe("processItem", () => {
     expect(alerts).toHaveLength(0);
   });
 
+  it("an unsubscribe wake suppresses other pending outbound rows, not its own goodbye", async () => {
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    seedClaim(db);
+    // A stale pending row from an earlier wake — the kind the sweeper would
+    // otherwise retry and deliver after the reader said goodbye.
+    db.store.messages.push({
+      id: "stale1",
+      subscriptionId: "sub1",
+      direction: "outbound",
+      body: "Παλιά είδηση.",
+      status: "pending",
+      createdAt: new Date("2026-03-10T09:00:00.000Z"),
+    });
+    const bird = new FakeBird();
+
+    await processItem(ITEM, {
+      db,
+      bird,
+      deps: makeDeps(
+        new FakeAnthropic([
+          {
+            content: [
+              toolUse("t1", "unsubscribe_user", { reason: "το ζήτησε" }),
+              toolUse("t2", "send_message", { text: "Εντάξει, σταματώ. Γεια!" }),
+              toolUse("t3", "finish_wake", { rationale: "Ζήτησε διαγραφή." }),
+            ],
+            stop_reason: "tool_use",
+          },
+        ]),
+      ),
+      alert: async () => {},
+    });
+
+    const stale = db.store.messages.find((m) => m.id === "stale1")!;
+    expect(stale.status).toBe("suppressed");
+    expect(stale.failureReason).toBe("unsubscribed");
+    // The goodbye itself went out — the reader gets the confirmation.
+    const goodbye = db.store.messages.find((m) => m.body === "Εντάξει, σταματώ. Γεια!")!;
+    expect(goodbye.status).toBe("sent");
+  });
+
   it("a lost claim aborts the record — delivered bytes stay delivered, with an alert", async () => {
     const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
     // The reclaimer bumped attempts: this worker's fence no longer matches.

--- a/services/notis/src/lib/__tests__/queue.test.ts
+++ b/services/notis/src/lib/__tests__/queue.test.ts
@@ -331,6 +331,36 @@ describe("processItem", () => {
     expect(bird.sends[0].text).toBe("Για την Κυψέλη λοιπόν...");
   });
 
+  it("answers over SMS when WhatsApp cannot carry the reply", async () => {
+    // The reader is SMS-only: their WhatsApp conversation never existed
+    // (cold template failed once; they reached us via the SMS fallback).
+    const db = makeFakeDb({ subscriptions: [{ ...SUB, birdConversationId: null }] });
+    seedClaim(db);
+    const bird = new FakeBird();
+
+    await processItem(ITEM, {
+      db,
+      bird,
+      deps: makeDeps(new FakeAnthropic(sendTurn)),
+      alert: async () => {},
+    });
+
+    // The WhatsApp leg failed; the SMS leg carried the answer, raw.
+    expect(bird.sends).toHaveLength(0);
+    expect(bird.smsSends).toHaveLength(1);
+    expect(bird.smsSends[0].text).toBe("Η απάντηση.");
+    const whatsappRow = db.store.messages.find(
+      (m) => m.direction === "outbound" && m.channel === "whatsapp",
+    )!;
+    expect(whatsappRow.status).toBe("failed");
+    const smsRow = db.store.messages.find((m) => m.channel === "sms")!;
+    expect(smsRow.status).toBe("sent");
+    expect(smsRow.fallbackForId).toBe(whatsappRow.id);
+    // The wake completed normally — the reader got their answer.
+    expect(db.store.wakes).toHaveLength(1);
+    expect(db.store.queue.get("q1")?.status).toBe("done");
+  });
+
   it("re-enqueues absorbed messages when the wake fails before any delivery", async () => {
     const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
     seedClaim(db);

--- a/services/notis/src/lib/__tests__/queue.test.ts
+++ b/services/notis/src/lib/__tests__/queue.test.ts
@@ -275,6 +275,62 @@ describe("processItem", () => {
     expect(goodbye.status).toBe("sent");
   });
 
+  it("absorbs a correction that queued while the wake was claimed — one answer, both bubbles", async () => {
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    seedClaim(db);
+    // The correction arrived after q1 was claimed: live-lane coalescing
+    // could not append (q1 is running), so it created its own pending row.
+    db.store.queue.set("q2", {
+      id: "q2",
+      subscriptionId: "sub1",
+      lane: "live",
+      status: "pending",
+      attempts: 0,
+      events: [
+        {
+          type: "user_message",
+          at: "2026-03-10T10:00:20.000Z",
+          text: "Σόρρυ άκυρο — στην Κυψέλη εννοούσα",
+        },
+      ],
+      runAfter: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const bird = new FakeBird();
+
+    await processItem(ITEM, {
+      db,
+      bird,
+      deps: makeDeps(
+        new FakeAnthropic([
+          {
+            content: [
+              toolUse("t1", "send_message", { text: "Για την Κυψέλη λοιπόν..." }),
+              toolUse("t2", "finish_wake", { rationale: "Απάντησα στη διόρθωση." }),
+            ],
+            stop_reason: "tool_use",
+          },
+        ]),
+      ),
+      alert: async () => {},
+    });
+
+    // The correction's own wake was consumed — no second answer coming.
+    expect(db.store.queue.get("q2")?.status).toBe("done");
+    expect(db.store.queue.get("q1")?.status).toBe("done");
+    // One wake, both reader messages on its record.
+    expect(db.store.wakes).toHaveLength(1);
+    const wake = db.store.wakes[0];
+    expect(Array.isArray(wake.events)).toBe(true);
+    expect((wake.events as Array<{ text?: string }>).map((e) => e.text)).toEqual([
+      "Τι ψηφίστηκε χθες;",
+      "Σόρρυ άκυρο — στην Κυψέλη εννοούσα",
+    ]);
+    expect(bird.sends).toHaveLength(1);
+    expect(bird.sends[0].text).toBe("Για την Κυψέλη λοιπόν...");
+  });
+
   it("a lost claim aborts the record — delivered bytes stay delivered, with an alert", async () => {
     const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
     // The reclaimer bumped attempts: this worker's fence no longer matches.

--- a/services/notis/src/lib/__tests__/queue.test.ts
+++ b/services/notis/src/lib/__tests__/queue.test.ts
@@ -331,31 +331,156 @@ describe("processItem", () => {
     expect(bird.sends[0].text).toBe("Για την Κυψέλη λοιπόν...");
   });
 
-  it("a lost claim aborts the record — delivered bytes stay delivered, with an alert", async () => {
+  it("re-enqueues absorbed messages when the wake fails before any delivery", async () => {
     const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
-    // The reclaimer bumped attempts: this worker's fence no longer matches.
+    seedClaim(db);
+    // The correction queued while q1 was claimed.
+    db.store.queue.set("q2", {
+      id: "q2",
+      subscriptionId: "sub1",
+      lane: "live",
+      status: "pending",
+      attempts: 0,
+      events: [
+        { type: "user_message", at: "2026-03-10T10:00:20.000Z", text: "Διόρθωση." },
+      ],
+      runAfter: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const bird = new FakeBird();
+
+    // Zero scripted turns: turn 0 absorbs q2, then the model call throws.
+    await processItem(ITEM, {
+      db,
+      bird,
+      deps: makeDeps(new FakeAnthropic([])),
+      alert: async () => {},
+    });
+
+    // Nothing was delivered, no wake landed — and the absorbed correction
+    // is back in a pending row instead of dying as done.
+    expect(bird.sends).toHaveLength(0);
+    expect(db.store.wakes).toHaveLength(0);
+    const pendingTexts = [...db.store.queue.values()]
+      .filter((q) => q.lane === "live" && q.status === "pending")
+      .flatMap((q) => (q.events as Array<{ text?: string }>).map((e) => e.text));
+    expect(pendingTexts).toContain("Διόρθωση.");
+    // The original item retries on its own row (failItem re-pended it).
+    expect(db.store.queue.get("q1")?.status).toBe("pending");
+  });
+
+  it("stops sending the moment the reader unsubscribes mid-wake", async () => {
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    seedClaim(db);
+    const bird = new FakeBird();
+    const inner = new FakeAnthropic([
+      {
+        content: [toolUse("t1", "send_message", { text: "Πρώτο." })],
+        stop_reason: "tool_use",
+      },
+      {
+        content: [
+          toolUse("t2", "send_message", { text: "Δεύτερο." }),
+          toolUse("t3", "finish_wake", { rationale: "Τέλος." }),
+        ],
+        stop_reason: "tool_use",
+      },
+    ]);
+    let calls = 0;
+    const stopping = {
+      create: async (params: Parameters<typeof inner.create>[0]) => {
+        calls++;
+        if (calls === 2) {
+          // Bare ΣΤΟΠ landed between turns: the handler flips the status.
+          db.store.subscriptions.get("sub1")!.status = "unsubscribed";
+        }
+        return inner.create(params);
+      },
+    };
+
+    await processItem(ITEM, {
+      db,
+      bird,
+      deps: makeDeps(stopping),
+      alert: async () => {},
+    });
+
+    // The second send never left and never even created a row: the deliver
+    // closure re-reads the subscription at the send instant.
+    expect(bird.sends).toHaveLength(1);
+    expect(bird.sends[0].text).toBe("Πρώτο.");
+    expect(db.store.messages.filter((m) => m.direction === "outbound")).toHaveLength(1);
+  });
+
+  it("a claim lost BEFORE the first turn aborts cleanly — nothing is sent", async () => {
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    // The reclaimer bumped attempts: this worker's fence no longer matches,
+    // and the turn-0 heartbeat notices before any model call or delivery.
     db.store.queue.set("q1", { id: "q1", status: "running", attempts: ITEM.attempts + 1 });
     const bird = new FakeBird();
-    const alerts: string[] = [];
 
     await processItem(ITEM, {
       db,
       bird,
       deps: makeDeps(new FakeAnthropic(sendTurn)),
+      alert: async () => {},
+    });
+
+    expect(bird.sends).toHaveLength(0);
+    expect(db.store.wakes).toHaveLength(0);
+    expect(db.store.queue.get("q1")?.status).toBe("running");
+    expect(db.store.queue.get("q1")?.attempts).toBe(ITEM.attempts + 1);
+  });
+
+  it("a claim lost AFTER a delivery finalizes fail-forward — bytes stay delivered, with an alert", async () => {
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    seedClaim(db);
+    const bird = new FakeBird();
+    const alerts: string[] = [];
+    // Two turns; the reclaimer steals the claim between them.
+    const inner = new FakeAnthropic([
+      {
+        content: [toolUse("t1", "send_message", { text: "Πρώτο μισό." })],
+        stop_reason: "tool_use",
+      },
+      {
+        content: [toolUse("t2", "finish_wake", { rationale: "Τέλος." })],
+        stop_reason: "tool_use",
+      },
+    ]);
+    let calls = 0;
+    const stealing = {
+      create: async (params: Parameters<typeof inner.create>[0]) => {
+        calls++;
+        if (calls === 2) {
+          // Reclaim between turn 1 (delivered) and turn 2.
+          db.store.queue.set("q1", {
+            id: "q1",
+            status: "running",
+            attempts: ITEM.attempts + 1,
+          });
+        }
+        return inner.create(params);
+      },
+    };
+
+    await processItem(ITEM, {
+      db,
+      bird,
+      deps: makeDeps(stealing),
       alert: async (m) => {
         alerts.push(m);
       },
     });
 
-    // The persist tx threw ClaimLostError: no wake row landed and the
-    // reclaimer's row was left untouched — it owns the item now.
-    expect(db.store.wakes).toHaveLength(0);
-    expect(db.store.queue.get("q1")?.status).toBe("running");
-    expect(db.store.queue.get("q1")?.attempts).toBe(ITEM.attempts + 1);
-    // But the incremental send went out mid-loop and cannot be recalled:
-    // the row stays wakeId-less, the reclaimer's run sees it in the
-    // conversation, and the alert is the operator's signal.
+    // The heartbeat caught the loss at turn 2, fail-forward finalized, and
+    // the persist's completeItem fence threw ClaimLostError: no wake row,
+    // the reclaimer's row untouched, but the delivered byte stands and the
+    // operator hears about the possible double answer.
     expect(bird.sends).toHaveLength(1);
+    expect(db.store.wakes).toHaveLength(0);
+    expect(db.store.queue.get("q1")?.attempts).toBe(ITEM.attempts + 1);
     const outbound = db.store.messages.find((m) => m.direction === "outbound")!;
     expect(outbound.status).toBe("sent");
     expect(outbound.wakeId ?? null).toBeNull();

--- a/services/notis/src/lib/__tests__/queue.test.ts
+++ b/services/notis/src/lib/__tests__/queue.test.ts
@@ -320,6 +320,7 @@ describe("resendStalePendingMessages", () => {
     body: "Νέα από τον δήμο σου.",
     channel: "whatsapp",
     proactive: true,
+    railed: true,
     deliveryMode: "template",
     template: "demos_update_news",
     status: "pending",
@@ -374,8 +375,15 @@ describe("resendStalePendingMessages", () => {
       subscriptions: [{ ...SUB }],
       settings: [{ key: "proactivePaused", value: true }],
     });
+    // railed: false is the stamp a reactive reply carries from creation —
+    // freeform mode alone no longer implies it.
     db.store.messages.push(
-      stalePendingProactive({ proactive: false, deliveryMode: "freeform", template: null }),
+      stalePendingProactive({
+        proactive: false,
+        railed: false,
+        deliveryMode: "freeform",
+        template: null,
+      }),
     );
     const bird = new FakeBird();
 

--- a/services/notis/src/lib/poller.ts
+++ b/services/notis/src/lib/poller.ts
@@ -244,6 +244,7 @@ async function enrollNewTargets(
           body: rendered.body,
           channel: "whatsapp",
           proactive: true,
+          railed: true,
           deliveryMode: "template",
           template: "demos_transition",
           status: "pending",

--- a/services/notis/src/lib/poller.ts
+++ b/services/notis/src/lib/poller.ts
@@ -12,7 +12,7 @@ import { buildDeps } from "./deps";
 import { toCityPreferences } from "./fanout";
 import { hasMainDb, mainDb } from "./main-db";
 import { normalizePhone } from "./phone";
-import { deliverPendingMessage } from "./queue";
+import { deliverPendingMessage, suppressPendingOutbound } from "./queue";
 import { enqueueBatchWake, isUniqueViolation } from "./queue-core";
 import { POLLER_STATUS_KEY, getProactiveSettings, putSetting } from "./settings";
 
@@ -304,6 +304,12 @@ async function reconcileSubscriptions(
             where: { id: sub.id },
             data: { status: "unsubscribed", unsubscribedAt: at, phone: null },
           });
+          // The third unsubscribe site gets the same cleanup as the other
+          // two: nothing queued may outlive the opt-out. sendFreeform needs
+          // only birdConversationId (which survives), so without this the
+          // sweeper would deliver a leftover pending row after the phone
+          // was removed.
+          await suppressPendingOutbound(tx, sub.id);
           // A model-less wake row: why this reader went silent must survive in
           // the decision log (the audit answer to "who unsubscribed them").
           const rationale =

--- a/services/notis/src/lib/queue-core.ts
+++ b/services/notis/src/lib/queue-core.ts
@@ -45,10 +45,44 @@ export interface ClaimedItem {
   attempts: number;
 }
 
+/**
+ * Enqueue on the live lane, coalescing per subscription like the batch lane:
+ * while a pending live row exists (the previous message's wake has not been
+ * claimed yet), a new inbound APPENDS its event instead of queueing behind —
+ * so «τι γίνεται με Χ;» followed seconds later by «άκυρο, Υ εννοούσα» runs as
+ * ONE wake that sees both messages, and the reader never gets an answer to a
+ * request they already corrected.
+ *
+ * The append is a compare-and-swap fenced on updatedAt (no raw SQL: the
+ * webhook handlers call this inside their interactive transaction, where a
+ * caught 23505 would poison the transaction — see enqueueBatchWake). A CAS
+ * loss re-reads; a row the claimer flipped to running no longer matches and
+ * the event correctly becomes a fresh pending row. The residual both-create
+ * race hits the partial unique index and fails the webhook, which Bird
+ * retries — the retry lands on the append path.
+ */
 export async function enqueueLiveWake(
   db: Db,
   input: { subscriptionId: string; event: unknown; runAfter?: Date },
 ): Promise<string> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const pending = await db.notisWakeQueue.findFirst({
+      where: { subscriptionId: input.subscriptionId, lane: "live", status: "pending" },
+      select: { id: true, events: true, updatedAt: true },
+    });
+    if (!pending) break;
+    const appended = await db.notisWakeQueue.updateMany({
+      where: { id: pending.id, status: "pending", updatedAt: pending.updatedAt },
+      data: {
+        events: [
+          ...(pending.events as Prisma.InputJsonValue[]),
+          input.event,
+        ] as Prisma.InputJsonValue,
+        updatedAt: new Date(),
+      },
+    });
+    if (appended.count === 1) return pending.id;
+  }
   const row = await db.notisWakeQueue.create({
     data: {
       subscriptionId: input.subscriptionId,
@@ -59,6 +93,38 @@ export async function enqueueLiveWake(
     select: { id: true },
   });
   return row.id;
+}
+
+/**
+ * Consume the subscription's pending live rows and return their events — the
+ * mid-run absorption primitive: a running wake adopts messages that arrived
+ * after it started, and the rows that would have answered them separately
+ * are closed as done so the reader never gets two answers.
+ *
+ * Ordering makes it lose-nothing: rows are flipped pending→done first
+ * (fenced, one by one), and events are read back AFTER the flip — an append
+ * that raced in before the flip is included in the read; one that lost the
+ * fence created a fresh pending row that stays for the next wake.
+ */
+export async function consumePendingLiveEvents(db: Db, subscriptionId: string): Promise<unknown[]> {
+  const rows = await db.notisWakeQueue.findMany({
+    where: { subscriptionId, lane: "live", status: "pending" },
+    select: { id: true },
+  });
+  if (rows.length === 0) return [];
+  const consumed: string[] = [];
+  for (const row of rows) {
+    const flipped = await db.notisWakeQueue.updateMany({
+      where: { id: row.id, status: "pending" },
+      data: { status: "done" },
+    });
+    if (flipped.count === 1) consumed.push(row.id);
+  }
+  if (consumed.length === 0) return [];
+  const done = await Promise.all(
+    consumed.map((id) => db.notisWakeQueue.findUnique({ where: { id } })),
+  );
+  return done.flatMap((r) => (Array.isArray(r?.events) ? (r.events as unknown[]) : []));
 }
 
 /**

--- a/services/notis/src/lib/queue-core.ts
+++ b/services/notis/src/lib/queue-core.ts
@@ -20,6 +20,10 @@ import type { NotisWakeQueue, Prisma, PrismaClient } from "../../generated/clien
 export type Db = PrismaClient | Prisma.TransactionClient;
 
 export const MAX_ATTEMPTS = 3;
+
+/** The queue states that are (or were) live work — what the panel thread
+ *  and the evaluation export both mean by "still in the queue". */
+export const LIVE_QUEUE_STATUSES = ["pending", "running", "failed"] as const;
 // Reclaim threshold for crash recovery. With the Anthropic client capped at
 // 3 minutes per call (lib/anthropic.ts), a single hung turn cannot push an
 // alive wake past this on its own; a pathological full-length wake that

--- a/services/notis/src/lib/queue-core.ts
+++ b/services/notis/src/lib/queue-core.ts
@@ -68,9 +68,10 @@ export async function enqueueLiveWake(
   for (let attempt = 0; attempt < 3; attempt++) {
     const pending = await db.notisWakeQueue.findFirst({
       where: { subscriptionId: input.subscriptionId, lane: "live", status: "pending" },
-      select: { id: true, events: true, updatedAt: true },
+      select: { id: true, events: true, updatedAt: true, runAfter: true },
     });
     if (!pending) break;
+    const runAfter = input.runAfter ?? new Date();
     const appended = await db.notisWakeQueue.updateMany({
       where: { id: pending.id, status: "pending", updatedAt: pending.updatedAt },
       data: {
@@ -78,6 +79,13 @@ export async function enqueueLiveWake(
           ...(pending.events as Prisma.InputJsonValue[]),
           input.event,
         ] as Prisma.InputJsonValue,
+        // A fresh reader message must not inherit a retry-backoff row's
+        // fate: pull runAfter forward (LEAST, like the batch path) and
+        // reset the attempts budget — materially this is a new wake, and
+        // without the reset the appended message could be terminally
+        // failed without a single model run of its own.
+        runAfter: pending.runAfter < runAfter ? pending.runAfter : runAfter,
+        attempts: 0,
         updatedAt: new Date(),
       },
     });
@@ -93,6 +101,23 @@ export async function enqueueLiveWake(
     select: { id: true },
   });
   return row.id;
+}
+
+/**
+ * Refresh a running claim's claimedAt — the wake's heartbeat. A wake can
+ * legally run far past STALE_CLAIM_MS (turns x the Anthropic client budget),
+ * and without a heartbeat the reclaimer starts a SECOND model run while the
+ * first still delivers. Touching the claim each turn keeps a live worker's
+ * claim fresh; a dead worker stops touching it and is reclaimed on the old
+ * schedule. Returns false when the claim is no longer ours — the caller
+ * must stop working.
+ */
+export async function touchClaim(db: Db, id: string, attempts: number): Promise<boolean> {
+  const touched = await db.notisWakeQueue.updateMany({
+    where: { id, status: "running", attempts },
+    data: { claimedAt: new Date() },
+  });
+  return touched.count === 1;
 }
 
 /**
@@ -286,21 +311,24 @@ export async function claimNext(db: Db): Promise<ClaimedItem | null> {
  * processItem): a 23505 inside one would abort it before the recovery could
  * run. Keep it that way.
  */
-async function mergeIntoPendingBatch(
+async function mergeIntoPendingRow(
   db: Db,
   id: string,
   attempts: number,
   runAfter: Date,
   note: string,
 ): Promise<void> {
+  // Lane-agnostic on purpose: BOTH lanes now carry a one-pending-per-sub
+  // partial unique index, so a running row of either lane can lose its
+  // re-pend to a newer pending row and must merge into it — a batch-only
+  // merge left a live row stranded in `running` until the stale reclaim.
   await db.$queryRaw`
     WITH src AS (
-      SELECT id, "subscriptionId", events
+      SELECT id, "subscriptionId", lane, events
       FROM "NotisWakeQueue"
       WHERE id = ${id}
         AND status = 'running'::"QueueItemStatus"
         AND attempts = ${attempts}
-        AND lane = 'batch'::"QueueLane"
     ), merged AS (
       UPDATE "NotisWakeQueue" p
       SET events = p.events || src.events,
@@ -308,7 +336,7 @@ async function mergeIntoPendingBatch(
           "updatedAt" = now()
       FROM src
       WHERE p."subscriptionId" = src."subscriptionId"
-        AND p.lane = 'batch'::"QueueLane"
+        AND p.lane = src.lane
         AND p.status = 'pending'::"QueueItemStatus"
         AND p.id <> src.id
       RETURNING p.id
@@ -341,7 +369,7 @@ export async function deferItem(
     });
   } catch (error) {
     if (!isUniqueViolation(error)) throw error;
-    await mergeIntoPendingBatch(db, id, attempts, runAfter, "deferred into a newer pending batch row");
+    await mergeIntoPendingRow(db, id, attempts, runAfter, "deferred into a newer pending row");
   }
 }
 
@@ -394,7 +422,7 @@ export async function failItem(
     // the retry they were owed.
     const src = await db.notisWakeQueue.findUnique({ where: { id }, select: { runAfter: true } });
     if (!src) return;
-    await mergeIntoPendingBatch(
+    await mergeIntoPendingRow(
       db,
       id,
       attempts,

--- a/services/notis/src/lib/queue.ts
+++ b/services/notis/src/lib/queue.ts
@@ -198,9 +198,55 @@ async function runOneWake(
     decisions,
   };
 
+  // Incremental delivery, reactive wakes only: someone is waiting and no
+  // rail applies to a reply, so each send goes out the moment the model
+  // writes it. The row is created wakeId-less here and adopted by the wake
+  // row at persistence; a row the send left pending is the sweeper's to
+  // finish. The batch lane (and every deliver-less caller: playground,
+  // dry-run, fixtures) keeps batch delivery at the boundary.
+  const incrementalIds: string[] = [];
+  const wakeDeps: Deps = reactive
+    ? {
+        ...deps,
+        deliver: async (text: string) => {
+          const message = await db.notisMessage.create({
+            data: {
+              subscriptionId: sub.id,
+              direction: "outbound",
+              body: text,
+              channel: "whatsapp",
+              proactive: capCountable,
+              deliveryMode: "freeform",
+              status: "pending",
+            },
+            select: { id: true },
+          });
+          incrementalIds.push(message.id);
+          try {
+            await deliverPendingMessage(db, bird, message.id, sub, alert);
+          } catch (error) {
+            return {
+              ok: false,
+              detail: error instanceof Error ? error.message : String(error),
+            };
+          }
+          const after = await db.notisMessage.findUnique({
+            where: { id: message.id },
+            select: { status: true, failureReason: true },
+          });
+          return after?.status === "sent"
+            ? { ok: true }
+            : {
+                ok: false,
+                detail: after?.failureReason ?? `status: ${after?.status ?? "unknown"}`,
+              };
+        },
+      }
+    : deps;
+
   // The wall clock, not the events' timestamps: this wake may have waited
   // out quiet hours or a pause since they were recorded.
-  const { outcome, trace } = await runWake(state, ordered, deps, { now: new Date() });
+  const { outcome, trace } = await runWake(state, ordered, wakeDeps, { now: new Date() });
 
   // The primary event picks the shell; the 24h window is judged at the SEND
   // moment, which is now — never at the event's timestamp. A meeting event
@@ -282,22 +328,31 @@ async function runOneWake(
     }
 
     const ids: string[] = [];
-    for (const text of outcome.messages) {
-      const message = await tx.notisMessage.create({
-        data: {
-          subscriptionId: sub.id,
-          wakeId: wake.id,
-          direction: "outbound",
-          body: text,
-          channel: "whatsapp",
-          proactive: capCountable,
-          deliveryMode: delivery?.mode,
-          template: delivery?.mode === "template" ? delivery.template : undefined,
-          status: "pending",
-        },
-        select: { id: true },
+    if (incrementalIds.length > 0) {
+      // The rows already exist (created mid-loop, delivered or left to the
+      // sweeper) — adopt them, so the panel's wakeId alignment holds.
+      await tx.notisMessage.updateMany({
+        where: { id: { in: incrementalIds } },
+        data: { wakeId: wake.id },
       });
-      ids.push(message.id);
+    } else {
+      for (const text of outcome.messages) {
+        const message = await tx.notisMessage.create({
+          data: {
+            subscriptionId: sub.id,
+            wakeId: wake.id,
+            direction: "outbound",
+            body: text,
+            channel: "whatsapp",
+            proactive: capCountable,
+            deliveryMode: delivery?.mode,
+            template: delivery?.mode === "template" ? delivery.template : undefined,
+            status: "pending",
+          },
+          select: { id: true },
+        });
+        ids.push(message.id);
+      }
     }
 
     // The claim fence: if the item was reclaimed while the model ran,
@@ -312,17 +367,39 @@ async function runOneWake(
     // P2028 also does not fire at the deadline — Prisma notices on the next
     // query — so a long lock wait blocks for its full duration, then dies.
     { timeout: PERSIST_TIMEOUT_MS },
-  );
+  ).catch(async (error: unknown) => {
+    // The record rolls back; incremental sends do not. A claim lost after
+    // real deliveries means the reclaimer will run the model again and may
+    // answer again — rare (this wake outlived STALE_CLAIM_MS), and the
+    // re-run's state assembly sees the sent rows, but the operator should
+    // know it happened.
+    if (error instanceof ClaimLostError && incrementalIds.length > 0) {
+      await alert(
+        `wake for ${sub.id} lost its claim after ${incrementalIds.length} incremental ` +
+          "deliveries — the reclaimer may answer again",
+      );
+    }
+    throw error;
+  });
 
   for (const at of unparseableSchedules) {
     await alert(`wake for ${sub.id} scheduled an unparseable instant (${at}) — note dropped`);
+  }
+
+  if (outcome.partialDeliveryError) {
+    await alert(
+      `wake for ${sub.id} finalized after a partial delivery ` +
+        `(${incrementalIds.length} rows): ${outcome.partialDeliveryError}`,
+    );
   }
 
   if (outboundIds.length === 0) return;
 
   if (reactive) {
     // A reply bypasses every rail — it goes out at 03:00 if the reader
-    // texted at 03:00, and decideDelivery guarantees freeform.
+    // texted at 03:00, and decideDelivery guarantees freeform. (With
+    // incremental delivery the sends already happened mid-loop and
+    // outboundIds is empty; this path is the deliver-less fallback.)
     await sendPendingMessages(db, bird, outboundIds, sub, alert);
     return;
   }

--- a/services/notis/src/lib/queue.ts
+++ b/services/notis/src/lib/queue.ts
@@ -25,6 +25,7 @@ import {
   MAX_ATTEMPTS,
   claimNext,
   completeItem,
+  consumePendingLiveEvents,
   deferItem,
   failItem,
   markFailed,
@@ -217,9 +218,19 @@ async function runOneWake(
   // dry-run, fixtures) keeps batch delivery at the boundary.
   const incrementalIds: string[] = [];
   let lastDeliverAt = 0;
+  const absorbEventsSchema = z.array(wakeEventSchema);
   const wakeDeps: Deps = reactive
     ? {
         ...deps,
+        // Mid-run absorption: messages that arrive while this wake runs are
+        // consumed (their queued wakes closed) and handed to the model, so
+        // the reader's correction supersedes the request it corrected.
+        absorb: async () => {
+          const raw = await consumePendingLiveEvents(db, sub.id);
+          if (raw.length === 0) return [];
+          const parsed = absorbEventsSchema.safeParse(raw);
+          return parsed.success ? parsed.data : [];
+        },
         deliver: async (text: string) => {
           const message = await db.notisMessage.create({
             data: {
@@ -269,7 +280,18 @@ async function runOneWake(
 
   // The wall clock, not the events' timestamps: this wake may have waited
   // out quiet hours or a pause since they were recorded.
-  const { outcome, trace } = await runWake(state, ordered, wakeDeps, { now: new Date() });
+  const { outcome, trace, absorbed } = await runWake(state, ordered, wakeDeps, {
+    now: new Date(),
+  });
+
+  // Absorbed reader messages belong to THIS wake now — their queue rows are
+  // consumed, so this record is the only place they can appear.
+  const finalEvents =
+    absorbed.length > 0
+      ? [...ordered, ...absorbed].sort((a, b) => a.at.localeCompare(b.at))
+      : ordered;
+  const finalPrimary = absorbed.length > 0 ? primaryEvent(finalEvents) : primary;
+  const finalLastAt = finalEvents[finalEvents.length - 1].at;
 
   // The primary event picks the shell; the 24h window is judged at the SEND
   // moment, which is now — never at the event's timestamp. A meeting event
@@ -320,12 +342,12 @@ async function runOneWake(
     const wake = await tx.notisWake.create({
       data: {
         subscriptionId: sub.id,
-        eventType: primary.type,
-        eventAt: new Date(lastAt),
-        event: primary as unknown as Prisma.InputJsonValue,
+        eventType: finalPrimary.type,
+        eventAt: new Date(finalLastAt),
+        event: finalPrimary as unknown as Prisma.InputJsonValue,
         // The full array only when the wake coalesced several events.
         events:
-          ordered.length > 1 ? (ordered as unknown as Prisma.InputJsonValue) : undefined,
+          finalEvents.length > 1 ? (finalEvents as unknown as Prisma.InputJsonValue) : undefined,
         decision: outcome.decision,
         rationale: outcome.rationale,
         outcome: outcome as unknown as Prisma.InputJsonValue,

--- a/services/notis/src/lib/queue.ts
+++ b/services/notis/src/lib/queue.ts
@@ -27,8 +27,10 @@ import {
   completeItem,
   consumePendingLiveEvents,
   deferItem,
+  enqueueLiveWake,
   failItem,
   markFailed,
+  touchClaim,
 } from "./queue-core";
 import { getProactiveSettings } from "./settings";
 
@@ -174,7 +176,10 @@ async function runOneWake(
   });
 
   const lastInbound = await db.notisMessage.findFirst({
-    where: { subscriptionId: sub.id, direction: "inbound" },
+    // WhatsApp only: Meta's 24h customer-service window opens on WhatsApp
+    // inbound alone — an SMS reply must not steer decideDelivery into a
+    // freeform send the platform will reject.
+    where: { subscriptionId: sub.id, direction: "inbound", channel: "whatsapp" },
     orderBy: { createdAt: "desc" },
     select: { createdAt: true },
   });
@@ -218,20 +223,49 @@ async function runOneWake(
   // dry-run, fixtures) keeps batch delivery at the boundary.
   const incrementalIds: string[] = [];
   let lastDeliverAt = 0;
-  const absorbEventsSchema = z.array(wakeEventSchema);
+  // Everything absorb has consumed so far: if the wake later fails BEFORE
+  // any delivery (the retry path), these must be re-enqueued or the
+  // messages die with rows nobody will ever run.
+  const consumedAbsorbed: WakeEvent[] = [];
+  // The heartbeat keeps a long wake's claim fresh so the stale reclaim only
+  // fires for actually-dead workers — wired for BOTH lanes.
+  const heartbeat = () => touchClaim(db, item.id, item.attempts);
   const wakeDeps: Deps = reactive
     ? {
         ...deps,
+        heartbeat,
         // Mid-run absorption: messages that arrive while this wake runs are
         // consumed (their queued wakes closed) and handed to the model, so
         // the reader's correction supersedes the request it corrected.
         absorb: async () => {
           const raw = await consumePendingLiveEvents(db, sub.id);
           if (raw.length === 0) return [];
-          const parsed = absorbEventsSchema.safeParse(raw);
-          return parsed.success ? parsed.data : [];
+          // Per element, not wholesale: one malformed row must not discard
+          // its well-formed siblings after they were already consumed.
+          const events: WakeEvent[] = [];
+          for (const candidate of raw) {
+            const parsed = wakeEventSchema.safeParse(candidate);
+            if (parsed.success) events.push(parsed.data);
+            else await alert(`absorb dropped an unparseable event for ${sub.id}`);
+          }
+          consumedAbsorbed.push(...events);
+          return events;
         },
         deliver: async (text: string) => {
+          // The consent boundary, re-read at the send instant: a ΣΤΟΠ that
+          // arrived after this wake started must stop its sends too — it is
+          // never enqueued, so absorb cannot surface it.
+          const freshSub = await db.notisSubscription.findUnique({
+            where: { id: sub.id },
+            select: { status: true },
+          });
+          if (freshSub?.status === "unsubscribed") {
+            return {
+              ok: false,
+              detail:
+                "the reader unsubscribed — send nothing further and finish the wake silently",
+            };
+          }
           const message = await db.notisMessage.create({
             data: {
               subscriptionId: sub.id,
@@ -268,21 +302,43 @@ async function runOneWake(
             where: { id: message.id },
             select: { status: true, failureReason: true },
           });
-          return after?.status === "sent"
-            ? { ok: true }
-            : {
-                ok: false,
-                detail: after?.failureReason ?? `status: ${after?.status ?? "unknown"}`,
-              };
+          // delivered/read can land between applySendResult and this read
+          // (Bird's status webhook) — they are success, not failure.
+          if (after && ["sent", "delivered", "read"].includes(after.status ?? "")) {
+            return { ok: true };
+          }
+          if (after?.status === "suppressed") {
+            return {
+              ok: false,
+              detail:
+                "suppressed: the reader unsubscribed — send nothing further and " +
+                "finish the wake silently",
+            };
+          }
+          return {
+            ok: false,
+            detail: after?.failureReason ?? `status: ${after?.status ?? "unknown"}`,
+          };
         },
       }
-    : deps;
+    : { ...deps, heartbeat };
 
   // The wall clock, not the events' timestamps: this wake may have waited
   // out quiet hours or a pause since they were recorded.
-  const { outcome, trace, absorbed } = await runWake(state, ordered, wakeDeps, {
-    now: new Date(),
-  });
+  let runResult: Awaited<ReturnType<typeof runWake>>;
+  try {
+    runResult = await runWake(state, ordered, wakeDeps, { now: new Date() });
+  } catch (error) {
+    // A pre-delivery failure retries the item — but absorb has already
+    // consumed the newer messages' own rows. Re-enqueue them (the CAS
+    // append merges into any newer pending row) so nothing the reader sent
+    // dies with a retryable error.
+    for (const event of consumedAbsorbed) {
+      await enqueueLiveWake(db, { subscriptionId: sub.id, event });
+    }
+    throw error;
+  }
+  const { outcome, trace, absorbed } = runResult;
 
   // Absorbed reader messages belong to THIS wake now — their queue rows are
   // consumed, so this record is the only place they can appear.
@@ -305,7 +361,7 @@ async function runOneWake(
       : undefined;
 
   const unparseableSchedules: string[] = [];
-  const outboundIds = await db.$transaction(
+  const persistOnce = () => db.$transaction(
     async (tx) => {
     // updatedAt is always touched: it is the conversation list's activity
     // sort key. (The update also serializes concurrent writers of this
@@ -316,27 +372,18 @@ async function runOneWake(
     // fires only on a user_message wake, so this is the user doing it.
     if (outcome.unsubscribe && sub.status !== "unsubscribed") {
       subData.status = "unsubscribed";
-      subData.unsubscribedAt = new Date(lastAt);
+      // finalLastAt, not lastAt: an unsubscribe honored from an ABSORBED
+      // message must not be dated before the request itself.
+      subData.unsubscribedAt = new Date(finalLastAt);
     }
     await tx.notisSubscription.update({ where: { id: sub.id }, data: subData });
 
-    // Nothing queued may outlive an unsubscribe: a pending row the sweeper
-    // would retry later (a transiently-failed send, held news) must die with
-    // the subscription — the rail predicate at delivery does not cover
-    // freeform reply rows. This wake's OWN rows are exempt: the goodbye the
-    // agent sends alongside unsubscribe_user must still go out (incremental
-    // rows already exist, so they are excluded by id; batch rows are created
-    // after this statement).
+    // Nothing queued may outlive an unsubscribe. This wake's OWN rows are
+    // exempt: the goodbye the agent sends alongside unsubscribe_user must
+    // still go out (incremental rows already exist, so they are excluded by
+    // id; batch rows are created after this statement).
     if (outcome.unsubscribe) {
-      await tx.notisMessage.updateMany({
-        where: {
-          subscriptionId: sub.id,
-          direction: "outbound",
-          status: "pending",
-          ...(incrementalIds.length > 0 ? { id: { notIn: incrementalIds } } : {}),
-        },
-        data: { status: "suppressed", failureReason: "unsubscribed" },
-      });
+      await suppressPendingOutbound(tx, sub.id, incrementalIds);
     }
 
     const wake = await tx.notisWake.create({
@@ -432,20 +479,47 @@ async function runOneWake(
     // P2028 also does not fire at the deadline — Prisma notices on the next
     // query — so a long lock wait blocks for its full duration, then dies.
     { timeout: PERSIST_TIMEOUT_MS },
-  ).catch(async (error: unknown) => {
-    // The record rolls back; incremental sends do not. A claim lost after
-    // real deliveries means the reclaimer will run the model again and may
-    // answer again — rare (this wake outlived STALE_CLAIM_MS), and the
-    // re-run's state assembly sees the sent rows, but the operator should
-    // know it happened.
-    if (error instanceof ClaimLostError && incrementalIds.length > 0) {
-      await alert(
-        `wake for ${sub.id} lost its claim after ${incrementalIds.length} incremental ` +
-          "deliveries — the reclaimer may answer again",
-      );
+  );
+
+  // The record can roll back; incremental sends cannot. After real
+  // deliveries a plain rethrow would retry the ITEM — re-running the model
+  // and re-delivering with fresh idempotency keys — so the persist step
+  // fails FORWARD like the loop does: one retry, then close the item with
+  // the loudest alert we have. Losing the record is bad; answering twice
+  // is worse.
+  let outboundIds: string[];
+  try {
+    outboundIds = await persistOnce();
+  } catch (error) {
+    if (error instanceof ClaimLostError) {
+      if (incrementalIds.length > 0) {
+        await alert(
+          `wake for ${sub.id} lost its claim after ${incrementalIds.length} incremental ` +
+            "deliveries — the reclaimer may answer again",
+        );
+      }
+      throw error;
     }
-    throw error;
-  });
+    if (incrementalIds.length === 0) throw error;
+    try {
+      outboundIds = await persistOnce();
+    } catch (secondError) {
+      if (secondError instanceof ClaimLostError) throw secondError;
+      const detail = secondError instanceof Error ? secondError.message : String(secondError);
+      await alert(
+        `wake for ${sub.id} DELIVERED ${incrementalIds.length} message(s) but its record ` +
+          `failed to persist twice (${detail}) — closing the item so the model does not ` +
+          "re-run; this wake has no record",
+      );
+      await markFailed(
+        db,
+        item.id,
+        item.attempts,
+        `delivered but persist failed: ${detail}`.slice(0, 300),
+      );
+      return;
+    }
+  }
 
   for (const at of unparseableSchedules) {
     await alert(`wake for ${sub.id} scheduled an unparseable instant (${at}) — note dropped`);
@@ -529,6 +603,28 @@ export const SUPPRESSION_REASONS = {
 } as const;
 
 export type SuppressionReason = keyof typeof SUPPRESSION_REASONS;
+
+/**
+ * Kill every pending outbound row of a subscription — the unsubscribe
+ * cleanup, shared by ALL status→unsubscribed sites (bare ΣΤΟΠ, the agent's
+ * unsubscribe_user, the poller's phone-gone). exceptIds spares the goodbye
+ * the unsubscribing wake itself sends.
+ */
+export async function suppressPendingOutbound(
+  db: PrismaClient | Prisma.TransactionClient,
+  subscriptionId: string,
+  exceptIds: string[] = [],
+): Promise<void> {
+  await db.notisMessage.updateMany({
+    where: {
+      subscriptionId,
+      direction: "outbound",
+      status: "pending",
+      ...(exceptIds.length > 0 ? { id: { notIn: exceptIds } } : {}),
+    },
+    data: { status: "suppressed", failureReason: "unsubscribed" satisfies SuppressionReason },
+  });
+}
 
 export async function suppressMessages(
   db: PrismaClient,
@@ -692,7 +788,9 @@ export async function deliverPendingMessage(
   const message = await db.notisMessage.findUnique({ where: { id: messageId } });
   if (!message || message.status !== "pending") return;
 
-  if (message.railed) {
+  // The union keeps the deploy window safe: rows written by OLD code after
+  // the backfill carry railed=false but still say proactive/template.
+  if (message.railed || message.proactive || message.deliveryMode === "template") {
     const blocked = await proactiveBlockReason(db, sub.id);
     if (blocked) {
       await suppressMessages(db, [messageId], blocked);
@@ -844,16 +942,16 @@ export async function sendProactiveMessages(
 /** Close a wake the weekly cap makes pointless, before any model spend. The
  *  events are consumed — a slot opens only as the week rolls, by which time
  *  this news is old — so a model-less wake row records what went unexamined. */
-async function skipCappedWake(
+/** Close an item without a model run, leaving a model-less wake row so the
+ *  decision log shows what went unexamined and why. */
+async function completeModelLessWake(
   db: PrismaClient,
   item: ClaimedItem,
   events: WakeEvent[],
+  rationale: string,
 ): Promise<void> {
   const ordered = [...events].sort((a, b) => a.at.localeCompare(b.at));
   const primary = primaryEvent(ordered);
-  const what =
-    ordered.length === 1 ? "Μία ενημέρωση δεν εξετάστηκε" : `${ordered.length} ενημερώσεις δεν εξετάστηκαν`;
-  const rationale = `(σύστημα) ${what} — ο χρήστης έχει ήδη ${WEEKLY_CAP} αυθόρμητα μηνύματα αυτή την εβδομάδα.`;
   await db.$transaction(async (tx) => {
     const owned = await completeItem(tx, item.id, item.attempts);
     if (!owned) throw new ClaimLostError(item.id);
@@ -881,6 +979,39 @@ async function skipCappedWake(
       },
     });
   });
+}
+
+async function skipCappedWake(
+  db: PrismaClient,
+  item: ClaimedItem,
+  events: WakeEvent[],
+): Promise<void> {
+  const what =
+    events.length === 1
+      ? "Μία ενημέρωση δεν εξετάστηκε"
+      : `${events.length} ενημερώσεις δεν εξετάστηκαν`;
+  await completeModelLessWake(
+    db,
+    item,
+    events,
+    `(σύστημα) ${what} — ο χρήστης έχει ήδη ${WEEKLY_CAP} αυθόρμητα μηνύματα αυτή την εβδομάδα.`,
+  );
+}
+
+/** A queued non-reactive wake for an unsubscribed reader must not burn a
+ *  model run whose every send the boundary would suppress anyway — and
+ *  must not write a post-unsubscribe «send» decision into the log. */
+async function skipUnsubscribedWake(
+  db: PrismaClient,
+  item: ClaimedItem,
+  events: WakeEvent[],
+): Promise<void> {
+  await completeModelLessWake(
+    db,
+    item,
+    events,
+    "(σύστημα) Ο αναγνώστης απεγγράφηκε πριν τρέξει το wake — καταναλώθηκε χωρίς μοντέλο.",
+  );
 }
 
 export async function processItem(item: ClaimedItem, overrides: DrainDeps = {}): Promise<void> {
@@ -925,6 +1056,13 @@ export async function processItem(item: ClaimedItem, overrides: DrainDeps = {}):
     const sub = await db.notisSubscription.findUnique({ where: { id: item.subscriptionId } });
     if (!sub) {
       await markFailed(db, item.id, item.attempts, "subscription no longer exists");
+      return;
+    }
+    // Reactive wakes still run for unsubscribed readers by design (a direct
+    // message deserves an answer); queued NON-reactive work died with the
+    // subscription — consume it without paying for a model run.
+    if (sub.status === "unsubscribed" && !isReactiveWake(events)) {
+      await skipUnsubscribedWake(db, item, events);
       return;
     }
     await runOneWake(db, item, sub, events, overrides);
@@ -1047,6 +1185,9 @@ export async function resendStalePendingMessages(overrides: DrainDeps = {}): Pro
       // that claim goes stale.
       OR: [{ sendingAt: null }, { sendingAt: { lt: staleClaimBefore } }],
     },
+    // Original order: unordered re-sends can reproduce the same-second
+    // handset inversion SEND_SPACING_MS exists to prevent.
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
     select: {
       id: true,
       body: true,

--- a/services/notis/src/lib/queue.ts
+++ b/services/notis/src/lib/queue.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import { decideDelivery } from "@/agent/delivery";
 import { runWake } from "@/agent/runWake";
-import { primaryEvent, wakeEventSchema } from "@/agent/schemas";
-import type { TemplateName } from "@/agent/templates";
+import { primaryEvent, wakeEventSchema, wakeEventsSchema } from "@/agent/schemas";
+import { renderTemplate, type TemplateName } from "@/agent/templates";
 import {
   CityPreference,
   CONVERSATION_WINDOW,
@@ -11,7 +11,7 @@ import {
   DecisionEntry,
   WakeEvent,
 } from "@/agent/types";
-import type { NotisSubscription, Prisma, PrismaClient } from "../../generated/client";
+import type { NotisMessage, NotisSubscription, Prisma, PrismaClient } from "../../generated/client";
 import { clampToActiveHours, isQuietHour } from "./active-hours";
 import { alert as sendAlert } from "./alert";
 import { BirdLike, SEND_TIMEOUT_MS, realBird } from "./bird";
@@ -82,6 +82,24 @@ export const SEND_SPACING_MS = 1_000;
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+/**
+ * Keyed send pacing: one implementation for every send path. `pace(key)`
+ * waits out the remainder of SEND_SPACING_MS since the key's previous send
+ * — the first send per key never waits, and different keys (readers) never
+ * delay each other, which is what the sweeper needs.
+ */
+export function makeSendPacer(gapMs: number = SEND_SPACING_MS) {
+  const lastByKey = new Map<string, number>();
+  return async (key: string): Promise<void> => {
+    const last = lastByKey.get(key);
+    if (last !== undefined) {
+      const wait = gapMs - (Date.now() - last);
+      if (wait > 0) await sleep(wait);
+    }
+    lastByKey.set(key, Date.now());
+  };
+}
+
 /** The persist transaction's budget. It holds the subscription's row lock —
  *  the same lock every inbound webhook for that reader waits on — so it needs
  *  room for contention, not just for its own writes. */
@@ -91,7 +109,7 @@ const PERSIST_TIMEOUT_MS = 30_000;
 // every minute, so leftovers are picked up immediately.
 const MAX_ITEMS_PER_DRAIN = 50;
 
-const eventsSchema = z.array(wakeEventSchema).min(1);
+const eventsSchema = wakeEventsSchema.min(1);
 
 /** How long a paused item sleeps before the claim looks at it again. */
 export const PAUSE_DEFER_MS = 15 * 60_000;
@@ -222,7 +240,7 @@ async function runOneWake(
   // finish. The batch lane (and every deliver-less caller: playground,
   // dry-run, fixtures) keeps batch delivery at the boundary.
   const incrementalIds: string[] = [];
-  let lastDeliverAt = 0;
+  const pace = makeSendPacer();
   // Everything absorb has consumed so far: if the wake later fails BEFORE
   // any delivery (the retry path), these must be re-enqueued or the
   // messages die with rows nobody will ever run.
@@ -285,29 +303,23 @@ async function runOneWake(
           // Same-turn tool calls arrive back-to-back; without a gap Bird
           // accepts them in the same second and the handset may show them
           // inverted. Cross-turn gaps already exceed the spacing.
-          const sinceLast = Date.now() - lastDeliverAt;
-          if (lastDeliverAt > 0 && sinceLast < SEND_SPACING_MS) {
-            await sleep(SEND_SPACING_MS - sinceLast);
-          }
-          lastDeliverAt = Date.now();
+          await pace(sub.id);
+          let outcome: SendOutcome | undefined;
           try {
-            await deliverPendingMessage(db, bird, message.id, sub, alert);
+            outcome = await deliverPendingMessage(db, bird, message.id, sub, alert);
           } catch (error) {
             return {
               ok: false,
               detail: error instanceof Error ? error.message : String(error),
             };
           }
-          const after = await db.notisMessage.findUnique({
-            where: { id: message.id },
-            select: { status: true, failureReason: true },
-          });
-          // delivered/read can land between applySendResult and this read
-          // (Bird's status webhook) — they are success, not failure.
-          if (after && ["sent", "delivered", "read"].includes(after.status ?? "")) {
-            return { ok: true };
+          if (outcome?.status === "sent") return { ok: true };
+          if (outcome?.status === "failed" && outcome.smsFallback === "sent") {
+            // The conversation continued on its second leg — tell the model
+            // which channel carried it.
+            return { ok: true, detail: "delivered over SMS (WhatsApp failed)" };
           }
-          if (after?.status === "suppressed") {
+          if (outcome?.status === "suppressed") {
             return {
               ok: false,
               detail:
@@ -315,9 +327,15 @@ async function runOneWake(
                 "finish the wake silently",
             };
           }
+          if (outcome?.status === "pending") {
+            return {
+              ok: false,
+              detail: "transient delivery failure — the sweeper retries it shortly",
+            };
+          }
           return {
             ok: false,
-            detail: after?.failureReason ?? `status: ${after?.status ?? "unknown"}`,
+            detail: outcome?.failureReason ?? `status: ${outcome?.status ?? "unknown"}`,
           };
         },
       }
@@ -546,15 +564,23 @@ async function runOneWake(
   await sendProactiveMessages(db, bird, outboundIds, sub, alert);
 }
 
+/** The outcome a send path reports upward — what the row now says, plus
+ *  what the SMS fallback did when WhatsApp failed terminally. */
+export interface SendOutcome {
+  status: "sent" | "pending" | "failed" | "suppressed";
+  failureReason?: string | null;
+  smsFallback?: "sent" | "held" | "failed" | "skipped";
+}
+
 /** Record a Bird send result on the message row: sent, stay-pending
  *  (transient — the sweeper retries under the same idempotency key), or
- *  terminal failed with an alert. */
+ *  terminal failed with an alert. Returns what it wrote. */
 async function applySendResult(
   db: PrismaClient,
   id: string,
   result: { success: boolean; messageId?: string; retryable?: boolean; error?: string },
   alert: (message: string) => Promise<void>,
-): Promise<void> {
+): Promise<SendOutcome> {
   if (result.success) {
     await db.notisMessage.update({
       where: { id },
@@ -569,6 +595,7 @@ async function applySendResult(
         failureReason: null,
       },
     });
+    return { status: "sent" };
   } else if (result.retryable) {
     // Transient (network, 5xx): the row STAYS pending so the sweeper
     // retries it under the same idempotency key once Bird recovers. The
@@ -581,6 +608,7 @@ async function applySendResult(
       },
     });
     console.warn(`[notis:queue] transient Bird failure for message ${id}, will retry:`, result.error);
+    return { status: "pending", failureReason: result.error ?? "unknown error" };
   } else {
     await db.notisMessage.update({
       where: { id },
@@ -591,7 +619,125 @@ async function applySendResult(
       },
     });
     await alert(`Bird send failed for message ${id}: ${result.error ?? "unknown error"}`);
+    return { status: "failed", failureReason: result.error ?? "unknown error" };
   }
+}
+
+/**
+ * One-shot SMS with the outcome recorded on the row. No idempotency key —
+ * the channels API has none — so every caller must guarantee single-fire
+ * (the fallback's unique fallbackForId, the held release's claim fence).
+ */
+export async function sendSmsAndRecord(
+  db: PrismaClient,
+  bird: BirdLike,
+  messageId: string,
+  phone: string,
+  text: string,
+  alert: (message: string) => Promise<void>,
+  context: string,
+): Promise<boolean> {
+  const result = await bird.sendSms({ phone, text });
+  if (result.success) {
+    await db.notisMessage.update({
+      where: { id: messageId },
+      data: { status: "sent", birdMessageId: result.messageId },
+    });
+    return true;
+  }
+  await db.notisMessage.update({
+    where: { id: messageId },
+    data: { status: "failed", failureReason: (result.error ?? "unknown error").slice(0, 300) },
+  });
+  await alert(`${context}: ${result.error ?? "unknown error"}`);
+  return false;
+}
+
+/**
+ * SMS as the conversation's second leg (PRD update): when a WhatsApp send
+ * fails TERMINALLY, the same content goes out once as an SMS — templates in
+ * their rendered shell with the footer, replies as the raw body (SMS has no
+ * formatting, links work as text). The sms row's unique fallbackForId makes
+ * every trigger path replay-proof.
+ *
+ * The rails follow the ROW's class: a railed row's fallback obeys pause and
+ * quiet hours (held to the 09:00 release) and never goes to an unsubscribed
+ * reader; a reply's fallback bypasses pause and quiet like the reply itself
+ * would, and only the unsubscribed check stands — consent outranks
+ * deliverability.
+ */
+export async function maybeSendSmsFallback(
+  db: PrismaClient,
+  bird: BirdLike,
+  failed: Pick<
+    NotisMessage,
+    | "id"
+    | "subscriptionId"
+    | "wakeId"
+    | "channel"
+    | "deliveryMode"
+    | "template"
+    | "proactive"
+    | "railed"
+    | "body"
+  >,
+  alert: (message: string) => Promise<void>,
+): Promise<"sent" | "held" | "failed" | "skipped"> {
+  if (failed.channel !== "whatsapp") return "skipped";
+
+  const sub = await db.notisSubscription.findUnique({ where: { id: failed.subscriptionId } });
+  if (!sub?.phone || sub.status === "unsubscribed") return "skipped";
+
+  if (failed.railed) {
+    const settings = await getProactiveSettings(db);
+    if (settings.paused) return "skipped";
+  }
+
+  const text =
+    failed.deliveryMode === "template" && failed.template
+      ? (() => {
+          const rendered = renderTemplate(failed.template as TemplateName, failed.body);
+          return `${rendered.body}\n\n${rendered.footer}`;
+        })()
+      : failed.body;
+  const held = failed.railed && isQuietHour(new Date());
+
+  let smsId: string;
+  try {
+    const sms = await db.notisMessage.create({
+      data: {
+        subscriptionId: failed.subscriptionId,
+        wakeId: failed.wakeId,
+        direction: "outbound",
+        body: text,
+        channel: "sms",
+        proactive: failed.proactive,
+        railed: failed.railed,
+        fallbackForId: failed.id,
+        status: "pending",
+        ...(held ? { failureReason: SMS_HELD_FOR_QUIET_HOURS } : {}),
+      },
+      select: { id: true },
+    });
+    smsId = sms.id;
+  } catch (error) {
+    if ((error as { code?: string }).code === "P2002") return "skipped"; // replayed trigger
+    throw error;
+  }
+
+  // Held rows leave here pending; the sweeper sends them at the release.
+  if (held) return "held";
+
+  const ok = await sendSmsAndRecord(
+    db,
+    bird,
+    smsId,
+    sub.phone,
+    text,
+    alert,
+    `SMS fallback failed for message ${failed.id}`,
+  );
+  return ok ? "sent" : "failed";
 }
 
 /** The rails' own vocabulary, Greek names included — one closed set shared
@@ -716,23 +862,22 @@ async function sendFreeform(
   message: { id: string; body: string },
   sub: Pick<NotisSubscription, "id" | "birdConversationId">,
   alert: (message: string) => Promise<void>,
-): Promise<void> {
+): Promise<SendOutcome> {
   if (!sub.birdConversationId) {
-    await applySendResult(
+    const outcome = await applySendResult(
       db,
       message.id,
       { success: false, retryable: false, error: "no birdConversationId on subscription" },
       alert,
     );
-    await alert(`subscription ${sub.id} has no birdConversationId — cannot deliver a reply`);
-    return;
+    return outcome;
   }
   const result = await bird.sendText({
     conversationId: sub.birdConversationId,
     text: message.body,
     idempotencyKey: message.id,
   });
-  await applySendResult(db, message.id, result, alert);
+  return applySendResult(db, message.id, result, alert);
 }
 
 /** Send `pending` outbound rows into the subscription's conversation. Also
@@ -748,14 +893,18 @@ export async function sendPendingMessages(
   sub: Pick<NotisSubscription, "id" | "birdConversationId">,
   alert: (message: string) => Promise<void>,
 ): Promise<void> {
-  let sentAny = false;
+  const pace = makeSendPacer();
   for (const id of messageIds) {
     const message = await db.notisMessage.findUnique({ where: { id } });
     if (!message || message.status !== "pending") continue;
-    if (sentAny) await sleep(SEND_SPACING_MS);
+    await pace(sub.id);
     if (!(await claimForSend(db, id))) continue;
-    await sendFreeform(db, bird, message, sub, alert);
-    sentAny = true;
+    const outcome = await sendFreeform(db, bird, message, sub, alert);
+    // The conversation's second leg applies to the deterministic replies
+    // too (the ΣΤΟΠ confirmation rides this path).
+    if (outcome.status === "failed" && message.channel === "whatsapp") {
+      await maybeSendSmsFallback(db, bird, message, alert);
+    }
   }
 }
 
@@ -784,9 +933,18 @@ export async function deliverPendingMessage(
   messageId: string,
   sub: Pick<NotisSubscription, "id" | "phone" | "userName" | "birdConversationId">,
   alert: (message: string) => Promise<void>,
-): Promise<void> {
+): Promise<SendOutcome | undefined> {
   const message = await db.notisMessage.findUnique({ where: { id: messageId } });
-  if (!message || message.status !== "pending") return;
+  if (!message || message.status !== "pending") return undefined;
+
+  // Terminal WhatsApp failures fall through to SMS here, in ONE place, so
+  // every trigger path (boundary, sweeper, incremental closure) gets the
+  // conversation's second leg for free.
+  const finish = async (outcome: SendOutcome): Promise<SendOutcome> => {
+    if (outcome.status !== "failed" || message.channel !== "whatsapp") return outcome;
+    const smsFallback = await maybeSendSmsFallback(db, bird, message, alert);
+    return { ...outcome, smsFallback };
+  };
 
   // The union keeps the deploy window safe: rows written by OLD code after
   // the backfill carry railed=false but still say proactive/template.
@@ -794,28 +952,28 @@ export async function deliverPendingMessage(
     const blocked = await proactiveBlockReason(db, sub.id);
     if (blocked) {
       await suppressMessages(db, [messageId], blocked);
-      return;
+      return { status: "suppressed", failureReason: blocked };
     }
   }
 
-  if (!(await claimForSend(db, messageId))) return;
+  if (!(await claimForSend(db, messageId))) return undefined;
 
   if (message.deliveryMode !== "template") {
-    await sendFreeform(db, bird, message, sub, alert);
-    return;
+    return finish(await sendFreeform(db, bird, message, sub, alert));
   }
 
   const template = message.template as TemplateName;
   // Every template send names its recipient, so a row without a phone is a
   // failure on both paths, not just the cold one.
   if (!sub.phone) {
-    await applySendResult(
-      db,
-      messageId,
-      { success: false, retryable: false, error: "no phone on subscription for a template send" },
-      alert,
+    return finish(
+      await applySendResult(
+        db,
+        messageId,
+        { success: false, retryable: false, error: "no phone on subscription for a template send" },
+        alert,
+      ),
     );
-    return;
   }
 
   if (sub.birdConversationId) {
@@ -826,8 +984,7 @@ export async function deliverPendingMessage(
       text: message.body,
       idempotencyKey: message.id,
     });
-    await applySendResult(db, messageId, result, alert);
-    return;
+    return finish(await applySendResult(db, messageId, result, alert));
   }
   const created = await bird.createConversationWithTemplate({
     phone: sub.phone,
@@ -849,8 +1006,7 @@ export async function deliverPendingMessage(
       text: message.body,
       idempotencyKey: message.id,
     });
-    await applySendResult(db, messageId, result, alert);
-    return;
+    return finish(await applySendResult(db, messageId, result, alert));
   }
   if (created.success && created.conversationId) {
     await db.notisSubscription.update({
@@ -866,7 +1022,7 @@ export async function deliverPendingMessage(
       `cold send ${messageId} got no Bird message id — delivery status for it cannot be tracked`,
     );
   }
-  await applySendResult(db, messageId, created, alert);
+  return finish(await applySendResult(db, messageId, created, alert));
 }
 
 /**
@@ -922,7 +1078,7 @@ export async function sendProactiveMessages(
     remaining = Math.max(0, WEEKLY_CAP - (await capUsage(db, sub.id, messageIds)));
   }
 
-  let sentAny = false;
+  const pace = makeSendPacer();
   for (const id of messageIds) {
     const row = byId.get(id);
     if (!row) continue;
@@ -933,9 +1089,8 @@ export async function sendProactiveMessages(
       }
       remaining--;
     }
-    if (sentAny) await sleep(SEND_SPACING_MS);
+    await pace(sub.id);
     await deliverPendingMessage(db, bird, id, sub, alert);
-    sentAny = true;
   }
 }
 
@@ -1145,19 +1300,15 @@ async function releaseHeldSms(
   });
   if (claimed.count !== 1) return;
 
-  const result = await bird.sendSms({ phone: sub.phone, text: message.body });
-  if (result.success) {
-    await db.notisMessage.update({
-      where: { id: message.id },
-      data: { status: "sent", birdMessageId: result.messageId },
-    });
-    return;
-  }
-  await db.notisMessage.update({
-    where: { id: message.id },
-    data: { status: "failed", failureReason: (result.error ?? "unknown error").slice(0, 300) },
-  });
-  await alert(`held SMS ${message.id} failed on release: ${result.error ?? "unknown error"}`);
+  await sendSmsAndRecord(
+    db,
+    bird,
+    message.id,
+    sub.phone,
+    message.body,
+    alert,
+    `held SMS ${message.id} failed on release`,
+  );
 }
 
 /**
@@ -1194,12 +1345,19 @@ export async function resendStalePendingMessages(overrides: DrainDeps = {}): Pro
       createdAt: true,
       channel: true,
       failureReason: true,
+      subscriptionId: true,
+      wakeId: true,
+      deliveryMode: true,
+      template: true,
+      proactive: true,
+      railed: true,
       subscription: {
         select: { id: true, phone: true, userName: true, birdConversationId: true },
       },
     },
     take: 50,
   });
+  const pace = makeSendPacer();
 
   const giveUpBefore = now - RESEND_GIVE_UP_MS;
   for (const message of stale) {
@@ -1217,6 +1375,11 @@ export async function resendStalePendingMessages(overrides: DrainDeps = {}): Pro
       });
       if (gaveUp.count !== 1) continue;
       await alert(`message ${message.id}: undeliverable for over an hour — giving up`);
+      // Give-up is a terminal WhatsApp failure like any other: the content
+      // still deserves its second leg.
+      if (message.channel === "whatsapp") {
+        await maybeSendSmsFallback(db, bird, message, alert);
+      }
       continue;
     }
     // SMS rows are never re-sent: the channels API has no idempotency key,
@@ -1234,6 +1397,7 @@ export async function resendStalePendingMessages(overrides: DrainDeps = {}): Pro
     // Bird never gets two simultaneous requests for one row under its
     // idempotency key. The stale filter above only avoids picking a row whose
     // claim is still fresh; the claim inside is the authoritative fence.
+    await pace(message.subscriptionId);
     await deliverPendingMessage(db, bird, message.id, message.subscription, alert);
   }
   return stale.length;

--- a/services/notis/src/lib/queue.ts
+++ b/services/notis/src/lib/queue.ts
@@ -68,6 +68,17 @@ export const RESEND_STALE_AFTER_MS = 2 * 60_000;
  *  twice under its idempotency key while a slow send is still in flight. */
 const SEND_CLAIM_TTL_MS = 2 * SEND_TIMEOUT_MS + 30_000;
 
+/**
+ * Gap between consecutive sends of one batch. Bird accepts same-second
+ * messages in order but WhatsApp shows no sub-minute ordering, and
+ * same-second deliveries have been observed inverted on the handset — the
+ * gap keeps each message's timestamp (and delivery) behind the previous
+ * one's. Applied between sends, never before the first.
+ */
+export const SEND_SPACING_MS = 1_000;
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
 /** The persist transaction's budget. It holds the subscription's row lock —
  *  the same lock every inbound webhook for that reader waits on — so it needs
  *  room for contention, not just for its own writes. */
@@ -205,6 +216,7 @@ async function runOneWake(
   // finish. The batch lane (and every deliver-less caller: playground,
   // dry-run, fixtures) keeps batch delivery at the boundary.
   const incrementalIds: string[] = [];
+  let lastDeliverAt = 0;
   const wakeDeps: Deps = reactive
     ? {
         ...deps,
@@ -216,12 +228,23 @@ async function runOneWake(
               body: text,
               channel: "whatsapp",
               proactive: capCountable,
+              // Reactive by construction: the closure exists only on
+              // reactive wakes, and a reply is never railed.
+              railed: false,
               deliveryMode: "freeform",
               status: "pending",
             },
             select: { id: true },
           });
           incrementalIds.push(message.id);
+          // Same-turn tool calls arrive back-to-back; without a gap Bird
+          // accepts them in the same second and the handset may show them
+          // inverted. Cross-turn gaps already exceed the spacing.
+          const sinceLast = Date.now() - lastDeliverAt;
+          if (lastDeliverAt > 0 && sinceLast < SEND_SPACING_MS) {
+            await sleep(SEND_SPACING_MS - sinceLast);
+          }
+          lastDeliverAt = Date.now();
           try {
             await deliverPendingMessage(db, bird, message.id, sub, alert);
           } catch (error) {
@@ -364,6 +387,7 @@ async function runOneWake(
             body: text,
             channel: "whatsapp",
             proactive: capCountable,
+            railed: !reactive,
             deliveryMode: delivery?.mode,
             template: delivery?.mode === "template" ? delivery.template : undefined,
             status: "pending",
@@ -606,11 +630,14 @@ export async function sendPendingMessages(
   sub: Pick<NotisSubscription, "id" | "birdConversationId">,
   alert: (message: string) => Promise<void>,
 ): Promise<void> {
+  let sentAny = false;
   for (const id of messageIds) {
     const message = await db.notisMessage.findUnique({ where: { id } });
     if (!message || message.status !== "pending") continue;
+    if (sentAny) await sleep(SEND_SPACING_MS);
     if (!(await claimForSend(db, id))) continue;
     await sendFreeform(db, bird, message, sub, alert);
+    sentAny = true;
   }
 }
 
@@ -643,7 +670,7 @@ export async function deliverPendingMessage(
   const message = await db.notisMessage.findUnique({ where: { id: messageId } });
   if (!message || message.status !== "pending") return;
 
-  if (message.proactive || message.deliveryMode === "template") {
+  if (message.railed) {
     const blocked = await proactiveBlockReason(db, sub.id);
     if (blocked) {
       await suppressMessages(db, [messageId], blocked);
@@ -775,6 +802,7 @@ export async function sendProactiveMessages(
     remaining = Math.max(0, WEEKLY_CAP - (await capUsage(db, sub.id, messageIds)));
   }
 
+  let sentAny = false;
   for (const id of messageIds) {
     const row = byId.get(id);
     if (!row) continue;
@@ -785,7 +813,9 @@ export async function sendProactiveMessages(
       }
       remaining--;
     }
+    if (sentAny) await sleep(SEND_SPACING_MS);
     await deliverPendingMessage(db, bird, id, sub, alert);
+    sentAny = true;
   }
 }
 

--- a/services/notis/src/lib/queue.ts
+++ b/services/notis/src/lib/queue.ts
@@ -275,6 +275,25 @@ async function runOneWake(
     }
     await tx.notisSubscription.update({ where: { id: sub.id }, data: subData });
 
+    // Nothing queued may outlive an unsubscribe: a pending row the sweeper
+    // would retry later (a transiently-failed send, held news) must die with
+    // the subscription — the rail predicate at delivery does not cover
+    // freeform reply rows. This wake's OWN rows are exempt: the goodbye the
+    // agent sends alongside unsubscribe_user must still go out (incremental
+    // rows already exist, so they are excluded by id; batch rows are created
+    // after this statement).
+    if (outcome.unsubscribe) {
+      await tx.notisMessage.updateMany({
+        where: {
+          subscriptionId: sub.id,
+          direction: "outbound",
+          status: "pending",
+          ...(incrementalIds.length > 0 ? { id: { notIn: incrementalIds } } : {}),
+        },
+        data: { status: "suppressed", failureReason: "unsubscribed" },
+      });
+    }
+
     const wake = await tx.notisWake.create({
       data: {
         subscriptionId: sub.id,

--- a/tests/integration/notis-queue.test.ts
+++ b/tests/integration/notis-queue.test.ts
@@ -10,6 +10,7 @@ import {
     STALE_CLAIM_MS,
     claimNext,
     completeItem,
+    consumePendingLiveEvents,
     deferItem,
     enqueueBatchWake,
     enqueueLiveWake,
@@ -122,10 +123,12 @@ describe('notis wake queue (live lane)', () => {
     test('one running wake per subscription: the second item waits for the first', async () => {
         const sub = await createSubscription('s3')
         await enqueueLiveWake(notisDb, { subscriptionId: sub, event: EVENT })
-        await enqueueLiveWake(notisDb, { subscriptionId: sub, event: { ...EVENT, text: 'δεύτερο' } })
 
         const first = await claimNext(notisDb)
         expect(first).not.toBeNull()
+        // The claim flipped the row to running, so the next message opens a
+        // FRESH pending row (before the claim it would have coalesced).
+        await enqueueLiveWake(notisDb, { subscriptionId: sub, event: { ...EVENT, text: 'δεύτερο' } })
         // Same subscription, first still running → nothing to claim.
         expect(await claimNext(notisDb)).toBeNull()
 
@@ -232,10 +235,11 @@ describe('notis wake queue (live lane)', () => {
     test('the partial unique index allows at most one running row per subscription', async () => {
         const sub = await createSubscription('s9')
         await enqueueLiveWake(notisDb, { subscriptionId: sub, event: EVENT })
-        await enqueueLiveWake(notisDb, { subscriptionId: sub, event: { ...EVENT, text: 'δεύτερο' } })
 
         const first = await claimNext(notisDb)
         expect(first).not.toBeNull()
+        // Enqueued after the claim: a fresh pending row beside the running one.
+        await enqueueLiveWake(notisDb, { subscriptionId: sub, event: { ...EVENT, text: 'δεύτερο' } })
 
         // Forcing the second row to running — what a raced claim would do —
         // must violate the index; claimNext maps that to nothing-claimable.
@@ -459,5 +463,66 @@ describe('notis wake queue (live lane)', () => {
         await deferItem(notisDb, claimed!.id, claimed!.attempts, new Date())
         const after = await notisDb.notisWakeQueue.findUnique({ where: { id: claimed!.id } })
         expect(after?.runAfter.getTime()).toBe(runAfter.getTime())
+    })
+})
+
+describe('live-lane coalescing and absorption', () => {
+    const msg = (text: string, at: string) => ({ type: 'user_message', at, text })
+
+    it('appends a second message to the pending live row, then consumes it atomically', async () => {
+        const sub = await createSubscription('coal1')
+        const firstId = await enqueueLiveWake(notisDb, {
+            subscriptionId: sub,
+            event: msg('Τι γίνεται με το μετρό στα Εξάρχεια;', '2026-03-10T10:00:00.000Z'),
+        })
+        const secondId = await enqueueLiveWake(notisDb, {
+            subscriptionId: sub,
+            event: msg('Σόρρυ άκυρο — στην Κυψέλη εννοούσα', '2026-03-10T10:00:20.000Z'),
+        })
+        // ONE row holding both messages, in arrival order.
+        expect(secondId).toBe(firstId)
+        const row = await notisDb.notisWakeQueue.findUnique({ where: { id: firstId } })
+        expect((row!.events as Array<{ text: string }>).map((e) => e.text)).toEqual([
+            'Τι γίνεται με το μετρό στα Εξάρχεια;',
+            'Σόρρυ άκυρο — στην Κυψέλη εννοούσα',
+        ])
+
+        // The partial unique index refuses a second pending live row outright.
+        await expect(
+            notisDb.notisWakeQueue.create({
+                data: { subscriptionId: sub, lane: 'live', events: [], runAfter: new Date() },
+            }),
+        ).rejects.toMatchObject({ code: 'P2002' })
+
+        // Consume: events come back, the row closes, a re-consume is empty.
+        const consumed = await consumePendingLiveEvents(notisDb, sub)
+        expect((consumed as Array<{ text: string }>).map((e) => e.text)).toEqual([
+            'Τι γίνεται με το μετρό στα Εξάρχεια;',
+            'Σόρρυ άκυρο — στην Κυψέλη εννοούσα',
+        ])
+        const after = await notisDb.notisWakeQueue.findUnique({ where: { id: firstId } })
+        expect(after!.status).toBe('done')
+        expect(await consumePendingLiveEvents(notisDb, sub)).toEqual([])
+    })
+
+    it('a running row is not appended to — the correction becomes a fresh pending row', async () => {
+        const sub = await createSubscription('coal2')
+        const firstId = await enqueueLiveWake(notisDb, {
+            subscriptionId: sub,
+            event: msg('πρώτο', '2026-03-10T10:00:00.000Z'),
+            runAfter: new Date(Date.now() - 1000),
+        })
+        const claimed = await claimNext(notisDb)
+        expect(claimed?.id).toBe(firstId)
+
+        const secondId = await enqueueLiveWake(notisDb, {
+            subscriptionId: sub,
+            event: msg('δεύτερο', '2026-03-10T10:00:20.000Z'),
+        })
+        expect(secondId).not.toBe(firstId)
+        // ...which is exactly what the running wake's absorb then consumes.
+        const consumed = await consumePendingLiveEvents(notisDb, sub)
+        expect((consumed as Array<{ text: string }>).map((e) => e.text)).toEqual(['δεύτερο'])
+        await completeItem(notisDb, claimed!.id, claimed!.attempts)
     })
 })


### PR DESCRIPTION
This PR contains the work of the first production days: fixes from live use, two reviewed feature sets, and the fixes from a max-effort code review.

## Reader-facing behavior

**Incremental delivery.** A reply used to reach the reader only after the whole wake finished: 30–60 seconds of silence, then every message at once. Reactive wakes now deliver each `send_message` the moment the model emits it. The shell injects `deps.deliver` for reactive wakes only. Rows are created wakeId-less mid-loop and adopted by the wake row at persistence. After the first delivery attempt, an error finalizes the wake instead of retrying it — a duplicate answer is worse than a truncated one. The batch lane keeps boundary delivery and all rails.

**A newer message supersedes the one being answered.** Two mechanisms cover the two windows. Before the wake starts: the live lane coalesces per subscription — a second inbound appends to the pending row (compare-and-swap; a new partial unique index enforces one pending live row per reader, and the append gives a fresh message a fresh budget). While the wake runs: mid-run absorption — the loop asks for newer messages at each turn start and before each turn's sends. Absorbed messages are consumed from the queue, injected into the model's conversation, and become part of the wake. Held sends get honest tool acks; a held turn commits nothing (no send, no schedule, no profile write, no unsubscribe) and grants a bonus turn; a turn-start update clears a latched unsubscribe. The model — not the shell — judges whether the new message cancels the old request or adds to it. Nothing is lost on failure: absorbed messages are re-enqueued when a wake fails before any delivery.

**SMS is a conversation channel.** When a WhatsApp send fails terminally, the same content goes out once as SMS: templates in their rendered shell, replies as the raw body. One function serves every trigger path (send boundary, incremental closure, sweeper give-up, delivery-status webhook), replay-proof via the unique `fallbackForId`. A railed row's fallback obeys pause and quiet hours; a reply's fallback bypasses them — only the unsubscribed check stands. Inbound SMS is served for enrolled readers: ΣΤΟΠ works over SMS (with an SMS confirmation), other messages wake the agent, and the answer falls back to SMS when WhatsApp cannot carry it. Nothing enrolls over SMS; unknown phones stay with the main app.

**Consent boundary.** Every unsubscribe path (bare ΣΤΟΠ, the agent tool, the poller's phone-gone) suppresses the reader's pending outbound in its transaction. The deliver closure re-reads the subscription at the send instant, so a ΣΤΟΠ that lands mid-wake stops the remaining sends. Queued non-reactive wakes for unsubscribed readers are consumed without a model run. `unsubscribe_user` is honored only on wakes that carry a reader message.

**Send spacing.** Consecutive sends go out at least one second apart (one keyed pacer for all four send paths). Same-second sends were observed arriving inverted on the handset.

**Prompt.** Links always carry the `https://` prefix (WhatsApp does not reliably make bare domains tappable), and a stated interest is read one notch wider than its words.

## Queue correctness

The claim machinery gained: a per-turn heartbeat so long wakes are not reclaimed mid-run (a lost claim aborts the loop); a lane-agnostic 23505 recovery (the live lane's new index could strand a failing row in `running`); fail-forward on the persist step after real deliveries; and deterministic, paced sweeper re-sends. The 24h window check counts WhatsApp inbound only. The SMS path enforces the same rollback and phone-ownership gates as WhatsApp.

## Admin panel

The thread shows in-flight and failed wakes (queue-backed records with state chips), every reader message of a coalesced or absorbing wake, orphaned deliveries, and reader/outgoing bubbles in one chronological stream. The system page's queue table shows live work only, with a 7-day failures footer; the digested-meetings ledger pages by 20. The overview gets a red cell when wakes failed or wait for a retry, «Τι λένε οι χρήστες» shows each reader once, the chart tooltip resolves repeated hour labels correctly, and suppressed sends have their own label, bar segment, and are excluded from the fail rate. A conversation exports as one JSON file (`?traces=0` for the light version) for offline evaluation. The settings roadmap card is gone.

## Infrastructure

Six indexes across both databases (`User.phone` was seq-scanned on every webhook event). CI runs the testcontainer contract suites, serially. Two notis migrations (`railed` flag with backfill; live-lane dedupe plus unique index) apply on deploy.

## Verification

260 unit tests and 102 integration tests green, plus the production build. A max-effort review (10 finder angles, per-candidate adversarial verification, gap sweep) ran against this branch; 15 of its 16 findings are fixed here and the 16th (SMS replies) became the SMS-channel feature. Regression tests cover the supersede flows, both claim-loss timings, the mid-wake ΣΤΟΠ, the retracted unsubscribe, the absorbed-message restore, and the SMS second leg end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
