### PR TITLE
Cover the valkey cache layer with integration tests

### DIFF
--- a/src/lib/cache/valkey.ts
+++ b/src/lib/cache/valkey.ts
@@ -100,3 +100,17 @@ export async function cacheHas(key: string): Promise<boolean> {
         return false;
     }
 }
+
+/**
+ * Close the shared client and clear the singleton.
+ *
+ * The server never calls this — the connection is meant to live as long as the
+ * process. It exists so tests can release the socket; without it an open
+ * handle keeps the runner alive after the suite finishes.
+ */
+export async function disconnectCache(): Promise<void> {
+    const existing = client;
+    client = null;
+    connectingPromise = null;
+    if (existing) await existing.quit().catch(() => existing.disconnect());
+}

--- a/tests/integration/cache-disabled.test.ts
+++ b/tests/integration/cache-disabled.test.ts
@@ -1,0 +1,22 @@
+/** @jest-environment node */
+import { cacheGetJSON, cacheSetJSON, cacheHas } from '@/lib/cache/valkey'
+
+/**
+ * The cache is optional: dev and previews run without CACHE_URL, and the layer
+ * must degrade to no-ops rather than throw.
+ *
+ * This lives in its own file because the client is a module-level singleton —
+ * once connected it is returned regardless of a later CACHE_URL change, so the
+ * unset path cannot be exercised in a file that has already connected.
+ */
+describe('valkey cache layer without CACHE_URL', () => {
+    beforeAll(() => {
+        delete process.env.CACHE_URL
+    })
+
+    it('no-ops instead of throwing', async () => {
+        expect(await cacheSetJSON('k', { a: 1 }, 60)).toBe(false)
+        expect(await cacheGetJSON('k')).toBeNull()
+        expect(await cacheHas('k')).toBe(false)
+    })
+})

--- a/tests/integration/cache.test.ts
+++ b/tests/integration/cache.test.ts
@@ -1,0 +1,74 @@
+/** @jest-environment node */
+import { GenericContainer, StartedTestContainer, Wait } from 'testcontainers'
+import { cacheGetJSON, cacheSetJSON, cacheHas, disconnectCache } from '@/lib/cache/valkey'
+
+/**
+ * Integration coverage for the Valkey cache layer.
+ *
+ * The layer is a thin wrapper over the `redis` client, and nothing exercised it
+ * before: every existing test mocks '@/lib/cache/valkey'. A redis major bump
+ * therefore passed CI while proving nothing about runtime behaviour.
+ *
+ * These tests run the real client against a real Valkey, over the surface the
+ * application actually uses — JSON round-tripping, TTL, and the no-op path when
+ * CACHE_URL is unset.
+ */
+
+let container: StartedTestContainer | undefined
+
+// The env mock proxies process.env at access time, so CACHE_URL can be set
+// after the module is imported.
+const setCacheUrl = (url: string | undefined) => {
+    if (url) process.env.CACHE_URL = url
+    else delete process.env.CACHE_URL
+}
+
+beforeAll(async () => {
+    container = await new GenericContainer('valkey/valkey:9-alpine')
+        .withExposedPorts(6379)
+        .withWaitStrategy(Wait.forLogMessage(/Ready to accept connections/))
+        .start()
+    setCacheUrl(`redis://${container.getHost()}:${container.getMappedPort(6379)}`)
+}, 120_000)
+
+afterAll(async () => {
+    // Release the socket before stopping the container, or the client retries
+    // against a dead endpoint and the open handle keeps jest alive.
+    await disconnectCache()
+    setCacheUrl(undefined)
+    await container?.stop()
+})
+
+describe('valkey cache layer', () => {
+    it('round-trips a JSON value', async () => {
+        expect(await cacheSetJSON('rt', { a: 1, nested: { b: [2, 3] } }, 60)).toBe(true)
+        expect(await cacheGetJSON<{ a: number; nested: { b: number[] } }>('rt')).toEqual({
+            a: 1,
+            nested: { b: [2, 3] },
+        })
+    })
+
+    it('reports presence only for keys that were written', async () => {
+        await cacheSetJSON('present', { x: true }, 60)
+        expect(await cacheHas('present')).toBe(true)
+        expect(await cacheHas('never-written')).toBe(false)
+    })
+
+    it('returns null for a missing key rather than throwing', async () => {
+        expect(await cacheGetJSON('absent')).toBeNull()
+    })
+
+    it('honours the TTL, so entries expire', async () => {
+        await cacheSetJSON('ttl', { v: 1 }, 1)
+        expect(await cacheHas('ttl')).toBe(true)
+        await new Promise((r) => setTimeout(r, 1500))
+        expect(await cacheHas('ttl')).toBe(false)
+    })
+
+    it('preserves falsy values, distinguishing them from a miss', async () => {
+        await cacheSetJSON('falsy', 0, 60)
+        expect(await cacheGetJSON('falsy')).toBe(0)
+        await cacheSetJSON('empty', '', 60)
+        expect(await cacheGetJSON('empty')).toBe('')
+    })
+})


