### PR TITLE
feat(product-updates): inline images and draft persistence in the composer

### DIFF
--- a/messages/el.json
+++ b/messages/el.json
@@ -1182,7 +1182,9 @@
         "successTitle": "Η αποστολή ολοκληρώθηκε",
         "successSummary": "Εστάλησαν: {sent}, απέτυχαν: {failed}.",
         "failedListWithCount": "Διευθύνσεις που απέτυχαν ({count})",
-        "errorTitle": "Η αποστολή απέτυχε"
+        "errorTitle": "Η αποστολή απέτυχε",
+        "draftRestored": "Επαναφέραμε το μη αποθηκευμένο πρόχειρό σας.",
+        "discardDraftButton": "Απόρριψη"
     },
     "SignIn": {
         "title": "Σύνδεση στο OpenCouncil",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1182,7 +1182,9 @@
         "successTitle": "Send complete",
         "successSummary": "Sent: {sent}, failed: {failed}.",
         "failedListWithCount": "Failed addresses ({count})",
-        "errorTitle": "Send failed"
+        "errorTitle": "Send failed",
+        "draftRestored": "Restored your unsaved draft.",
+        "discardDraftButton": "Discard"
     },
     "SignIn": {
         "title": "Sign in to OpenCouncil",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1182,7 +1182,9 @@
     "successTitle": "Envoi terminé",
     "successSummary": "Envoyés : {sent}, échecs : {failed}.",
     "failedListWithCount": "Adresses en échec ({count})",
-    "errorTitle": "Échec de l'envoi"
+    "errorTitle": "Échec de l'envoi",
+    "draftRestored": "Brouillon non enregistré restauré.",
+    "discardDraftButton": "Supprimer"
   },
   "SignIn": {
     "title": "Connexion à OpenCouncil",

--- a/messages/sr.json
+++ b/messages/sr.json
@@ -1182,7 +1182,9 @@
         "successTitle": "Слање је завршено",
         "successSummary": "Послато: {sent}, неуспешно: {failed}.",
         "failedListWithCount": "Неуспешне адресе ({count})",
-        "errorTitle": "Слање није успело"
+        "errorTitle": "Слање није успело",
+        "draftRestored": "Враћен је ваш несачувани нацрт.",
+        "discardDraftButton": "Одбаци"
     },
     "SignIn": {
         "title": "Пријава на OpenCouncil",

--- a/src/components/admin/product-updates/ProductUpdateEmailEditor.tsx
+++ b/src/components/admin/product-updates/ProductUpdateEmailEditor.tsx
@@ -26,10 +26,13 @@ import {
     AlignLeft,
     AlignCenter,
     AlignRight,
+    Image as ImageIcon,
+    Loader2,
 } from 'lucide-react';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { buildImageTag, validateImageFile, ACCEPTED_IMAGE_TYPES } from './imageTag';
 
 export interface ProductUpdateEmailEditorHandle {
     /** Returns the current markdown source (with {{...}} placeholders intact). */
@@ -283,6 +286,64 @@ export const ProductUpdateEmailEditor = forwardRef<
     const [openPanel, setOpenPanel] = useState<'colors' | 'fontSize' | 'components' | null>(null);
     const [activeTab, setActiveTab] = useState<'compose' | 'preview'>('compose');
     const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [imageUploading, setImageUploading] = useState(false);
+    const [imageError, setImageError] = useState<string | null>(null);
+
+    /** Read the intrinsic width so the width attribute matches the real image. */
+    const readNaturalWidth = (file: File): Promise<number> =>
+        new Promise((resolve) => {
+            const objectUrl = URL.createObjectURL(file);
+            const probe = new window.Image();
+            probe.onload = () => {
+                URL.revokeObjectURL(objectUrl);
+                resolve(probe.naturalWidth);
+            };
+            probe.onerror = () => {
+                URL.revokeObjectURL(objectUrl);
+                resolve(0);
+            };
+            probe.src = objectUrl;
+        });
+
+    const handleImageSelected = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        e.target.value = ''; // let the admin re-pick the same file
+        if (!file) return;
+
+        const validation = validateImageFile(file);
+        if (!validation.ok) {
+            setImageError(validation.error);
+            return;
+        }
+
+        setImageError(null);
+        setImageUploading(true);
+        try {
+            const naturalWidth = await readNaturalWidth(file);
+            const formData = new FormData();
+            formData.append('file', file);
+            const res = await fetch('/api/upload', { method: 'POST', body: formData });
+            if (!res.ok) throw new Error('upload failed');
+            const { url } = await res.json();
+            const tag = buildImageTag(url, naturalWidth);
+            // Splice into state rather than execCommand. The upload is async, so
+            // it can resolve after the admin switched to the Preview tab, which
+            // hides the textarea — focus()/execCommand would then be a no-op and
+            // silently drop the image. Read the live caret (still valid while
+            // hidden) so edits made during the upload are respected.
+            setMarkdown((prev) => {
+                const el = textareaRef.current;
+                const start = el ? el.selectionStart : prev.length;
+                const end = el ? el.selectionEnd : prev.length;
+                return prev.slice(0, start) + tag + prev.slice(end);
+            });
+        } catch {
+            setImageError('Could not upload the image. Try again.');
+        } finally {
+            setImageUploading(false);
+        }
+    };
 
     const togglePanel = (panel: 'colors' | 'fontSize' | 'components') =>
         setOpenPanel((prev) => (prev === panel ? null : panel));
@@ -462,7 +523,36 @@ export const ProductUpdateEmailEditor = forwardRef<
                     >
                         <Component className="h-4 w-4" />
                     </Button>
+
+                    {/* Image upload */}
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 w-8 p-0"
+                        title="Insert image"
+                        aria-label="Insert image"
+                        disabled={imageUploading}
+                        onClick={() => fileInputRef.current?.click()}
+                    >
+                        {imageUploading ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                            <ImageIcon className="h-4 w-4" />
+                        )}
+                    </Button>
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept={ACCEPTED_IMAGE_TYPES.join(',')}
+                        className="hidden"
+                        onChange={handleImageSelected}
+                    />
                 </div>
