### PR TITLE
notis: detect drift between the template mirror and Bird

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,35 @@ jobs:
 
       - run: SKIP_ENV_VALIDATION=1 npm run build -w notis
 
+      # The template mirror in src/agent/templates.ts is a hand-copy of the
+      # Bird console, and only Bird knows when it goes stale. A variable added
+      # there makes every send of that shell fail with a terminal 422 that
+      # degrades quietly to SMS, so the check belongs before the deploy rather
+      # than in a reader's inbox.
+      #
+      # Skipped without credentials — forks and Dependabot cannot read secrets,
+      # and a missing key must not fail their builds. It still runs on every
+      # push to this repository, which is where a template edit lands.
+      - name: Check the Bird template mirror for drift
+        # The skip is a shell test rather than a step `if`: a step's own env
+        # block is not visible to its condition, and `secrets` is not available
+        # there either. This way the skip is also visible in the log.
+        run: |
+          if [ -z "$BIRD_API_KEY" ]; then
+            echo "No Bird credentials in this context — skipping the drift check."
+            exit 0
+          fi
+          npm run check:templates -w notis
+        env:
+          BIRD_API_KEY: ${{ secrets.BIRD_API_KEY }}
+          BIRD_WORKSPACE_ID: ${{ secrets.BIRD_WORKSPACE_ID }}
+          BIRD_WHATSAPP_TEMPLATE_DEMOS_INTRO: ${{ secrets.BIRD_WHATSAPP_TEMPLATE_DEMOS_INTRO }}
+          BIRD_WHATSAPP_TEMPLATE_DEMOS_TRANSITION: ${{ secrets.BIRD_WHATSAPP_TEMPLATE_DEMOS_TRANSITION }}
+          BIRD_WHATSAPP_TEMPLATE_DEMOS_UPDATE_AGENDA: ${{ secrets.BIRD_WHATSAPP_TEMPLATE_DEMOS_UPDATE_AGENDA }}
+          BIRD_WHATSAPP_TEMPLATE_DEMOS_UPDATE_NEWS: ${{ secrets.BIRD_WHATSAPP_TEMPLATE_DEMOS_UPDATE_NEWS }}
+          BIRD_WHATSAPP_TEMPLATE_DEMOS_FOLLOWUP: ${{ secrets.BIRD_WHATSAPP_TEMPLATE_DEMOS_FOLLOWUP }}
+          SKIP_ENV_VALIDATION: "1"
+
   integration:
     name: Integration (testcontainers)
     runs-on: ubuntu-latest

--- a/services/notis/package.json
+++ b/services/notis/package.json
@@ -12,7 +12,8 @@
     "prisma:generate": "prisma generate --schema prisma/schema.prisma && prisma generate --schema prisma/main-views.prisma",
     "prisma:migrate": "prisma migrate dev --schema prisma/schema.prisma",
     "prisma:deploy": "prisma migrate deploy --schema prisma/schema.prisma",
-    "eval:prompt": "tsx scripts/eval-prompt.ts"
+    "eval:prompt": "tsx scripts/eval-prompt.ts",
+    "check:templates": "tsx scripts/check-template-drift.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.116.0",

