### PR TITLE
feat(mcp): filter meetings by administrative body

### DIFF
--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -18,6 +18,7 @@ module.exports = {
         '^@/lib/notifications/welcome$': '<rootDir>/tests/mocks/notificationsWelcome.ts',
         '^@/lib/discord$': '<rootDir>/tests/mocks/discord.ts',
         '^@/lib/cities$': '<rootDir>/tests/mocks/cities.ts',
+        '^next-intl/server$': '<rootDir>/tests/mocks/nextIntlServer.ts',
         '^@/(.*)$': '<rootDir>/src/$1',
     },
     transform: {

--- a/src/lib/mcp/__tests__/server.test.ts
+++ b/src/lib/mcp/__tests__/server.test.ts
@@ -6,7 +6,9 @@
 // goes stale every time a tool is added.
 jest.mock('../data', () =>
     new Proxy({ __esModule: true } as Record<string, unknown>, {
-        get: (target, prop: string) => (prop in target ? target[prop] : jest.fn()),
+        // Memoized, not a fresh mock per access: the forwarding tests below
+        // assert on the same function object the tool callback closed over.
+        get: (target, prop: string) => (target[prop] ??= jest.fn()),
     })
 );
 
@@ -15,10 +17,11 @@ jest.mock('../data', () =>
 jest.mock('../../db/prisma', () => ({ __esModule: true, default: {} }));
 
 import { Realm } from '@prisma/client';
-import type { McpServer } from '@modelcontextprotocol/server';
+import type { McpServer, ServerContext } from '@modelcontextprotocol/server';
 import { registerOpenCouncilServer } from '../server';
 import { mcpRealmStore, requestContext } from '../realm-context';
 import type { McpIdentity } from '../auth';
+import * as data from '../data';
 
 const HIGHLIGHT_TOOLS = [
     'create_highlight', 'generate_highlight_video', 'list_highlights',
@@ -32,17 +35,25 @@ const CATEGORIES = ['discovery', 'directory', 'meetings', 'highlights'];
 type RecordedToolConfig = {
     annotations?: { readOnlyHint?: boolean };
     _meta?: { category?: string };
+    inputSchema?: { parse: (value: unknown) => unknown };
 };
+type ToolHandler = (args: never, ctx: ServerContext) => Promise<unknown>;
+
+/** A tool context carrying the identity verifyMcpToken would have attached. */
+const ctxFor = (identity: McpIdentity) =>
+    ({ http: { authInfo: { extra: { identity } } } }) as unknown as ServerContext;
 
 /** What a connection with this identity would see in tools/list & prompts/list. */
 function advertised(identity: McpIdentity, { inRequestScope = true } = {}) {
     const tools: string[] = [];
     const prompts: string[] = [];
     const meta: Record<string, RecordedToolConfig> = {};
+    const handlers: Record<string, ToolHandler> = {};
     const recorder = {
-        registerTool: (name: string, config: RecordedToolConfig) => {
+        registerTool: (name: string, config: RecordedToolConfig, handler: ToolHandler) => {
             tools.push(name);
             meta[name] = config;
+            handlers[name] = handler;
         },
         registerPrompt: (name: string) => { prompts.push(name); },
     } as unknown as McpServer;
@@ -53,7 +64,7 @@ function advertised(identity: McpIdentity, { inRequestScope = true } = {}) {
     } else {
         register();
     }
-    return { tools, prompts, meta };
+    return { tools, prompts, meta, handlers };
 }
 
 describe('highlight tools are advertised only on authenticated connections', () => {
@@ -101,5 +112,71 @@ describe('tool metadata', () => {
             typeof meta[name].annotations?.readOnlyHint !== 'boolean'
             || !CATEGORIES.includes(meta[name]._meta?.category ?? '')
         )).toEqual([]);
+    });
+});
+
+describe('administrative-body filtering', () => {
+    // Regression guard for a real incident: an assistant asked "when did the
+    // 3rd κοινότητα last meet", found no body filter on list_meetings, fell
+    // back to relevance-ranked search, and reported a session six months
+    // stale. The filter has to reach the data layer, not just the schema.
+    beforeEach(() => jest.clearAllMocks());
+
+    it('accepts both body filters on list_meetings', () => {
+        const schema = advertised(USER).meta.list_meetings.inputSchema!;
+        expect(schema.parse({
+            cityId: 'athens',
+            administrativeBodyIds: ['body-1'],
+            administrativeBodyTypes: ['community'],
+        })).toMatchObject({
+            administrativeBodyIds: ['body-1'],
+            administrativeBodyTypes: ['community'],
+        });
+    });
+
+    it('rejects a body type outside the schema enum', () => {
+        const schema = advertised(USER).meta.list_meetings.inputSchema!;
+        expect(() => schema.parse({ cityId: 'athens', administrativeBodyTypes: ['κοινότητα'] }))
+            .toThrow();
+    });
+
+    it('rejects an empty body filter rather than listing every meeting', () => {
+        // The data layer skips a zero-length filter, so `[]` would widen the
+        // query to the whole city — the opposite of what passing it means.
+        const schema = advertised(USER).meta.list_meetings.inputSchema!;
+        expect(() => schema.parse({ cityId: 'athens', administrativeBodyIds: [] })).toThrow();
+        expect(() => schema.parse({ cityId: 'athens', administrativeBodyTypes: [] })).toThrow();
+    });
+
+    it('forwards both body filters and the caller identity to the data layer', async () => {
+        const { handlers } = advertised(USER);
+        await handlers.list_meetings(
+            {
+                cityId: 'athens',
+                page: 1,
+                pageSize: 10,
+                administrativeBodyIds: ['body-1'],
+                administrativeBodyTypes: ['community'],
+            } as never,
+            ctxFor(USER)
+        );
+
+        expect(data.mcpListMeetings).toHaveBeenCalledWith(
+            'athens',
+            expect.objectContaining({
+                administrativeBodyIds: ['body-1'],
+                administrativeBodyTypes: ['community'],
+            }),
+            USER
+        );
+    });
+
+    it('passes the caller identity to get_city', async () => {
+        // get_city only lists draft-only bodies to a caller who can see
+        // drafts, so dropping the identity would silently hide them.
+        const { handlers } = advertised(USER);
+        await handlers.get_city({ cityId: 'athens' } as never, ctxFor(SERVICE));
+
+        expect(data.mcpGetCity).toHaveBeenCalledWith('athens', SERVICE);
     });
 });

--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -1,11 +1,15 @@
 import prisma from '@/lib/db/prisma';
-import { Prisma, DiscussionStatus } from '@prisma/client';
+import { Prisma, DiscussionStatus, type AdministrativeBodyType } from '@prisma/client';
 import { searchInRealm } from '@/lib/search/core';
 import { getCities, getCity, getListedCityAtPoint, filterCityIdsByRealm } from '@/lib/db/cities';
 import { getHotSubjectsNearPoint, withDistances } from '@/lib/hotSubjects';
 import { getCouncilMeetingsForCity } from '@/lib/db/meetings';
 import { getPeopleForCity, getPerson, type PersonWithRelations } from '@/lib/db/people';
 import { getPartiesForCity, getParty } from '@/lib/db/parties';
+import {
+    getAdministrativeBodiesForCity,
+    getAdministrativeBodiesWithPublicMeetings,
+} from '@/lib/db/administrativeBodies';
 import { getSubject, getDiscussionSecondsForSubjects, getHotSubjectsCached } from '@/lib/db/subject';
 import { currentBaseUrl, currentRealm } from './realm-context';
 import { getTranscript } from '@/lib/db/transcript';
@@ -162,12 +166,42 @@ async function requireRealmCity(cityId: string): Promise<void> {
     return assertCitiesInRealm([cityId]);
 }
 
-export async function mcpGetCity(cityId: string) {
+/**
+ * Body ids are opaque to the caller, so a hallucinated id, a stale one, or one
+ * belonging to another city has to fail loudly. Filtering on it silently would
+ * return an empty list — indistinguishable from a body that never met, which
+ * is the reading these tools exist to prevent.
+ */
+async function requireCityBodies(cityId: string, bodyIds: string[]): Promise<void> {
+    const known = await prisma.administrativeBody.findMany({
+        where: { cityId, id: { in: bodyIds } },
+        select: { id: true },
+    });
+    const found = new Set(known.map(body => body.id));
+    const unknown = [...new Set(bodyIds)].filter(id => !found.has(id));
+    if (unknown.length > 0) {
+        throw new NotFoundError(
+            `Unknown administrative body for ${cityId}: ${unknown.join(', ')}. See get_city.`
+        );
+    }
+}
+
+export async function mcpGetCity(cityId: string, identity: McpIdentity) {
     await requireRealmCity(cityId);
-    const city = await getCity(cityId);
+    const [city, parties, includeUnreleased] = await Promise.all([
+        getCity(cityId),
+        getPartiesForCity(cityId),
+        canSeeUnreleased(identity, cityId),
+    ]);
     if (!city) throw new NotFoundError('City not found');
 
-    const parties = await getPartiesForCity(cityId);
+    // The bodies carry the ids list_meetings filters by, so a body whose
+    // meetings are all drafts would be a dead filter option for anyone who
+    // cannot see drafts — offer it only to the callers who can.
+    const administrativeBodies = includeUnreleased
+        ? await getAdministrativeBodiesForCity(cityId)
+        : await getAdministrativeBodiesWithPublicMeetings(cityId);
+
     return {
         id: city.id,
         name: city.name,
@@ -180,6 +214,12 @@ export async function mcpGetCity(cityId: string) {
             people: city._count.persons,
             parties: city._count.parties,
         },
+        administrativeBodies: administrativeBodies.map(body => ({
+            id: body.id,
+            name: body.name,
+            name_en: body.name_en,
+            type: body.type,
+        })),
         parties: parties.map(party => ({
             id: party.id,
             name: party.name,
@@ -245,10 +285,21 @@ export async function mcpGetParty(partyId: string) {
 
 export async function mcpListMeetings(
     cityId: string,
-    options: { page: number; pageSize: number; from?: string; to?: string; timeFilter?: 'upcoming' | 'past' },
+    options: {
+        page: number;
+        pageSize: number;
+        from?: string;
+        to?: string;
+        timeFilter?: 'upcoming' | 'past';
+        administrativeBodyIds?: string[];
+        administrativeBodyTypes?: AdministrativeBodyType[];
+    },
     identity: McpIdentity
 ) {
     await requireRealmCity(cityId);
+    if (options.administrativeBodyIds?.length) {
+        await requireCityBodies(cityId, options.administrativeBodyIds);
+    }
     const meetings = await getCouncilMeetingsForCity(cityId, {
         includeUnreleased: await canSeeUnreleased(identity, cityId),
         page: options.page,
@@ -256,6 +307,8 @@ export async function mcpListMeetings(
         from: options.from ? new Date(options.from) : undefined,
         to: options.to ? new Date(options.to) : undefined,
         timeFilter: options.timeFilter,
+        administrativeBodyIds: options.administrativeBodyIds,
+        administrativeBodyTypes: options.administrativeBodyTypes,
     });
 
     return {
@@ -785,7 +838,7 @@ async function editableCities(identity: McpIdentity): Promise<EditableCities> {
 
 export async function mcpFetch(id: string, identity: McpIdentity) {
     if (id.startsWith('city:')) {
-        const city = await mcpGetCity(id.slice('city:'.length));
+        const city = await mcpGetCity(id.slice('city:'.length), identity);
         return {
             id,
             title: city.name,

--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -304,8 +304,12 @@ export async function mcpListMeetings(
         includeUnreleased: await canSeeUnreleased(identity, cityId),
         page: options.page,
         pageSize: options.pageSize,
-        from: options.from ? new Date(options.from) : undefined,
-        to: options.to ? new Date(options.to) : undefined,
+        from: options.from ? new Date(`${options.from}T00:00:00.000Z`) : undefined,
+        // `to` is documented as inclusive, and the underlying filter is `lte`
+        // against a timestamp — so the bound has to be the end of that day.
+        // Parsed as a bare date it lands on midnight and drops every meeting
+        // held later that day.
+        to: options.to ? new Date(`${options.to}T23:59:59.999Z`) : undefined,
         timeFilter: options.timeFilter,
         administrativeBodyIds: options.administrativeBodyIds,
         administrativeBodyTypes: options.administrativeBodyTypes,

--- a/src/lib/mcp/instructions.ts
+++ b/src/lib/mcp/instructions.ts
@@ -9,6 +9,8 @@ Data model: cities (municipalities) hold council meetings; each meeting has subj
 How to work:
 - For "what is happening in the councils lately", start with \`list_hot_subjects\` — every municipality at once, ranked by debate time.
 - Use the \`search\` tool to find subjects by topic, person, party, city or date range. Use \`list_cities\` / \`list_people\` to resolve names to IDs first. Omit the query text for a filter-only listing (e.g. everything a person spoke about, newest first).
+- A \`search\` query returns subjects ranked by relevance, not by date. The top hit is not the newest one, and a page of results is not the whole record — never read "not on page 1" as "does not exist".
+- For "when did this body last meet", use \`list_meetings\` with \`administrativeBodyIds\` and \`timeFilter: "past"\` — \`get_city\` lists the bodies and their ids. Without \`timeFilter\` the top row can be a meeting that has not happened yet. \`search\` cannot answer this at all: it ranks subjects, and carries no body filter.
 - For "what has the council discussed near this address", use \`list_nearby_subjects\` with lat/lng: subjects pinned within the radius come first with distances, then municipality-wide ones (distanceMeters null). It only scans recent meetings — report an empty list as "nothing since oldestMeetingScanned", not "nothing".
 - Use \`get_subject\` for a subject's details and \`get_subject_transcript\` for exactly what was said about it, with utterance IDs.
 - To find which subjects of a meeting mattered, rank \`get_meeting\`'s subjects by \`discussionSeconds\` (debate time) — agenda order says nothing about importance, and most items pass without discussion.

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -72,9 +72,14 @@ export function registerOpenCouncilServer(server: McpServer) {
             _meta: category('discovery'),
             description:
                 'Full-text and semantic search over council meeting subjects (agenda items). ' +
-                'Filter by city, person, party, topic or date range. Omit the query to list ' +
-                'everything matching the filters, newest first — e.g. all subjects a person ' +
-                'spoke about, or all subjects in a date range. Returns compact results with URLs; ' +
+                'Filter by city, person, party, topic or date range. With a query, results are ' +
+                'ranked by relevance, not by date: the top hit is not the most recent match, and ' +
+                'absence from the first page is not absence from the record — page on, or widen ' +
+                'the filters, before concluding something does not exist. It ranks subjects, not ' +
+                'meetings, and cannot filter by administrative body — use list_meetings for that. ' +
+                'Omit the query to list everything matching the filters, newest first — e.g. all ' +
+                'subjects a person spoke about, or all subjects in a date range. ' +
+                'Returns compact results with URLs; ' +
                 'use get_subject / get_subject_transcript with a result id for details. `total` is ' +
                 'the search index\'s own match count — report it as approximate ("about N"), and ' +
                 'note it is omitted entirely when results had to be withheld.',

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod4';
+import { AdministrativeBodyType } from '@prisma/client';
 import type { McpServer, ServerContext, CallToolResult } from '@modelcontextprotocol/server';
 import { ApiError } from '@/lib/api/errors';
 import { identityFromContext } from './auth';
@@ -179,10 +180,13 @@ export function registerOpenCouncilServer(server: McpServer) {
             title: 'Get municipality',
             annotations: { readOnlyHint: true, openWorldHint: false },
             _meta: category('directory'),
-            description: 'Get a municipality profile, including its political parties.',
+            description:
+                'Get a municipality profile: its political parties, and its administrative ' +
+                'bodies — the council, committees and κοινότητες that hold meetings. Each body ' +
+                'carries the id that list_meetings filters by.',
             inputSchema: z.object({ cityId: z.string().min(1) }),
         },
-        args => run(() => mcpGetCity(args.cityId))
+        (args, ctx: ServerContext) => run(() => mcpGetCity(args.cityId, identityFromContext(ctx)))
     );
 
     server.registerTool(
@@ -230,12 +234,22 @@ export function registerOpenCouncilServer(server: McpServer) {
             title: 'List meetings',
             annotations: { readOnlyHint: true, openWorldHint: false },
             _meta: category('meetings'),
-            description: 'List a municipality\'s council meetings, newest first (or soonest first for upcoming).',
+            description:
+                'List a municipality\'s council meetings, newest first (or soonest first for ' +
+                'upcoming). Unfiltered it mixes scheduled meetings in with held ones, and a ' +
+                'scheduled meeting sorts ahead of every held one — pass timeFilter to separate ' +
+                'them. administrativeBodyIds answers "when did this body last meet": pair it ' +
+                'with timeFilter "past" for the last held session, "upcoming" for the next one.',
             inputSchema: z.object({
                 cityId: z.string().min(1),
                 from: z.iso.date().optional().describe('ISO date (YYYY-MM-DD), inclusive'),
                 to: z.iso.date().optional().describe('ISO date (YYYY-MM-DD), inclusive'),
-                timeFilter: z.enum(['upcoming', 'past']).optional(),
+                timeFilter: z.enum(['upcoming', 'past']).optional()
+                    .describe('Keep only meetings already held ("past") or still to come ("upcoming"). Omitted, the list holds both'),
+                administrativeBodyIds: z.array(z.string().min(1)).min(1).optional()
+                    .describe('Restrict to these administrative body ids (see get_city). An unknown id is an error, not an empty list. Takes precedence over administrativeBodyTypes'),
+                administrativeBodyTypes: z.array(z.enum(AdministrativeBodyType)).min(1).optional()
+                    .describe('Restrict to bodies of these kinds: council (Δημοτικό or Περιφερειακό Συμβούλιο), committee (Δημοτική or Περιφερειακή Επιτροπή), community (Δημοτική Κοινότητα; municipalities only)'),
                 pageSize: z.number().int().min(1).max(50).default(10),
                 ...paginationShape,
             }),
@@ -244,7 +258,15 @@ export function registerOpenCouncilServer(server: McpServer) {
             run(() =>
                 mcpListMeetings(
                     args.cityId,
-                    { page: args.page, pageSize: args.pageSize, from: args.from, to: args.to, timeFilter: args.timeFilter },
+                    {
+                        page: args.page,
+                        pageSize: args.pageSize,
+                        from: args.from,
+                        to: args.to,
+                        timeFilter: args.timeFilter,
+                        administrativeBodyIds: args.administrativeBodyIds,
+                        administrativeBodyTypes: args.administrativeBodyTypes,
+                    },
                     identityFromContext(ctx)
                 )
             )

--- a/tests/integration/mcp-meetings.test.ts
+++ b/tests/integration/mcp-meetings.test.ts
@@ -1,0 +1,200 @@
+/** @jest-environment node */
+import { Realm } from '@prisma/client'
+import prisma from '@/lib/db/prisma'
+import { mcpGetCity, mcpListMeetings } from '@/lib/mcp/data'
+import { mcpRealmStore, requestContext } from '@/lib/mcp/realm-context'
+import { ensureTestDb, resetDatabase } from '../helpers/test-db'
+import { createAdministrativeBody, createCity, createMeeting } from '../helpers/factories'
+
+// Anonymous, like a public connector: it sees released meetings only.
+const ANON = null
+// A service key, which sees a city's drafts.
+const SERVICE = { type: 'service', keyName: 'test' } as const
+
+/** Run a tool implementation inside the realm scope the route handler opens. */
+const asRequest = <T>(fn: () => Promise<T>) =>
+    mcpRealmStore.run(requestContext(Realm.greece, 'opencouncil.gr', ANON), fn)
+
+const page = { page: 1, pageSize: 10 }
+
+describe('MCP meeting listing by administrative body - integration', () => {
+    let communityId: string
+    let committeeId: string
+
+    beforeAll(async () => {
+        await ensureTestDb()
+    })
+
+    beforeEach(async () => {
+        await resetDatabase(prisma)
+        await createCity({ id: 'athens', realm: Realm.greece })
+
+        const community = await createAdministrativeBody('athens', {
+            name: '3η Δημοτική Κοινότητα',
+            name_en: '3rd Municipal Community',
+            type: 'community',
+        })
+        const committee = await createAdministrativeBody('athens', {
+            name: 'Δημοτική Επιτροπή',
+            name_en: 'Municipal Committee',
+            type: 'committee',
+        })
+        communityId = community.id
+        committeeId = committee.id
+
+        // The incident's shape: the community met in January and again in
+        // July, while the committee kept meeting through August. Any
+        // recent-weeks window returns committee meetings only, which is what
+        // sent an assistant to relevance-ranked search and a stale answer.
+        await createMeeting('athens', {
+            id: 'jan28', dateTime: new Date('2026-01-28T16:30:00Z'),
+            administrativeBodyId: communityId, released: true,
+        })
+        await createMeeting('athens', {
+            id: 'jul14', dateTime: new Date('2026-07-14T15:30:00Z'),
+            administrativeBodyId: communityId, released: true,
+        })
+        await createMeeting('athens', {
+            id: 'aug18', dateTime: new Date('2026-08-18T07:30:00Z'),
+            administrativeBodyId: committeeId, released: true,
+        })
+        // The community also has a session still to come, as the real one did
+        // three days after the conversation that started this.
+        await createMeeting('athens', {
+            id: 'future', dateTime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+            administrativeBodyId: communityId, released: true,
+        })
+    })
+
+    test('administrativeBodyIds returns that body\'s meetings, newest first', async () => {
+        const { meetings } = await asRequest(() =>
+            mcpListMeetings('athens', { ...page, administrativeBodyIds: [communityId] }, ANON))
+
+        expect(meetings.map(m => m.id)).toEqual(['future', 'jul14', 'jan28'])
+    })
+
+    test('the body filter alone puts a scheduled meeting first, timeFilter separates them', async () => {
+        // Why the tool description tells a caller to pair the two: a bare body
+        // filter answers "when did this body last meet" with a date that has
+        // not happened yet.
+        const bare = await asRequest(() =>
+            mcpListMeetings('athens', { ...page, administrativeBodyIds: [communityId] }, ANON))
+        const past = await asRequest(() =>
+            mcpListMeetings('athens', {
+                ...page, administrativeBodyIds: [communityId], timeFilter: 'past',
+            }, ANON))
+        const upcoming = await asRequest(() =>
+            mcpListMeetings('athens', {
+                ...page, administrativeBodyIds: [communityId], timeFilter: 'upcoming',
+            }, ANON))
+
+        expect(bare.meetings[0].id).toBe('future')
+        expect(past.meetings.map(m => m.id)).toEqual(['jul14', 'jan28'])
+        expect(upcoming.meetings.map(m => m.id)).toEqual(['future'])
+    })
+
+    test('administrativeBodyTypes separates κοινότητες from επιτροπές', async () => {
+        const community = await asRequest(() => mcpListMeetings('athens', {
+            ...page, administrativeBodyTypes: ['community'], timeFilter: 'past',
+        }, ANON))
+        const committee = await asRequest(() => mcpListMeetings('athens', {
+            ...page, administrativeBodyTypes: ['committee'], timeFilter: 'past',
+        }, ANON))
+
+        expect(community.meetings.map(m => m.id)).toEqual(['jul14', 'jan28'])
+        expect(committee.meetings.map(m => m.id)).toEqual(['aug18'])
+    })
+
+    test('an unknown body id is an error, not an empty list', async () => {
+        // An empty list would read as "this body never met" — the inference
+        // that produced the incident in the first place.
+        await expect(asRequest(() => mcpListMeetings('athens', {
+            ...page, administrativeBodyIds: ['no-such-body'],
+        }, ANON))).rejects.toThrow(/Unknown administrative body.*get_city/)
+    })
+
+    test('a body id from another city is rejected too', async () => {
+        await createCity({ id: 'chania', realm: Realm.greece })
+        const foreign = await createAdministrativeBody('chania', { type: 'council' })
+
+        await expect(asRequest(() => mcpListMeetings('athens', {
+            ...page, administrativeBodyIds: [foreign.id],
+        }, ANON))).rejects.toThrow(/Unknown administrative body/)
+    })
+
+    test('ids take precedence over types, matching the data layer', async () => {
+        const { meetings } = await asRequest(() => mcpListMeetings('athens', {
+            ...page,
+            administrativeBodyIds: [committeeId],
+            administrativeBodyTypes: ['community'],
+            timeFilter: 'past',
+        }, ANON))
+
+        expect(meetings.map(m => m.id)).toEqual(['aug18'])
+    })
+
+    test('the filter composes with a date window', async () => {
+        const { meetings } = await asRequest(() => mcpListMeetings('athens', {
+            ...page,
+            administrativeBodyIds: [communityId],
+            from: '2026-02-01',
+        }, ANON))
+
+        expect(meetings.map(m => m.id)).toEqual(['future', 'jul14'])
+    })
+
+    test('get_city hands back body ids that list_meetings accepts', async () => {
+        // The round trip is the point: a caller resolves «3η Δημοτική
+        // Κοινότητα» to an id here and filters with it, without guessing.
+        const city = await asRequest(() => mcpGetCity('athens', ANON))
+        const resolved = city.administrativeBodies.find(b => b.name === '3η Δημοτική Κοινότητα')
+
+        expect(resolved).toMatchObject({ id: communityId, type: 'community' })
+
+        const { meetings } = await asRequest(() => mcpListMeetings('athens', {
+            ...page, administrativeBodyIds: [resolved!.id], timeFilter: 'past',
+        }, ANON))
+        expect(meetings.map(m => m.id)).toEqual(['jul14', 'jan28'])
+    })
+
+    test('get_city withholds a body whose meetings are all drafts', async () => {
+        const draftOnly = await createAdministrativeBody('athens', {
+            name: 'Επιτροπή Ποιότητας Ζωής',
+            name_en: 'Quality of Life Committee',
+            type: 'committee',
+        })
+        await createMeeting('athens', {
+            id: 'draft', dateTime: new Date('2026-08-20T07:30:00Z'),
+            administrativeBodyId: draftOnly.id, released: false,
+        })
+
+        const city = await asRequest(() => mcpGetCity('athens', ANON))
+
+        // Anonymous callers cannot see the drafts, so offering the body would
+        // only produce an empty filter.
+        expect(city.administrativeBodies.map(b => b.id)).not.toContain(draftOnly.id)
+        expect(city.administrativeBodies.map(b => b.id)).toEqual(
+            expect.arrayContaining([communityId, committeeId]))
+    })
+
+    test('get_city offers a draft-only body to a caller who can see drafts', async () => {
+        const draftOnly = await createAdministrativeBody('athens', {
+            name: 'Επιτροπή Ποιότητας Ζωής',
+            name_en: 'Quality of Life Committee',
+            type: 'committee',
+        })
+        await createMeeting('athens', {
+            id: 'draft', dateTime: new Date('2026-08-20T07:30:00Z'),
+            administrativeBodyId: draftOnly.id, released: false,
+        })
+
+        const city = await asRequest(() => mcpGetCity('athens', SERVICE))
+        expect(city.administrativeBodies.map(b => b.id)).toContain(draftOnly.id)
+
+        // The id has to be usable, or listing it is worse than withholding it.
+        const { meetings } = await asRequest(() => mcpListMeetings('athens', {
+            ...page, administrativeBodyIds: [draftOnly.id],
+        }, SERVICE))
+        expect(meetings.map(m => m.id)).toEqual(['draft'])
+    })
+})

--- a/tests/integration/mcp-meetings.test.ts
+++ b/tests/integration/mcp-meetings.test.ts
@@ -143,6 +143,20 @@ describe('MCP meeting listing by administrative body - integration', () => {
         expect(meetings.map(m => m.id)).toEqual(['future', 'jul14'])
     })
 
+    test('both date bounds are inclusive of meetings held that day', async () => {
+        // jul14 is at 15:30. A bound parsed as bare midnight would drop it
+        // from either end, though both are documented as inclusive.
+        const to = await asRequest(() => mcpListMeetings('athens', {
+            ...page, administrativeBodyIds: [communityId], to: '2026-07-14',
+        }, ANON))
+        const from = await asRequest(() => mcpListMeetings('athens', {
+            ...page, administrativeBodyIds: [communityId], from: '2026-07-14',
+        }, ANON))
+
+        expect(to.meetings.map(m => m.id)).toEqual(['jul14', 'jan28'])
+        expect(from.meetings.map(m => m.id)).toEqual(['future', 'jul14'])
+    })
+
     test('get_city hands back body ids that list_meetings accepts', async () => {
         // The round trip is the point: a caller resolves «3η Δημοτική
         // Κοινότητα» to an id here and filters with it, without guessing.

--- a/tests/mocks/nextIntlServer.ts
+++ b/tests/mocks/nextIntlServer.ts
@@ -1,0 +1,46 @@
+/**
+ * `next-intl/server` ships ESM that jest does not transform, so any module
+ * whose import graph reaches it fails to load. Integration tests exercise
+ * data access, not copy, so translations resolve to their key.
+ *
+ * The exports here mirror what `src/` actually imports. Add to this list when
+ * src starts using another one — the failure otherwise is an opaque
+ * "not a function" rather than a missing mapping.
+ */
+type Translator = ((key: string) => string) & {
+    rich: (key: string) => string
+    markup: (key: string) => string
+    raw: (key: string) => string
+    has: (key: string) => boolean
+}
+
+function translator(): Translator {
+    const t = ((key: string) => key) as Translator
+    t.rich = (key: string) => key
+    t.markup = (key: string) => key
+    t.raw = (key: string) => key
+    t.has = () => true
+    return t
+}
+
+export async function getTranslations() {
+    return translator()
+}
+
+export async function getLocale() {
+    return 'el'
+}
+
+export async function getMessages() {
+    return {}
+}
+
+export function setRequestLocale() {
+    // no-op: nothing in an integration test reads the request locale
+}
+
+export function getRequestConfig(
+    fn: (params: { locale: string }) => unknown
+) {
+    return fn
+}


### PR DESCRIPTION
## Why

Notis told a reader that the 3rd Municipal Community of Athens last met on **28 January**. The body had met six more times since — 18/02, 18/03, 22/04, 20/05, 17/06, 14/07 — and had another session **three days after the conversation**.

The data was complete and correct. The MCP had no way to reach it.

`list_meetings` accepted a city and a date range only. `search` carries no body filter, and it ranks subjects by relevance rather than by date. So Notis searched narrow date windows, found no κοινότητα meeting, fell back to `search("3η Δημοτική Κοινότητα Πετράλωνα Γκάζι συνεδρίαση")`, and read the one `3η Δημοτική Κοινότητα` row on page 1 as the most recent session.

I reproduced the query against production. The ranking is stable: that January row scores 44.4 at rank 1, the other nine rows on page 1 are Δημοτικό Συμβούλιο items that only *mention* the 3rd community, and the real 14 July session sits at **rank 18** — outside the default `pageSize: 10`. Its subjects discuss parking in Petralona and never say "3η Δημοτική Κοινότητα".

One call answers the question correctly today: `list_meetings(cityId: "athens", timeFilter: "past", pageSize: 50)` returns the July session at item 16. Notis never made it, because no tool advertised that a body filter was possible.

## What changed

**`list_meetings` takes a body filter.** New `administrativeBodyIds` and `administrativeBodyTypes` parameters. `getCouncilMeetingsForCity` already supported both — the embed widget uses them. The MCP layer dropped them on the way through.

**`get_city` returns the city's administrative bodies.** Id, name, `name_en` and type, so a caller can resolve «3η Δημοτική Κοινότητα» to the id `list_meetings` takes instead of guessing. `get_city` becomes identity-aware for this: a body whose meetings are all drafts is a dead filter option for a caller who cannot see drafts, so only a caller who can see them receives it.

**`search` documents its ranking.** The tool description and the server instructions now say a query ranks subjects by relevance, that the top hit is not the newest match, and that a row missing from page 1 is not proof of absence. Both point at `list_meetings` for "when did this body last meet".

## Testing

- **Integration** (`tests/integration/mcp-meetings.test.ts`, 6 tests, real Postgres): rebuilds the incident's shape — a community that met in January and July, a committee that kept meeting through August — and asserts the filter returns the July session, that types separate κοινότητες from επιτροπές, that ids win over types, that the filter composes with a date window, that a `get_city` body id round-trips into `list_meetings`, and that a draft-only body stays hidden from anonymous callers.
- **Unit** (`src/lib/mcp/__tests__/server.test.ts`, 4 tests): the schema accepts both filters and rejects an unknown body type; the handler forwards both filters and the caller identity to the data layer. Verified these fail when the pass-through is removed.
- Full suite: 1652 unit tests pass, 114 integration tests pass, `npm run lint` and `npm run build` clean.

`next-intl/server` ships ESM that jest does not transform, so any module importing `src/lib/mcp/data.ts` failed to load under the integration config. A mock maps it to its keys.

## Notes for review

- This does not fix everything behind the incident. Notis re-researches from scratch on every wake — `runWake` builds a fresh message array and only delivered texts carry over — so it had already retrieved the 27 August session two minutes earlier, in the previous wake, and could not remember it. That is a `services/notis` concern, not an MCP one, and is left alone here.
- No database migration. The filter uses columns and a code path that already exist.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2pyLFuMDSdhLZ19U5gg2t)_



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds administrative-body filtering to MCP meeting listings and exposes usable body identifiers through `get_city`.
- Adds ID- and type-based administrative-body filters with validation and caller-aware visibility.
- Makes date boundaries inclusive for the full specified calendar day.
- Clarifies relevance ranking and directs body-specific queries to `list_meetings`.
- Adds unit and integration coverage for filtering, visibility, validation, and date bounds.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/mcp/server.ts | Adds non-empty administrative-body filter schemas, forwards filters and identity, and updates MCP tool guidance; the previously reported empty-filter issue is fixed. |
| src/lib/mcp/data.ts | Validates body IDs, applies body filters and inclusive UTC date bounds, and returns identity-aware administrative-body metadata. |
| tests/integration/mcp-meetings.test.ts | Covers body filtering, filter precedence, date composition, visibility, and identifier round-tripping without the previously reported unsafe cast. |
| src/lib/mcp/__tests__/server.test.ts | Verifies schema rejection of empty filters and confirms filters and caller identity reach the data layer. |
| src/lib/mcp/instructions.ts | Documents relevance-ranked search behavior and the correct workflow for finding a body's latest meeting. |

<sub>Reviews (2): Last reviewed commit: ["fix(mcp): make the list\_meetings date bo..."](https://github.com/schemalabz/opencouncil/commit/399f4dc7f57945bf4940dc9454d7961d31f97757) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56224989)</sub>

<!-- /greptile_comment -->