### PR TITLE
fix(notis): decide meeting events by the meeting date, not the task

### DIFF
--- a/services/notis/prompts/system.md
+++ b/services/notis/prompts/system.md
@@ -177,8 +177,7 @@ update to what they already know, never as if it were news to them.
 
 An agenda_processed wake fires before the meeting happens: you are previewing
 what is scheduled. Write in future terms — what will be discussed, what is
-proposed — and never state outcomes, votes, or what anyone said, even if a
-record you can see already contains them. Results and exchanges belong to
+proposed — and never state outcomes or votes. Results and exchanges belong to
 meeting_summarized wakes, after the meeting.
 
 This holds on every wake, including replies: a meeting dated after

--- a/services/notis/src/app/admin/(panel)/playground/__tests__/deriveQueue.test.ts
+++ b/services/notis/src/app/admin/(panel)/playground/__tests__/deriveQueue.test.ts
@@ -8,32 +8,29 @@ const meetings = [
 ];
 
 describe("deriveQueue", () => {
-  it("emits agenda (−3d) and summary (+1d) events per meeting, merged chronologically", () => {
+  it("emits one summary event (+1d) per meeting, merged chronologically", () => {
     const queue = deriveQueue(meetings, "2026-05-01");
     expect(queue.map((q) => q.id)).toEqual([
-      "athens:m1:agenda",
       "athens:m1:summary",
-      "patras:p1:agenda",
       "patras:p1:summary",
-      "athens:m2:agenda",
       "athens:m2:summary",
     ]);
-    expect(queue[0].event.at).toBe("2026-05-07T18:00:00.000Z");
-    expect(queue[1].event.at).toBe("2026-05-11T18:00:00.000Z");
+    expect(queue[0].event.at).toBe("2026-05-11T18:00:00.000Z");
     expect(queue.every((q) => q.status === "pending")).toBe(true);
     expect(queue.every((q) => "brief" in q.event && (q.event.brief as { pending: boolean }).pending)).toBe(true);
   });
 
+  // The archive holds only the post-meeting state, so a simulated agenda wake
+  // would preview a meeting whose outcomes it can already read.
+  it("never emits a pre-meeting agenda event", () => {
+    const queue = deriveQueue(meetings, "2020-01-01");
+    expect(queue.every((q) => q.event.type === "meeting_summarized")).toBe(true);
+  });
+
   it("clips events before the start date but has no end bound", () => {
-    const queue = deriveQueue(meetings, "2026-05-09");
-    // m1 agenda (05-07) is before the start; everything later stays.
-    expect(queue.map((q) => q.id)).toEqual([
-      "athens:m1:summary",
-      "patras:p1:agenda",
-      "patras:p1:summary",
-      "athens:m2:agenda",
-      "athens:m2:summary",
-    ]);
+    const queue = deriveQueue(meetings, "2026-05-12");
+    // m1's summary (05-11) is before the start; everything later stays.
+    expect(queue.map((q) => q.id)).toEqual(["patras:p1:summary", "athens:m2:summary"]);
   });
 
   it("insertChronological places items before later pending events", () => {
@@ -46,6 +43,6 @@ describe("deriveQueue", () => {
     const next = insertChronological(queue, item);
     const idx = next.findIndex((q) => q.id === "sched-1");
     expect(next[idx - 1].id).toBe("athens:m1:summary");
-    expect(next[idx + 1].id).toBe("patras:p1:agenda");
+    expect(next[idx + 1].id).toBe("patras:p1:summary");
   });
 });

--- a/services/notis/src/app/admin/(panel)/playground/deriveQueue.ts
+++ b/services/notis/src/app/admin/(panel)/playground/deriveQueue.ts
@@ -11,11 +11,26 @@ export interface MeetingSummary {
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Derive the playground event queue from real released meetings: each meeting
- * emits agenda_processed 3 days before and meeting_summarized 1 day after its
- * date, merged across cities in chronological order. The simulation has only
- * a start date — it runs forward through everything published since. Briefs
- * are lazy ({pending: true}) until a step actually needs them.
+ * Derive the playground event queue from real released meetings: one
+ * meeting_summarized per meeting, 1 day after its date, merged across cities
+ * in chronological order. The simulation has only a start date — it runs
+ * forward through everything published since. Briefs are lazy
+ * ({pending: true}) until a step actually needs them.
+ *
+ * No agenda_processed here, deliberately. The playground replays the archive,
+ * and the archive keeps one state per meeting: the one after it happened.
+ * Nothing reconstructs the record as it stood before, so an agenda wake
+ * simulated from it is a post-meeting wake wearing a preview label — its
+ * brief carries the real discussionSeconds and descriptions written from the
+ * transcript, and every opencouncil tool the agent reaches for on that wake
+ * returns votes and exchanges. The `phase: "agenda"` embargo in editorialPass
+ * and the "Before vs after the meeting" section of the system prompt then
+ * decide how much of that leaks, so the same setup previews one run and
+ * reports the next. That is not agenda behaviour to evaluate; it is noise.
+ *
+ * Real agenda_processed wakes still ship — the poller fans them out from the
+ * task feed, before the meeting, against a record that genuinely holds no
+ * outcomes. The playground is the wrong place to judge them.
  */
 export function deriveQueue(meetings: MeetingSummary[], from: string): WakeRecord[] {
   const fromMs = new Date(from).getTime();
@@ -24,31 +39,22 @@ export function deriveQueue(meetings: MeetingSummary[], from: string): WakeRecor
   for (const m of meetings) {
     const meetingMs = new Date(m.dateTime).getTime();
     if (Number.isNaN(meetingMs)) continue;
-    const meetingDate = m.dateTime.slice(0, 10);
-    const shared = {
-      cityId: m.cityId,
-      meetingId: m.id,
-      meetingName: m.name,
-      meetingDate,
-      adminBody: m.administrativeBody ?? null,
-      brief: { pending: true as const },
-    };
-    const agendaAt = new Date(meetingMs - 3 * DAY_MS).toISOString();
     const summaryAt = new Date(meetingMs + 1 * DAY_MS).toISOString();
-    if (new Date(agendaAt).getTime() >= fromMs) {
-      items.push({
-        id: `${m.cityId}:${m.id}:agenda`,
-        event: { type: "agenda_processed", at: agendaAt, ...shared },
-        status: "pending",
-      });
-    }
-    if (new Date(summaryAt).getTime() >= fromMs) {
-      items.push({
-        id: `${m.cityId}:${m.id}:summary`,
-        event: { type: "meeting_summarized", at: summaryAt, ...shared },
-        status: "pending",
-      });
-    }
+    if (new Date(summaryAt).getTime() < fromMs) continue;
+    items.push({
+      id: `${m.cityId}:${m.id}:summary`,
+      event: {
+        type: "meeting_summarized",
+        at: summaryAt,
+        cityId: m.cityId,
+        meetingId: m.id,
+        meetingName: m.name,
+        meetingDate: m.dateTime.slice(0, 10),
+        adminBody: m.administrativeBody ?? null,
+        brief: { pending: true as const },
+      },
+      status: "pending",
+    });
   }
 
   return items.sort((a, b) => new Date(a.event.at).getTime() - new Date(b.event.at).getTime());

--- a/services/notis/src/app/admin/(panel)/playground/store.ts
+++ b/services/notis/src/app/admin/(panel)/playground/store.ts
@@ -13,7 +13,7 @@ import { insertChronological } from "./deriveQueue";
 
 export function emptyStore(): PlaygroundStore {
   return {
-    version: 4,
+    version: 5,
     setup: { done: false, from: "" },
     sim: {
       state: {
@@ -41,7 +41,7 @@ export function loadStore(): PlaygroundStore {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     if (!raw) return emptyStore();
     const parsed = JSON.parse(raw) as PlaygroundStore;
-    if (parsed.version !== 4) {
+    if (parsed.version !== 5) {
       // Never destroy a store this build cannot read (a newer deploy's data,
       // or corruption): stash it aside so the session's saves cannot clobber it.
       window.localStorage.setItem(`${STORAGE_KEY}:incompatible`, raw);

--- a/services/notis/src/app/admin/(panel)/playground/types.ts
+++ b/services/notis/src/app/admin/(panel)/playground/types.ts
@@ -69,7 +69,14 @@ export interface Snapshot {
 }
 
 export interface PlaygroundStore {
-  version: 4;
+  /**
+   * Bumped to 5 when the queue stopped carrying pre-meeting agenda wakes.
+   * A version-4 store was built by the old derivation, so its queue still
+   * holds agenda items that this build must never run — and no partial
+   * cleanup survives a rewind, which can turn a completed item back into a
+   * pending one. loadStore stashes such a store aside instead.
+   */
+  version: 5;
   setup: { done: boolean; from: string };
   sim: Sim;
   traces: Record<string, WakeTrace>;

--- a/services/notis/src/lib/__tests__/poller.test.ts
+++ b/services/notis/src/lib/__tests__/poller.test.ts
@@ -1,6 +1,6 @@
 import type { EditorialBrief } from "../../agent/types";
-import { MAX_EVENTS_PER_TICK, runPollerTick } from "../poller";
-import { PROACTIVE_PAUSED_KEY } from "../settings";
+import { MAX_EVENTS_PER_TICK, classifyEvent, runPollerTick } from "../poller";
+import { PROACTIVE_PAUSED_KEY, futureSummaryAlertKey } from "../settings";
 import { type FakeDb, type Row, eventIdentity, makeFakeDb } from "./fake-db";
 import { FakeBird } from "./fake-bird";
 
@@ -443,6 +443,200 @@ describe("meeting events", () => {
     });
   }
 
+  // The whole disposition table in one place, straight off classifyEvent.
+  // The poller tests below prove the wiring; this proves the rule.
+  describe("classifyEvent", () => {
+    const at = new Date(NOW);
+    const staleBefore = new Date(NOW.getTime() - 30 * 24 * 60 * 60_000);
+    const on = (type: string, meetingDate: string) =>
+      classifyEvent({ type, meetingDate: new Date(meetingDate) }, at, staleBefore);
+
+    it.each([
+      ["processAgenda", "2026-08-20T18:00:00.000Z", "fanout", "meeting still ahead"],
+      ["processAgenda", "2026-08-15T18:00:00.000Z", "late-agenda", "held four days ago"],
+      ["processAgenda", "2026-01-10T18:00:00.000Z", "stale", "held months ago"],
+      ["summarize", "2026-08-20T18:00:00.000Z", "future-summary", "cannot be summarized yet"],
+      ["summarize", "2026-08-15T18:00:00.000Z", "fanout", "held four days ago"],
+      ["summarize", "2026-08-04T18:00:00.000Z", "fanout", "held two weeks ago"],
+      ["summarize", "2026-01-10T18:00:00.000Z", "stale", "held months ago"],
+    ])("%s dated %s → %s (%s)", (type, meetingDate, expected) => {
+      expect(on(type, meetingDate)).toBe(expected);
+    });
+  });
+
+  it("consumes a late agenda without editorial spend or a wake", async () => {
+    // processAgenda succeeding AFTER the meeting was held: a late upload or a
+    // backfill. Previewing it would describe a meeting the archive already
+    // has the transcript of. Its summarize event is the real news.
+    const db = seededDb();
+    const main = makeFakeMain({
+      users: [{ id: "user1", name: "Μαρία", phone: "+306900000001" }],
+      targets: [target("user1", "athens")],
+      events: [
+        meetingRow("task-late-agenda", {
+          type: "processAgenda",
+          meetingId: "m-held",
+          meetingDate: new Date("2026-08-15T18:00:00.000Z"),
+        }),
+      ],
+    });
+
+    const result = await runPollerTick({
+      db,
+      main,
+      bird: new FakeBird(),
+      alert: async () => {},
+      now,
+      editorial: editorialOk,
+    });
+
+    expect(editorialOk).not.toHaveBeenCalled();
+    expect(result.lateAgendaConsumed).toBe(1);
+    expect(result.wakesEnqueued).toBe(0);
+    expect(db.store.queue.size).toBe(0);
+    // Recorded, so it stops re-surfacing — and so the dedup identity is taken.
+    expect(processedFor(db, "athens", "m-held", "processAgenda")).toBeDefined();
+  });
+
+  it("fans out an agenda for a meeting that has not happened yet", async () => {
+    const db = seededDb();
+    const main = makeFakeMain({
+      users: [{ id: "user1", name: "Μαρία", phone: "+306900000001" }],
+      targets: [target("user1", "athens")],
+      events: [
+        meetingRow("task-agenda", {
+          type: "processAgenda",
+          meetingId: "m-upcoming",
+          meetingDate: new Date("2026-08-20T18:00:00.000Z"),
+        }),
+      ],
+    });
+
+    const result = await runPollerTick({
+      db,
+      main,
+      bird: new FakeBird(),
+      alert: async () => {},
+      now,
+      editorial: editorialOk,
+    });
+
+    expect(result.lateAgendaConsumed).toBe(0);
+    expect(result.wakesEnqueued).toBe(1);
+    const [event] = [...db.store.queue.values()][0].events as Array<{ type: string }>;
+    expect(event.type).toBe("agenda_processed");
+  });
+
+  it("holds a summary for a future-dated meeting, alarms once, and never consumes it", async () => {
+    // A meeting cannot be summarized before it happens: the dateTime is
+    // wrong. Nobody is woken, ops hears about it once rather than every
+    // five-minute tick, and the event stays available for a corrected date.
+    const db = seededDb();
+    const events = [
+      meetingRow("task-future", {
+        meetingId: "m-future",
+        meetingDate: new Date("2026-08-20T18:00:00.000Z"),
+      }),
+    ];
+    const main = makeFakeMain({
+      users: [{ id: "user1", name: "Μαρία", phone: "+306900000001" }],
+      targets: [target("user1", "athens")],
+      events,
+    });
+    const alerts: string[] = [];
+    const opts = {
+      db,
+      main,
+      bird: new FakeBird(),
+      alert: async (m: string) => {
+        alerts.push(m);
+      },
+      now,
+      editorial: editorialOk,
+    };
+
+    const result = await runPollerTick(opts);
+
+    expect(editorialOk).not.toHaveBeenCalled();
+    expect(result.futureSummaryHeld).toBe(1);
+    expect(result.wakesEnqueued).toBe(0);
+    expect(db.store.queue.size).toBe(0);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toContain("athens/m-future");
+    // Not consumed: the dedup identity stays free.
+    expect(processedFor(db, "athens", "m-future", "summarize")).toBeUndefined();
+    expect(db.store.settings.get(futureSummaryAlertKey("athens", "m-future"))).toBeDefined();
+
+    // Second tick: still held, but the alarm does not repeat.
+    const again = await runPollerTick(opts);
+    expect(again.futureSummaryHeld).toBe(1);
+    expect(alerts).toHaveLength(1);
+
+    // The date is corrected — the same event now fans out.
+    events[0].meetingDate = new Date("2026-08-17T18:00:00.000Z");
+    const fixed = await runPollerTick(opts);
+    expect(fixed.futureSummaryHeld).toBe(0);
+    expect(fixed.wakesEnqueued).toBe(1);
+    expect(processedFor(db, "athens", "m-future", "summarize")).toBeDefined();
+  });
+
+  it("wakes for a summary of a meeting held two weeks ago", async () => {
+    // Transcription and summarization take time; age alone must not suppress
+    // a meeting's first and only summary.
+    const db = seededDb();
+    const main = makeFakeMain({
+      users: [{ id: "user1", name: "Μαρία", phone: "+306900000001" }],
+      targets: [target("user1", "athens")],
+      events: [
+        meetingRow("task-old-summary", {
+          meetingId: "m-fortnight",
+          meetingDate: new Date("2026-08-04T18:00:00.000Z"),
+        }),
+      ],
+    });
+
+    const result = await runPollerTick({
+      db,
+      main,
+      bird: new FakeBird(),
+      alert: async () => {},
+      now,
+      editorial: editorialOk,
+    });
+
+    expect(result.staleConsumed).toBe(0);
+    expect(result.wakesEnqueued).toBe(1);
+  });
+
+  it("never wakes twice for the same meeting and event type", async () => {
+    // The dedup identity is (cityId, meetingId, type) — never the task. A
+    // re-run writes a NEW TaskStatus row, and that must not read as news.
+    const db = seededDb();
+    const main = makeFakeMain({
+      users: [{ id: "user1", name: "Μαρία", phone: "+306900000001" }],
+      targets: [target("user1", "athens")],
+      events: [
+        meetingRow("task1", { meetingId: "m-dedup" }),
+        meetingRow("task1-rerun", { meetingId: "m-dedup" }),
+      ],
+    });
+    const opts = {
+      db,
+      main,
+      bird: new FakeBird(),
+      alert: async () => {},
+      now,
+      editorial: editorialOk,
+    };
+
+    const first = await runPollerTick(opts);
+    expect(first.wakesEnqueued).toBe(1);
+
+    const second = await runPollerTick(opts);
+    expect(second.wakesEnqueued).toBe(0);
+    expect(editorialOk).toHaveBeenCalledTimes(1);
+  });
+
   it("consumes a stale meeting's event without editorial spend or a wake", async () => {
     // completedAt is TaskStatus.updatedAt underneath: a re-run (batchRerun
     // --force) or a bulk touch of old rows makes a years-old meeting look
@@ -719,5 +913,71 @@ describe("meeting events", () => {
     expect(result.eventsProcessed).toBe(MAX_EVENTS_PER_TICK + 3);
     expect(editorialOk).not.toHaveBeenCalled();
     expect(db.store.queue.size).toBe(0);
+  });
+
+  it("seedOnly consumes every disposition, data errors included, and alarms about none", async () => {
+    // A row left unconsumed by the quiet start fans out to the whole cohort
+    // on some later tick — the one thing seedOnly exists to prevent. The
+    // future-dated summary is the case that used to survive it.
+    const db = seededDb();
+    const main = makeFakeMain({
+      users: [{ id: "user1", name: "Μαρία", phone: "+306900000001" }],
+      targets: [target("user1", "athens")],
+      events: [
+        meetingRow("task-future", {
+          meetingId: "m-future",
+          meetingDate: new Date("2026-08-20T18:00:00.000Z"),
+        }),
+        meetingRow("task-late-agenda", {
+          type: "processAgenda",
+          meetingId: "m-held",
+          meetingDate: new Date("2026-08-15T18:00:00.000Z"),
+        }),
+        meetingRow("task-stale", {
+          meetingId: "m-old",
+          meetingDate: new Date("2024-03-10T18:00:00.000Z"),
+        }),
+        meetingRow("task-normal", { meetingId: "m-normal" }),
+      ],
+    });
+    const alerts: string[] = [];
+
+    const result = await runPollerTick(
+      {
+        db,
+        main,
+        bird: new FakeBird(),
+        alert: async (m: string) => {
+          alerts.push(m);
+        },
+        now,
+        editorial: editorialOk,
+      },
+      { seedOnly: true },
+    );
+
+    expect(result.eventsProcessed).toBe(4);
+    expect(result.futureSummaryHeld).toBe(0);
+    expect(alerts).toHaveLength(0);
+    expect(editorialOk).not.toHaveBeenCalled();
+    expect(db.store.queue.size).toBe(0);
+    expect(processedFor(db, "athens", "m-future", "summarize")).toBeDefined();
+    expect(processedFor(db, "athens", "m-held", "processAgenda")).toBeDefined();
+    expect(processedFor(db, "athens", "m-old", "summarize")).toBeDefined();
+    expect(processedFor(db, "athens", "m-normal", "summarize")).toBeDefined();
+
+    // The seeded deployment stays quiet on the next tick too.
+    const again = await runPollerTick({
+      db,
+      main,
+      bird: new FakeBird(),
+      alert: async (m: string) => {
+        alerts.push(m);
+      },
+      now,
+      editorial: editorialOk,
+    });
+    expect(again.wakesEnqueued).toBe(0);
+    expect(alerts).toHaveLength(0);
   });
 });

--- a/services/notis/src/lib/poller.ts
+++ b/services/notis/src/lib/poller.ts
@@ -1,4 +1,4 @@
-import type { PrismaClient as MainViewsClient } from "../../generated/main-client";
+import type { MeetingEventRow, PrismaClient as MainViewsClient } from "../../generated/main-client";
 import type { Prisma, PrismaClient } from "../../generated/client";
 import { editorialPass } from "@/agent/editorialPass";
 import { seedProfileFromPreferences } from "@/agent/profileSeed";
@@ -14,7 +14,13 @@ import { hasMainDb, mainDb } from "./main-db";
 import { normalizePhone } from "./phone";
 import { deliverPendingMessage, suppressPendingOutbound } from "./queue";
 import { enqueueBatchWake, isUniqueViolation } from "./queue-core";
-import { POLLER_STATUS_KEY, getProactiveSettings, putSetting } from "./settings";
+import {
+  POLLER_STATUS_KEY,
+  futureSummaryAlertKey,
+  getProactiveSettings,
+  hasSetting,
+  putSetting,
+} from "./settings";
 
 /**
  * The five-minute poller — every link between OpenCouncil and notis is a
@@ -58,6 +64,10 @@ export interface PollerResult {
   wakesEnqueued: number;
   /** Events consumed without a wake because the meeting itself is old news. */
   staleConsumed: number;
+  /** Agenda events consumed without a wake because the meeting already happened. */
+  lateAgendaConsumed: number;
+  /** Summarize events held back because the meeting is still dated in the future. */
+  futureSummaryHeld: number;
   editorialCostUsd: number;
 }
 
@@ -93,6 +103,8 @@ const emptyResult = (ran: boolean, reason?: string): PollerResult => ({
   eventsProcessed: 0,
   wakesEnqueued: 0,
   staleConsumed: 0,
+  lateAgendaConsumed: 0,
+  futureSummaryHeld: 0,
   editorialCostUsd: 0,
 });
 
@@ -426,6 +438,73 @@ async function fireScheduledWakes(
 }
 
 /**
+ * What the poller does with one meeting event, decided by its type and the
+ * MEETING's own date — never by when the task finished. The table:
+ *
+ * | event          | meeting ahead | meeting past      |
+ * |----------------|---------------|-------------------|
+ * | processAgenda  | fanout        | late-agenda       |
+ * | summarize      | future-summary| fanout            |
+ *
+ * `stale` overrides both for a meeting older than STALE_MEETING_MS. That is
+ * a blast-radius floor, not part of the semantics above: completedAt is
+ * TaskStatus.updatedAt, so one `batchRerun --force` over the archive would
+ * otherwise pay an editorial pass per meeting and WhatsApp whole cohorts
+ * about years-old news. Dedup does not cover it — a meeting notis never
+ * recorded (pre-launch history) has no processed row to match.
+ *
+ * - `late-agenda`: a processAgenda task that succeeded after the meeting was
+ *   held (a late upload, a backfill, batchRerun --force). Fanning it out
+ *   would preview a meeting that already happened, against an archive that
+ *   by then carries the transcript. The summarize event is that meeting's
+ *   real news and arrives on its own.
+ * - `future-summary`: a meeting cannot be summarized before it happens, so
+ *   this is a data error — almost always a wrong CouncilMeeting.dateTime.
+ *   The poller alarms and sends nothing. Unlike the other two it is NOT
+ *   consumed, so correcting the date lets the same event fan out — but only
+ *   while the task row is still inside EVENT_LOOKBACK_MS. completedAt is
+ *   TaskStatus.updatedAt and does not move when CouncilMeeting.dateTime is
+ *   fixed, so a later fix needs the summarize task re-run. The alarm says so.
+ */
+export type EventDisposition = "fanout" | "stale" | "late-agenda" | "future-summary";
+
+export function classifyEvent(
+  row: Pick<MeetingEventRow, "type" | "meetingDate">,
+  at: Date,
+  staleBefore: Date,
+): EventDisposition {
+  if (row.meetingDate < staleBefore) return "stale";
+  const ahead = row.meetingDate > at;
+  if (row.type === "processAgenda") return ahead ? "fanout" : "late-agenda";
+  return ahead ? "future-summary" : "fanout";
+}
+
+/**
+ * Record an event as consumed without a wake — the same row seedOnly writes,
+ * with no brief and no fan-out. Returns false when a concurrent tick got
+ * there first.
+ */
+async function consumeEvent(db: PrismaClient, row: MeetingEventRow): Promise<boolean> {
+  try {
+    await db.notisProcessedEvent.create({
+      data: {
+        taskId: row.taskId,
+        type: row.type,
+        cityId: row.cityId,
+        meetingId: row.meetingId,
+        meetingName: row.meetingName,
+        meetingDate: row.meetingDate,
+        adminBodyName: row.adminBodyName,
+      },
+    });
+    return true;
+  } catch {
+    // Raced by a concurrent tick — already recorded.
+    return false;
+  }
+}
+
+/**
  * Phase (d) — meeting events: only released meetings (the public MCP gates
  * on released, so an early wake cannot ground; unreleased events are NOT
  * recorded, and a later release fires naturally). Dedup by (cityId,
@@ -471,58 +550,63 @@ async function processMeetingEvents(
     select: { cityId: true, meetingId: true, type: true },
   });
   const processedIds = new Set(processed.map(identity));
-  const unprocessed = candidates.filter((c) => !processedIds.has(identity(c)));
-
-  // Consume stale meetings without a wake: record them like seedOnly does so
-  // they stop re-surfacing every tick, but pay no editorial pass and enqueue
-  // nothing. Agenda events for upcoming meetings have future dates and are
-  // untouched.
-  const staleBefore = new Date(now().getTime() - STALE_MEETING_MS);
-  const stale = unprocessed.filter((c) => c.meetingDate < staleBefore);
-  for (const row of stale) {
-    try {
-      await db.notisProcessedEvent.create({
-        data: {
-          taskId: row.taskId,
-          type: row.type,
-          cityId: row.cityId,
-          meetingId: row.meetingId,
-          meetingName: row.meetingName,
-          meetingDate: row.meetingDate,
-          adminBodyName: row.adminBodyName,
-        },
-      });
-      result.staleConsumed++;
-    } catch {
-      // Raced by a concurrent tick — already recorded.
-    }
+  // Collapse duplicates WITHIN the tick too. A re-run leaves two succeeded
+  // task rows for the same meeting and phase, and both land in one lookback
+  // window. The processed row only exists after the first one commits, so
+  // without this the second pays a full editorial pass and then throws it
+  // away on the unique violation — and burns a MAX_EVENTS_PER_TICK slot
+  // doing it. Candidates arrive ordered completedAt asc, so the first wins.
+  const byIdentity = new Map<string, MeetingEventRow>();
+  for (const c of candidates) {
+    const id = identity(c);
+    if (!processedIds.has(id) && !byIdentity.has(id)) byIdentity.set(id, c);
   }
-
-  const fresh = unprocessed.filter((c) => c.meetingDate >= staleBefore);
-  if (fresh.length === 0) return;
+  const unprocessed = [...byIdentity.values()];
 
   if (opts.seedOnly) {
-    // Quiet start: mark the whole backlog consumed, wake nobody.
-    for (const row of fresh) {
-      try {
-        await db.notisProcessedEvent.create({
-          data: {
-            taskId: row.taskId,
-            type: row.type,
-            cityId: row.cityId,
-            meetingId: row.meetingId,
-            meetingName: row.meetingName,
-            meetingDate: row.meetingDate,
-            adminBodyName: row.adminBodyName,
-          },
-        });
-        result.eventsProcessed++;
-      } catch {
-        // Raced by a concurrent tick — already recorded.
-      }
+    // Quiet start: mark the whole backlog consumed, wake nobody, alarm about
+    // nothing. Every disposition is the same here, data errors included — a
+    // seeded deployment must not act on anything it finds, and a row left
+    // unconsumed would fan out to the whole cohort on some later tick.
+    for (const row of unprocessed) {
+      if (await consumeEvent(db, row)) result.eventsProcessed++;
     }
     return;
   }
+
+  // Sort every unprocessed event by classifyEvent's table, then act on each
+  // bucket. Consuming records the row the same way seedOnly does, so it stops
+  // re-surfacing every tick, with no editorial pass and nothing enqueued.
+  const staleBefore = new Date(now().getTime() - STALE_MEETING_MS);
+  const at = now();
+  const byDisposition = new Map<EventDisposition, MeetingEventRow[]>();
+  for (const row of unprocessed) {
+    const disposition = classifyEvent(row, at, staleBefore);
+    byDisposition.set(disposition, [...(byDisposition.get(disposition) ?? []), row]);
+  }
+
+  for (const row of byDisposition.get("stale") ?? []) {
+    if (await consumeEvent(db, row)) result.staleConsumed++;
+  }
+  for (const row of byDisposition.get("late-agenda") ?? []) {
+    if (await consumeEvent(db, row)) result.lateAgendaConsumed++;
+  }
+  // Deliberately NOT consumed — see classifyEvent. The settings key holds the
+  // alarm to once per meeting instead of once per five-minute tick, so the
+  // alarm has to carry the whole remedy: it is the only one ops gets.
+  for (const row of byDisposition.get("future-summary") ?? []) {
+    result.futureSummaryHeld++;
+    const key = futureSummaryAlertKey(row.cityId, row.meetingId);
+    if (await hasSetting(db, key)) continue;
+    await alert(
+      `summarize completed for ${row.cityId}/${row.meetingId} (${row.taskId}) but the meeting is dated ${row.meetingDate.toISOString()}, in the future — nobody was woken. ` +
+        `Fix CouncilMeeting.dateTime. Do it within ${EVENT_LOOKBACK_MS / 86_400_000} days of the task completing and the next tick fans the event out by itself; after that the row leaves the event feed, so re-run the summarize task to bring it back.`,
+    );
+    await putSetting(db, key, { at: at.toISOString(), taskId: row.taskId });
+  }
+
+  const fresh = byDisposition.get("fanout") ?? [];
+  if (fresh.length === 0) return;
 
   const subs = await db.notisSubscription.findMany({
     where: { status: "active" },
@@ -553,22 +637,7 @@ async function processMeetingEvents(
     // Nobody to wake: record the event as consumed without paying for an
     // editorial pass. A subscriber arriving later gets the NEXT event.
     if (audience.length === 0) {
-      try {
-        await db.notisProcessedEvent.create({
-          data: {
-            taskId: row.taskId,
-            type: row.type,
-            cityId: row.cityId,
-            meetingId: row.meetingId,
-            meetingName: row.meetingName,
-            meetingDate: row.meetingDate,
-            adminBodyName: row.adminBodyName,
-          },
-        });
-        result.eventsProcessed++;
-      } catch {
-        /* raced — already recorded */
-      }
+      if (await consumeEvent(db, row)) result.eventsProcessed++;
       continue;
     }
 

--- a/services/notis/src/lib/settings.ts
+++ b/services/notis/src/lib/settings.ts
@@ -19,10 +19,23 @@ export interface ProactiveSettings {
 export const PROACTIVE_PAUSED_KEY = "proactivePaused";
 export const POLLER_STATUS_KEY = "pollerStatus";
 
+/**
+ * One key per meeting whose summarize event arrived while the meeting was
+ * still dated in the future — a data error the poller alarms on. The key
+ * makes the alarm fire once instead of every five-minute tick; the event
+ * itself stays unconsumed, so correcting the date still fans it out.
+ */
+export const futureSummaryAlertKey = (cityId: string, meetingId: string) =>
+  `futureSummaryAlerted:${cityId}:${meetingId}`;
+
 export async function getProactiveSettings(db: Db): Promise<ProactiveSettings> {
   const row = await db.notisSetting.findUnique({ where: { key: PROACTIVE_PAUSED_KEY } });
   // Absent means paused: deployments start dark on purpose.
   return { paused: row === null ? true : row.value === true };
+}
+
+export async function hasSetting(db: Db, key: string): Promise<boolean> {
+  return (await db.notisSetting.findUnique({ where: { key } })) !== null;
 }
 
 export async function putSetting(db: Db, key: string, value: unknown): Promise<void> {


### PR DESCRIPTION
## The problem

Notis sends two kinds of proactive message about a meeting. An agenda message
is a preview, before the meeting. A summary message is a report, after the
meeting.

The poller chose between them by the task type alone. It never compared the
task to the meeting's own date. Two cases went out wrong.

**A late agenda.** A `processAgenda` task can succeed after the meeting takes
place. A late upload does this. A backfill does this. `batchRerun --force`
does this. The poller then sent a "coming up" preview about a meeting that
already happened. By that time the archive holds the transcript of that
meeting. The prompt cannot correct this. The message is a preview, and every
record behind it says the opposite.

**A summary that arrives too early.** A `summarize` task for a meeting still
dated in the future fanned out as a normal report. A meeting cannot be
summarized before it happens. This is a data error. It is almost always a
wrong `CouncilMeeting.dateTime`.

The playground had the same problem, in a stronger form. It replays the
archive, and the archive keeps one state per meeting: the state after the
meeting. Nothing reconstructs the earlier state. Every simulated agenda wake
was therefore a post-meeting wake with a preview label.

## The change

`classifyEvent` in `poller.ts` now holds the full table. The meeting's date
decides, not the task.

| Event | Meeting is ahead | Meeting took place |
|---|---|---|
| `processAgenda` | fan out | consume, no message |
| `summarize` | hold, alarm, do **not** consume | fan out |

A meeting older than 30 days is consumed with no message, whatever its type.
This is a blast-radius floor, not part of the table above. `completedAt` is
`TaskStatus.updatedAt`, so one `batchRerun --force` over the archive would
otherwise pay for one editorial pass per meeting. It would also message whole
groups of readers about years-old news. The dedup does not stop this, because
a meeting that Notis never recorded has no processed row to match.

The held summary is the one case that stays unconsumed. A correction to the
date must let the same event fan out. A settings key for each meeting keeps
the alarm to one message. Without the key the alarm repeats every five
minutes.

`deriveQueue` in the playground now makes `meeting_summarized` events only.
The playground store version goes from 4 to 5. A version-4 queue still holds
agenda items, and no partial cleanup stays correct: a rewind turns a completed
item back into a pending one. `loadStore` puts such a store aside and the
session starts again.

## Two more fixes that the table exposed

Duplicate task rows for one meeting and one phase now collapse inside a tick.
A re-run leaves two succeeded rows in the same 7-day window. The processed row
only exists after the first row commits. The second row therefore paid for a
full editorial pass and then threw it away on the unique violation. It also
used one of the four `MAX_EVENTS_PER_TICK` slots.

`seedOnly` now consumes the whole backlog before any disposition acts. A held
summary used to survive a quiet start. It then fanned out to every reader on a
later tick. This is the one thing `seedOnly` exists to prevent.

## Prompt

`system.md` drops the clause "even if a record you can see already contains
them" from the agenda section. With the guard in place, an agenda wake means
the meeting is ahead. The paragraph below already states the rule where it
belongs: the meeting date against `current_time`. That paragraph also covers
replies.

## Checks

- `npm test -w notis` — 338 tests pass.
- `npx tsc --noEmit` — clean.
- `next build` — succeeds.

New tests cover each row of the table, the held summary and its single alarm,
a corrected date that fans out, one message for each (meeting, event type),
and `seedOnly` against every disposition.

## Open question for the reviewer

`STALE_MEETING_MS` still stops a summary for a meeting older than 30 days.
A first summary of a five-week-old meeting is therefore consumed in silence.
Transcription and summarization take time, so this can happen. The floor
protects against a bulk re-run of the archive. A floor keyed on the Notis
launch date would give the same protection and let a late summary through.
Tell me if you want that instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_017FuTerRZfUb5RNgYYCmk21)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR classifies Notis meeting events from the meeting date instead of the task type alone.
- It consumes late agenda and stale events without sending a message.
- It holds future-dated summaries and sends one operational alert.
- It deduplicates task reruns within each poller tick.
- It changes the playground to generate summary events only and invalidates version-4 stores.
- It adds disposition, deduplication, seed-only, and playground queue tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no concrete changed-code failure remains.

The meeting-date disposition table matches the view contract, deduplication preserves one event per meeting phase, and the playground migration prevents old agenda items from reappearing.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| services/notis/src/lib/poller.ts | Adds date-based event classification, in-tick deduplication, held-summary alerts, and full-backlog seed consumption without a confirmed defect. |
| services/notis/src/lib/settings.ts | Adds a stable per-meeting key that limits future-summary alerts to one. |
| services/notis/src/app/admin/(panel)/playground/deriveQueue.ts | Removes simulated agenda wakes because the archive exposes only post-meeting state. |
| services/notis/src/app/admin/(panel)/playground/store.ts | Rejects incompatible version-4 playground stores after the queue contract changes. |
| services/notis/src/app/admin/(panel)/playground/types.ts | Updates the persisted playground store type to version 5. |
| services/notis/prompts/system.md | Removes redundant agenda guidance now that the poller enforces pre-meeting agenda wakes. |
| services/notis/src/lib/__tests__/poller.test.ts | Covers the disposition table, held-summary recovery, rerun deduplication, stale events, and seed-only behavior. |
| services/notis/src/app/admin/(panel)/playground/__tests__/deriveQueue.test.ts | Updates queue expectations to summary-only simulation. |

<sub>Reviews (1): Last reviewed commit: ["fix(notis): decide meeting events by the..."](https://github.com/schemalabz/opencouncil/commit/9e2f90c36b13a04a87592a482930a164de517c79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56609018)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Background task orchestration](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/background-task-orchestration.md)
- Knowledge Base — [Resident notifications](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/resident-notifications.md)
- Knowledge Base — [Notis notification service](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/notis-notification-service.md)
</details>


<!-- /greptile_comment -->