### PR TITLE
fix(meetings): apply date range and timeFilter together

### DIFF
--- a/src/lib/__tests__/meetings.test.ts
+++ b/src/lib/__tests__/meetings.test.ts
@@ -95,6 +95,80 @@ describe('getCouncilMeetingsForCity - Pagination', () => {
   });
 });
 
+describe('getCouncilMeetingsForCity - date range and timeFilter', () => {
+  const NOW = new Date('2026-08-24T12:00:00.000Z');
+
+  type DateTimeFilter = { gt?: Date; gte?: Date; lte?: Date };
+
+  const dateTimeArg = (): DateTimeFilter | undefined =>
+    (mockFindMany.mock.calls[0][0] as { where?: { dateTime?: DateTimeFilter } }).where?.dateTime;
+
+  const orderByArg = (): unknown =>
+    (mockFindMany.mock.calls[0][0] as { orderBy?: unknown }).orderBy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers().setSystemTime(NOW);
+    mockFindMany.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('keeps the past bound when a from date is also given', async () => {
+    const from = new Date('2026-01-01T00:00:00.000Z');
+    await getCouncilMeetingsForCity('test-city', { from, timeFilter: 'past' });
+
+    expect(dateTimeArg()).toEqual({ gte: from, lte: NOW });
+    expect(orderByArg()).toEqual([{ dateTime: 'desc' }, { createdAt: 'desc' }]);
+  });
+
+  it('keeps the upcoming bound when a to date is also given', async () => {
+    const to = new Date('2026-12-31T23:59:59.999Z');
+    await getCouncilMeetingsForCity('test-city', { to, timeFilter: 'upcoming' });
+
+    expect(dateTimeArg()).toEqual({ gt: NOW, lte: to });
+    expect(orderByArg()).toEqual([{ dateTime: 'asc' }, { createdAt: 'asc' }]);
+  });
+
+  it('uses the to date as the upper bound when it is earlier than now', async () => {
+    const to = new Date('2026-06-30T23:59:59.999Z');
+    await getCouncilMeetingsForCity('test-city', { to, timeFilter: 'past' });
+
+    expect(dateTimeArg()).toEqual({ lte: to });
+  });
+
+  it('uses now as the upper bound when the to date is later than now', async () => {
+    await getCouncilMeetingsForCity('test-city', {
+      to: new Date('2026-12-31T23:59:59.999Z'),
+      timeFilter: 'past',
+    });
+
+    expect(dateTimeArg()).toEqual({ lte: NOW });
+  });
+
+  it('applies a from/to range on its own', async () => {
+    const from = new Date('2026-01-01T00:00:00.000Z');
+    const to = new Date('2026-03-31T23:59:59.999Z');
+    await getCouncilMeetingsForCity('test-city', { from, to });
+
+    expect(dateTimeArg()).toEqual({ gte: from, lte: to });
+  });
+
+  it('applies timeFilter on its own', async () => {
+    await getCouncilMeetingsForCity('test-city', { timeFilter: 'past' });
+
+    expect(dateTimeArg()).toEqual({ lte: NOW });
+  });
+
+  it('sets no dateTime filter when neither is given', async () => {
+    await getCouncilMeetingsForCity('test-city', {});
+
+    expect(dateTimeArg()).toBeUndefined();
+  });
+});
+
 describe('generateUniqueMeetingId', () => {
   const april20 = new Date('2026-04-20T12:00:00+03:00');
 

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -130,19 +130,18 @@ export async function getCouncilMeetingsForCity(cityId: string, { includeUnrelea
         const skip = page ? (page - 1) * pageSize : undefined;
         const take = page ? pageSize : limit;
 
-        // Build dateTime filter
+        // Build dateTime filter. An explicit from/to range and timeFilter are
+        // independent constraints, so they intersect. Only `past` and `to` set
+        // the same bound, and there the earlier of the two wins.
         const now = new Date();
-        const timeFilterValue = timeFilter === 'upcoming'
-            ? { gt: now }
-            : timeFilter === 'past'
-                ? { lte: now }
-                : undefined;
-        const dateTimeFilter = (from || to)
-            ? {
-                ...(from && { gte: from }),
-                ...(to && { lte: to }),
-            }
-            : timeFilterValue;
+        const upperBound = timeFilter === 'past'
+            ? (to && to < now ? to : now)
+            : to;
+        const dateTimeFilter = {
+            ...(timeFilter === 'upcoming' && { gt: now }),
+            ...(from && { gte: from }),
+            ...(upperBound && { lte: upperBound }),
+        };
 
         // Specific bodies (ids) take precedence over the broader type filter.
         let bodyFilter: Prisma.CouncilMeetingWhereInput = {};
@@ -157,7 +156,7 @@ export async function getCouncilMeetingsForCity(cityId: string, { includeUnrelea
             where: {
                 cityId,
                 released: includeUnreleased ? undefined : true,
-                ...(dateTimeFilter && { dateTime: dateTimeFilter }),
+                ...(Object.keys(dateTimeFilter).length > 0 && { dateTime: dateTimeFilter }),
                 ...bodyFilter,
             },
             orderBy: timeFilter === 'upcoming'


### PR DESCRIPTION
## Problem

`getCouncilMeetingsForCity` treats the `from`/`to` range and `timeFilter` as either/or. A date bound replaces `timeFilter` in the `where` clause. The `orderBy` still keys on `timeFilter`. A `past` query with a `from` date therefore sorts newest first over a set with no upper bound. The top row can be a meeting that is not held yet.

The MCP tool `list_meetings` is the only caller that sends both. The other callers send one or the other: the REST route sends `from`/`to`, and the embed page and the public cached wrapper send `timeFilter`.

The server instructions tell the model to pair `administrativeBodyIds` with `timeFilter: "past"` to find when a body last met. That answer is wrong when the same call carries a date bound.

## Reproduction

Calls to the production MCP server on 2026-08-24, for Athens and the `Δημοτικό Συμβούλιο` body:

| call | top row |
| --- | --- |
| `{timeFilter: "past"}` | `jul29_2_2026` — correct |
| `{timeFilter: "past", from: "2026-01-01"}` | `aug26_2026` — a meeting two days in the future |

The mirror case fails in the same way. `{timeFilter: "upcoming", to: "2026-12-31"}` returns meetings from June 2024, oldest first.

## Fix

The range and `timeFilter` are now independent constraints that intersect.

- `upcoming` adds `gt: now` next to `gte: from` and `lte: to`.
- `past` and `to` both set the upper bound, so the earlier of the two wins.

A call with neither still sets no `dateTime` filter.

## Tests

`src/lib/__tests__/meetings.test.ts` gets 7 cases for this interaction. Three of them fail on `main` and pass with this change. The other four pin behavior that stays the same: the range alone, `timeFilter` alone, and neither.

The full unit suite passes: 117 suites, 1659 tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3EgDUS3cfCJFTWFN8gdoz)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes meeting retrieval so explicit date bounds and `timeFilter` are applied together rather than one replacing the other.
- Intersects `from` and `to` with past or upcoming constraints.
- Uses the earlier of `to` and the current time as the upper bound for past meetings.
- Adds focused unit coverage for combined filters and unchanged standalone behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable regressions or blocking failures were identified.

The revised query intersects independently requested constraints, retains established past/upcoming boundaries and ordering, and preserves behavior for callers using only ranges, only time filters, or neither.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/db/meetings.ts | Correctly composes date-range and relative-time constraints while preserving existing ordering and no-filter behavior. |
| src/lib/__tests__/meetings.test.ts | Adds deterministic fake-time tests covering the reported combined-filter regression and existing standalone cases. |

<sub>Reviews (1): Last reviewed commit: ["fix(meetings): apply date range and time..."](https://github.com/schemalabz/opencouncil/commit/5a26a16c037fb20cf7715242b57812771724cf8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56293020)</sub>

<!-- /greptile_comment -->