### PR TITLE
Cap the integration job's runtime, and run it against Postgres 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
   integration:
     name: Integration (testcontainers)
     runs-on: ubuntu-latest
+    # The suite runs in about two minutes. A container that never becomes
+    # ready would otherwise hold the runner for the six-hour default.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -72,7 +72,7 @@ export async function ensureTestDb(): Promise<{ databaseUrl: string }> {
     const POSTGRES_PASSWORD = 'test'
     const POSTGRES_DB = 'testdb'
 
-    const container = await new GenericContainer('postgis/postgis:15-3.3')
+    const container = await new GenericContainer('postgis/postgis:16-3.5')
         .withEnvironment({
             POSTGRES_USER,
             POSTGRES_PASSWORD,


### PR DESCRIPTION
Two small follow-ups to the integration job #632 added. Both surfaced while reviewing that infrastructure; neither is a defect in it.

## Cap the job's runtime

The job has no `timeout-minutes`, so a container that never becomes ready holds a runner for the six-hour default. The suite completes in about two minutes, so 20 is generous.

## Run against Postgres 16

The suite ran on **Postgres 15** while every other environment is on **16**:

| Environment | Postgres | PostGIS |
|---|---|---|
| Integration tests (before) | **15** | 3.3 |
| Nix dev shell / previews | 16 | 3.3.5 |
| docker-compose | 16 | 3.5 |
| Production | 16 | — |

Tests could pass on a major nothing else runs.

There is no `postgis/postgis:16-3.3` image — PostGIS 3.3 was never published for Postgres 16 — so this moves to `16-3.5`, matching the docker-compose default.

Worth stating plainly: **PostGIS still differs across environments.** `flake.nix` pins 3.3.5 for production parity, docker-compose and now the tests use 3.5. The Postgres major is the gap that matters here, and the PostGIS spread predates this PR, so it is left alone rather than resolved on a guess.

## Verification

Run locally exactly as CI runs it — `prisma:generate` for both clients, then `--runInBand`:

```
Test Suites: 11 passed, 11 total
Tests:       102 passed, 102 total
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR limits the integration CI job to 20 minutes and updates its test database from PostgreSQL 15/PostGIS 3.3 to PostgreSQL 16/PostGIS 3.5.

- Adds a generous timeout to prevent indefinitely stalled containers from occupying runners.
- Aligns integration tests with the PostgreSQL major version used elsewhere.
- Uses the same PostGIS container image already configured as the docker-compose default.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or workflow failures identified.

The timeout retains substantial documented runtime headroom, while the new database image matches an existing repository environment and remains compatible with the integration helper’s extension and schema setup.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds a 20-minute integration-job timeout with substantial headroom over the documented two-minute runtime. |
| tests/helpers/test-db.ts | Updates the integration-test container to PostgreSQL 16/PostGIS 3.5 without conflicting with the test schema setup or migration path. |

<sub>Reviews (1): Last reviewed commit: ["test(integration): run against Postgres ..."](https://github.com/schemalabz/opencouncil/commit/eaae570a2c6fa7fb250d2b4fbd297061f9a5751a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56167721)</sub>

<!-- /greptile_comment -->