--- a/services/notis/scripts/check-template-drift.ts
+++ b/services/notis/scripts/check-template-drift.ts
@@ -1,0 +1,96 @@
+/**
+ * Compare the template mirror in src/agent/templates.ts against what Bird
+ * actually holds.
+ *
+ *   npm run check:templates
+ *
+ * Why this exists. Every variable a shell declares must be supplied or Bird
+ * rejects the send with a 422, and a 422 is terminal — the row fails, the SMS
+ * fallback covers it, and the reader gets the text without buttons. Nothing
+ * else notices. That is how link_path shipped broken: the console changed,
+ * the repository did not, and the first proactive update failed in production
+ * days later.
+ *
+ * The mirror's own unit tests cannot catch this. They compare the file to
+ * constants typed from the same reading, and to itself. Only Bird knows.
+ *
+ * Exits 1 on drift, 0 when the mirror is current, and 78 (EX_CONFIG) when it
+ * cannot ask — a missing key must not read as "no drift".
+ */
+import { TEMPLATES, compareTemplateVariables, type TemplateName } from "@/agent/templates";
+import { templateProjectId } from "@/lib/bird";
+import { env } from "@/env.mjs";
+
+interface ChannelTemplate {
+  variables?: Array<{ key?: string }>;
+}
+
+async function birdVariables(projectId: string): Promise<string[]> {
+  const url = `https://api.bird.com/workspaces/${env.BIRD_WORKSPACE_ID}/projects/${projectId}/channel-templates?limit=100`;
+  const response = await fetch(url, {
+    headers: { Authorization: `AccessKey ${env.BIRD_API_KEY}` },
+  });
+  if (!response.ok) {
+    throw new Error(`Bird returned ${response.status} for project ${projectId}: ${await response.text()}`);
+  }
+  const body = (await response.json()) as { results?: ChannelTemplate[] };
+  // A project can hold several versions; a variable declared by any of them
+  // can reach a send, so the union is the safe comparison.
+  const keys = new Set<string>();
+  for (const template of body.results ?? []) {
+    for (const variable of template.variables ?? []) {
+      if (variable.key) keys.add(variable.key);
+    }
+  }
+  return [...keys];
+}
+
+async function main() {
+  if (!env.BIRD_API_KEY || !env.BIRD_WORKSPACE_ID) {
+    console.error("BIRD_API_KEY and BIRD_WORKSPACE_ID are required to check for drift.");
+    process.exit(78);
+  }
+
+  const drifted: string[] = [];
+  const skipped: string[] = [];
+
+  for (const name of Object.keys(TEMPLATES) as TemplateName[]) {
+    const projectId = templateProjectId(name);
+    if (!projectId) {
+      // demos_checkin has no project id and no send path. Reported rather
+      // than passed over, so "checked" never overstates itself.
+      skipped.push(name);
+      continue;
+    }
+    const drift = compareTemplateVariables(name, await birdVariables(projectId));
+    if (!drift) {
+      console.log(`  ok       ${name}`);
+      continue;
+    }
+    drifted.push(name);
+    console.error(`  DRIFT    ${name}`);
+    if (drift.missing.length) {
+      console.error(
+        `           Bird declares ${drift.missing.join(", ")} and we never send it — every send of this shell fails with a 422.`,
+      );
+    }
+    if (drift.unexpected.length) {
+      console.error(`           we send ${drift.unexpected.join(", ")}, which Bird does not declare.`);
+    }
+  }
+
+  if (skipped.length) console.log(`\nnot checked (no project id): ${skipped.join(", ")}`);
+
+  if (drifted.length) {
+    console.error(
+      `\n${drifted.length} template(s) drifted. Update hasVariable/hasLinkPath in src/agent/templates.ts to match the Bird console.`,
+    );
+    process.exit(1);
+  }
+  console.log("\nthe mirror matches Bird.");
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(78);
+});

--- a/services/notis/src/agent/templates.ts
+++ b/services/notis/src/agent/templates.ts
@@ -252,3 +252,36 @@ export function linkPathFromText(text: string): string | undefined {
     .replace(/[.,;:!?»)\]]+$/, "");
   return path || undefined;
 }
+
+/**
+ * The variables a shell declares, as Bird names them.
+ *
+ * One list, used by two callers that must never disagree: the sender builds
+ * its parameters from it, and the drift check compares it to what the Bird
+ * console actually holds. A mirror checked against a different list from the
+ * one the sender uses would pass while the sends still failed.
+ */
+export function declaredVariables(name: TemplateName): string[] {
+  const def = TEMPLATES[name];
+  return [...(def.hasVariable ? ["demos_text"] : []), ...(def.hasLinkPath ? ["link_path"] : [])];
+}
+
+export interface TemplateDrift {
+  template: TemplateName;
+  /** Bird declares it; we never send it — every send of this shell 422s. */
+  missing: string[];
+  /** We send it; Bird does not declare it. Ignored today, but the mirror is wrong. */
+  unexpected: string[];
+}
+
+/** Compare one shell's mirror against the variable keys Bird reports. */
+export function compareTemplateVariables(
+  name: TemplateName,
+  birdKeys: string[],
+): TemplateDrift | null {
+  const ours = new Set(declaredVariables(name));
+  const theirs = new Set(birdKeys);
+  const missing = [...theirs].filter((k) => !ours.has(k)).sort();
+  const unexpected = [...ours].filter((k) => !theirs.has(k)).sort();
+  return missing.length || unexpected.length ? { template: name, missing, unexpected } : null;
+}