### PR DESCRIPTION
## Why

Nothing exercised `src/lib/cache/valkey.ts`. Every test that touched it called `jest.mock('@/lib/cache/valkey')` — which reads as coverage but never executes the module.

The consequence is visible on #437, which bumps `redis` across two majors. It is green, and that green proves the code typechecks and lints. It proves nothing about whether the cache still works, because no test runs it.

Now that the integration suite runs in CI, that gap is closeable.

## What this covers

The three exported functions, against a real Valkey container:

- JSON round-trip, including nested values
- presence versus a key that was never written
- TTL expiry
- falsy values (`0`, `""`) preserved and distinguishable from a miss
- the no-op path when `CACHE_URL` is unset, as in dev and previews

Testing our wrapper rather than the redis client is deliberate: it covers the client APIs transitively *and* our serialization, TTL handling, and degraded behaviour.

## Two things writing it surfaced

**The module had no disposal hook.** `disconnect()` is called internally when replacing a stale client, but nothing let a caller release the connection. The first run hung with an open handle keeping jest alive. `disconnectCache()` is a production file changed to serve a test, which I would normally avoid — the alternative was `--forceExit`, which hides leaks rather than fixing them.

**The client is a module-level singleton that ignores a later `CACHE_URL` change.** Once connected, it is returned regardless. Correct for a server process, but it means the unconfigured path cannot be tested in a file that has already connected — hence the second, small test file.

Neither was visible from reading the module.

## Verification

Both test files, run against each redis version:

| redis | result |
|---|---|
| 4.7.1 (current main) | 2 suites, 6 tests pass |
| 6.2.1 (#437) | 2 suites, 6 tests pass |

Scope, stated honestly: this is evidence the upgrade is safe **for the five client methods this wrapper uses**, not that redis 6 is safe in general.

## Relationship to #437

Deliberately separate. Landing this first means #437 rebases onto a main that already has the coverage, and its own CI run then verifies redis 6 against these tests rather than anyone asserting it does. Adding the tests to that branch instead would not survive Dependabot's next rebase.

Refs #437.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds integration coverage for the Valkey cache wrapper and a disposal hook used to release its shared Redis connection after tests.
- Tests JSON round trips, key presence, misses, expiration, and falsy values against a Valkey container.
- Verifies no-op behavior when `CACHE_URL` is absent.
- Adds `disconnectCache()` for deterministic connection cleanup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/cache/valkey.ts | Adds an exported cleanup function that clears singleton state and closes the existing cache client. |
| tests/integration/cache.test.ts | Adds container-backed integration coverage for serialization, presence checks, misses, TTL expiration, and falsy values. |
| tests/integration/cache-disabled.test.ts | Verifies that all cache operations degrade safely when caching is unconfigured. |

<sub>Reviews (2): Last reviewed commit: ["test(integration): cover the valkey cach..."](https://github.com/schemalabz/opencouncil/commit/5ea123e2c4e38f22ade8f6d47e6753fee50f3fc5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56211370)</sub>

<!-- /greptile_comment -->