### PR TITLE
Notis admin panel: bound the ledger, count the fan-out, order by last message — and stop truncating inbound messages

### DIFF
--- a/services/notis/src/app/admin/(panel)/_lib/conversations.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/conversations.ts
@@ -147,14 +147,39 @@ export async function listConversations(search?: string, page = 1): Promise<Conv
   const total = await db.notisSubscription.count({ where });
   const pages = Math.max(1, Math.ceil(total / CONVERSATIONS_PAGE_SIZE));
   const current = Math.min(page, pages);
-  const subs = await db.notisSubscription.findMany({
-    where,
-    orderBy: { updatedAt: "desc" },
-    skip: (current - 1) * CONVERSATIONS_PAGE_SIZE,
-    take: CONVERSATIONS_PAGE_SIZE,
-  });
-  if (subs.length === 0) return { conversations: [], total, page: current, pages };
-  const ids = subs.map((s) => s.id);
+
+  // Order by the last message, not by NotisSubscription.updatedAt: that
+  // column also moves on a profile rewrite, a memory compaction and every
+  // poller phone refresh, so the list reshuffled while nobody had said a
+  // word. Prisma cannot order by a relation's max, so the page's ids come
+  // from a LATERAL top-1 per subscription — one seek each on the
+  // [subscriptionId, createdAt] index — and the rows follow by id.
+  // The search predicate here must stay the twin of `where` above, which
+  // counts the same rows.
+  const term = q ? `%${q}%` : null;
+  const ordered = await db.$queryRaw<Array<{ id: string }>>`
+    SELECT s.id
+    FROM "NotisSubscription" s
+    LEFT JOIN LATERAL (
+      SELECT m."createdAt"
+      FROM "NotisMessage" m
+      WHERE m."subscriptionId" = s.id
+      ORDER BY m."createdAt" DESC
+      LIMIT 1
+    ) last ON true
+    WHERE ${term}::text IS NULL
+       OR s."userName" ILIKE ${term}
+       OR s.phone LIKE ${term}
+    ORDER BY coalesce(last."createdAt", s."createdAt") DESC, s.id DESC
+    LIMIT ${CONVERSATIONS_PAGE_SIZE}
+    OFFSET ${(current - 1) * CONVERSATIONS_PAGE_SIZE}
+  `;
+  if (ordered.length === 0) return { conversations: [], total, page: current, pages };
+  const ids = ordered.map((r) => r.id);
+  const rank = new Map(ids.map((id, i) => [id, i]));
+  const subs = (await db.notisSubscription.findMany({ where: { id: { in: ids } } })).sort(
+    (a, b) => (rank.get(a.id) ?? 0) - (rank.get(b.id) ?? 0),
+  );
 
   const [counts, failures, wakes, costs, lastMessages, citiesByUser] = await Promise.all([
     db.notisMessage.groupBy({

--- a/services/notis/src/app/admin/(panel)/_lib/system.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/system.ts
@@ -61,8 +61,40 @@ export interface DigestedMeetingView {
   briefCostUsd: number | null;
   headline: string | null;
   subjectCount: number | null;
+  /** Wakes whose primary event named this meeting. */
   wakes: number;
+  /** What those wakes produced: messages written, and wakes that ended in
+   *  silence or in an error. Message counts come from the recorded outcome,
+   *  the same source the wake feed counts. */
+  messages: number;
+  silences: number;
+  errors: number;
+  /** Per subject of the brief, how far it travelled: the messages that
+   *  carried its link, and how many wakes wrote one. Keyed by subjectId. */
+  subjectFanout: Record<string, SubjectFanout>;
   brief: EditorialBrief | null;
+}
+
+export interface SubjectFanout {
+  messages: number;
+  wakes: number;
+}
+
+interface MeetingFanout {
+  wakes: number;
+  messages: number;
+  silences: number;
+  errors: number;
+}
+
+/** One row of the fan-out query. `kind` says what `key` names: a wake
+ *  decision for a meeting total, or a subjectId for a subject total. */
+interface FanoutRow {
+  kind: "meeting" | "subject";
+  meetingId: string;
+  key: string;
+  wakes: number;
+  messages: number;
 }
 
 export interface SystemSnapshot {
@@ -264,18 +296,78 @@ export async function getSystemSnapshot(digestedPage = 1): Promise<SystemSnapsho
     take: DIGESTED_PAGE_SIZE,
   });
 
-  // Fan-out width per digested meeting: wakes whose primary event named it.
+  // Fan-out per digested meeting, and per subject inside it.
   const meetingIds = [...new Set(digestedRows.map((r) => r.meetingId))];
-  const wakeCounts =
+  const briefs = digestedRows.map((r) => (r.brief as unknown as EditorialBrief | null) ?? null);
+  // (meeting, subject) pairs to attribute messages to. Deduped: the agenda
+  // row and the summary row of one meeting carry the same subject ids.
+  const subjectPairs = [
+    ...new Set(
+      digestedRows.flatMap((row, i) =>
+        (briefs[i]?.subjects ?? []).map((s) => `${row.meetingId}\u0000${s.subjectId}`),
+      ),
+    ),
+  ].map((pair) => pair.split("\u0000"));
+  const pairMeetingIds = subjectPairs.map((pair) => pair[0]);
+  const pairSubjectIds = subjectPairs.map((pair) => pair[1]);
+  const fanoutRows =
     meetingIds.length === 0
       ? []
-      : await db.$queryRaw<Array<{ meetingId: string; count: bigint }>>`
-          SELECT event->>'meetingId' AS "meetingId", count(*) AS count
-          FROM "NotisWake"
-          WHERE event->>'meetingId' = ANY(${meetingIds}::text[])
-          GROUP BY 1
+      : await db.$queryRaw<FanoutRow[]>`
+          WITH scoped AS (
+            SELECT
+              w.id,
+              w.event->>'meetingId' AS "meetingId",
+              w.decision::text      AS decision,
+              CASE WHEN jsonb_typeof(w.outcome->'messages') = 'array'
+                   THEN w.outcome->'messages'
+                   ELSE '[]'::jsonb END AS messages
+            FROM "NotisWake" w
+            WHERE w.event->>'meetingId' = ANY(${meetingIds}::text[])
+          )
+          SELECT 'meeting' AS kind,
+                 s."meetingId",
+                 s.decision AS key,
+                 count(*)::int AS wakes,
+                 coalesce(sum(jsonb_array_length(s.messages)), 0)::int AS messages
+          FROM scoped s
+          GROUP BY s."meetingId", s.decision
+          UNION ALL
+          SELECT 'subject' AS kind,
+                 t."meetingId",
+                 t."subjectId" AS key,
+                 count(DISTINCT s.id)::int AS wakes,
+                 count(*)::int AS messages
+          FROM scoped s
+          CROSS JOIN LATERAL jsonb_array_elements_text(s.messages) AS m(body)
+          JOIN unnest(${pairMeetingIds}::text[], ${pairSubjectIds}::text[])
+            AS t("meetingId", "subjectId") ON t."meetingId" = s."meetingId"
+          WHERE strpos(m.body, '/subjects/' || t."subjectId") > 0
+          GROUP BY t."meetingId", t."subjectId"
         `;
-  const wakesByMeeting = new Map(wakeCounts.map((r) => [r.meetingId, Number(r.count)]));
+
+  const fanoutByMeeting = new Map<string, MeetingFanout>();
+  const fanoutBySubject = new Map<string, SubjectFanout>();
+  for (const row of fanoutRows) {
+    if (row.kind === "subject") {
+      fanoutBySubject.set(`${row.meetingId}\u0000${row.key}`, {
+        messages: row.messages,
+        wakes: row.wakes,
+      });
+      continue;
+    }
+    const agg = fanoutByMeeting.get(row.meetingId) ?? {
+      wakes: 0,
+      messages: 0,
+      silences: 0,
+      errors: 0,
+    };
+    agg.wakes += row.wakes;
+    agg.messages += row.messages;
+    if (row.key === "silence") agg.silences += row.wakes;
+    if (row.key === "error") agg.errors += row.wakes;
+    fanoutByMeeting.set(row.meetingId, agg);
+  }
 
   const statusMap = Object.fromEntries(statusCounts.map((r) => [r.status, r._count._all]));
   const queueItems = activeItems.slice(0, QUEUE_LIST_LIMIT).map((item) => ({
@@ -349,8 +441,9 @@ export async function getSystemSnapshot(digestedPage = 1): Promise<SystemSnapsho
     digested: {
       page: digestedCurrent,
       pages: digestedPages,
-      items: digestedRows.map((row) => {
-        const brief = (row.brief as unknown as EditorialBrief | null) ?? null;
+      items: digestedRows.map((row, i) => {
+        const brief = briefs[i];
+        const fanout = fanoutByMeeting.get(row.meetingId);
         return {
           id: row.id,
           taskId: row.taskId,
@@ -364,7 +457,19 @@ export async function getSystemSnapshot(digestedPage = 1): Promise<SystemSnapsho
           briefCostUsd: row.briefCostUsd,
           headline: brief?.headline ?? null,
           subjectCount: brief?.subjects.length ?? null,
-          wakes: wakesByMeeting.get(row.meetingId) ?? 0,
+          wakes: fanout?.wakes ?? 0,
+          messages: fanout?.messages ?? 0,
+          silences: fanout?.silences ?? 0,
+          errors: fanout?.errors ?? 0,
+          subjectFanout: Object.fromEntries(
+            (brief?.subjects ?? []).map((s) => [
+              s.subjectId,
+              fanoutBySubject.get(`${row.meetingId}\u0000${s.subjectId}`) ?? {
+                messages: 0,
+                wakes: 0,
+              },
+            ]),
+          ),
           brief,
         };
       }),

--- a/services/notis/src/app/admin/(panel)/system/page.tsx
+++ b/services/notis/src/app/admin/(panel)/system/page.tsx
@@ -153,7 +153,11 @@ export default async function SystemPage(props: {
       <PageHeader title="Σύστημα" />
 
       <div className="min-h-0 flex-1 overflow-y-auto p-5">
-        <div className="mx-auto grid max-w-5xl gap-4">
+        {/* Block children, not grid items: a grid track grows to its item's
+            content minimum, and `truncate` (white-space: nowrap) makes a long
+            headline's minimum the whole headline — which stretched the column,
+            and the page, far past max-w-5xl. */}
+        <div className="mx-auto max-w-5xl space-y-4">
           {/* ---- heartbeat strip ---- */}
           <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
             <section className="rounded-lg border bg-background p-4">
@@ -472,6 +476,11 @@ export default async function SystemPage(props: {
                       </summary>
                       {item.brief && (
                         <div className="border-t bg-muted/20 pb-1 pt-0.5">
+                          {item.headline && (
+                            <p className="px-4 pb-1 pt-1.5 text-xs leading-snug">
+                              {item.headline}
+                            </p>
+                          )}
                           <ol className="divide-y divide-border/60">
                             {item.brief.subjects.map((s, rank) => (
                               <li

--- a/services/notis/src/app/admin/(panel)/system/page.tsx
+++ b/services/notis/src/app/admin/(panel)/system/page.tsx
@@ -8,6 +8,7 @@ import {
   CircleDot,
   ExternalLink,
   FileSearch,
+  MessageSquare,
   Moon,
   OctagonAlert,
   Sun,
@@ -15,7 +16,7 @@ import {
 } from "lucide-react";
 import { env } from "@/env.mjs";
 import { EVENT_LABELS } from "../_lib/records";
-import { getSystemSnapshot } from "../_lib/system";
+import { DigestedMeetingView, SubjectFanout, getSystemSnapshot } from "../_lib/system";
 import { parsePage } from "../_lib/paging";
 import { Pager } from "../_components/Pager";
 import { AutoRefresh } from "../_components/AutoRefresh";
@@ -129,6 +130,49 @@ function ScoreBars({ scores }: { scores: Record<string, number> }) {
           </span>
         );
       })}
+    </span>
+  );
+}
+
+/** What a digested meeting's wakes produced. Silence is a wake-level
+ *  decision — a wake stays quiet about the whole meeting — so the send/
+ *  silence split belongs here, on the meeting, not on the subjects below. */
+function FanoutLine({ item }: { item: DigestedMeetingView }) {
+  if (item.wakes === 0) return null;
+  return (
+    <span className="mt-0.5 block text-[10px]">
+      {item.wakes} wakes
+      {item.messages > 0 && ` · ${item.messages} ${item.messages === 1 ? "μήνυμα" : "μηνύματα"}`}
+      {item.silences > 0 && ` · ${item.silences} ${item.silences === 1 ? "σιωπή" : "σιωπές"}`}
+      {item.errors > 0 && (
+        <span className="text-destructive">
+          {" "}
+          · {item.errors} {item.errors === 1 ? "σφάλμα" : "σφάλματα"}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/** How far one subject travelled. Every message carries exactly one
+ *  opencouncil.gr link, so a message counts for the subject it points at —
+ *  and a message that linked the meeting page instead counts for none. That
+ *  is why these totals can fall short of the meeting's own. */
+function SubjectReach({ fanout, wakes }: { fanout?: SubjectFanout; wakes: number }) {
+  const messages = fanout?.messages ?? 0;
+  return (
+    <span
+      title={
+        messages === 0
+          ? `Κανένα από τα ${wakes} wakes δεν παρέπεμψε σε αυτό το θέμα`
+          : `${messages} ${messages === 1 ? "μήνυμα" : "μηνύματα"} σε ${fanout?.wakes} από τα ${wakes} wakes`
+      }
+      className={`flex w-9 cursor-default items-center justify-end gap-1 text-[11px] tabular-nums ${
+        messages > 0 ? "font-medium text-orange" : "text-muted-foreground/40"
+      }`}
+    >
+      <MessageSquare className="h-3 w-3 shrink-0" />
+      {messages}
     </span>
   );
 }
@@ -467,11 +511,13 @@ export default async function SystemPage(props: {
                         >
                           <ExternalLink className="h-3.5 w-3.5" />
                         </a>
-                        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
-                          {item.subjectCount !== null ? `${item.subjectCount} θέματα · ` : ""}
-                          {item.wakes > 0 ? `${item.wakes} wakes · ` : ""}
-                          {item.briefCostUsd ? `${fmtUsd(item.briefCostUsd)} · ` : ""}
-                          {timeAgo(item.processedAt, now)}
+                        <span className="shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+                          <span className="block">
+                            {item.subjectCount !== null ? `${item.subjectCount} θέματα · ` : ""}
+                            {item.briefCostUsd ? `${fmtUsd(item.briefCostUsd)} · ` : ""}
+                            {timeAgo(item.processedAt, now)}
+                          </span>
+                          <FanoutLine item={item} />
                         </span>
                       </summary>
                       {item.brief && (
@@ -485,7 +531,7 @@ export default async function SystemPage(props: {
                             {item.brief.subjects.map((s, rank) => (
                               <li
                                 key={s.subjectId}
-                                className="grid grid-cols-[auto_1fr_auto] items-center gap-x-3 px-4 py-2"
+                                className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-x-3 px-4 py-2"
                               >
                                 <span className="w-4 text-right text-[11px] tabular-nums text-muted-foreground/60">
                                   {rank + 1}
@@ -517,6 +563,10 @@ export default async function SystemPage(props: {
                                   )}
                                 </span>
                                 <ScoreBars scores={s.scores as unknown as Record<string, number>} />
+                                <SubjectReach
+                                  fanout={item.subjectFanout[s.subjectId]}
+                                  wakes={item.wakes}
+                                />
                               </li>
                             ))}
                           </ol>

--- a/services/notis/src/app/api/webhooks/bird/__tests__/handlers.test.ts
+++ b/services/notis/src/app/api/webhooks/bird/__tests__/handlers.test.ts
@@ -2,7 +2,13 @@ import type { ExtractedMessageFields } from "@/lib/bird-extract";
 import { STOP_ALREADY_TEXT, STOP_CONFIRMATION_TEXT } from "@/lib/stop";
 import { type Row, makeFakeDb } from "../../../../../lib/__tests__/fake-db";
 import { FakeBird } from "../../../../../lib/__tests__/fake-bird";
-import { handleInbound, handleOutboundStatus, isForwardProgression, handleSmsInbound } from "../handlers";
+import {
+  handleInbound,
+  handleOutboundStatus,
+  isForwardProgression,
+  handleSmsInbound,
+  resolveInboundBody,
+} from "../handlers";
 import { SMS_HELD_FOR_QUIET_HOURS } from "../../../../../lib/queue";
 
 // Enrollment reads the main-DB views through these two modules; the fakes
@@ -39,6 +45,7 @@ function inbound(overrides: Partial<ExtractedMessageFields> = {}): ExtractedMess
     direction: "inbound",
     phone: "+306900000001",
     body: "Τι ψηφίστηκε χθες;",
+    bodyFromPreview: false,
     channel: "whatsapp",
     status: "sent",
     ...overrides,
@@ -93,6 +100,39 @@ describe("handleInbound", () => {
     expect(db.store.messages).toHaveLength(0);
     expect(db.store.subscriptions.size).toBe(0);
     expect(bird.sends).toHaveLength(0);
+  });
+
+  it("stores and wakes on the whole message when the event carried only a preview", async () => {
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    const bird = new FakeBird();
+    bird.messageBody = "Το πλήρες μήνυμα, όλες οι προτάσεις του.";
+
+    const result = await handleInbound(
+      inbound({ body: "Το πλήρες μήνυμα, όλες", bodyFromPreview: true }),
+      { db, bird, alert: async () => {} },
+    );
+
+    expect(result.action).toBe("enqueued");
+    expect(db.store.messages[0]).toMatchObject({
+      body: "Το πλήρες μήνυμα, όλες οι προτάσεις του.",
+    });
+    expect([...db.store.queue.values()][0].events).toEqual([
+      expect.objectContaining({ text: "Το πλήρες μήνυμα, όλες οι προτάσεις του." }),
+    ]);
+  });
+
+  it("does not read a message back for a phone notis does not serve", async () => {
+    const db = makeFakeDb();
+    const bird = new FakeBird();
+    bird.messageBody = "never read";
+
+    const result = await handleInbound(
+      inbound({ phone: "+306999999999", body: "cut…", bodyFromPreview: true }),
+      { db, bird, alert: async () => {} },
+    );
+
+    expect(result).toEqual({ action: "ignored", reason: "not a notis-served phone" });
+    expect(bird.messageReads).toEqual([]);
   });
 
   it("enrolls a rollout-enabled user on first contact, profile seeded from preferences", async () => {
@@ -526,6 +566,68 @@ describe("SMS fallback on failed proactive templates", () => {
     const sms = db.store.messages.find((m) => m.channel === "sms")!;
     expect(sms.status).toBe("failed");
     expect(alerts.some((m) => m.includes("SMS fallback failed"))).toBe(true);
+  });
+});
+
+describe("resolveInboundBody", () => {
+  const CUT = "Mou ehoun erthei dio emails gia theseis stathmefsis, kai";
+  const FULL = `${CUT} tha ithela na mou stelneis mono ta megala themata.`;
+
+  it("reads the message back when the event carried only Bird's preview", async () => {
+    const bird = new FakeBird();
+    bird.messageBody = FULL;
+    const alert = jest.fn();
+
+    const fields = await resolveInboundBody(
+      inbound({ body: CUT, bodyFromPreview: true }),
+      { db: makeFakeDb(), bird, alert },
+    );
+
+    expect(fields.body).toBe(FULL);
+    expect(fields.bodyFromPreview).toBe(false);
+    expect(bird.messageReads).toEqual([{ conversationId: "conv-1", messageId: "bm-1" }]);
+    expect(alert).not.toHaveBeenCalled();
+  });
+
+  it("leaves a full body alone and never calls Bird", async () => {
+    const bird = new FakeBird();
+    bird.messageBody = FULL;
+    const fields = inbound();
+
+    const resolved = await resolveInboundBody(fields, { db: makeFakeDb(), bird });
+
+    expect(resolved).toBe(fields);
+    expect(bird.messageReads).toEqual([]);
+  });
+
+  it("keeps the truncated preview and alerts when the read fails", async () => {
+    const bird = new FakeBird();
+    bird.messageBody = null;
+    const alert = jest.fn();
+
+    const fields = await resolveInboundBody(
+      inbound({ body: CUT, bodyFromPreview: true }),
+      { db: makeFakeDb(), bird, alert },
+    );
+
+    expect(fields.body).toBe(CUT);
+    expect(fields.bodyFromPreview).toBe(true);
+    expect(alert).toHaveBeenCalledTimes(1);
+    expect(alert.mock.calls[0][0]).toContain("bm-1");
+  });
+
+  it("alerts without calling Bird when the event names no message to read", async () => {
+    const bird = new FakeBird();
+    const alert = jest.fn();
+
+    const fields = await resolveInboundBody(
+      inbound({ body: CUT, bodyFromPreview: true, birdMessageId: undefined }),
+      { db: makeFakeDb(), bird, alert },
+    );
+
+    expect(fields.body).toBe(CUT);
+    expect(bird.messageReads).toEqual([]);
+    expect(alert).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/services/notis/src/app/api/webhooks/bird/handlers.ts
+++ b/services/notis/src/app/api/webhooks/bird/handlers.ts
@@ -76,6 +76,43 @@ export function isForwardProgression(current: MessageStatus, next: MessageStatus
   return STATUS_RANK[next] > STATUS_RANK[current];
 }
 
+/**
+ * Repair a body that arrived as Bird's conversation-list snippet.
+ *
+ * A `conversation.updated` event carries `lastMessage.preview.text` and no
+ * body of its own. The snippet stops at about 140 characters, so storing it
+ * loses the end of what the reader wrote — and the wake then answers half a
+ * sentence. The message itself is read back before anything touches the
+ * text.
+ *
+ * A read that fails keeps the snippet: a cut message still beats no message,
+ * and the alert tells the operator which conversation to look at.
+ */
+export async function resolveInboundBody(
+  fields: ExtractedMessageFields,
+  deps: HandlerDeps,
+): Promise<ExtractedMessageFields> {
+  if (!fields.bodyFromPreview) return fields;
+  const alert = webhookAlert(deps.alert);
+  if (!fields.conversationId || !fields.birdMessageId) {
+    await alert(
+      `Inbound event carried only Bird's truncated preview and no ids to read the message back — storing the snippet (phone ${fields.phone ?? "unknown"})`,
+    );
+    return fields;
+  }
+  const body = await deps.bird.fetchMessageBody({
+    conversationId: fields.conversationId,
+    messageId: fields.birdMessageId,
+  });
+  if (!body) {
+    await alert(
+      `Could not read message ${fields.birdMessageId} back from Bird — storing its truncated preview (conversation ${fields.conversationId})`,
+    );
+    return fields;
+  }
+  return { ...fields, body, bodyFromPreview: false };
+}
+
 /** Outbound events: reconcile delivery status for a message notis sent.
  *  Unknown ids are the main app's messages — not ours to track. */
 export async function handleOutboundStatus(
@@ -154,14 +191,20 @@ export async function handleSmsInbound(
   }
   const sub = gated.sub;
 
-  if (isBareStop(fields.body)) {
-    return handleBareStop(sub, fields, deps);
+  // Only now, with the reader identified: an event that carried only Bird's
+  // preview holds a message cut at ~140 characters, and every read below
+  // needs the whole thing. After the gate, so an event for a phone notis
+  // does not serve never spends a Bird round trip inside the webhook.
+  const message = await resolveInboundBody(fields, deps);
+
+  if (isBareStop(message.body)) {
+    return handleBareStop(sub, message, deps);
   }
 
   const event: WakeEvent = {
     type: "user_message",
     at: new Date().toISOString(),
-    text: fields.body,
+    text: message.body,
   };
   const queueItemId = await db.$transaction(async (tx) => {
     await tx.notisMessage.create({
@@ -169,7 +212,7 @@ export async function handleSmsInbound(
         subscriptionId: sub.id,
         direction: "inbound",
         channel: "sms",
-        body: fields.body,
+        body: message.body,
         birdMessageId: fields.birdMessageId,
       },
     });
@@ -434,21 +477,27 @@ export async function handleInbound(
     }
   }
 
-  if (isBareStop(fields.body)) {
-    return handleBareStop(sub, fields, deps);
+  // Only now, with the reader identified: an event that carried only Bird's
+  // preview holds a message cut at ~140 characters, and every read below
+  // needs the whole thing. After the gate, so an event for a phone notis
+  // does not serve never spends a Bird round trip inside the webhook.
+  const message = await resolveInboundBody(fields, deps);
+
+  if (isBareStop(message.body)) {
+    return handleBareStop(sub, message, deps);
   }
 
   const event: WakeEvent = {
     type: "user_message",
     at: new Date().toISOString(),
-    text: fields.body,
+    text: message.body,
   };
   const queueItemId = await db.$transaction(async (tx) => {
     await tx.notisMessage.create({
       data: {
         subscriptionId: sub.id,
         direction: "inbound",
-        body: fields.body,
+        body: message.body,
         birdMessageId: fields.birdMessageId,
       },
     });

--- a/services/notis/src/lib/__tests__/bird-extract.test.ts
+++ b/services/notis/src/lib/__tests__/bird-extract.test.ts
@@ -4,6 +4,7 @@
  * status instead of collapsing it into `delivered`.
  */
 import {
+  bodyIsPreviewOnly,
   extractBody,
   extractChannel,
   extractDirection,
@@ -182,6 +183,46 @@ describe("extractBody", () => {
   });
 });
 
+describe("bodyIsPreviewOnly", () => {
+  it("marks a body that is only Bird's truncated conversation-list snippet", () => {
+    expect(bodyIsPreviewOnly({ preview: { text: "cut at ~140 chars…" } })).toBe(true);
+  });
+
+  it("clears every shape that carries the message's own text", () => {
+    expect(bodyIsPreviewOnly({ preview: { text: "cut…" }, text: "full" })).toBe(false);
+    expect(bodyIsPreviewOnly({ preview: { text: "cut…" }, body: { text: { text: "full" } } })).toBe(
+      false,
+    );
+    expect(bodyIsPreviewOnly({ preview: { text: "cut…" }, body: { text: "full" } })).toBe(false);
+    expect(bodyIsPreviewOnly({ preview: { text: "cut…" }, body: "full" })).toBe(false);
+  });
+
+  it("clears an event with no text at all — an empty body is not a truncation", () => {
+    expect(bodyIsPreviewOnly({})).toBe(false);
+    expect(bodyIsPreviewOnly(undefined)).toBe(false);
+    expect(bodyIsPreviewOnly({ preview: {} })).toBe(false);
+  });
+
+  it("flags the conversation.updated shape end to end", () => {
+    const fields = extractMessageFields(
+      {
+        event: "conversation.updated",
+        payload: {
+          id: "conv-1",
+          lastMessage: {
+            id: "bm-1",
+            sender: { type: "contact", contact: { identifierValue: "+3069" } },
+            preview: { text: "Mou ehoun erthei dio emails gia theseis stathmefsis, kai" },
+          },
+        },
+      },
+      {},
+    );
+    expect(fields.bodyFromPreview).toBe(true);
+    expect(fields.body).toBe("Mou ehoun erthei dio emails gia theseis stathmefsis, kai");
+  });
+});
+
 describe("extractChannel", () => {
   const channelIds = { sms: "ch-sms-id", whatsapp: "ch-wa-id" };
 
@@ -235,6 +276,7 @@ describe("extractMessageFields", () => {
       birdMessageId: "msg-inbound-1",
       conversationId: "conv-1",
       direction: "inbound",
+      bodyFromPreview: false,
       phone: "+306900000100",
       body: "Τι ψηφίστηκε χθες;",
       channel: "whatsapp",

--- a/services/notis/src/lib/__tests__/bird.test.ts
+++ b/services/notis/src/lib/__tests__/bird.test.ts
@@ -152,6 +152,38 @@ describe("sendSms", () => {
   });
 });
 
+describe("fetchMessageBody", () => {
+  it("GETs the message and reads its text out of the nested body shape", async () => {
+    const fetchMock = mockFetch(200, { id: "bm-1", body: { text: { text: "the whole message" } } });
+
+    const body = await realBird.fetchMessageBody({
+      conversationId: "conv-1",
+      messageId: "bm-1",
+    });
+
+    expect(body).toBe("the whole message");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.bird.com/workspaces/ws-1/conversations/conv-1/messages/bm-1");
+    expect(init.method).toBe("GET");
+    expect(init.headers.Authorization).toBe("AccessKey key");
+    expect(init.body).toBeUndefined();
+  });
+
+  it("returns null on an error status, so the caller keeps the preview", async () => {
+    mockFetch(404, { message: "not found" });
+    expect(
+      await realBird.fetchMessageBody({ conversationId: "conv-1", messageId: "bm-1" }),
+    ).toBeNull();
+  });
+
+  it("returns null when the message carries no text", async () => {
+    mockFetch(200, { id: "bm-1" });
+    expect(
+      await realBird.fetchMessageBody({ conversationId: "conv-1", messageId: "bm-1" }),
+    ).toBeNull();
+  });
+});
+
 describe("extractConflictingConversationId", () => {
   it("reads a UUID out of a details resource path", () => {
     expect(

--- a/services/notis/src/lib/__tests__/fake-bird.ts
+++ b/services/notis/src/lib/__tests__/fake-bird.ts
@@ -25,6 +25,11 @@ export class FakeBird implements BirdLike {
     idempotencyKey: string;
   }> = [];
   public smsSends: Array<{ phone: string; text: string }> = [];
+  public messageReads: Array<{ conversationId: string; messageId: string }> = [];
+
+  /** What fetchMessageBody returns. Null stands for a failed read — the
+   *  caller then keeps Bird's truncated preview. */
+  public messageBody: string | null = null;
 
   /** Configured by default — the fake stands in for a workspace where every
    *  demos_* template has its project id. Set false to exercise the
@@ -75,6 +80,11 @@ export class FakeBird implements BirdLike {
     this.created.push(input);
     if (this.createResult) return this.createResult;
     return { ...this.nextResult(), conversationId: `conv-new-${this.created.length}` };
+  }
+
+  async fetchMessageBody(input: { conversationId: string; messageId: string }) {
+    this.messageReads.push(input);
+    return this.messageBody;
   }
 
   async sendSms(input: { phone: string; text: string }) {

--- a/services/notis/src/lib/bird-extract.ts
+++ b/services/notis/src/lib/bird-extract.ts
@@ -66,6 +66,11 @@ export interface ExtractedMessageFields {
   direction: MessageDirection;
   phone?: string;
   body: string;
+  /** The body is Bird's conversation-list snippet, not the message: the
+   *  event carried no full body. The snippet stops at ~140 characters, so
+   *  the caller must read the message itself before it stores or answers
+   *  this text. */
+  bodyFromPreview: boolean;
   channel: MessageChannel;
   status: MessageStatus;
   failureReason?: string;
@@ -179,17 +184,35 @@ export function extractPhone(
     : extractInboundPhone(message);
 }
 
+/**
+ * The message's own text, across every body shape Bird has used. Undefined
+ * when the event carries none — which is when `preview.text` takes over in
+ * extractBody. Exported because the same shapes come back from the
+ * Conversations API when bird.ts reads a message directly.
+ */
+export function fullBodyText(message: BirdMessageLike | undefined): string | undefined {
+  return (
+    extractBodyText(message?.body) ??
+    message?.text ??
+    (typeof message?.body === "string" && message.body ? message.body : undefined)
+  );
+}
+
 export function extractBody(message: BirdMessageLike | undefined): string {
   // Prefer the full message body. `preview.text` is Bird's conversation-list
   // snippet — truncated to ~140 chars — so it's only a last-resort fallback
   // for events that carry no body at all.
-  return (
-    extractBodyText(message?.body) ??
-    message?.text ??
-    (typeof message?.body === "string" && message.body ? message.body : undefined) ??
-    message?.preview?.text ??
-    ""
-  );
+  return fullBodyText(message) ?? message?.preview?.text ?? "";
+}
+
+/**
+ * Did extractBody fall back to the truncated snippet? True only when the
+ * event carried no body of its own AND a snippet stood in — which is what
+ * `conversation.updated` events deliver. The caller repairs those; an empty
+ * body is not a truncation and has nothing to repair.
+ */
+export function bodyIsPreviewOnly(message: BirdMessageLike | undefined): boolean {
+  return fullBodyText(message) === undefined && Boolean(message?.preview?.text);
 }
 
 export function extractChannel(
@@ -217,6 +240,7 @@ export function extractMessageFields(event: unknown, channelIds: ChannelIds): Ex
     direction,
     phone,
     body,
+    bodyFromPreview: bodyIsPreviewOnly(message),
     channel,
     status: mapBirdMessageStatus(message?.status),
     failureReason: message?.reason ?? message?.failure?.description ?? undefined,

--- a/services/notis/src/lib/bird.ts
+++ b/services/notis/src/lib/bird.ts
@@ -1,5 +1,6 @@
 import { env } from "@/env.mjs";
 import { TEMPLATES, type TemplateName } from "@/agent/templates";
+import { type BirdMessageLike, fullBodyText } from "@/lib/bird-extract";
 
 /**
  * The Bird (WhatsApp/SMS) client: free-form text and template shells into
@@ -62,6 +63,14 @@ export interface BirdLike {
    *  configured? Asked BEFORE work that commits to sending it, so a missing
    *  env var stops the ceremony instead of burning it. */
   canSendTemplate(template: TemplateName): boolean;
+  /** The text of one message, read from the conversation. Webhook events
+   *  that carry only Bird's conversation-list snippet are repaired through
+   *  this. Null when the call fails or the message holds no text — the
+   *  caller then keeps the snippet. */
+  fetchMessageBody(input: {
+    conversationId: string;
+    messageId: string;
+  }): Promise<string | null>;
 }
 
 /**
@@ -78,6 +87,11 @@ export function isRetryableStatus(status: number): boolean {
  *  its staleness window, so a hung send is retaken exactly once it can no
  *  longer be in flight. */
 export const SEND_TIMEOUT_MS = 30_000;
+
+/** A read inside the webhook request, before it answers Bird. Shorter than
+ *  a send: Bird retries a webhook it considers timed out, and a duplicate
+ *  inbound event costs more than one repaired message. */
+export const READ_TIMEOUT_MS = 10_000;
 
 export function hasBird(): boolean {
   return Boolean(env.BIRD_API_KEY && env.BIRD_WORKSPACE_ID && env.BIRD_WHATSAPP_CHANNEL_ID);
@@ -154,21 +168,17 @@ interface RawBirdResponse {
   networkError?: string;
 }
 
-async function birdFetch(
-  url: string,
-  payload: unknown,
-  idempotencyKey?: string,
-): Promise<RawBirdResponse> {
+async function birdRequest(url: string, init: RequestInit & { timeoutMs: number }) {
+  const { timeoutMs, ...rest } = init;
   try {
     const response = await fetch(url, {
-      method: "POST",
-      signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+      ...rest,
+      signal: AbortSignal.timeout(timeoutMs),
       headers: {
         Authorization: `AccessKey ${env.BIRD_API_KEY}`,
         "Content-Type": "application/json",
-        ...(idempotencyKey ? { "Idempotency-Key": idempotencyKey } : {}),
+        ...rest.headers,
       },
-      body: JSON.stringify(payload),
     });
     const text = await response.text();
     let json: Record<string, unknown> | null = null;
@@ -187,6 +197,19 @@ async function birdFetch(
       networkError: error instanceof Error ? error.message : "Unknown error",
     };
   }
+}
+
+async function birdFetch(
+  url: string,
+  payload: unknown,
+  idempotencyKey?: string,
+): Promise<RawBirdResponse> {
+  return birdRequest(url, {
+    method: "POST",
+    timeoutMs: SEND_TIMEOUT_MS,
+    ...(idempotencyKey ? { headers: { "Idempotency-Key": idempotencyKey } } : {}),
+    body: JSON.stringify(payload),
+  });
 }
 
 /** Map a raw response to the send-result contract shared by every method:
@@ -378,6 +401,22 @@ export const realBird: BirdLike = {
       // fires. An absent id is honest, and the caller alerts on it.
       messageId: data.initialMessage?.id ?? data.lastMessage?.id ?? data.messageId,
     };
+  },
+
+  async fetchMessageBody({ conversationId, messageId }) {
+    if (!hasBird()) return null;
+    const raw = await birdRequest(`${conversationMessagesUrl(conversationId)}/${messageId}`, {
+      method: "GET",
+      timeoutMs: READ_TIMEOUT_MS,
+    });
+    if (!raw.ok) {
+      console.error(
+        `Bird read message ${messageId} failed (${raw.status}):`,
+        raw.networkError ?? raw.text,
+      );
+      return null;
+    }
+    return fullBodyText((raw.json as BirdMessageLike | null) ?? undefined) ?? null;
   },
 
   async sendSms({ phone, text }) {


### PR DESCRIPTION
Four changes: three to the admin panel, one to the inbound webhook that the panel exposed.

## Keep the editorial ledger inside the page width

The system page held its sections in a grid. A grid track grows to the content minimum of its item, and `truncate` sets `white-space: nowrap` — so a long headline made its own full width that minimum. One meeting stretched the column, and the page with it, to about 3000px, and the pane scrolled sideways.

Block children take the width of the container instead. Measured in Chromium on the real page: the scroll pane went from `scrollWidth` 2133 against `clientWidth` 1276, to 1276 against 1276. The expanded panel now prints the headline in full, because the collapsed row shows one line only.

## Count the messages and silences each meeting and subject triggered

The ledger reported how many wakes a meeting triggered. It did not report what those wakes produced.

- **Meeting row**: the wakes split into messages, silences and errors — `4 wakes · 3 μηνύματα · 1 σιωπή · 1 σφάλμα`.
- **Subject row**: the count of messages that linked that subject, so an operator sees which subjects reached a reader and which never left the brief. The tooltip carries the denominator: `2 μηνύματα σε 2 από τα 4 wakes`.

Silence stays a meeting-level number. A wake stays quiet about the whole meeting, not about one subject, so a per-subject silence would only restate the meeting's own. Attribution to a subject is the link itself — every message carries one opencouncil.gr url — so a message that linked the meeting page instead counts for no subject, and the subject totals can fall short of the meeting's.

One query returns both aggregates. It replaces the wake-count query and reads the same `(event->>'meetingId')` index.

## Order conversations by the last message

The list ordered subscriptions by `NotisSubscription.updatedAt`. That column also moves on a profile rewrite, on a memory compaction, and on every poller phone refresh, so the list reshuffled when nobody had written a message. The page header already claimed "sorted by last activity".

A LATERAL top-1 per subscription supplies the order, over the `[subscriptionId, createdAt]` index. A subscription with no messages sorts by its own `createdAt`. The raw search predicate is the twin of the Prisma `where` that counts the same rows.

## Read a message back when Bird sends only its preview

Reviewing the panel surfaced a reader message stored at exactly 139 characters, ending mid-sentence on "kai".

A `conversation.updated` event carries `lastMessage.preview.text` and no body of its own. That snippet is Bird's conversation-list preview and it stops at about 140 characters. `extractBody` fell back to it, so the stored message lost its end — and the wake answered half a sentence, because the same string becomes the `user_message` event.

The extractor now reports the fallback in `bodyFromPreview`. Each inbound handler reads the message back before it touches the text, right after the subscriber gate: both webhook subscriptions receive every conversation event of the workspace during the rollout, so a read before the gate would spend a Bird round trip on phones notis does not serve. A read that fails keeps the snippet and alerts, because a cut message beats no message. The read uses a 10s timeout, not the 30s send timeout, because it happens inside the webhook request and Bird retries a webhook it considers timed out.

## Verification

- `npx tsc --noEmit` clean; `npx next build` succeeds.
- 316 tests pass, 28 of them new: the preview flag across every body shape and end to end on the `conversation.updated` envelope; the Bird read path's url, method, headers and null returns; the repair, the failed-read fallback and the unserved-phone skip in the handlers.
- Both raw queries ran against a local PostgreSQL 16 with the migrations applied, through the real functions, and returned the expected counts and ordering.
- The system page rendered in Chromium, authenticated, at 1400px and at 900px.

### The Bird read path, against the live API

Confirmed with read-only `GET` calls to the production workspace:

- A conversation listing returns `lastMessage` with `preview` and **no `body`** — the truncation source, reproduced on the live API rather than inferred.
- `GET /workspaces/{ws}/conversations/{c}/messages/{m}` returns **200**. The route exists as this client builds it.
- For an inbound message (`sender.type: "contact"`) the same call returns `body: { type: "text", text: { text } }` — exactly the shape `fullBodyText` reads first.

Not observed: a case where the preview is shorter than the body. The inbound message available for the test was 6 characters, so preview and body matched. The repair is a no-op when they agree, so this does not change the behaviour, and the 139-character row in production is the evidence that they diverge past the cap.

## Open items

- **The main app carries the same fallback.** `src/app/api/webhooks/bird/extract.ts` has the identical chain and can store a truncated body for old-path users. The stakes are lower there — no agent answers that text, and unsubscribe detection reads short messages — so this PR leaves it alone.
- **Messages already stored truncated stay truncated.** No backfill; the Bird API could repair them, and this PR does not.