--- a/services/notis/src/lib/__tests__/bird.test.ts
+++ b/services/notis/src/lib/__tests__/bird.test.ts
@@ -1,4 +1,10 @@
-import { FALLBACK_LINK_PATH, extractConflictingConversationId, realBird } from "../bird";
+import {
+  FALLBACK_LINK_PATH,
+  describeMissingVariable,
+  extractConflictingConversationId,
+  realBird,
+} from "../bird";
+import { compareTemplateVariables, declaredVariables } from "@/agent/templates";
 
 jest.mock("@/env.mjs", () => ({
   env: {
@@ -307,5 +313,51 @@ describe("template parameters", () => {
       idempotencyKey: "k3",
     });
     expect((calls[0]?.template as { parameters: unknown[] })?.parameters).toEqual([]);
+  });
+});
+
+describe("describeMissingVariable", () => {
+  it("lifts the variable name out of Bird's 422 body", () => {
+    const body = JSON.stringify({
+      code: "InvalidPayload",
+      message: "One or more fields provided in the request body are malformed",
+      details: { ".parameters": ["missing value for variable 'link_path'"] },
+    });
+    const described = describeMissingVariable(body);
+    expect(described).toContain("link_path");
+    expect(described).toContain("templates.ts");
+  });
+
+  it("says nothing for any other failure", () => {
+    expect(describeMissingVariable(JSON.stringify({ code: "RateLimited" }))).toBe("");
+    expect(describeMissingVariable(null)).toBe("");
+  });
+});
+
+describe("template variable mirror", () => {
+  it("the sender's parameters are exactly what the shell declares", () => {
+    // The drift check compares this same list against Bird, so the thing
+    // verified is the thing sent.
+    expect(declaredVariables("demos_update_news")).toEqual(["demos_text", "link_path"]);
+    expect(declaredVariables("demos_transition")).toEqual([]);
+  });
+
+  it("reports a variable Bird declares that we never send", () => {
+    const drift = compareTemplateVariables("demos_transition", ["link_path"]);
+    expect(drift).toEqual({ template: "demos_transition", missing: ["link_path"], unexpected: [] });
+  });
+
+  it("reports a variable we send that Bird does not declare", () => {
+    const drift = compareTemplateVariables("demos_update_news", ["demos_text"]);
+    expect(drift).toEqual({
+      template: "demos_update_news",
+      missing: [],
+      unexpected: ["link_path"],
+    });
+  });
+
+  it("is silent when the mirror is current", () => {
+    expect(compareTemplateVariables("demos_update_news", ["link_path", "demos_text"])).toBeNull();
+    expect(compareTemplateVariables("demos_intro", [])).toBeNull();
   });
 });

--- a/services/notis/src/lib/bird.ts
+++ b/services/notis/src/lib/bird.ts
@@ -1,5 +1,5 @@
 import { env } from "@/env.mjs";
-import { TEMPLATES, type TemplateName } from "@/agent/templates";
+import { declaredVariables, type TemplateName } from "@/agent/templates";
 import { type BirdMessageLike, fullBodyText } from "@/lib/bird-extract";
 
 /**
@@ -147,16 +147,15 @@ export const FALLBACK_LINK_PATH = "explain";
 function templateBody(template: TemplateName, text: string, linkPath?: string) {
   const projectId = templateProjectId(template);
   if (!projectId) return null;
-  const def = TEMPLATES[template];
-  const parameters: Array<{ type: string; key: string; value: string }> = [];
-  if (def.hasVariable) parameters.push({ type: "string", key: "demos_text", value: text });
-  if (def.hasLinkPath) {
-    parameters.push({
-      type: "string",
-      key: "link_path",
-      value: linkPath?.trim() || FALLBACK_LINK_PATH,
-    });
-  }
+  const values: Record<string, string> = {
+    demos_text: text,
+    link_path: linkPath?.trim() || FALLBACK_LINK_PATH,
+  };
+  const parameters = declaredVariables(template).map((key) => ({
+    type: "string",
+    key,
+    value: values[key] ?? "",
+  }));
   return { projectId, version: "latest", locale: "el", parameters };
 }
 
@@ -214,6 +213,26 @@ async function birdFetch(
 
 /** Map a raw response to the send-result contract shared by every method:
  *  network → retryable, 5xx → retryable, 4xx and in-body rejections → not. */
