### PR TITLE
fix(notis): repair delivery before bookkeeping in the wake loop

### DIFF
--- a/services/notis/src/agent/__tests__/runWake.test.ts
+++ b/services/notis/src/agent/__tests__/runWake.test.ts
@@ -576,6 +576,154 @@ describe("runWake", () => {
     }
   });
 
+  it("a repair nudge on the final turn is granted the turn it needs", async () => {
+    // Both repairs are owed, and the delivery one lands on the penultimate
+    // turn. Without a grant the bookkeeping nudge rides out on the final turn
+    // with nothing left to answer it: the commitment is lost, and the wake
+    // records finishWakeMissing for a contract the model was never given a
+    // turn to keep.
+    const stranded =
+      "Ναι, πέρασαν άλλα δύο θέματα: η ανάπλαση και το πάρκινγκ. Θα σου πω μόλις βγει η απόφαση για το δεύτερο.";
+    const fake = new FakeAnthropic([
+      {
+        content: [
+          text(stranded),
+          toolUse("t1", "finish_wake", {
+            rationale: "Της απάντησα.",
+            learnedSomethingLasting: false,
+            promisedFollowUp: true,
+          }),
+        ],
+        stop_reason: "tool_use",
+      },
+      {
+        content: [
+          toolUse("t2", "send_message", { text: "Ναι, πέρασαν άλλα δύο θέματα." }),
+          toolUse("t3", "finish_wake", {
+            rationale: "Της τα έστειλα.",
+            learnedSomethingLasting: false,
+            promisedFollowUp: true,
+          }),
+        ],
+        stop_reason: "tool_use",
+      },
+      {
+        content: [
+          toolUse("t4", "record_commitment", { slug: "parking", what: "Να της πω για το πάρκινγκ." }),
+          toolUse("t5", "finish_wake", {
+            rationale: "Το κατέγραψα.",
+            learnedSomethingLasting: false,
+            promisedFollowUp: true,
+          }),
+        ],
+        stop_reason: "tool_use",
+      },
+    ]);
+    const deps = makeDeps(fake);
+    deps.config = { ...deps.config, maxTurns: 2 };
+    const { outcome, trace } = await runWake(
+      makeState(),
+      [{ type: "user_message", at: FIXED_NOW.toISOString(), text: "τίποτα άλλο;" }],
+      deps,
+    );
+
+    expect(outcome.repairs).toEqual(["stranded-prose/finish", "promised/no-commitment"]);
+    expect(outcome.messages).toEqual(["Ναι, πέρασαν άλλα δύο θέματα."]);
+    expect(outcome.commitments?.record).toEqual([
+      { slug: "parking", what: "Να της πω για το πάρκινγκ." },
+    ]);
+    // The nudge was answered, so the wake finished under its own contract.
+    expect(outcome.finishWakeMissing).toBeUndefined();
+    // Three model turns on a cap of two: one grant per nudge that had no
+    // turn left, and each repair is one-shot.
+    expect(trace.turns.filter((t) => t.role !== "injected")).toHaveLength(3);
+  });
+
+  it("the grant covers a single nudge on the final turn too", async () => {
+    // The same hazard with one repair: it predates the two budgets.
+    const fake = new FakeAnthropic([
+      {
+        content: [toolUse("t1", "finish_wake", { rationale: "Της απάντησα ήδη νοερά." })],
+        stop_reason: "tool_use",
+      },
+      {
+        content: [
+          toolUse("t2", "send_message", { text: "Η απάντηση." }),
+          toolUse("t3", "finish_wake", { rationale: "Απάντησα μετά το nudge." }),
+        ],
+        stop_reason: "tool_use",
+      },
+    ]);
+    const deps = makeDeps(fake);
+    deps.config = { ...deps.config, maxTurns: 1 };
+    const { outcome } = await runWake(
+      makeState(),
+      [{ type: "user_message", at: FIXED_NOW.toISOString(), text: "λοιπόν;" }],
+      deps,
+    );
+
+    expect(outcome.repairs).toEqual(["zero-send/finish"]);
+    expect(outcome.messages).toEqual(["Η απάντηση."]);
+    expect(outcome.finishWakeMissing).toBeUndefined();
+  });
+
+  it("a pause on the granted turn does not spend it", async () => {
+    // The nudge fires on the last allowed turn and takes its grant. The
+    // granted request comes back as a tool-less pause_turn — the server
+    // continuing its research, not the model answering. That pause must not
+    // be the turn the nudge was given.
+    const fake = new FakeAnthropic([
+      {
+        content: [toolUse("t1", "finish_wake", { rationale: "Της απάντησα ήδη νοερά." })],
+        stop_reason: "tool_use",
+      },
+      { content: [text("…")], stop_reason: "pause_turn" },
+      {
+        content: [
+          toolUse("t2", "send_message", { text: "Η απάντηση." }),
+          toolUse("t3", "finish_wake", { rationale: "Απάντησα μετά το nudge." }),
+        ],
+        stop_reason: "tool_use",
+      },
+    ]);
+    const deps = makeDeps(fake);
+    deps.config = { ...deps.config, maxTurns: 1 };
+    const { outcome, trace } = await runWake(
+      makeState(),
+      [{ type: "user_message", at: FIXED_NOW.toISOString(), text: "λοιπόν;" }],
+      deps,
+    );
+
+    expect(outcome.messages).toEqual(["Η απάντηση."]);
+    expect(outcome.repairs).toEqual(["zero-send/finish"]);
+    expect(outcome.finishWakeMissing).toBeUndefined();
+    expect(trace.turns.filter((t) => t.role !== "injected")).toHaveLength(3);
+  });
+
+  it("the grant has a ceiling: an endless pause loop still terminates", async () => {
+    // Each pause asks for the grant again, so the extension needs a bound of
+    // its own. maxTurns 1 plus MAX_REPAIR_TURNS 4.
+    const fake = new FakeAnthropic([
+      {
+        content: [toolUse("t1", "finish_wake", { rationale: "Της απάντησα ήδη νοερά." })],
+        stop_reason: "tool_use",
+      },
+      ...Array.from({ length: 20 }, () => ({ content: [text("…")], stop_reason: "pause_turn" })),
+    ]);
+    const deps = makeDeps(fake);
+    deps.config = { ...deps.config, maxTurns: 1 };
+    const { outcome, trace } = await runWake(
+      makeState(),
+      [{ type: "user_message", at: FIXED_NOW.toISOString(), text: "λοιπόν;" }],
+      deps,
+    );
+
+    expect(trace.turns.filter((t) => t.role !== "injected")).toHaveLength(5);
+    // The wake really did run out without finishing, and it says so.
+    expect(outcome.finishWakeMissing).toBe(true);
+    expect(outcome.rationale).toBe("Της απάντησα ήδη νοερά.");
+  });
+
   it("send: send_message tool calls become ordered messages and tool_results echo back", async () => {
     const fake = new FakeAnthropic([
       {

--- a/services/notis/src/agent/__tests__/runWake.test.ts
+++ b/services/notis/src/agent/__tests__/runWake.test.ts
@@ -381,6 +381,201 @@ describe("runWake", () => {
     expect(trace.turns).toHaveLength(3);
   });
 
+  it("delivery is repaired before bookkeeping, and the commitment still lands", async () => {
+    // The reader asked a question; the model wrote the answer as prose next to
+    // its tool calls AND reported a promise. The prose is what the reader is
+    // waiting for, so it must win the first nudge — the commitment gets its
+    // own.
+    const stranded =
+      "Ναι, πέρασαν άλλα δύο θέματα: η ανάπλαση και το πάρκινγκ. Θα σου πω μόλις βγει η απόφαση για το δεύτερο.";
+    const fake = new FakeAnthropic([
+      {
+        content: [
+          text(stranded),
+          toolUse("t1", "finish_wake", {
+            rationale: "Της απάντησα και της υποσχέθηκα συνέχεια.",
+            learnedSomethingLasting: false,
+            promisedFollowUp: true,
+          }),
+        ],
+        stop_reason: "tool_use",
+      },
+      {
+        content: [
+          toolUse("t2", "send_message", { text: "Ναι, πέρασαν άλλα δύο θέματα." }),
+          toolUse("t3", "finish_wake", {
+            rationale: "Της τα έστειλα.",
+            learnedSomethingLasting: false,
+            promisedFollowUp: true,
+          }),
+        ],
+        stop_reason: "tool_use",
+      },
+      {
+        content: [
+          toolUse("t4", "record_commitment", { slug: "parking", what: "Να της πω για το πάρκινγκ." }),
+          toolUse("t5", "finish_wake", {
+            rationale: "Της τα έστειλα και κατέγραψα την υπόσχεση.",
+            learnedSomethingLasting: false,
+            promisedFollowUp: true,
+          }),
+        ],
+        stop_reason: "tool_use",
+      },
+    ]);
+    const { outcome } = await runWake(
+      makeState(),
+      [{ type: "user_message", at: FIXED_NOW.toISOString(), text: "τίποτα άλλο;" }],
+      makeDeps(fake),
+    );
+
+    expect(outcome.decision).toBe("send");
+    expect(outcome.messages).toEqual(["Ναι, πέρασαν άλλα δύο θέματα."]);
+    // Delivery first, bookkeeping second — one budget each.
+    expect(outcome.repairs).toEqual(["stranded-prose/finish", "promised/no-commitment"]);
+    expect(outcome.commitments?.record).toEqual([
+      { slug: "parking", what: "Να της πω για το πάρκινγκ." },
+    ]);
+    // The rationale protection composes across both nudges: the bookkeeping
+    // turn adds no send, so the rationale from the delivery turn stands.
+    expect(outcome.rationale).toBe("Της τα έστειλα.");
+  });
+
+  it("a bookkeeping nudge leaves the delivery budget alone, in either order", async () => {
+    // Promise with no commitment fires first here (nothing is undelivered
+    // yet). The model then strands prose — the delivery repair must still be
+    // available for it.
+    const stranded =
+      "Α, και κάτι ακόμα που ξέχασα: η συνεδρίαση για το πάρκινγκ μετατέθηκε για την επόμενη εβδομάδα.";
+    const fake = new FakeAnthropic([
+      {
+        content: [
+          toolUse("t1", "send_message", { text: "Θα σου πω." }),
+          toolUse("t2", "finish_wake", {
+            rationale: "Της υποσχέθηκα ενημέρωση.",
+            learnedSomethingLasting: false,
+            promisedFollowUp: true,
+          }),
+        ],
+        stop_reason: "tool_use",
+      },
+      {
+        content: [
+          text(stranded),
+          toolUse("t3", "record_commitment", { slug: "parking", what: "Να της πω για το πάρκινγκ." }),
+          toolUse("t4", "finish_wake", {
+            rationale: "Το κατέγραψα.",
+            learnedSomethingLasting: false,
+            promisedFollowUp: true,
+          }),
+        ],
+        stop_reason: "tool_use",
+      },
+      {
+        content: [
+          toolUse("t5", "send_message", { text: "Α, και η συνεδρίαση μετατέθηκε." }),
+          toolUse("t6", "finish_wake", {
+            rationale: "Της είπα και για τη μετάθεση.",
+            learnedSomethingLasting: false,
+            promisedFollowUp: true,
+          }),
+        ],
+        stop_reason: "tool_use",
+      },
+    ]);
+    const { outcome } = await runWake(
+      makeState(),
+      [{ type: "user_message", at: FIXED_NOW.toISOString(), text: "θα με ενημερώσεις;" }],
+      makeDeps(fake),
+    );
+
+    expect(outcome.repairs).toEqual(["promised/no-commitment", "stranded-prose/finish"]);
+    expect(outcome.messages).toEqual(["Θα σου πω.", "Α, και η συνεδρίαση μετατέθηκε."]);
+  });
+
+  it("each budget is still one-shot: a second bookkeeping nudge never fires", async () => {
+    const fake = new FakeAnthropic([
+      {
+        content: [
+          toolUse("t1", "send_message", { text: "Θα σου πω." }),
+          toolUse("t2", "finish_wake", {
+            rationale: "Της υποσχέθηκα ενημέρωση.",
+            learnedSomethingLasting: false,
+            promisedFollowUp: true,
+          }),
+        ],
+        stop_reason: "tool_use",
+      },
+      // Nudged, and still no commitment: the wake ends rather than looping.
+      {
+        content: [
+          toolUse("t3", "finish_wake", {
+            rationale: "Δεν χρειάζεται καταγραφή.",
+            learnedSomethingLasting: false,
+            promisedFollowUp: true,
+          }),
+        ],
+        stop_reason: "tool_use",
+      },
+    ]);
+    const { outcome, trace } = await runWake(
+      makeState(),
+      [{ type: "user_message", at: FIXED_NOW.toISOString(), text: "θα με ενημερώσεις;" }],
+      makeDeps(fake),
+    );
+
+    expect(outcome.repairs).toEqual(["promised/no-commitment"]);
+    expect(outcome.commitments).toBeUndefined();
+    // Two model turns plus the one injected nudge.
+    expect(trace.turns).toHaveLength(3);
+  });
+
+  it("the dangling-tool-call backstop still fires when a reader update lands the same turn", async () => {
+    // An end_turn that carries a tool_use block: the repair path appends the
+    // assistant turn verbatim, so the call sits unanswered in the MIDDLE of
+    // the message list. A message absorbed at the next turn's start must not
+    // hide it — the request would 400 with «`tool_use` ids were found without
+    // `tool_result` blocks», and every retry reproduces that.
+    const fake = new FakeAnthropic([
+      { content: [text("σκέψη"), toolUse("d1", "send_message", { text: "x" })], stop_reason: "end_turn" },
+      { content: [toolUse("t1", "send_message", { text: "Η απάντηση." })], stop_reason: "tool_use" },
+      { content: [text("Απάντησα.")], stop_reason: "end_turn" },
+    ]);
+    let calls = 0;
+    const { outcome } = await runWake(
+      makeState(),
+      [{ type: "user_message", at: FIXED_NOW.toISOString(), text: "ερώτηση" }],
+      makeDeps(fake, {
+        absorb: async () =>
+          ++calls === 2
+            ? [{ type: "user_message" as const, at: FIXED_NOW.toISOString(), text: "και κάτι ακόμα" }]
+            : [],
+        deliver: async () => ({ ok: true }),
+      }),
+    );
+
+    expect(outcome.repairs).toContain("dangling-tool-calls");
+    for (const req of fake.requests) {
+      const msgs = req.messages as Array<{ role?: string; content?: unknown }>;
+      msgs.forEach((m, i) => {
+        if (m.role !== "assistant" || !Array.isArray(m.content)) return;
+        const ids = m.content
+          .filter((b): b is { type: string; id: string } => (b as { type?: string }).type === "tool_use")
+          .map((b) => b.id);
+        if (ids.length === 0) return;
+        const next = msgs[i + 1];
+        const answered = new Set<string>();
+        if (next?.role === "user" && Array.isArray(next.content)) {
+          for (const block of next.content) {
+            const b = block as { type?: string; tool_use_id?: string };
+            if (b.type === "tool_result" && b.tool_use_id) answered.add(b.tool_use_id);
+          }
+        }
+        expect(ids.filter((id) => !answered.has(id))).toEqual([]);
+      });
+    }
+  });
+
   it("send: send_message tool calls become ordered messages and tool_results echo back", async () => {
     const fake = new FakeAnthropic([
       {

--- a/services/notis/src/agent/runWake.ts
+++ b/services/notis/src/agent/runWake.ts
@@ -171,7 +171,14 @@ export async function runWake(
   let unsubscribe: { reason: string } | undefined;
   let rationale = "";
   let refused = false;
-  let repaired = false;
+  // Repairs come in two kinds and must not compete for one budget. A
+  // DELIVERY repair puts an answer in front of a reader who is still
+  // waiting; a BOOKKEEPING repair only saves state that a later wake would
+  // like to have. One nudge each, delivery checked first: a wake that both
+  // stranded its answer as prose and reported a promise used to spend its
+  // single nudge on the commitment, and the reader got nothing at all.
+  let deliveryRepaired = false;
+  let bookkeepingRepaired = false;
   let finished = false;
   // Instrument-panel truth: repairs that fired, and terminal anomalies. A
   // rescued or cut wake must never be indistinguishable from a healthy one —
@@ -451,75 +458,101 @@ export async function runWake(
 
       // finish_wake ends the wake in the same turn as the sends — no extra
       // model pass — unless a repair is owed, in which case the nudge rides
-      // along with the tool_results and the loop continues once.
-      let nudge: string | undefined;
-      // Set by the branches that name their own repair; the fallthrough
-      // branches leave it unset and the shared block below picks the tag.
-      let repairTag: string | undefined;
-      if (finished && !repaired) {
-        if (declaredPromise && commitmentsRecorded.length === 0 && !unsubscribe) {
-          preNudgeRationale = rationale;
-          sentAtNudge = sent.length;
-          repairTag = "promised/no-commitment";
-          nudge =
-            "(system check) You answered that you promised the reader a follow-up, but " +
-            "you never called record_commitment — so nothing will remind you: the " +
-            "decision log rolls, and by the time the thing happens this exchange is out " +
-            "of view. Record it now with a short slug, then call finish_wake again. If " +
-            "you promised nothing after all, finish with promisedFollowUp false.";
-        } else if (declaredLearning && profileRewrite === undefined && !unsubscribe) {
-          preNudgeRationale = rationale;
-          sentAtNudge = sent.length;
-          repairTag = "declared-learning/no-profile";
-          nudge =
-            "(system check) You answered that this wake taught you something lasting " +
-            "about the reader, but you never called update_taste_profile — so it is " +
-            "about to be forgotten: the conversation and the decision log both roll. " +
-            "Write the durable part into the profile now (a few short sentences, taste " +
-            "not transcript), then call finish_wake again. If you were wrong and there " +
-            "is nothing lasting, finish with learnedSomethingLasting false.";
-        } else if (hasUserMessage && sent.length === 0 && !unsubscribe) {
-          preNudgeRationale = rationale;
-          sentAtNudge = sent.length;
+      // along with the tool_results and the loop continues. At most one nudge
+      // per turn: each one costs a model turn of its own.
+      let nudge: { text: string; tag: string; kind: "delivery" | "bookkeeping" } | undefined;
+      // Delivery repairs come first, and each kind carries its own budget:
+      // the reader feels an undelivered answer, and nobody but us feels a
+      // missing commitment. A spent delivery budget falls through to the
+      // bookkeeping checks, which still have theirs.
+      if (finished) {
+        if (!deliveryRepaired && hasUserMessage && sent.length === 0 && !unsubscribe) {
           // When the answer sits stranded as prose, quote it back. Without the
           // quote the model rereads its own text above and concludes it already
           // answered ("message already sent") — observed failure.
-          nudge = strandedProse
-            ? "(system check) The person asked you something directly and NOTHING has " +
-              "been delivered to them — they are still waiting. The text you wrote next " +
-              "to your tool calls was NOT delivered; nothing reaches the person except " +
-              "send_message content. The undelivered text was:\n«" +
+          nudge = {
+            kind: "delivery",
+            tag: strandedProse ? "stranded-prose/finish" : "zero-send/finish",
+            text: strandedProse
+              ? "(system check) The person asked you something directly and NOTHING has " +
+                "been delivered to them — they are still waiting. The text you wrote next " +
+                "to your tool calls was NOT delivered; nothing reaches the person except " +
+                "send_message content. The undelivered text was:\n«" +
+                strandedProse.slice(0, 1200) +
+                "»\nIf it was meant for them, send it now with send_message, then " +
+                "finish_wake again with the wake's own rationale — about the reader and " +
+                "this wake's decision, never about this check. If you truly intend to stay " +
+                "silent, call finish_wake again to confirm."
+              : "(system check) You finished the wake without sending anything, but the " +
+                "person asked you something directly. Nothing has been delivered to them — " +
+                "they are still waiting. If you meant to answer them, call send_message " +
+                "with the message now, then finish_wake again with the wake's own " +
+                "rationale — about the reader and this wake's decision, never about this " +
+                "check. If you truly intend to stay silent, call finish_wake again to " +
+                "confirm.",
+          };
+        } else if (!deliveryRepaired && strandedProse) {
+          nudge = {
+            kind: "delivery",
+            tag: "stranded-prose/finish",
+            text:
+              "(system check) You wrote prose in the same turn as your tool calls. That " +
+              "prose was NOT delivered — nothing reaches the person except send_message " +
+              "content. The undelivered text was:\n«" +
               strandedProse.slice(0, 1200) +
-              "»\nIf it was meant for them, send it now with send_message, then " +
-              "finish_wake again with the wake's own rationale — about the reader and " +
-              "this wake's decision, never about this check. If you truly intend to stay " +
-              "silent, call finish_wake again to confirm."
-            : "(system check) You finished the wake without sending anything, but the " +
-              "person asked you something directly. Nothing has been delivered to them — " +
-              "they are still waiting. If you meant to answer them, call send_message " +
-              "with the message now, then finish_wake again with the wake's own " +
-              "rationale — about the reader and this wake's decision, never about this " +
-              "check. If you truly intend to stay silent, call finish_wake again to " +
-              "confirm.";
-        } else if (strandedProse) {
-          preNudgeRationale = rationale;
-          sentAtNudge = sent.length;
-          nudge =
-            "(system check) You wrote prose in the same turn as your tool calls. That " +
-            "prose was NOT delivered — nothing reaches the person except send_message " +
-            "content. The undelivered text was:\n«" +
-            strandedProse.slice(0, 1200) +
-            "»\nIf it was meant for the person, send it now with send_message, rephrased " +
-            "so the conversation reads naturally, then finish_wake again. If it was only " +
-            "reasoning, call finish_wake again with the wake's own rationale — about the " +
-            "reader and this wake's decision, never about this check.";
+              "»\nIf it was meant for the person, send it now with send_message, rephrased " +
+              "so the conversation reads naturally, then finish_wake again. If it was only " +
+              "reasoning, call finish_wake again with the wake's own rationale — about the " +
+              "reader and this wake's decision, never about this check.",
+          };
+        } else if (
+          !bookkeepingRepaired &&
+          declaredPromise &&
+          commitmentsRecorded.length === 0 &&
+          !unsubscribe
+        ) {
+          nudge = {
+            kind: "bookkeeping",
+            tag: "promised/no-commitment",
+            text:
+              "(system check) You answered that you promised the reader a follow-up, but " +
+              "you never called record_commitment — so nothing will remind you: the " +
+              "decision log rolls, and by the time the thing happens this exchange is out " +
+              "of view. Record it now with a short slug, then call finish_wake again. If " +
+              "you promised nothing after all, finish with promisedFollowUp false.",
+          };
+        } else if (
+          !bookkeepingRepaired &&
+          declaredLearning &&
+          profileRewrite === undefined &&
+          !unsubscribe
+        ) {
+          nudge = {
+            kind: "bookkeeping",
+            tag: "declared-learning/no-profile",
+            text:
+              "(system check) You answered that this wake taught you something lasting " +
+              "about the reader, but you never called update_taste_profile — so it is " +
+              "about to be forgotten: the conversation and the decision log both roll. " +
+              "Write the durable part into the profile now (a few short sentences, taste " +
+              "not transcript), then call finish_wake again. If you were wrong and there " +
+              "is nothing lasting, finish with learnedSomethingLasting false.",
+          };
         }
         if (nudge) {
-          repaired = true;
+          preNudgeRationale = rationale;
+          sentAtNudge = sent.length;
           finished = false;
-          repairs.push(repairTag ?? (strandedProse ? "stranded-prose/finish" : "zero-send/finish"));
-          recordInjected(nudge);
-          strandedProse = undefined;
+          repairs.push(nudge.tag);
+          recordInjected(nudge.text);
+          if (nudge.kind === "delivery") {
+            deliveryRepaired = true;
+            // The quote is in the nudge now; a bookkeeping nudge quotes
+            // nothing, so it must leave the prose for the delivery check.
+            strandedProse = undefined;
+          } else {
+            bookkeepingRepaired = true;
+          }
         }
       }
 
@@ -530,7 +563,7 @@ export async function runWake(
       if (results.length > 0 || nudge || holdNote) {
         const extras = [
           ...(holdNote ? [{ type: "text", text: holdNote }] : []),
-          ...(nudge ? [{ type: "text", text: nudge }] : []),
+          ...(nudge ? [{ type: "text", text: nudge.text }] : []),
         ];
         const content = extras.length > 0 ? [...results, ...extras] : results;
         if (!finished) markLatest(content);
@@ -540,9 +573,11 @@ export async function runWake(
       continue;
     }
 
-    // end_turn: two observed low-effort failure modes get ONE bounded repair
-    // pass between them, so a broken wake self-corrects instead of shipping.
-    if (response.stop_reason === "end_turn" && !repaired) {
+    // end_turn: two observed low-effort failure modes, both of them an answer
+    // the reader never got, so both spend the delivery budget — ONE bounded
+    // repair pass between them, and a broken wake self-corrects before it
+    // ships.
+    if (response.stop_reason === "end_turn" && !deliveryRepaired) {
       // (a) The person wrote to us and the model produced neither a send nor
       // an unsubscribe: it wrote its answer into the final text instead of
       // the tool. Never fires on proactive wakes — silence is their default.
@@ -552,7 +587,7 @@ export async function runWake(
         // the decision-log rationale the next thirty wakes read as memory.
         preNudgeRationale = rationale;
         sentAtNudge = sent.length;
-        repaired = true;
+        deliveryRepaired = true;
         repairs.push("zero-send/end-turn");
         const nudge =
           "(system check) Your final text above is an operator rationale — it was NOT " +
@@ -571,7 +606,7 @@ export async function runWake(
       if (strandedProse) {
         preNudgeRationale = rationale;
         sentAtNudge = sent.length;
-        repaired = true;
+        deliveryRepaired = true;
         repairs.push("stranded-prose/end-turn");
         const nudge =
           "(system check) In an earlier turn you wrote prose in the same turn as your " +

--- a/services/notis/src/agent/runWake.ts
+++ b/services/notis/src/agent/runWake.ts
@@ -15,6 +15,13 @@ import {
 
 const MAX_TOKENS = 16000;
 
+/**
+ * Hard ceiling on turns granted so a repair nudge can be answered. A
+ * server-side research loop can pause many times over, and each pause asks
+ * for the grant again, so the extension needs a bound of its own.
+ */
+const MAX_REPAIR_TURNS = 4;
+
 /** Longest commitment handle we store. The tool asks for a short one; this is
  *  what happens when the model does not oblige. */
 const SLUG_MAX_CHARS = 40;
@@ -215,6 +222,28 @@ export async function runWake(
   // wake (sends discarded, absorbed rows consumed, nothing pending). Two
   // grants bound the extension.
   let bonusTurns = 0;
+  // Turns granted so a repair nudge can be answered. Separate from
+  // bonusTurns: the hold grant caps itself at two, and a repair must not
+  // eat that allowance.
+  let repairTurns = 0;
+  // True from the moment a nudge is injected until a response arrives that
+  // could answer it. A tool-less pause_turn is the server continuing a turn,
+  // not the model answering, so it leaves the nudge outstanding.
+  let nudgeOutstanding = false;
+  /**
+   * A nudge asks the model to do something, so it needs a turn to be
+   * answered in. Fired on the last allowed turn it gets none: the loop
+   * exits with the nudge unanswered, the repair never happens, and the wake
+   * records finishWakeMissing — a contract breach the model did not commit,
+   * on a turn it was never given. Each repair kind is one-shot, so the
+   * repair paths ask at most twice, and only for a wake already at the
+   * ceiling. The pause path asks again for a nudge it left outstanding, so
+   * MAX_REPAIR_TURNS bounds the total.
+   */
+  const grantTurnForNudge = (turn: number) => {
+    if (repairTurns >= MAX_REPAIR_TURNS) return;
+    if (turn + 1 >= deps.config.maxTurns + bonusTurns + repairTurns) repairTurns++;
+  };
   /**
    * The API rejects any request whose assistant turn carries `tool_use`
    * blocks that the next message does not answer — and the whole wake dies
@@ -270,7 +299,7 @@ export async function runWake(
   };
 
   try {
-  for (let turn = 0; turn < deps.config.maxTurns + bonusTurns; turn++) {
+  for (let turn = 0; turn < deps.config.maxTurns + bonusTurns + repairTurns; turn++) {
     if (deps.heartbeat && !(await deps.heartbeat())) {
       // The claim is no longer ours: a reclaimer is (or will be) running
       // this wake. Stop immediately — before the first delivery this is a
@@ -309,8 +338,14 @@ export async function runWake(
     // fails the same way.
     if (response.stop_reason === "pause_turn" && !response.content.some(isToolUseBlock)) {
       messages.push({ role: "assistant", content: response.content });
+      // A pause is not an answer. If a nudge is still waiting for one, this
+      // iteration must not be the turn that was granted for it.
+      if (nudgeOutstanding) grantTurnForNudge(turn);
       continue;
     }
+    // Any other stop reason is the model answering — well, badly, or not at
+    // all, but the nudge has had its turn.
+    nudgeOutstanding = false;
 
     if (response.stop_reason === "tool_use" || response.stop_reason === "pause_turn") {
       // Last look before bytes leave: if the reader wrote again while this
@@ -543,6 +578,8 @@ export async function runWake(
           preNudgeRationale = rationale;
           sentAtNudge = sent.length;
           finished = false;
+          nudgeOutstanding = true;
+          grantTurnForNudge(turn);
           repairs.push(nudge.tag);
           recordInjected(nudge.text);
           if (nudge.kind === "delivery") {
@@ -588,6 +625,8 @@ export async function runWake(
         preNudgeRationale = rationale;
         sentAtNudge = sent.length;
         deliveryRepaired = true;
+        nudgeOutstanding = true;
+        grantTurnForNudge(turn);
         repairs.push("zero-send/end-turn");
         const nudge =
           "(system check) Your final text above is an operator rationale — it was NOT " +
@@ -607,6 +646,8 @@ export async function runWake(
         preNudgeRationale = rationale;
         sentAtNudge = sent.length;
         deliveryRepaired = true;
+        nudgeOutstanding = true;
+        grantTurnForNudge(turn);
         repairs.push("stranded-prose/end-turn");
         const nudge =
           "(system check) In an earlier turn you wrote prose in the same turn as your " +


### PR DESCRIPTION
Two defects were reported in `runWake.ts`. The first one is real and this PR fixes it. The second one does not reproduce against the current code, and this PR adds a test that pins the property.

## 1. Confirmed: a wake spends its only repair on bookkeeping and delivers nothing

`runWake` gives a wake one chance to correct itself. Four repairs shared one `repaired` flag, and the chain checked the two bookkeeping repairs first:

1. `promised/no-commitment` — bookkeeping
2. `declared-learning/no-profile` — bookkeeping
3. `zero-send/finish` — delivery
4. `stranded-prose/finish` — delivery

The first match set the flag and blocked the other three. The nudge block then cleared `strandedProse` in every case, so the evidence of the undelivered answer disappeared too.

The sequence that fails:

- The reader asks a question.
- The model writes the answer as prose next to its tool calls. Nothing reaches the reader, because only `send_message` content does.
- The model calls `finish_wake` with `promisedFollowUp: true` and no `record_commitment`.
- Branch 1 fires. It asks the model to record a commitment. It sets `repaired`, and it clears `strandedProse`.
- No delivery repair can fire after that, on the finish path or on the `end_turn` path.

The reader waits for an answer. The wake records `decision: "silence"` with one repair tag, which reads as a healthy rescued wake.

The two failures are not equal. A missing commitment costs the agent some memory. An undelivered answer costs the reader the thing they asked for, and only they can see it.

Verified against the code before the fix:

```
repairs: [ 'promised/no-commitment' ]   decision: silence   messages: []
```

### The fix

Delivery repairs run first, and each kind carries its own budget:

- `deliveryRepaired` — the two finish-path delivery repairs and the two `end_turn` repairs.
- `bookkeepingRepaired` — the promise and the profile repairs.

A spent delivery budget falls through to the bookkeeping checks, which still have theirs. A bookkeeping nudge no longer clears `strandedProse`, because the delivery check that has not run yet still needs it. At most one nudge fires per turn, because each nudge costs a model turn.

A wake that owes both repairs now delivers the answer first, then records the commitment. The cost is one more model turn at most, inside the `maxTurns` cap of 8.

The repair tags do not change. The admin panel already counts repairs and pluralizes the label, so a wake with two tags renders correctly.

## 2. Not reproduced: `absorbAtTurnStart()` before `answerDanglingToolCalls()`

The report says an absorbed message that lands after an assistant turn with unanswered `tool_use` blocks makes the backstop a no-op, and the request still goes out malformed.

That describes the backstop as it was in 6ae33e6, which only examined the last message:

```js
const last = messages[messages.length - 1];
if (last?.role !== "assistant" || !Array.isArray(last.content)) return;
```

An absorbed note made the tail a user message, so that version returned early.

Commit b302214 already widened the backstop. It scans every assistant turn, and it merges the synthetic `tool_result` blocks into whatever user message follows, or splices a new one:

```js
if (next?.role === "user" && Array.isArray(next.content)) {
  next.content.unshift(...results);
} else {
  messages.splice(i + 1, 0, { role: "user", content: results });
}
```

Both orderings now produce the same well-formed message list, so the swap changes nothing. A test run that absorbs a reader message on the exact turn after an orphaned assistant turn confirms it: `dangling-tool-calls` fires, and every `tool_use` id in every request is answered by the next message.

I did not swap the two calls, because the swap would be a no-op that the diff would present as a fix. The new test pins the order-independence instead, so a future narrowing of the backstop fails the suite.

## Tests

Four tests are added to `runWake.test.ts`:

- Delivery is repaired before bookkeeping, and the commitment still lands. **This one fails without the fix.**
- A bookkeeping nudge leaves the delivery budget alone, in either order.
- Each budget stays one-shot: a second bookkeeping nudge never fires.
- The dangling-tool-call backstop still fires when a reader update lands the same turn.

The first test also pins a behaviour worth knowing: the pre-nudge rationale protection composes across both nudges. The bookkeeping turn adds no send, so the rationale from the delivery turn stands.

`307 tests pass across 29 suites. tsc --noEmit is clean.`

---
_Generated by [Claude Code](https://claude.ai/code/session_0125MXKB1FQjpkjkQNLohmYu)_





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prioritizes resident-facing delivery repairs over bookkeeping repairs and gives each repair category a separate one-shot budget.
- Grants bounded extra turns when a repair nudge is injected at the loop limit.
- Preserves the grant across tool-less `pause_turn` responses while bounding endless pause loops.
- Adds regression coverage for repair ordering, turn grants, repair ceilings, and dangling tool-call handling.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| services/notis/src/agent/runWake.ts | Reorders and separates repair budgets, grants bounded response turns for nudges, and preserves an outstanding nudge across tool-less pauses; the previously reported turn-budget defects are addressed. |
| services/notis/src/agent/__tests__/runWake.test.ts | Adds focused regression tests for delivery-before-bookkeeping behavior, bounded repair grants, pause handling, and dangling tool-call repair. |

<sub>Reviews (3): Last reviewed commit: ["fix(notis): grant a repair nudge the tur..."](https://github.com/schemalabz/opencouncil/commit/68a3133e669c019918f05c9bd99a0a7c976bbd52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56295958)</sub>

**Context used:**

- Knowledge Base — [Notis notification service](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/notis-notification-service.md)

<!-- /greptile_comment -->