+
+                {imageError && (
+                    <p className="px-1 text-sm text-destructive">{imageError}</p>
+                )}
 
                 {openPanel === 'colors' && (
                     <div className="flex flex-wrap items-center gap-2 rounded-md border bg-muted/30 p-2">

--- a/src/components/admin/product-updates/ProductUpdateEmailEditor.tsx
+++ b/src/components/admin/product-updates/ProductUpdateEmailEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import { SANITIZE_CONFIG } from '@/lib/email/templates/productUpdateDefault';
@@ -48,6 +48,8 @@ interface ProductUpdateEmailEditorProps {
     initialContent?: string;
     /** id assigned to the underlying textarea so an external <label htmlFor=...> can target it. */
     textareaId?: string;
+    /** Called with the current markdown whenever it changes (typing or toolbar edits). */
+    onChange?: (markdown: string) => void;
 }
 
 interface TransformResult {
@@ -281,7 +283,7 @@ const Divider = () => <div className="w-px self-stretch bg-border mx-1" />;
 export const ProductUpdateEmailEditor = forwardRef<
     ProductUpdateEmailEditorHandle,
     ProductUpdateEmailEditorProps
->(({ initialContent = '', textareaId }, ref) => {
+>(({ initialContent = '', textareaId, onChange }, ref) => {
     const [markdown, setMarkdown] = useState(initialContent);
     const [openPanel, setOpenPanel] = useState<'colors' | 'fontSize' | 'components' | null>(null);
     const [activeTab, setActiveTab] = useState<'compose' | 'preview'>('compose');
@@ -368,6 +370,13 @@ export const ProductUpdateEmailEditor = forwardRef<
         getMarkdown: () => markdown,
         getSanitizedHtml: () => sanitizedHtml,
     }), [markdown, sanitizedHtml]);
+
+    // Notify the parent on every markdown change so it can persist a draft.
+    // This covers typed edits and toolbar/image inserts alike, because both
+    // route through setMarkdown.
+    useEffect(() => {
+        onChange?.(markdown);
+    }, [markdown, onChange]);
 
     /**
      * Continue list / quote markers when Enter is pressed inside one of them.

--- a/src/components/admin/product-updates/SendProductUpdateDialog.tsx
+++ b/src/components/admin/product-updates/SendProductUpdateDialog.tsx
@@ -14,13 +14,14 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Mail, Loader2, CheckCircle, XCircle, AlertTriangle, X } from 'lucide-react';
+import { Mail, Loader2, CheckCircle, XCircle, AlertTriangle, X, RotateCcw } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import {
     ProductUpdateEmailEditor,
     type ProductUpdateEmailEditorHandle,
 } from './ProductUpdateEmailEditor';
 import { DEFAULT_PRODUCT_UPDATE_TEMPLATE_MARKDOWN } from '@/lib/email/templates/productUpdateDefault';
+import { loadDraft, saveDraft, clearDraft } from './draftStorage';
 
 interface SendResult {
     sent: number;
@@ -51,6 +52,36 @@ export function SendProductUpdateDialog() {
     const [customTags, setCustomTags] = useState<string[]>([]);
     const [tagInput, setTagInput] = useState('');
     const [tagError, setTagError] = useState<string | null>(null);
+    const [body, setBody] = useState(DEFAULT_PRODUCT_UPDATE_TEMPLATE_MARKDOWN);
+    // Bumping this remounts the editor so it re-seeds from `body` on restore/discard.
+    const [editorSeed, setEditorSeed] = useState(0);
+    const [draftRestored, setDraftRestored] = useState(false);
+
+    // A pristine compose state is the default template with no subject and no tags.
+    // We never persist it, so opening the dialog does not create a junk draft.
+    const isPristine =
+        subject === '' &&
+        customTags.length === 0 &&
+        body === DEFAULT_PRODUCT_UPDATE_TEMPLATE_MARKDOWN;
+
+    // Restore an unsaved draft when the dialog opens.
+    useEffect(() => {
+        if (!open) return;
+        const draft = loadDraft();
+        if (!draft) return;
+        setSubject(draft.subject);
+        setCustomTags(draft.tags);
+        setBody(draft.body);
+        setEditorSeed((n) => n + 1);
+        setDraftRestored(true);
+    }, [open]);
+
+    // Auto-save the draft as the admin edits, so an accidental close does not lose it.
+    useEffect(() => {
+        if (!open || isPristine) return;
+        const timer = setTimeout(() => saveDraft({ subject, body, tags: customTags }), 500);
+        return () => clearTimeout(timer);
+    }, [open, isPristine, subject, body, customTags]);
 
     // Fetch the live recipient counts (opted-in + total registered) when the dialog opens.
     useEffect(() => {
@@ -82,13 +113,31 @@ export function SendProductUpdateDialog() {
     const handleOpenChange = (next: boolean) => {
         setOpen(next);
         if (!next) {
+            // Flush the latest state to storage before closing, so edits made
+            // inside the autosave debounce window are not lost on a fast close.
+            // Skip after a successful send: a bulk send already cleared the draft,
+            // and re-saving would restore an update that already went out.
+            if (status !== 'success' && !isPristine) saveDraft({ subject, body, tags: customTags });
             setSubject('');
             setTestEmail('');
             setCustomTags([]);
             setTagInput('');
             setTagError(null);
+            setBody(DEFAULT_PRODUCT_UPDATE_TEMPLATE_MARKDOWN);
+            setEditorSeed((n) => n + 1);
+            setDraftRestored(false);
             reset();
         }
+    };
+
+    const handleDiscardDraft = () => {
+        clearDraft();
+        setSubject('');
+        setCustomTags([]);
+        setTagInput('');
+        setBody(DEFAULT_PRODUCT_UPDATE_TEMPLATE_MARKDOWN);
+        setEditorSeed((n) => n + 1);
+        setDraftRestored(false);
     };
 
     const addTagFromInput = () => {
@@ -149,6 +198,12 @@ export function SendProductUpdateDialog() {
             const data: SendResult = await res.json();
             setResult(data);
             setStatus('success');
+            // The update went out to everyone — drop the saved draft so the next
+            // compose starts clean. A test send keeps the draft for more editing.
+            if (nextStatus === 'sending-all') {
+                clearDraft();
+                setDraftRestored(false);
+            }
         } catch (error) {
             console.error('Product update send error:', error);
             setErrorMessage(error instanceof Error ? error.message : String(error));
@@ -184,6 +239,21 @@ export function SendProductUpdateDialog() {
                 </DialogHeader>
 
                 <div className="space-y-4 w-full">
+                    {draftRestored && (
+                        <div className="flex items-center justify-between gap-2 rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
+                            <span>{t('draftRestored')}</span>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 gap-1 text-blue-800 hover:bg-blue-100"
+                                onClick={handleDiscardDraft}
+                            >
+                                <RotateCcw className="h-3.5 w-3.5" />
+                                {t('discardDraftButton')}
+                            </Button>
+                        </div>
+                    )}
+
                     <div className="space-y-2">
                         <Label htmlFor="product-update-subject">{t('subjectLabel')}</Label>
                         <Input
@@ -200,8 +270,10 @@ export function SendProductUpdateDialog() {
                         <Label htmlFor="product-update-body">{t('bodyLabel')}</Label>
                         <div className="rounded-md border bg-background">
                             <ProductUpdateEmailEditor
+                                key={editorSeed}
                                 ref={editorRef}
-                                initialContent={DEFAULT_PRODUCT_UPDATE_TEMPLATE_MARKDOWN}
+                                initialContent={body}
+                                onChange={setBody}
                                 textareaId="product-update-body"
                             />
                         </div>

--- a/src/components/admin/product-updates/draftStorage.test.ts
+++ b/src/components/admin/product-updates/draftStorage.test.ts
@@ -1,0 +1,34 @@
+/** @jest-environment jsdom */
+import { loadDraft, saveDraft, clearDraft, DRAFT_STORAGE_KEY } from './draftStorage';
+
+describe('product update draft storage', () => {
+    beforeEach(() => window.localStorage.clear());
+
+    it('returns null when no draft is stored', () => {
+        expect(loadDraft()).toBeNull();
+    });
+
+    it('round-trips a saved draft', () => {
+        saveDraft({ subject: 'Hi', body: '# Body', tags: ['a', 'b'] });
+        expect(loadDraft()).toEqual({ subject: 'Hi', body: '# Body', tags: ['a', 'b'] });
+    });
+
+    it('clears a stored draft', () => {
+        saveDraft({ subject: 'Hi', body: 'b', tags: [] });
+        clearDraft();
+        expect(loadDraft()).toBeNull();
+    });
+
+    it('returns null for a malformed stored value', () => {
+        window.localStorage.setItem(DRAFT_STORAGE_KEY, '{"subject":123}');
+        expect(loadDraft()).toBeNull();
+    });
+
+    it('drops non-string tags rather than failing', () => {
+        window.localStorage.setItem(
+            DRAFT_STORAGE_KEY,
+            JSON.stringify({ subject: 's', body: 'b', tags: ['ok', 5, null] }),
+        );
+        expect(loadDraft()).toEqual({ subject: 's', body: 'b', tags: ['ok'] });
+    });
+});

--- a/src/components/admin/product-updates/draftStorage.ts
+++ b/src/components/admin/product-updates/draftStorage.ts
@@ -1,0 +1,52 @@
+export const DRAFT_STORAGE_KEY = 'product-update-draft';
+
+export interface ProductUpdateDraft {
+    subject: string;
+    body: string;
+    tags: string[];
+}
+
+/**
+ * Read the saved compose draft. Returns null when nothing is stored or the
+ * stored value is not a well-formed draft, so a corrupt entry never throws.
+ */
+export function loadDraft(): ProductUpdateDraft | null {
+    if (typeof window === 'undefined') return null;
+    try {
+        const raw = window.localStorage.getItem(DRAFT_STORAGE_KEY);
+        if (!raw) return null;
+        const parsed: unknown = JSON.parse(raw);
+        if (typeof parsed !== 'object' || parsed === null) return null;
+        const candidate = parsed as Record<string, unknown>;
+        if (typeof candidate.subject !== 'string') return null;
+        if (typeof candidate.body !== 'string') return null;
+        if (!Array.isArray(candidate.tags)) return null;
+        return {
+            subject: candidate.subject,
+            body: candidate.body,
+            tags: candidate.tags.filter((tag): tag is string => typeof tag === 'string'),
+        };
+    } catch {
+        return null;
+    }
+}
+
+/** Persist the compose draft. Storage failures (quota, disabled) are ignored. */
+export function saveDraft(draft: ProductUpdateDraft): void {
+    if (typeof window === 'undefined') return;
+    try {
+        window.localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
+    } catch {
+        // storage unavailable or full — a failed autosave must not break editing
+    }
+}
+
+/** Remove the saved compose draft. */
+export function clearDraft(): void {
+    if (typeof window === 'undefined') return;
+    try {
+        window.localStorage.removeItem(DRAFT_STORAGE_KEY);
+    } catch {
+        // ignore
+    }
+}

--- a/src/components/admin/product-updates/imageTag.test.ts
+++ b/src/components/admin/product-updates/imageTag.test.ts
@@ -1,0 +1,37 @@
+import { buildImageTag, validateImageFile, MAX_IMAGE_BYTES } from './imageTag';
+
+describe('buildImageTag', () => {
+    it('clamps a wide image to the 600px content width', () => {
+        expect(buildImageTag('https://cdn/a.png', 4000)).toBe(
+            '<img src="https://cdn/a.png" alt="" width="600" style="max-width:100%;height:auto;display:block;">',
+        );
+    });
+
+    it('keeps the natural width for a narrow image', () => {
+        expect(buildImageTag('https://cdn/a.png', 320)).toContain('width="320"');
+    });
+
+    it('falls back to the content width when the natural width is unknown', () => {
+        expect(buildImageTag('https://cdn/a.png', 0)).toContain('width="600"');
+    });
+
+    it('escapes & and " in the URL so the src attribute cannot break', () => {
+        expect(buildImageTag('https://cdn/a"b&c.png', 100)).toContain(
+            'src="https://cdn/a&quot;b&amp;c.png"',
+        );
+    });
+});
+
+describe('validateImageFile', () => {
+    it('accepts a PNG under the size cap', () => {
+        expect(validateImageFile({ type: 'image/png', size: 1000 })).toEqual({ ok: true });
+    });
+
+    it('rejects a WebP', () => {
+        expect(validateImageFile({ type: 'image/webp', size: 1000 }).ok).toBe(false);
+    });
+
+    it('rejects an oversized image', () => {
+        expect(validateImageFile({ type: 'image/png', size: MAX_IMAGE_BYTES + 1 }).ok).toBe(false);
+    });
+});

--- a/src/components/admin/product-updates/imageTag.ts
+++ b/src/components/admin/product-updates/imageTag.ts
@@ -1,0 +1,30 @@
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+export const ACCEPTED_IMAGE_TYPES = ['image/png', 'image/jpeg', 'image/gif'] as const;
+export const EMAIL_CONTENT_WIDTH = 600;
+
+/**
+ * Build cross-client compatible <img> markup for a product-update email.
+ * Outlook desktop ignores max-width, so the width attribute carries the real
+ * constraint. It never exceeds the email content width and never upscales a
+ * small image. The style shrinks the image on mobile and modern clients.
+ */
+export function buildImageTag(url: string, naturalWidth: number): string {
+    const width = Math.min(Math.round(naturalWidth) || EMAIL_CONTENT_WIDTH, EMAIL_CONTENT_WIDTH);
+    // Escape the attribute-unsafe characters. A crafted filename can put a
+    // double quote in the upload URL, which would otherwise end the src early.
+    const safeUrl = url.replaceAll('&', '&amp;').replaceAll('"', '&quot;');
+    return `<img src="${safeUrl}" alt="" width="${width}" style="max-width:100%;height:auto;display:block;">`;
+}
+
+export type ImageValidation = { ok: true } | { ok: false; error: string };
+
+/** Guard the type and the size, because POST /api/upload validates neither. */
+export function validateImageFile(file: { type: string; size: number }): ImageValidation {
+    if (!ACCEPTED_IMAGE_TYPES.includes(file.type as (typeof ACCEPTED_IMAGE_TYPES)[number])) {
+        return { ok: false, error: 'Use a PNG, JPEG, or GIF image.' };
+    }
+    if (file.size > MAX_IMAGE_BYTES) {
+        return { ok: false, error: 'Image must be 5 MB or smaller.' };
+    }
+    return { ok: true };
+}

--- a/src/lib/email/templates/productUpdateDefault.test.ts
+++ b/src/lib/email/templates/productUpdateDefault.test.ts
@@ -1,0 +1,29 @@
+/** @jest-environment jsdom */
+import DOMPurify from 'dompurify';
+import { SANITIZE_CONFIG } from './productUpdateDefault';
+
+describe('SANITIZE_CONFIG image support', () => {
+    it('keeps an img with src, alt, width, height and style', () => {
+        const html =
+            '<img src="https://cdn.example.com/a.png" alt="hi" width="600" height="300" style="max-width:100%;height:auto;display:block;">';
+        const out = DOMPurify.sanitize(html, SANITIZE_CONFIG);
+        expect(out).toContain('<img');
+        expect(out).toContain('src="https://cdn.example.com/a.png"');
+        expect(out).toContain('alt="hi"');
+        expect(out).toContain('width="600"');
+        expect(out).toContain('style="max-width:100%;height:auto;display:block;"');
+    });
+
+    it('strips a javascript: src', () => {
+        const out = DOMPurify.sanitize('<img src="javascript:alert(1)">', SANITIZE_CONFIG);
+        expect(out).not.toContain('javascript:');
+    });
+
+    it('strips an onerror handler', () => {
+        const out = DOMPurify.sanitize(
+            '<img src="https://cdn.example.com/a.png" onerror="alert(1)">',
+            SANITIZE_CONFIG,
+        );
+        expect(out).not.toContain('onerror');
+    });
+});

--- a/src/lib/email/templates/productUpdateDefault.ts
+++ b/src/lib/email/templates/productUpdateDefault.ts
@@ -11,8 +11,9 @@ export const SANITIZE_CONFIG = {
         'blockquote', 'hr', 'br',
         'h1', 'h2', 'h3', 'h4', 'h5',
         'strong', 'em',
+        'img',
     ],
-    ALLOWED_ATTR: ['style', 'href'],
+    ALLOWED_ATTR: ['style', 'href', 'src', 'alt', 'width', 'height'],
 };
 
 /**


### PR DESCRIPTION
Closes #677

This PR makes two related improvements to the admin product-update composer.

## 1. Inline images in the email body

Admins can add inline images to a product-update email. The composer gets an image button that uploads a file to DigitalOcean Spaces and inserts the hosted image at the cursor.

- The shared DOMPurify allowlist (`SANITIZE_CONFIG`) now permits `img` with `src`, `alt`, `width`, and `height`. This config drives both the editor preview and the shipped email, so images render in both. DOMPurify still strips `javascript:` sources and `on*` handlers.
- A pure helper (`imageTag.ts`) builds cross-client compatible markup and validates the file. It escapes `&` and `"` in the URL so a crafted filename cannot break the `src` attribute.
- The composer adds an Image button. It uploads through the existing `/api/upload` route and splices the markup at the live caret, so a Preview-tab switch during the upload does not drop the image.

### Mailbox compatibility

- The composer accepts PNG, JPEG, and GIF only. Outlook desktop and older clients cannot decode WebP or AVIF.
- Outlook desktop ignores `max-width`, so the markup carries an HTML `width` attribute set to `min(naturalWidth, 600)`. The image never exceeds the 600px content width. It never upscales. `max-width:100%;height:auto` keeps it responsive on mobile.
- The admin can hand-edit the `width` and `height` attributes in the textarea. The sanitizer keeps them.

### Live preview

The editor's Preview tab renders the exact sanitized HTML at the 600px email width, so the image appears as it will in modern clients. Outlook desktop rendering is verified with the test-email step, because no in-app preview reproduces its Word engine.

### Current limitations

- No in-editor resize or crop. The image inserts at `min(naturalWidth, 600)` px. To change the size, edit the `width`/`height` attributes in the textarea by hand.
- No alignment control. Images insert as a left-aligned block. The text-align toolbar buttons do not move a block image.
- PNG, JPEG, and GIF only. No WebP or AVIF (see Mailbox compatibility).
- Uploaded images stay in the S3 `uploads/` bucket. There is no cleanup for images added to a draft that is never sent.

## 2. Draft persistence

A written update could be lost to an accidental close, a refresh, or a crash, because the composer held its state in memory only.

- The composer autosaves the subject, body, and tags to `localStorage` as the admin edits. A flush-save on close covers the autosave debounce window.
- On reopen with a saved draft, the composer restores it and shows a "Restored your unsaved draft" notice. A discard action returns to the default template.
- The composer clears the draft after a successful send to all recipients. The test-email address stays transient.
- `localStorage` rather than `sessionStorage`, so the draft survives a tab close or a crash, not only a refresh.

## Test on preview

1. Open pr-678.opencouncil.dev.
2. Log in as superadmin with dev quick-login.
3. Open Send Product Update.

Images:
4. Click the image button. Pick a PNG.
5. Confirm the upload finishes. Confirm the image shows in the Preview tab.
6. Send a [TEST] email to your own address.
7. Open the email in Gmail and in Outlook. Confirm the image renders at the correct size.

Draft persistence:
8. Type a subject and body. Close the dialog. Reopen it.
9. Confirm the subject and body return, with the "Restored your unsaved draft" notice.
10. Click Discard. Confirm the composer returns to the default template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds inline image uploads and persistent local drafts to the product-update composer.

- Adds image validation, upload handling, email-safe image markup, and preview support.
- Restores, autosaves, discards, and clears product-update drafts.
- Adds localized draft controls and focused helper tests.

<h3>Confidence Score: 4/5</h3>

The PR is not safe to merge until image insertion stops replacing the selection that exists when the upload completes.

The upload completion callback reads the current textarea selection and uses it as a replacement range. A selection made after upload starts can therefore lose newly selected content.

**Files Needing Attention:** src/components/admin/product-updates/ProductUpdateEmailEditor.tsx

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/admin/product-updates/ProductUpdateEmailEditor.tsx | Adds image upload and insertion support, but the previously reported completion-time selection replacement remains. |
| src/components/admin/product-updates/SendProductUpdateDialog.tsx | Adds draft restoration, debounced persistence, close-time flushing, discard behavior, and cleanup after bulk sends. |
| src/components/admin/product-updates/draftStorage.ts | Adds guarded localStorage serialization, validation, loading, and removal for composer drafts. |
| src/components/admin/product-updates/imageTag.ts | Adds image type and size validation plus escaped, width-constrained email image markup. |
| src/lib/email/templates/productUpdateDefault.ts | Extends the shared sanitizer allowlist so inline images and their sizing attributes survive preview and delivery. |

<sub>Reviews (5): Last reviewed commit: ["feat(product-updates): persist the compo..."](https://github.com/schemalabz/opencouncil/commit/abff390916bce89151328acc15c6169ee58d96ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56194993)</sub>

<!-- /greptile_comment -->