+/**
+ * Bird names the variable it wanted; say so first.
+ *
+ * A missing template variable is a terminal 422 that hits EVERY send of that
+ * shell, and the operator sees one generic failure line per message with no
+ * hint that a whole class is broken. Lifting the variable name to the front
+ * of the error turns the alert into its own diagnosis: the shell is declaring
+ * something the mirror in templates.ts does not know about.
+ */
+const MISSING_VARIABLE = /missing value for variable '([^']+)'/i;
+
+export function describeMissingVariable(body: string | null): string {
+  const key = body ? MISSING_VARIABLE.exec(body)?.[1] : undefined;
+  if (!key) return "";
+  return (
+    `Bird requires the template variable '${key}', which this send did not supply — ` +
+    `the shell's entry in src/agent/templates.ts is out of date with the Bird console. `
+  );
+}
+
 function toSendResult(raw: RawBirdResponse, what: string): BirdSendResult {
   if (raw.networkError) {
     console.error(`Bird ${what} error:`, raw.networkError);
@@ -225,7 +244,7 @@ function toSendResult(raw: RawBirdResponse, what: string): BirdSendResult {
       success: false,
       status: raw.status,
       retryable: isRetryableStatus(raw.status),
-      error: `API returned ${raw.status}: ${raw.text}`,
+      error: `${describeMissingVariable(raw.text)}API returned ${raw.status}: ${raw.text}`,
     };
   }
   const envelope = (raw.json ?? {}) as BirdResponseEnvelope;


### PR DESCRIPTION
Follow-up to #682, which fixed the missing `link_path` but left the gap that allowed it.

## The problem

The shells in `src/agent/templates.ts` are a hand-copy of the Bird console. Every variable a shell declares must be supplied, or Bird rejects the send with a 422. A 422 is terminal: the row fails, the SMS fallback covers it, and the reader gets the text without buttons. Nothing else notices.

That is how `link_path` shipped broken. The console changed on 23 August. The repository did not. The first proactive update failed days later, and it surfaced as one alert line rather than as "every send of this shell is failing".

**The mirror's unit tests cannot catch this.** They compare the file to constants typed from the same reading, and to itself. Both pass forever while Bird moves on. Only Bird knows.

## Two defences

### Before the deploy

`npm run check:templates` reads each shell's declared variables from Bird and compares them to the mirror.

```
  ok       demos_intro
  ok       demos_transition
  DRIFT    demos_checkin
           Bird declares link_path and we never send it — every send of this shell fails with a 422.
```

It runs in the notis CI job. Without credentials it skips with a visible log line, so forks and Dependabot are unaffected. Missing credentials exit 78, not 0 — "cannot ask" must never read as "no drift".

### After it

Bird's 422 body already names the variable it wanted. The send error now lifts that name to the front and says which file is stale:

> Bird requires the template variable 'link_path', which this send did not supply — the shell's entry in src/agent/templates.ts is out of date with the Bird console.

One alert now carries its own diagnosis.

## One list, two callers

`declaredVariables()` builds the wire parameters **and** is what the check compares. The thing verified is the thing sent. A mirror checked against a different list from the one the sender uses would pass while the sends still failed.

## Setup needed

The CI step needs these repository secrets. Until they exist the step skips cleanly, so this PR is safe to merge first:

- `BIRD_API_KEY`, `BIRD_WORKSPACE_ID`
- `BIRD_WHATSAPP_TEMPLATE_DEMOS_{INTRO,TRANSITION,UPDATE_AGENDA,UPDATE_NEWS,FOLLOWUP}`

## Known limits

- `demos_checkin` has no project id and no send path, so it cannot be checked. The script reports it as not checked rather than passing over it silently.
- The check reads the union of variables across a project's template versions. A variable declared by any version can reach a send, so the union is the safe comparison.

## Verification

- Against the console as it stands: no drift.
- A simulated variable added to a shell: reported by name.
- Without credentials: exits 78.
- `npx tsc --noEmit` clean, `npm test` 309 passing, build succeeds.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a CI drift check between Notis template declarations and Bird, centralizes the variable list used by both checking and sending, and improves diagnostics for missing-variable responses.
- Adds the `check:templates` command and wires it into the Notis CI job.
- Compares locally declared template variables with Bird project metadata.
- Builds outgoing Bird parameters from the shared declaration helper.
- Adds targeted tests for variable comparison and terminal 422 diagnostics.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until missing project IDs for sendable templates fail the drift check instead of allowing CI to pass.

A sendable template whose optional project secret is absent is recorded as not checked, but skipped templates do not affect the process exit status, allowing the exact template drift this change is intended to prevent to reach deployment.

**Files Needing Attention:** services/notis/scripts/check-template-drift.ts, .github/workflows/ci.yml

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds the credential-gated Bird template drift check to the Notis CI job. |
| services/notis/scripts/check-template-drift.ts | Implements Bird metadata retrieval, template-variable comparison, reporting, and process exit handling. |
| services/notis/src/agent/templates.ts | Adds shared helpers for declaring and comparing each template’s wire variables. |
| services/notis/src/lib/bird.ts | Uses shared variable declarations to construct template parameters and enriches missing-variable errors. |
| services/notis/src/lib/__tests__/bird.test.ts | Covers shared variable declarations, drift comparison, and missing-variable diagnostics. |
| services/notis/package.json | Exposes the template drift checker as a workspace script. |

<sub>Reviews (2): Last reviewed commit: ["feat(notis): detect drift between the te..."](https://github.com/schemalabz/opencouncil/commit/e6e7d17263b17fb1c432381a20f3277a3712b6db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56285754)</sub>

<!-- /greptile_comment -->