### PR TITLE
feat(notis): cap unreplied template sends, not proactive messages

### DIFF
--- a/services/notis/prisma/schema.prisma
+++ b/services/notis/prisma/schema.prisma
@@ -199,14 +199,15 @@ model NotisMessage {
   direction MessageDirection
   body      String
   channel   MessageChannel   @default(whatsapp)
-  // Cap-countable (unprompted) send: the wake had no user_message event and
-  // was not purely a reply-continuation follow-up. Not the same as
-  // deliveryMode=template — a scheduled wake inside the 24h window sends
-  // freeform yet is unprompted.
+  // Unprompted send: the wake had no user_message event and was not purely a
+  // reply-continuation follow-up. Not the same as deliveryMode=template — a
+  // scheduled wake inside the 24h window sends freeform yet is unprompted.
+  // The panel reads it. It does NOT decide the proactive limit: that rail
+  // counts unreplied TEMPLATE sends, one per wake.
   proactive Boolean          @default(false)
   // The delivery-instant rails (unsubscribed / paused / shadow) apply to
   // this row. Distinct from `proactive`: a reply-continuation follow-up is
-  // railed but cap-exempt, and a reactive reply (including the ΣΤΟΠ
+  // railed but not unprompted, and a reactive reply (including the ΣΤΟΠ
   // confirmation) is neither. Stamped at creation from the wake class, so
   // every delivery path — boundary, sweeper, incremental — asks one flag
   // instead of re-deriving the class per call site.
@@ -241,7 +242,8 @@ model NotisMessage {
 // Why the schedule exists decides the template shell when it fires outside
 // the 24h window: a promised answer to a reader question rides
 // demos_followup; a self-scheduled follow-up to proactive news rides
-// demos_update_news. Reply-origin fires are also cap-exempt.
+// demos_update_news. That is all it decides — the proactive limit counts
+// both, because outside the window both are cold pushes.
 enum ScheduledWakeOrigin {
   reply
   proactive

--- a/services/notis/prompts/system.md
+++ b/services/notis/prompts/system.md
@@ -173,6 +173,11 @@ That is one story, not three. Write again only when something genuinely new
 happened for them — a decision, a reversal, a date — and then write it as an
 update to what they already know, never as if it were news to them.
 
+One line in that record can read NOT SENT. That is a message you wrote and a
+rail stopped: the person never received it and does not know a word of it.
+Treat the story as untold. If it still matters, write it fresh — never as an
+update to something they never read, and never with an apology for the gap.
+
 ## Before vs after the meeting
 
 An agenda_processed wake fires before the meeting happens: you are previewing
@@ -322,4 +327,4 @@ else is silently lost. A rationale that says you replied when you never called
 send_message is a lie.
 
 Message caps, quiet hours and templates are enforced outside you. Never mention
-them to the reader.
+them to the reader, and never mention a NOT SENT line to them either.

--- a/services/notis/src/agent/prompt.ts
+++ b/services/notis/src/agent/prompt.ts
@@ -1,6 +1,7 @@
 import { distanceLine, locationPoints, locationText } from "./geo";
 import {
   CONVERSATION_WINDOW,
+  ConversationMessage,
   DECISION_WINDOW,
   EditorialBrief,
   Prompts,
@@ -83,6 +84,21 @@ export function neutralizeFences(text: string): string {
   );
 }
 
+/**
+ * One conversation turn, rendered. Compaction folds aged-out turns into
+ * `memory` through this same function: a held-back message rendered as "you
+ * sent" on that side would put the falsehood somewhere that never ages out,
+ * and every later wake would read it as delivered.
+ */
+export function conversationLine(m: ConversationMessage): string {
+  const label = m.notSent
+    ? `NOT SENT (${m.notSent} — they never received this, so they do not know it)`
+    : m.from === "reader"
+      ? "they wrote"
+      : "you sent";
+  return `[${m.at}] ${label}: «${neutralizeFences(m.text)}»`;
+}
+
 export function renderEvent(event: WakeEvent, state: WakeState): string {
   switch (event.type) {
     case "agenda_processed":
@@ -127,21 +143,21 @@ export function assembleUserTurn(state: WakeState, events: WakeEvent[], now: Dat
 
   // The conversation is the record of what actually reached this reader —
   // in production, drawn from the message table's own delivery status, so a
-  // suppressed or failed send is absent and the model never treats a stopped
-  // message as delivered.
+  // failed send is absent and the model never treats a stopped message as
+  // delivered. A send the proactive limit held back is the one exception: it
+  // is present and labelled, because the agent wrote that text and needs to
+  // know the reader never got it.
   const turnsOmitted = Math.max(0, state.conversation.length - CONVERSATION_WINDOW);
   const conversation = state.conversation
     .slice(-CONVERSATION_WINDOW)
-    .map(
-      (m) =>
-        `[${m.at}] ${m.from === "reader" ? "they wrote" : "you sent"}: «${neutralizeFences(m.text)}»`,
-    )
+    .map(conversationLine)
     .join("\n");
   const conversationHeader = turnsOmitted > 0 ? `(${turnsOmitted} older messages omitted)\n` : "";
 
   // The decision log — why the agent acted, silences included. A send
   // decision whose text is absent from the conversation was stopped or
-  // failed before it reached the reader.
+  // failed before it reached the reader; when the proactive limit stopped
+  // it, the text is present and marked NOT SENT instead.
   const decisionsOmitted = Math.max(0, state.decisions.length - DECISION_WINDOW);
   const decisions = state.decisions
     .slice(-DECISION_WINDOW)

--- a/services/notis/src/agent/schemas.ts
+++ b/services/notis/src/agent/schemas.ts
@@ -66,13 +66,20 @@ export const commitmentSchema = z.object({
 });
 
 /** One turn of the real WhatsApp thread — what actually reached the reader
- *  (sent/delivered/read outbound) and what they wrote (inbound). A suppressed
- *  or failed message never appears, so the agent cannot mistake a stopped send
- *  for a delivered one. */
+ *  (sent/delivered/read outbound) and what they wrote (inbound). A failed
+ *  message never appears, so the agent cannot mistake a stopped send for a
+ *  delivered one. */
 export const conversationMessageSchema = z.object({
   at: z.string(),
   from: z.enum(["reader", "notis"]),
   text: z.string(),
+  /**
+   * Set when the agent wrote this text for the reader and a rail stopped it
+   * before it left. The proactive limit is the only rail that shows its work
+   * this way — every other stopped send is simply absent. The prompt renders
+   * it as NOT SENT, so the agent knows the reader has not heard this.
+   */
+  notSent: z.literal("proactive limit").optional(),
 });
 
 export const wakeStateSchema = z.object({

--- a/services/notis/src/app/admin/(panel)/_components/WhatsAppChat.tsx
+++ b/services/notis/src/app/admin/(panel)/_components/WhatsAppChat.tsx
@@ -247,7 +247,7 @@ function DeliveryGlyph({ delivery }: { delivery: MessageDelivery }) {
     case "failed":
       return <AlertCircle className={cls} style={{ color: "#b42318" }} />;
     case "suppressed":
-      // A rail (weekly cap, pause) stopped the send.
+      // A rail (proactive limit, pause) stopped the send.
       return <EyeOff className={cls} style={{ color: "#8696a0" }} />;
     default:
       return null;

--- a/services/notis/src/app/admin/(panel)/_lib/metrics.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/metrics.ts
@@ -110,7 +110,7 @@ export interface PeriodStats {
   /** Shared editorial passes in the period — once per meeting event, on top
    *  of the per-wake model cost. */
   editorialCostUsd: number;
-  /** Rail-stopped sends in the period, by reason (weekly cap, παύση, …). */
+  /** Rail-stopped sends in the period, by reason (όριο μηνυμάτων, παύση, …). */
   suppressions: Array<{ reason: string; count: number }>;
 }
 

--- a/services/notis/src/app/admin/(panel)/_lib/system.ts
+++ b/services/notis/src/app/admin/(panel)/_lib/system.ts
@@ -3,7 +3,7 @@ import { EditorialBrief } from "@/agent/types";
 import { ActivePhase, activePhase, clampToActiveHours } from "@/lib/active-hours";
 import { hasNotisDb, notisDb } from "@/lib/db";
 import { POLLER_STATUS_KEY, getProactiveSettings } from "@/lib/settings";
-import { WEEKLY_CAP } from "@/lib/queue";
+import { subscriptionsAtTemplateCap } from "@/lib/queue";
 
 /**
  * The system page's snapshot: queue state with per-item deadlines, the
@@ -135,33 +135,22 @@ const EMPTY: SystemSnapshot = {
   atCap: [],
 };
 
-/** Users whose rolling-week unprompted budget is spent — the same countable
- *  rule the send boundary applies. */
+/** Readers whose rolling-week budget of cold pushes is spent — measured by
+ *  the same code the send boundary enforces, so the two cannot drift. */
 async function usersAtCap(db: ReturnType<typeof notisDb>) {
-  const counts = await db.notisMessage.groupBy({
-    by: ["subscriptionId"],
-    where: {
-      proactive: true,
-      createdAt: { gte: new Date(Date.now() - 7 * 24 * 60 * 60_000) },
-      status: { in: ["pending", "sent", "delivered", "read"] },
-    },
-    _count: { _all: true },
-  });
-  const capped = counts.filter((c) => c._count._all >= WEEKLY_CAP);
+  const capped = await subscriptionsAtTemplateCap(db);
   if (capped.length === 0) return [];
   const subs = await db.notisSubscription.findMany({
     where: { id: { in: capped.map((c) => c.subscriptionId) } },
     select: { id: true, userId: true, userName: true },
   });
   const byId = new Map(subs.map((s) => [s.id, s]));
-  return capped
-    .map((c) => ({
-      subscriptionId: c.subscriptionId,
-      userId: byId.get(c.subscriptionId)?.userId ?? c.subscriptionId,
-      userName: byId.get(c.subscriptionId)?.userName ?? "—",
-      count: c._count._all,
-    }))
-    .sort((a, b) => b.count - a.count);
+  return capped.map((c) => ({
+    subscriptionId: c.subscriptionId,
+    userId: byId.get(c.subscriptionId)?.userId ?? c.subscriptionId,
+    userName: byId.get(c.subscriptionId)?.userName ?? "—",
+    count: c.count,
+  }));
 }
 
 export interface RailsNow {

--- a/services/notis/src/app/admin/(panel)/page.tsx
+++ b/services/notis/src/app/admin/(panel)/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { CalendarClock, EyeOff, Gauge, Moon, OctagonAlert, Sun, TriangleAlert } from "lucide-react";
 import { EVENT_LABELS } from "./_lib/records";
+import { suppressionLabel } from "@/lib/queue";
 import { getRailsNow } from "./_lib/system";
 import { Countdown } from "./_components/Countdown";
 import { DeltaChip } from "./_components/DeltaChip";
@@ -373,12 +374,6 @@ function RecentInboundList({ stats }: { stats: OverviewStats }) {
   );
 }
 
-const SUPPRESSION_LABELS: Record<string, string> = {
-  "weekly cap": "όριο εβδομάδας",
-  paused: "παύση",
-  unsubscribed: "απεγγραφή",
-};
-
 async function RailsStrip({ suppressions }: { suppressions: Array<{ reason: string; count: number }> }) {
   const rails = await getRailsNow();
   if (!rails) return null;
@@ -473,7 +468,7 @@ async function RailsStrip({ suppressions }: { suppressions: Array<{ reason: stri
             <p className="text-sm font-semibold tabular-nums">{suppressedTotal}</p>
             <p className="text-[10px] uppercase tracking-wider text-muted-foreground">
               {suppressions
-                .map((r) => `${SUPPRESSION_LABELS[r.reason] ?? r.reason} ${r.count}`)
+                .map((r) => `${suppressionLabel(r.reason)} ${r.count}`)
                 .join(" · ")}
             </p>
           </div>

--- a/services/notis/src/app/admin/(panel)/system/page.tsx
+++ b/services/notis/src/app/admin/(panel)/system/page.tsx
@@ -292,8 +292,9 @@ export default async function SystemPage(props: {
             <section className="rounded-lg border border-amber-500/40 bg-background p-4">
               <p className="text-sm font-medium">Στο εβδομαδιαίο όριο</p>
               <p className="mt-0.5 text-xs text-muted-foreground">
-                Οι χρήστες αυτοί δεν λαμβάνουν άλλα αυθόρμητα μηνύματα μέχρι να κυλήσει η
-                εβδομάδα· οι απαντήσεις δεν περιορίζονται.
+                Οι χρήστες αυτοί έχουν λάβει μηνύματα προτύπου που δεν απάντησαν μέσα σε
+                24 ώρες. Δεν λαμβάνουν άλλο μέχρι να κυλήσουν αυτά από την εβδομάδα· οι
+                απαντήσεις τους δεν περιορίζονται ποτέ.
               </p>
               <div className="mt-3 flex flex-wrap gap-2">
                 {snap.atCap.map((u) => (

--- a/services/notis/src/app/admin/(panel)/system/page.tsx
+++ b/services/notis/src/app/admin/(panel)/system/page.tsx
@@ -15,6 +15,7 @@ import {
   TriangleAlert,
 } from "lucide-react";
 import { env } from "@/env.mjs";
+import { WEEKLY_TEMPLATE_CAP } from "@/lib/queue";
 import { EVENT_LABELS } from "../_lib/records";
 import { DigestedMeetingView, SubjectFanout, getSystemSnapshot } from "../_lib/system";
 import { parsePage } from "../_lib/paging";
@@ -305,7 +306,9 @@ export default async function SystemPage(props: {
                   >
                     <UserAvatar seed={u.userId} size={20} />
                     {u.userName}
-                    <span className="tabular-nums text-muted-foreground">{u.count}/3</span>
+                    <span className="tabular-nums text-muted-foreground">
+                      {u.count}/{WEEKLY_TEMPLATE_CAP}
+                    </span>
                   </Link>
                 ))}
               </div>

--- a/services/notis/src/lib/__tests__/compaction.test.ts
+++ b/services/notis/src/lib/__tests__/compaction.test.ts
@@ -339,4 +339,53 @@ describe("maybeCompact", () => {
     expect(sent).toContain("already_tracked_do_not_repeat");
     expect(sent).toContain("kypseli-metro");
   });
+
+  test("a send the proactive limit held back folds as NOT SENT, never as delivered", async () => {
+    // `memory` never ages out, so a message the reader never received must
+    // not be summarised into it as one they were told. The live prompt
+    // labels these rows; the fold has to label them the same way.
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    // Older than anything seed() writes, so it is inside the folded range
+    // rather than the live window the prompt still renders itself.
+    db.store.messages.push({
+      id: "held",
+      subscriptionId: "sub1",
+      direction: "outbound",
+      status: "suppressed",
+      failureReason: "proactive limit",
+      body: "ΚΡΑΤΗΜΕΝΟ ΚΕΙΜΕΝΟ",
+      createdAt: new Date(SETTLED.getTime() - 24 * 60 * 60_000),
+    });
+    seed(db, COMPACT_WAKES_AT + 20, COMPACT_MESSAGES_AT + 20);
+    const fake = new FakeAnthropic([{ content: [text("Σύνοψη.")], stop_reason: "end_turn" }]);
+
+    await maybeCompact(db, { ...SUB_ARG }, { deps: makeDeps(fake), now: () => NOW });
+
+    const input = String((fake.requests[0].messages[0] as { content: unknown }).content);
+    const held = input.split("\n").find((line) => line.includes("ΚΡΑΤΗΜΕΝΟ ΚΕΙΜΕΝΟ"));
+    expect(held).toBeDefined();
+    expect(held).toContain("NOT SENT (proactive limit");
+    // The marker REPLACES the delivered label; it does not sit beside it.
+    expect(held).not.toContain("you sent");
+  });
+
+  test("a send another rail stopped never reaches the summariser at all", async () => {
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }] });
+    db.store.messages.push({
+      id: "paused",
+      subscriptionId: "sub1",
+      direction: "outbound",
+      status: "suppressed",
+      failureReason: "paused",
+      body: "ΠΑΥΜΕΝΟ ΚΕΙΜΕΝΟ",
+      createdAt: new Date(SETTLED.getTime() - 24 * 60 * 60_000),
+    });
+    seed(db, COMPACT_WAKES_AT + 20, COMPACT_MESSAGES_AT + 20);
+    const fake = new FakeAnthropic([{ content: [text("Σύνοψη.")], stop_reason: "end_turn" }]);
+
+    await maybeCompact(db, { ...SUB_ARG }, { deps: makeDeps(fake), now: () => NOW });
+
+    const input = String((fake.requests[0].messages[0] as { content: unknown }).content);
+    expect(input).not.toContain("ΠΑΥΜΕΝΟ ΚΕΙΜΕΝΟ");
+  });
 });

--- a/services/notis/src/lib/__tests__/queue-rails.test.ts
+++ b/services/notis/src/lib/__tests__/queue-rails.test.ts
@@ -3,13 +3,14 @@ import { WakeEvent } from "../../agent/types";
 import type { NotisSubscription } from "../../../generated/client";
 import { type ClaimedItem } from "../queue-core";
 import { PROACTIVE_PAUSED_KEY } from "../settings";
-import { WEEKLY_CAP, deliverPendingMessage, processItem } from "../queue";
+import { WEEKLY_TEMPLATE_CAP, deliverPendingMessage, processItem } from "../queue";
 import { type Row, makeFakeDb } from "./fake-db";
 import { FakeBird } from "./fake-bird";
 
 /**
- * The proactive send boundary: shadow, pause, weekly cap, unsubscribed —
- * and the classes that bypass or soften them (reactive, reply-continuation).
+ * The proactive send boundary: shadow, pause, the proactive limit,
+ * unsubscribed — and the classes that bypass them (reactive, an open 24h
+ * window).
  */
 
 const SUB: Row = {
@@ -51,6 +52,96 @@ function batchItem(events: WakeEvent[]): ClaimedItem {
 
 function seedClaim(db: ReturnType<typeof makeFakeDb>, attempts = 1) {
   db.store.queue.set("q1", { id: "q1", status: "running", attempts });
+}
+
+/** One template send that reached the reader, `hoursAgo` ago, on its own wake
+ *  — one occasion against the proactive limit. `bubbles` writes several rows
+ *  under that one wake, which is the case the row-counting cap got wrong. */
+function seedTemplateSend(
+  db: ReturnType<typeof makeFakeDb>,
+  key: string,
+  hoursAgo: number,
+  bubbles = 1,
+) {
+  const at = new Date(Date.now() - hoursAgo * 3_600_000);
+  db.store.wakes.push({
+    id: `wake-${key}`,
+    subscriptionId: "sub1",
+    eventType: "meeting_summarized",
+    eventAt: at,
+    decision: "send",
+    rationale: "άξιζε",
+    outcome: null,
+    truncated: false,
+    model: "claude-sonnet-5",
+  });
+  for (let b = 0; b < bubbles; b++) {
+    db.store.messages.push({
+      id: `${key}-${b}`,
+      subscriptionId: "sub1",
+      wakeId: `wake-${key}`,
+      direction: "outbound",
+      channel: "whatsapp",
+      body: `παλιό μήνυμα ${key}-${b}`,
+      proactive: true,
+      railed: true,
+      deliveryMode: "template",
+      template: "demos_update_news",
+      status: "sent",
+      failureReason: null,
+      createdAt: at,
+    });
+  }
+}
+
+/** Just over the 24h reply window, so one reply can answer exactly one push:
+ *  a reply an hour after a send still lands before the next one, and 25h
+ *  after it lands after the next one. */
+const SEND_SPACING_H = 25;
+const WEEK_H = 7 * 24;
+
+/** `count` unreplied template sends, oldest first. Returns each one's age in
+ *  hours so a test can place a reply relative to the send it answers.
+ *
+ *  Individually answerable sends have to be more than 24h apart, so at most
+ *  six of them fit in the rolling week. Raise WEEKLY_TEMPLATE_CAP past that
+ *  and this throws rather than seeding sends outside the window, where they
+ *  would not be counted and every cap test would pass for the wrong reason. */
+function seedTemplateSends(
+  db: ReturnType<typeof makeFakeDb>,
+  count: number,
+  { bubbles = 1, prefix = "old" }: { bubbles?: number; prefix?: string } = {},
+): number[] {
+  if (count * SEND_SPACING_H >= WEEK_H) {
+    throw new Error(
+      `${count} sends spaced ${SEND_SPACING_H}h apart do not fit in the rolling ` +
+        "week — the fixture, or the cap, needs rethinking",
+    );
+  }
+  const ages: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const hoursAgo = (count - i) * SEND_SPACING_H;
+    seedTemplateSend(db, `${prefix}${i}`, hoursAgo, bubbles);
+    ages.push(hoursAgo);
+  }
+  return ages;
+}
+
+function seedInbound(
+  db: ReturnType<typeof makeFakeDb>,
+  key: string,
+  hoursAgo: number,
+  channel: "whatsapp" | "sms" = "whatsapp",
+) {
+  db.store.messages.push({
+    id: key,
+    subscriptionId: "sub1",
+    direction: "inbound",
+    channel,
+    body: "τι έγινε τελικά;",
+    status: null,
+    createdAt: new Date(Date.now() - hoursAgo * 3_600_000),
+  });
 }
 
 function liveSettings(): Row[] {
@@ -182,21 +273,10 @@ describe("proactive rails", () => {
     }
   });
 
-  it("weekly cap: a saturated reader's unprompted wake never reaches the model", async () => {
+  it("proactive limit: a reader at the cap gets no further template, and no model run", async () => {
     const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: liveSettings() });
     seedClaim(db);
-    for (let i = 0; i < WEEKLY_CAP; i++) {
-      db.store.messages.push({
-        id: `old${i}`,
-        subscriptionId: "sub1",
-        direction: "outbound",
-        body: `παλιό μήνυμα ${i}`,
-        proactive: true,
-        status: "sent",
-        failureReason: null,
-        createdAt: new Date(Date.now() - (i + 1) * 3_600_000),
-      });
-    }
+    seedTemplateSends(db, WEEKLY_TEMPLATE_CAP);
     const bird = new FakeBird();
     const anthropic = new FakeAnthropic(sendTurn);
 
@@ -209,7 +289,7 @@ describe("proactive rails", () => {
 
     expect(anthropic.requests).toHaveLength(0);
     expect(bird.templateSends).toHaveLength(0);
-    expect(db.store.messages.some((m) => m.wakeId)).toBe(false);
+    expect(db.store.messages.some((m) => m.wakeId === "wake-new")).toBe(false);
     expect(db.store.queue.get("q1")?.status).toBe("done");
     // A model-less wake row says what went unexamined, so the next wake's
     // decision log is not left believing this reader was told.
@@ -219,44 +299,220 @@ describe("proactive rails", () => {
     expect(String(skipped.rationale)).toContain("δεν εξετάστηκε");
   });
 
-  it("weekly cap filled DURING the wake: the send is suppressed", async () => {
+  it("one wake is one send against the limit, however many bubbles it wrote", async () => {
+    // The rule the row-counting cap got wrong. One occasion short of the cap,
+    // carrying far more ROWS than the whole week's budget, still leaves the
+    // reader room for one more push.
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: liveSettings() });
+    seedClaim(db);
+    seedTemplateSends(db, WEEKLY_TEMPLATE_CAP - 1, { bubbles: WEEKLY_TEMPLATE_CAP });
+    const bird = new FakeBird();
+
+    await processItem(batchItem([meetingEvent()]), {
+      db,
+      bird,
+      deps: makeDeps(new FakeAnthropic(sendTurn)),
+      alert: async () => {},
+    });
+
+    expect(bird.templateSends).toHaveLength(1);
+  });
+
+  it("a reply within 24h clears the send that drew it — on either channel", async () => {
+    for (const channel of ["whatsapp", "sms"] as const) {
+      const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: liveSettings() });
+      seedClaim(db);
+      const ages = seedTemplateSends(db, WEEKLY_TEMPLATE_CAP);
+      // Answers the oldest push and nothing else: it lands 1h after that send
+      // and BEFORE every later one, so exactly one occasion is cleared.
+      seedInbound(db, "reply", ages[0] - 1, channel);
+      const bird = new FakeBird();
+
+      await processItem(batchItem([meetingEvent()]), {
+        db,
+        bird,
+        deps: makeDeps(new FakeAnthropic(sendTurn)),
+        alert: async () => {},
+      });
+
+      expect(bird.templateSends).toHaveLength(1);
+    }
+  });
+
+  it("a reply after the 24h window has closed does not clear anything", async () => {
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: liveSettings() });
+    seedClaim(db);
+    const ages = seedTemplateSends(db, WEEKLY_TEMPLATE_CAP);
+    // 25 hours after the oldest push — one hour too late to answer it, and
+    // still before every later one, so it clears none of them.
+    seedInbound(db, "reply", ages[0] - 25);
+    const bird = new FakeBird();
+    const anthropic = new FakeAnthropic(sendTurn);
+
+    await processItem(batchItem([meetingEvent()]), {
+      db,
+      bird,
+      deps: makeDeps(anthropic),
+      alert: async () => {},
+    });
+
+    expect(anthropic.requests).toHaveLength(0);
+    expect(bird.templateSends).toHaveLength(0);
+  });
+
+  it("a template that arrived as an SMS fallback counts once, not twice or never", async () => {
+    // WhatsApp failed and the second leg carried it: the reader's handset
+    // still buzzed, so the occasion counts. Both rows are ONE occasion, so
+    // the pair must not spend two slots either.
+    const seedFallbacks = (db: ReturnType<typeof makeFakeDb>, count: number) => {
+      seedTemplateSends(db, count);
+      for (let i = 0; i < count; i++) {
+        const failed = db.store.messages.find((m) => m.id === `old${i}-0`)!;
+        failed.status = "failed";
+        failed.failureReason = "boom";
+        db.store.messages.push({
+          id: `sms${i}`,
+          subscriptionId: "sub1",
+          wakeId: `wake-old${i}`,
+          fallbackForId: `old${i}-0`,
+          direction: "outbound",
+          channel: "sms",
+          body: "το ίδιο κείμενο, με SMS",
+          proactive: true,
+          railed: true,
+          status: "sent",
+          failureReason: null,
+          createdAt: failed.createdAt as Date,
+        });
+      }
+    };
+
+    // At the cap: counted at all, so the next push is stopped.
+    const atCap = makeFakeDb({ subscriptions: [{ ...SUB }], settings: liveSettings() });
+    seedClaim(atCap);
+    seedFallbacks(atCap, WEEKLY_TEMPLATE_CAP);
+    const stopped = new FakeBird();
+    const unusedModel = new FakeAnthropic(sendTurn);
+    await processItem(batchItem([meetingEvent()]), {
+      db: atCap,
+      bird: stopped,
+      deps: makeDeps(unusedModel),
+      alert: async () => {},
+    });
+    expect(unusedModel.requests).toHaveLength(0);
+    expect(stopped.templateSends).toHaveLength(0);
+
+    // One short of it: twice as many ROWS as the whole budget, and still
+    // under the cap — so the two legs are one occasion, not two.
+    const underCap = makeFakeDb({ subscriptions: [{ ...SUB }], settings: liveSettings() });
+    seedClaim(underCap);
+    seedFallbacks(underCap, WEEKLY_TEMPLATE_CAP - 1);
+    const sending = new FakeBird();
+    await processItem(batchItem([meetingEvent()]), {
+      db: underCap,
+      bird: sending,
+      deps: makeDeps(new FakeAnthropic(sendTurn)),
+      alert: async () => {},
+    });
+    expect(sending.templateSends).toHaveLength(1);
+  });
+
+  it("an open 24h window is never capped: a freeform push goes out at the limit", async () => {
+    // The limit counts cold pushes. Inside the window the reader is talking
+    // to us, so the send costs them nothing they did not invite.
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: liveSettings() });
+    seedClaim(db);
+    seedTemplateSends(db, WEEKLY_TEMPLATE_CAP);
+    // Two hours ago, and more than 24h after every push above — so it opens
+    // the window without clearing a single occasion.
+    seedInbound(db, "recent", 2);
+    const bird = new FakeBird();
+
+    await processItem(batchItem([meetingEvent()]), {
+      db,
+      bird,
+      deps: makeDeps(new FakeAnthropic(sendTurn)),
+      alert: async () => {},
+    });
+
+    expect(bird.templateSends).toHaveLength(0);
+    expect(bird.sends).toHaveLength(1);
+  });
+
+  it("the limit fills DURING the wake: the whole wake is suppressed, not part of it", async () => {
     const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: liveSettings() });
     seedClaim(db);
     const bird = new FakeBird();
-    // The cap is clear at claim time and full by the time the boundary runs
-    // — the race the pre-model check cannot see.
-    // The cap fills WHILE the model runs — the one case the pre-model check
-    // cannot see, modelled by a client that writes the sends as it answers.
-    const scripted = new FakeAnthropic(sendTurn);
+    // Clear at claim time and full by the time the boundary runs — the race
+    // the pre-model check cannot see, modelled by a client that fills the
+    // budget as it answers.
+    const twoBubbles = [
+      {
+        content: [
+          toolUse("t1", "send_message", { text: "Πρώτο μήνυμα." }),
+          toolUse("t2", "send_message", { text: "Δεύτερο μήνυμα." }),
+          toolUse("t3", "finish_wake", { rationale: "Άξιζε." }),
+        ],
+        stop_reason: "tool_use",
+      },
+    ];
+    const scripted = new FakeAnthropic(twoBubbles);
     const anthropic = {
       create: async (params: Parameters<typeof scripted.create>[0]) => {
-        for (let i = 0; i < WEEKLY_CAP; i++) {
-          db.store.messages.push({
-            id: `mid${i}`,
-            subscriptionId: "sub1",
-            direction: "outbound",
-            body: `ενδιάμεσο μήνυμα ${i}`,
-            proactive: true,
-            status: "sent",
-            failureReason: null,
-            createdAt: new Date(),
-          });
-        }
+        seedTemplateSends(db, WEEKLY_TEMPLATE_CAP, { prefix: "mid" });
         return scripted.create(params);
       },
     };
-    const deps = makeDeps(anthropic);
 
-    await processItem(batchItem([meetingEvent()]), { db, bird, deps, alert: async () => {} });
+    await processItem(batchItem([meetingEvent()]), {
+      db,
+      bird,
+      deps: makeDeps(anthropic),
+      alert: async () => {},
+    });
 
-    const outbound = db.store.messages.find((m) => m.wakeId)!;
-    expect(outbound.status).toBe("suppressed");
-    expect(outbound.failureReason).toBe("weekly cap");
+    const outbound = db.store.messages.filter((m) => String(m.body).endsWith("μήνυμα."));
+    expect(outbound).toHaveLength(2);
+    // All-or-nothing: half a story on the handset is worse than none.
+    for (const row of outbound) {
+      expect(row.status).toBe("suppressed");
+      expect(row.failureReason).toBe("proactive limit");
+    }
     expect(bird.templateSends).toHaveLength(0);
-    // No correction is written anywhere: the suppressed row is simply
-    // excluded from the conversation the next wake reads, so the agent
-    // cannot mistake it for a delivered message.
-    expect(db.store.wakes.filter((w) => (w.model ?? null) === null)).toHaveLength(0);
+  });
+
+  it("a send the limit held back reaches the next wake's prompt as NOT SENT", async () => {
+    // The agent wrote that text for this reader and it never left. Hiding it
+    // would have the next wake write the same news again, believing it was
+    // never said.
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: liveSettings() });
+    seedClaim(db);
+    db.store.messages.push({
+      id: "held",
+      subscriptionId: "sub1",
+      direction: "outbound",
+      status: "suppressed",
+      failureReason: "proactive limit",
+      body: "Η πλατεία παίρνει 2,3 εκατ.",
+      createdAt: new Date(Date.now() - 60 * 60_000),
+    });
+    const silenceTurn = [
+      { content: [toolUse("t1", "finish_wake", { rationale: "όχι τώρα" })], stop_reason: "tool_use" },
+    ];
+    const anthropic = new FakeAnthropic(silenceTurn);
+
+    await processItem(batchItem([meetingEvent()]), {
+      db,
+      bird: new FakeBird(),
+      deps: makeDeps(anthropic),
+      alert: async () => {},
+    });
+
+    const userTurn = (
+      anthropic.requests[0].messages[0] as { content: Array<{ text: string }> }
+    ).content[0].text;
+    expect(userTurn).toContain("Η πλατεία παίρνει 2,3 εκατ.");
+    expect(userTurn).toContain("NOT SENT (proactive limit");
   });
 
   it("the decision log the model sees comes from the wake rows", async () => {
@@ -296,17 +552,18 @@ describe("proactive rails", () => {
     expect(userTurn).toContain("τίποτα κοντά τους αυτή τη φορά");
   });
 
-  it("the conversation the model sees is the real message record — a suppressed message is excluded", async () => {
+  it("the conversation the model sees is the real message record — a paused send is excluded", async () => {
     // The core of #9: the prompt's conversation comes from the message table's
     // delivery status, not a journal claim. A delivered message and an inbound
-    // reply appear; a suppressed one never does, so the agent cannot treat a
-    // stopped send as one the reader received.
+    // reply appear; a send another rail stopped never does, so the agent cannot
+    // treat it as one the reader received. The proactive limit is the single
+    // exception, and it is labelled — see the NOT SENT case above.
     const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: liveSettings() });
     seedClaim(db);
     const past = new Date(Date.now() - 60 * 60_000);
     db.store.messages.push(
       { id: "d1", subscriptionId: "sub1", direction: "outbound", status: "delivered", body: "Η πλατεία ανακαινίζεται.", createdAt: past },
-      { id: "x1", subscriptionId: "sub1", direction: "outbound", status: "suppressed", body: "ΑΥΤΟ δεν εστάλη.", createdAt: past },
+      { id: "x1", subscriptionId: "sub1", direction: "outbound", status: "suppressed", failureReason: "paused", body: "ΑΥΤΟ δεν εστάλη.", createdAt: past },
       { id: "i1", subscriptionId: "sub1", direction: "inbound", status: null, body: "Πότε αρχίζει;", createdAt: past },
     );
     const silenceTurn = [
@@ -329,23 +586,22 @@ describe("proactive rails", () => {
     expect(userTurn).not.toContain("ΑΥΤΟ δεν εστάλη."); // suppressed → hidden
   });
 
-  it("cap ignores rows that never reached anyone (cap/pause suppressions, failures)", async () => {
+  it("the limit ignores template sends that never reached anyone", async () => {
+    // Suppressed and failed rows never arrived, so they buy the reader
+    // nothing and cost them nothing. Three of them leave the budget whole.
     const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: liveSettings() });
     seedClaim(db);
-    for (const [i, [status, reason]] of [
-      ["suppressed", "weekly cap"],
+    const stopped: Array<[string, string]> = [
+      ["suppressed", "proactive limit"],
       ["suppressed", "paused"],
       ["failed", "boom"],
-    ].entries()) {
-      db.store.messages.push({
-        id: `old${i}`,
-        subscriptionId: "sub1",
-        direction: "outbound",
-        proactive: true,
-        status,
-        failureReason: reason,
-        createdAt: new Date(Date.now() - (i + 1) * 3_600_000),
-      });
+    ];
+    seedTemplateSends(db, WEEKLY_TEMPLATE_CAP);
+    for (let i = 0; i < WEEKLY_TEMPLATE_CAP; i++) {
+      const [status, reason] = stopped[i % stopped.length];
+      const row = db.store.messages.find((m) => m.id === `old${i}-0`)!;
+      row.status = status;
+      row.failureReason = reason;
     }
     const bird = new FakeBird();
 
@@ -359,38 +615,31 @@ describe("proactive rails", () => {
     expect(bird.templateSends).toHaveLength(1);
   });
 
-  it("a promised follow-up (scheduled, origin reply) is cap-exempt", async () => {
+  it("a promised follow-up is capped like any other cold push", async () => {
+    // The old per-message cap exempted these. The proactive limit does not:
+    // outside the 24h window a promised follow-up buzzes a handset exactly
+    // like news does, and the reader asked days ago.
     const replyFollowup: WakeEvent = {
       type: "scheduled",
       at: new Date().toISOString(),
       reason: "υποσχέθηκα να επανέλθω",
       origin: "reply",
     };
-    // At the cap: the follow-up still goes out.
     const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: liveSettings() });
     seedClaim(db);
-    for (let i = 0; i < WEEKLY_CAP; i++) {
-      db.store.messages.push({
-        id: `old${i}`,
-        subscriptionId: "sub1",
-        direction: "outbound",
-        body: `παλιό μήνυμα ${i}`,
-        proactive: true,
-        status: "sent",
-        failureReason: null,
-        createdAt: new Date(Date.now() - (i + 1) * 3_600_000),
-      });
-    }
+    seedTemplateSends(db, WEEKLY_TEMPLATE_CAP);
     const bird = new FakeBird();
+    const anthropic = new FakeAnthropic(sendTurn);
+
     await processItem(batchItem([replyFollowup]), {
       db,
       bird,
-      deps: makeDeps(new FakeAnthropic(sendTurn)),
+      deps: makeDeps(anthropic),
       alert: async () => {},
     });
-    const followup = db.store.messages.find((m) => m.wakeId)!;
-    expect(followup.status).toBe("sent");
-    expect(followup.template).toBe("demos_followup");
+
+    expect(anthropic.requests).toHaveLength(0);
+    expect(bird.templateSends).toHaveLength(0);
   });
 
   it("an unsubscribed-mid-flight reader gets nothing proactive", async () => {

--- a/services/notis/src/lib/__tests__/queue-rails.test.ts
+++ b/services/notis/src/lib/__tests__/queue-rails.test.ts
@@ -3,7 +3,12 @@ import { WakeEvent } from "../../agent/types";
 import type { NotisSubscription } from "../../../generated/client";
 import { type ClaimedItem } from "../queue-core";
 import { PROACTIVE_PAUSED_KEY } from "../settings";
-import { WEEKLY_TEMPLATE_CAP, deliverPendingMessage, processItem } from "../queue";
+import {
+  UNSETTLED_DEFER_MS,
+  WEEKLY_TEMPLATE_CAP,
+  deliverPendingMessage,
+  processItem,
+} from "../queue";
 import { type Row, makeFakeDb } from "./fake-db";
 import { FakeBird } from "./fake-bird";
 
@@ -479,6 +484,61 @@ describe("proactive rails", () => {
       expect(row.failureReason).toBe("proactive limit");
     }
     expect(bird.templateSends).toHaveLength(0);
+  });
+
+  it("a limit spent on sends still in flight defers the wake instead of dropping it", async () => {
+    // Dropping is permanent: the events are consumed. A reader cannot ignore
+    // a push that has not arrived, so the wake waits for those rows to
+    // settle rather than dying on them.
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: liveSettings() });
+    seedClaim(db);
+    seedTemplateSends(db, WEEKLY_TEMPLATE_CAP);
+    // One is a transient Bird failure the sweeper is still retrying.
+    db.store.messages.find((m) => m.id === "old0-0")!.status = "pending";
+    const bird = new FakeBird();
+    const anthropic = new FakeAnthropic(sendTurn);
+
+    await processItem(batchItem([meetingEvent()]), {
+      db,
+      bird,
+      deps: makeDeps(anthropic),
+      alert: async () => {},
+    });
+
+    expect(anthropic.requests).toHaveLength(0);
+    expect(bird.templateSends).toHaveLength(0);
+    const item = db.store.queue.get("q1")!;
+    expect(item.status).toBe("pending");
+    // deferItem undoes the attempt, so waiting is never a retry.
+    expect(item.attempts).toBe(0);
+    expect((item.runAfter as Date).getTime()).toBeGreaterThan(Date.now());
+    expect((item.runAfter as Date).getTime()).toBeLessThanOrEqual(Date.now() + UNSETTLED_DEFER_MS);
+    // Nothing was recorded as unexamined: the wake has not been decided yet.
+    expect(db.store.wakes.every((w) => w.decision !== "silence")).toBe(true);
+  });
+
+  it("a limit spent on sends that arrived still drops the wake", async () => {
+    // The other half of the rule: pending rows are the only reason to wait.
+    // Once they are on the handset the budget is real and the wake is closed.
+    const db = makeFakeDb({ subscriptions: [{ ...SUB }], settings: liveSettings() });
+    seedClaim(db);
+    seedTemplateSends(db, WEEKLY_TEMPLATE_CAP);
+    db.store.messages.find((m) => m.id === "old0-0")!.status = "pending";
+    // One more that DID arrive, so the cap holds without the pending one.
+    seedTemplateSend(db, "arrived", 5);
+    const bird = new FakeBird();
+    const anthropic = new FakeAnthropic(sendTurn);
+
+    await processItem(batchItem([meetingEvent()]), {
+      db,
+      bird,
+      deps: makeDeps(anthropic),
+      alert: async () => {},
+    });
+
+    expect(anthropic.requests).toHaveLength(0);
+    expect(db.store.queue.get("q1")?.status).toBe("done");
+    expect(String(db.store.wakes.at(-1)!.rationale)).toContain("δεν εξετάστηκε");
   });
 
   it("a send the limit held back reaches the next wake's prompt as NOT SENT", async () => {

--- a/services/notis/src/lib/compaction.ts
+++ b/services/notis/src/lib/compaction.ts
@@ -8,10 +8,15 @@ import {
   Deps,
   MEMORY_MAX_CHARS,
 } from "@/agent/types";
+import { conversationLine } from "@/agent/prompt";
 import { normalizeUsage, usageToCost } from "@/agent/pricing";
 import { alert as sendAlert } from "./alert";
 import { buildDeps } from "./deps";
-import { conversationMessageFilter } from "./queue-core";
+import {
+  CONVERSATION_ROW_SELECT,
+  conversationMessageFilter,
+  toConversationMessage,
+} from "./conversation";
 import { putSetting } from "./settings";
 
 /**
@@ -128,9 +133,11 @@ export async function maybeCompact(
 
     const past = sub.memoryThrough ? { gt: sub.memoryThrough } : undefined;
     // Every message query here — counting, edge-finding and folding — uses the
-    // SAME filter the live conversation uses. A boundary computed over rows the
-    // agent never sees (suppressed, failed, still pending) lands in the wrong
-    // place and folds visible messages out of the window behind it.
+    // SAME filter the live conversation uses, and folds through the same
+    // renderer. A boundary computed over rows the agent never sees (failed,
+    // still pending) lands in the wrong place and folds visible messages out
+    // of the window behind it; a renderer that disagrees puts a message the
+    // reader never received into `memory` as one they did.
     const wakeWhere = { subscriptionId: sub.id, ...(past ? { eventAt: past } : {}) };
     const messageWhere = {
       subscriptionId: sub.id,
@@ -183,7 +190,7 @@ export async function maybeCompact(
       db.notisMessage.findMany({
         where: { ...messageWhere, createdAt: range },
         orderBy: { createdAt: "asc" },
-        select: { direction: true, body: true, createdAt: true },
+        select: CONVERSATION_ROW_SELECT,
       }),
       db.notisCommitment.findMany({
         where: { subscriptionId: sub.id, resolvedAt: null },
@@ -213,14 +220,11 @@ export async function maybeCompact(
       `</already_tracked_do_not_repeat>`,
       ``,
       `<aged_out_messages>`,
-      messages
-        .map(
-          (m) =>
-            `[${m.createdAt.toISOString()}] ${
-              m.direction === "inbound" ? "they wrote" : "you sent"
-            }: «${m.body}»`,
-        )
-        .join("\n") || "(none)",
+      // The live prompt's own renderer. A send the proactive limit held back
+      // is in this range like any other row, and folding it as "you sent"
+      // would write into `memory` — which never ages out — that the reader
+      // was told something they never received.
+      messages.map((m) => conversationLine(toConversationMessage(m))).join("\n") || "(none)",
       `</aged_out_messages>`,
       ``,
       `<aged_out_decisions>`,

--- a/services/notis/src/lib/conversation.ts
+++ b/services/notis/src/lib/conversation.ts
@@ -1,0 +1,86 @@
+import type { ConversationMessage } from "@/agent/types";
+import type { Prisma } from "../../generated/client";
+
+/**
+ * What the agent is shown of the message record, in one place.
+ *
+ * Three readers have to agree exactly: the live conversation window, and
+ * both the counting and the folding sides of compaction. They disagree in
+ * two different ways when this is duplicated, and both are silent:
+ * - a filter that admits a row the renderer mislabels writes a falsehood
+ *   into the prompt;
+ * - a boundary computed over rows the agent never sees lands in the wrong
+ *   place and folds visible messages out of the window behind it.
+ */
+
+/**
+ * The failureReason a proactive-limit suppression carries. queue.ts holds
+ * the Greek label and type-checks this string against the rail vocabulary.
+ */
+export const PROACTIVE_LIMIT_REASON = "proactive limit";
+
+/**
+ * Which message rows count as "what was said" — everything the reader
+ * wrote, the outbound rows that reached them, and the sends the proactive
+ * limit held back. A failed or still-pending send never appears, so the
+ * agent cannot mistake a stopped message for a delivered one.
+ *
+ * The proactive-limit rows are the one exception, and toConversationMessage
+ * marks every one of them. They belong in the window because the agent
+ * WROTE that text for this reader: hide it and the next wake writes the same
+ * news again, believing it was never said. Every other stopped send is
+ * either a retry still in flight or a reader who is gone, and neither is a
+ * thing the agent should reason about.
+ *
+ * A function rather than a shared literal: the return annotation supplies
+ * the Prisma types the inline form used to get from context, and every
+ * caller gets its own object.
+ */
+export function conversationMessageFilter(): Prisma.NotisMessageWhereInput {
+  return {
+    OR: [
+      { direction: "inbound" },
+      { direction: "outbound", status: { in: ["sent", "delivered", "read"] } },
+      {
+        direction: "outbound",
+        status: "suppressed",
+        failureReason: PROACTIVE_LIMIT_REASON,
+      },
+    ],
+  };
+}
+
+/** The columns toConversationMessage reads. Every caller selects these, so a
+ *  new one cannot forget the pair that decides the notSent marker. */
+export const CONVERSATION_ROW_SELECT = {
+  direction: true,
+  body: true,
+  createdAt: true,
+  status: true,
+  failureReason: true,
+} as const;
+
+interface ConversationRow {
+  direction: string;
+  body: string;
+  createdAt: Date;
+  status: string | null;
+  failureReason: string | null;
+}
+
+/**
+ * One row as the agent sees it. The marker is read from the row's own
+ * reason, not inferred from `suppressed` alone: widening the filter above
+ * would otherwise label a pause or an unsubscribe as a proactive-limit hold,
+ * with nothing to catch it.
+ */
+export function toConversationMessage(row: ConversationRow): ConversationMessage {
+  return {
+    at: row.createdAt.toISOString(),
+    from: row.direction === "inbound" ? "reader" : "notis",
+    text: row.body,
+    ...(row.status === "suppressed" && row.failureReason === PROACTIVE_LIMIT_REASON
+      ? ({ notSent: PROACTIVE_LIMIT_REASON } as const)
+      : {}),
+  };
+}

--- a/services/notis/src/lib/queue-core.ts
+++ b/services/notis/src/lib/queue-core.ts
@@ -25,29 +25,6 @@ export const MAX_ATTEMPTS = 3;
  *  and the evaluation export both mean by "still in the queue". */
 export const LIVE_QUEUE_STATUSES = ["pending", "running", "failed"] as const;
 
-/**
- * Which message rows count as "what was actually said" — everything the
- * reader wrote, and only the outbound rows that reached them. A suppressed,
- * failed or still-pending send never appears, so the agent cannot mistake a
- * stopped message for a delivered one.
- *
- * A function rather than a shared literal: the return annotation supplies the
- * Prisma types the inline form used to get from context, and every caller gets
- * its own object.
- *
- * Exported because three readers must agree exactly: the live conversation
- * window, and both the counting and the folding sides of compaction. When
- * they drift, compaction computes a boundary from rows the agent never sees
- * and folds visible messages out of the window behind it.
- */
-export function conversationMessageFilter(): Prisma.NotisMessageWhereInput {
-  return {
-    OR: [
-      { direction: "inbound" },
-      { direction: "outbound", status: { in: ["sent", "delivered", "read"] } },
-    ],
-  };
-}
 // Reclaim threshold for crash recovery. With the Anthropic client capped at
 // 3 minutes per call (lib/anthropic.ts), a single hung turn cannot push an
 // alive wake past this on its own; a pathological full-length wake that

--- a/services/notis/src/lib/queue.ts
+++ b/services/notis/src/lib/queue.ts
@@ -26,7 +26,6 @@ import { hasNotisDb, notisDb } from "./db";
 import { citiesForUser } from "./fanout";
 import { hasMainDb } from "./main-db";
 import {
-  conversationMessageFilter,
   ClaimLostError,
   ClaimedItem,
   MAX_ATTEMPTS,
@@ -40,6 +39,12 @@ import {
   touchClaim,
 } from "./queue-core";
 import { maybeCompact } from "./compaction";
+import {
+  CONVERSATION_ROW_SELECT,
+  PROACTIVE_LIMIT_REASON,
+  conversationMessageFilter,
+  toConversationMessage,
+} from "./conversation";
 import { getProactiveSettings } from "./settings";
 
 /**
@@ -127,19 +132,48 @@ const QUIET_MARGIN_MS = 10 * 60_000;
 /** How many promises the agent may carry for one reader. The block has to stay
  *  readable, and a reader with twenty open promises effectively has none. */
 export const MAX_OPEN_COMMITMENTS = 5;
-/** The hard rail: at most this many unprompted messages per rolling week. */
-export const WEEKLY_CAP = 3;
+/**
+ * The hard rail: at most this many UNREPLIED template sends per rolling week.
+ *
+ * A template send is a cold push. It reaches a reader whose 24h WhatsApp
+ * window is shut, so nothing they did invited it. Once this many have gone
+ * unanswered the reader is not reading, and the next one does not go out.
+ *
+ * The unit is the WAKE, not the message row: one wake is one occasion the
+ * handset buzzed, however many bubbles the agent wrote for it. Counting rows
+ * let a three-bubble wake spend a whole week, and let the boundary deliver
+ * half a wake once the budget ran out mid-batch.
+ *
+ * Freeform sends are never capped. They happen only inside the 24h window,
+ * which only the reader can open, so a freeform send answers someone who is
+ * already in the conversation.
+ */
+export const WEEKLY_TEMPLATE_CAP = 5;
 const WEEK_MS = 7 * 24 * 60 * 60_000;
+/** How long a template send has to draw an answer before it counts against
+ *  the cap for good. A send inside this window with no answer yet already
+ *  counts — the rail has to stop a burst on the day it happens — and stops
+ *  counting if the reader answers in time. Answer later and the send stays
+ *  counted: the window is the reader's chance to show that push landed, and
+ *  it does not reopen. */
+const REPLY_WINDOW_MS = 24 * 60 * 60_000;
+/** Delivery states that mean the row reached the reader, or still will.
+ *  `failed` and `suppressed` never arrived, so they never count. */
+const REACHED_STATUSES = ["pending", "sent", "delivered", "read"];
 
 /** Reactive = the reader spoke; bypasses every rail. */
 export function isReactiveWake(events: WakeEvent[]): boolean {
   return events.some((e) => e.type === "user_message");
 }
 
-/** Cap-countable (unprompted): not reactive, and not purely a promised
- *  follow-up to a reader question. A mixed coalesced wake counts,
- *  conservatively. */
-export function isCapCountable(events: WakeEvent[]): boolean {
+/** Unprompted: not reactive, and not purely a promised follow-up to a reader
+ *  question. A mixed coalesced wake counts, conservatively. Stamped on the
+ *  message row as `proactive`, which the panel reads.
+ *
+ *  It does NOT decide the template cap. That rail counts cold pushes, and a
+ *  promised follow-up that lands outside the 24h window is as cold as any
+ *  other — the reader asked days ago and has heard nothing since. */
+export function isUnprompted(events: WakeEvent[]): boolean {
   if (isReactiveWake(events)) return false;
   const allReplyFollowups = events.every(
     (e) => e.type === "scheduled" && (e.origin ?? "reply") === "reply",
@@ -179,7 +213,7 @@ async function runOneWake(
   const primary = primaryEvent(ordered);
   const lastAt = ordered[ordered.length - 1].at;
   const reactive = isReactiveWake(ordered);
-  const capCountable = isCapCountable(ordered);
+  const unprompted = isUnprompted(ordered);
 
   // The decision log comes from the wake records themselves — one row per
   // wake, including the shell's own model-less decisions (a ΣΤΟΠ pre-step, a
@@ -207,20 +241,18 @@ async function runOneWake(
     };
   });
 
-  const lastInbound = await db.notisMessage.findFirst({
-    // WhatsApp only: Meta's 24h customer-service window opens on WhatsApp
-    // inbound alone — an SMS reply must not steer decideDelivery into a
-    // freeform send the platform will reject.
-    where: { subscriptionId: sub.id, direction: "inbound", channel: "whatsapp" },
-    orderBy: { createdAt: "desc" },
-    select: { createdAt: true },
-  });
+  const windowOpenedAt = await lastWhatsAppInboundAt(db, sub.id);
 
   // The conversation the agent sees is the real message record: inbound
   // messages, and outbound messages that actually reached the reader. A
-  // suppressed or failed send is excluded, so the agent never treats a
-  // stopped message as delivered — the delivery status is the source of
-  // truth, not a claim written before the send.
+  // failed send is excluded, so the agent never treats a stopped message as
+  // delivered — the delivery status is the source of truth, not a claim
+  // written before the send.
+  //
+  // The one exception is a send the proactive limit held back. That text was
+  // written FOR this reader and never left, so it is shown with notSent set:
+  // hiding it would have the next wake write the same news again, believing
+  // it was never said.
   const messageRows = await db.notisMessage.findMany({
     where: {
       subscriptionId: sub.id,
@@ -229,13 +261,9 @@ async function runOneWake(
     },
     orderBy: [{ createdAt: "desc" }, { id: "desc" }],
     take: CONVERSATION_WINDOW,
-    select: { direction: true, body: true, createdAt: true },
+    select: CONVERSATION_ROW_SELECT,
   });
-  const conversation = messageRows.reverse().map((m) => ({
-    at: m.createdAt.toISOString(),
-    from: m.direction === "inbound" ? ("reader" as const) : ("notis" as const),
-    text: m.body,
-  }));
+  const conversation = messageRows.reverse().map(toConversationMessage);
 
   const cities = await assembleCities(sub);
   // Open promises never age out: unlike the two windows above, a commitment
@@ -315,7 +343,7 @@ async function runOneWake(
               direction: "outbound",
               body: text,
               channel: "whatsapp",
-              proactive: capCountable,
+              proactive: unprompted,
               // Reactive by construction: the closure exists only on
               // reactive wakes, and a reply is never railed.
               railed: false,
@@ -400,7 +428,7 @@ async function runOneWake(
   // send has no SMS fallback (that covers template rows only).
   const delivery =
     outcome.messages.length > 0
-      ? decideDelivery(primary, lastInbound?.createdAt.toISOString(), new Date())
+      ? decideDelivery(primary, windowOpenedAt, new Date())
       : undefined;
 
   const unparseableSchedules: string[] = [];
@@ -516,9 +544,10 @@ async function runOneWake(
         unparseableSchedules.push(scheduled.at);
         continue;
       }
-      // The poller fires these. Origin decides the eventual template shell
-      // and the cap exemption: a schedule made while answering the reader
-      // is a promised reply; one made after proactive news is not.
+      // The poller fires these. Origin decides the eventual template shell:
+      // a schedule made while answering the reader is a promised reply; one
+      // made after proactive news is not. It no longer decides anything about
+      // the cap — outside the 24h window both are cold pushes.
       await tx.notisScheduledWake.create({
         data: {
           subscriptionId: sub.id,
@@ -546,7 +575,7 @@ async function runOneWake(
             direction: "outbound",
             body: text,
             channel: "whatsapp",
-            proactive: capCountable,
+            proactive: unprompted,
             railed: !reactive,
             deliveryMode: delivery?.mode,
             template: delivery?.mode === "template" ? delivery.template : undefined,
@@ -818,10 +847,20 @@ export async function maybeSendSmsFallback(
 export const SUPPRESSION_REASONS = {
   unsubscribed: "απεγγραφή",
   paused: "παύση",
+  [PROACTIVE_LIMIT_REASON]: "όριο μηνυμάτων",
+  // Written by the per-message weekly cap the template cap replaced. Nothing
+  // writes it any more; the entry stays so the panel still labels old rows.
   "weekly cap": "όριο εβδομάδας",
 } as const;
 
 export type SuppressionReason = keyof typeof SUPPRESSION_REASONS;
+
+/** The Greek name for a reason read off a message row. A reason the set does
+ *  not name — a Bird error string, a rail added without a label — reads
+ *  through as itself rather than disappearing from the panel. */
+export function suppressionLabel(reason: string): string {
+  return (SUPPRESSION_REASONS as Record<string, string>)[reason] ?? reason;
+}
 
 /**
  * Kill every pending outbound row of a subscription — the unsubscribe
@@ -862,26 +901,193 @@ export async function suppressMessages(
   });
 }
 
+/** One outbound row, as the cap rule reads it. */
+interface CapRow {
+  id: string;
+  wakeId: string | null;
+  fallbackForId: string | null;
+  deliveryMode: string | null;
+  status: string | null;
+  createdAt: Date;
+}
+
+const CAP_ROW_SELECT = {
+  id: true,
+  wakeId: true,
+  fallbackForId: true,
+  deliveryMode: true,
+  status: true,
+  createdAt: true,
+} as const;
+
 /**
- * Countable history for the weekly cap: unprompted rows from the rolling
- * week that reached or will reach the reader. Suppressed rows never arrived
- * and never count. Exported so the panel and the pre-model check measure
- * exactly what the send boundary enforces.
+ * The only outbound rows an occasion can be built from: the template send
+ * itself, and the SMS fallback that carries it when WhatsApp fails. A
+ * freeform row can never make an occasion countable — decideDelivery gives
+ * every row of a wake the same mode — so leaving it in the database keeps
+ * both reads proportional to the pushes made, not to how much anyone talks.
  */
-export async function capUsage(
+function countableOutboundFilter(): Prisma.NotisMessageWhereInput {
+  return {
+    direction: "outbound",
+    OR: [{ deliveryMode: "template" }, { fallbackForId: { not: null } }],
+  };
+}
+
+/**
+ * The occasion a row belongs to. `wakeId` is the real answer; two rows have
+ * none and fall back:
+ * - the enrollment intro is written by the poller with no wake at all, so it
+ *   is its own occasion;
+ * - an SMS fallback of a wake-less row points at the row it replaces, which
+ *   keeps the two legs of one push on a single key.
+ * A fallback of a row that HAS a wake already carries that same wakeId, so
+ * it groups correctly without the second clause.
+ */
+function capGroupKey(row: CapRow): string {
+  return row.wakeId ?? row.fallbackForId ?? row.id;
+}
+
+/**
+ * The rule itself, over one reader's rows: how many of the rolling week's
+ * template sends drew no answer.
+ *
+ * An occasion counts when it pushed a template AND something in it reached
+ * the reader. The WhatsApp row and its SMS fallback share an occasion, so a
+ * template that failed on WhatsApp and arrived as an SMS counts once — the
+ * handset still buzzed with it, and the reader still owes no answer twice.
+ *
+ * Replied means any inbound message, on either channel, inside
+ * REPLY_WINDOW_MS of the moment the push reached them. An SMS reply is an
+ * answer like any other here; only decideDelivery cares which channel opened
+ * Meta's 24h window.
+ */
+function countUnrepliedTemplateSends(outbound: CapRow[], inboundAt: Date[]): number {
+  const occasions = new Map<string, { template: boolean; reachedAt: Date | null }>();
+  for (const row of outbound) {
+    const key = capGroupKey(row);
+    const occasion = occasions.get(key) ?? { template: false, reachedAt: null };
+    if (row.deliveryMode === "template") occasion.template = true;
+    if (row.status !== null && REACHED_STATUSES.includes(row.status)) {
+      if (occasion.reachedAt === null || row.createdAt < occasion.reachedAt) {
+        occasion.reachedAt = row.createdAt;
+      }
+    }
+    occasions.set(key, occasion);
+  }
+
+  let unreplied = 0;
+  for (const { template, reachedAt } of occasions.values()) {
+    if (!template || reachedAt === null) continue;
+    const deadline = reachedAt.getTime() + REPLY_WINDOW_MS;
+    const replied = inboundAt.some((at) => at > reachedAt && at.getTime() <= deadline);
+    if (!replied) unreplied++;
+  }
+  return unreplied;
+}
+
+/**
+ * The reader's spent budget: unreplied template sends in the rolling week.
+ * Exported so the pre-model check, the send boundary and the panel all
+ * measure exactly the same thing.
+ *
+ * `excludeIds` drops the rows of the wake being decided right now. They are
+ * already written and pending by the time the boundary asks, and a wake must
+ * not count against itself.
+ */
+export async function unrepliedTemplateSends(
   db: PrismaClient,
   subscriptionId: string,
   excludeIds: string[] = [],
 ): Promise<number> {
-  return db.notisMessage.count({
-    where: {
-      subscriptionId,
-      proactive: true,
-      ...(excludeIds.length > 0 ? { id: { notIn: excludeIds } } : {}),
-      createdAt: { gte: new Date(Date.now() - WEEK_MS) },
-      status: { in: ["pending", "sent", "delivered", "read"] },
-    },
+  const since = new Date(Date.now() - WEEK_MS);
+  const [outbound, inbound] = await Promise.all([
+    db.notisMessage.findMany({
+      where: {
+        subscriptionId,
+        createdAt: { gte: since },
+        ...(excludeIds.length > 0 ? { id: { notIn: excludeIds } } : {}),
+        ...countableOutboundFilter(),
+      },
+      select: CAP_ROW_SELECT,
+    }),
+    db.notisMessage.findMany({
+      where: { subscriptionId, direction: "inbound", createdAt: { gte: since } },
+      select: { createdAt: true },
+    }),
+  ]);
+  return countUnrepliedTemplateSends(
+    outbound,
+    inbound.map((m) => m.createdAt),
+  );
+}
+
+/**
+ * Every reader whose budget is spent. The panel needs this for its at-cap
+ * warning; a second implementation there would drift from the one the
+ * boundary enforces, so it calls here instead.
+ *
+ * Two narrow reads rather than one wide one: the first is bounded by the
+ * pushes actually made this week, and the second only asks about the readers
+ * that first one found. Everything else — a chatty reader's replies, every
+ * freeform send — never reaches Node.
+ */
+export async function subscriptionsAtTemplateCap(
+  db: PrismaClient,
+): Promise<Array<{ subscriptionId: string; count: number }>> {
+  const since = new Date(Date.now() - WEEK_MS);
+  const pushes = await db.notisMessage.findMany({
+    where: { createdAt: { gte: since }, ...countableOutboundFilter() },
+    select: { ...CAP_ROW_SELECT, subscriptionId: true },
   });
+  if (pushes.length === 0) return [];
+
+  const outbound = new Map<string, CapRow[]>();
+  for (const row of pushes) {
+    const rows = outbound.get(row.subscriptionId) ?? [];
+    rows.push(row);
+    outbound.set(row.subscriptionId, rows);
+  }
+
+  const replies = await db.notisMessage.findMany({
+    where: {
+      subscriptionId: { in: [...outbound.keys()] },
+      direction: "inbound",
+      createdAt: { gte: since },
+    },
+    select: { subscriptionId: true, createdAt: true },
+  });
+  const inbound = new Map<string, Date[]>();
+  for (const row of replies) {
+    const times = inbound.get(row.subscriptionId) ?? [];
+    times.push(row.createdAt);
+    inbound.set(row.subscriptionId, times);
+  }
+
+  const spent: Array<{ subscriptionId: string; count: number }> = [];
+  for (const [subscriptionId, rows] of outbound) {
+    const count = countUnrepliedTemplateSends(rows, inbound.get(subscriptionId) ?? []);
+    if (count >= WEEKLY_TEMPLATE_CAP) spent.push({ subscriptionId, count });
+  }
+  return spent.sort((a, b) => b.count - a.count);
+}
+
+/**
+ * The instant Meta's 24h customer-service window last opened: the reader's
+ * last WhatsApp inbound. WhatsApp only — an SMS reply does not open the
+ * window, so it must not steer decideDelivery into a freeform send the
+ * platform rejects.
+ */
+async function lastWhatsAppInboundAt(
+  db: PrismaClient,
+  subscriptionId: string,
+): Promise<string | undefined> {
+  const row = await db.notisMessage.findFirst({
+    where: { subscriptionId, direction: "inbound", channel: "whatsapp" },
+    orderBy: { createdAt: "desc" },
+    select: { createdAt: true },
+  });
+  return row?.createdAt.toISOString();
 }
 
 /**
@@ -1028,8 +1234,8 @@ async function linkPathForMessage(
  *
  * The rails apply to UNPROMPTED sends — a proactive row, or any template
  * send. `proactive` alone was the wrong key: a reply-continuation follow-up
- * is a template send but `proactive: false` (cap-exempt), and it must still
- * respect a ΣΤΟΠ. A free-form row is a reactive reply (decideDelivery
+ * is a template send but `proactive: false`, and it must still respect a
+ * ΣΤΟΠ. A free-form row is a reactive reply (decideDelivery
  * guarantees free-form for those), so it bypasses the rails — which is what
  * lets a ΣΤΟΠ confirmation still reach a reader who just unsubscribed.
  */
@@ -1152,15 +1358,16 @@ export async function deliverPendingMessage(
 
 /**
  * The proactive send boundary — the rails in order, per PRD §6:
- * unsubscribed race → kill switch → weekly cap → send. Suppressions land
- * as status `suppressed` with the reason in failureReason, so the panel
+ * unsubscribed race → kill switch → proactive limit → send. Suppressions
+ * land as status `suppressed` with the reason in failureReason, so the panel
  * shows exactly what a rail stopped and why.
  *
  * The unsubscribed and paused rails are enforced per row inside
  * deliverPendingMessage against live state; the batch-level checks here read
  * the same state once so a whole wake short-circuits with a single alert
- * instead of per message. The weekly cap belongs here, where the batch is
- * visible: the rows of one wake share the remaining budget.
+ * instead of per message. The proactive limit belongs here, where the whole
+ * wake is visible: it counts occasions, so it stops all of a wake's rows or
+ * none of them.
  */
 export async function sendProactiveMessages(
   db: PrismaClient,
@@ -1191,37 +1398,34 @@ export async function sendProactiveMessages(
 
   const rows = await db.notisMessage.findMany({
     where: { id: { in: messageIds } },
-    select: { id: true, proactive: true },
+    select: { id: true, deliveryMode: true },
   });
-  const byId = new Map(rows.map((r) => [r.id, r]));
 
-  // The weekly cap covers unprompted messages only. processItem checks it
-  // before the model too; this pass catches the wake that filled the budget
-  // while it ran.
-  let remaining = Number.POSITIVE_INFINITY;
-  if (rows.some((r) => r.proactive)) {
-    remaining = Math.max(0, WEEKLY_CAP - (await capUsage(db, sub.id, messageIds)));
+  // The proactive limit covers cold pushes only — template sends. processItem
+  // checks it before the model too; this pass catches the reader whose window
+  // shut, or whose budget filled, while the model ran.
+  //
+  // All of the wake or none of it. One wake is one occasion against the cap,
+  // so there is no partial budget to spend, and half a story on the reader's
+  // handset is worse than the whole story next week. decideDelivery gives
+  // every row of a wake the same mode, so the template rows ARE the wake.
+  if (rows.some((r) => r.deliveryMode === "template")) {
+    const spent = await unrepliedTemplateSends(db, sub.id, messageIds);
+    if (spent >= WEEKLY_TEMPLATE_CAP) {
+      await suppressMessages(db, messageIds, PROACTIVE_LIMIT_REASON);
+      return;
+    }
   }
 
+  const known = new Set(rows.map((r) => r.id));
   const pace = makeSendPacer();
   for (const id of messageIds) {
-    const row = byId.get(id);
-    if (!row) continue;
-    if (row.proactive) {
-      if (remaining <= 0) {
-        await suppressMessages(db, [id], "weekly cap");
-        continue;
-      }
-      remaining--;
-    }
+    if (!known.has(id)) continue;
     await pace(sub.id);
     await deliverPendingMessage(db, bird, id, sub, alert);
   }
 }
 
-/** Close a wake the weekly cap makes pointless, before any model spend. The
- *  events are consumed — a slot opens only as the week rolls, by which time
- *  this news is old — so a model-less wake row records what went unexamined. */
 /** Close an item without a model run, leaving a model-less wake row so the
  *  decision log shows what went unexamined and why. */
 async function completeModelLessWake(
@@ -1261,10 +1465,20 @@ async function completeModelLessWake(
   });
 }
 
+/**
+ * Close a wake the proactive limit makes pointless, before any model spend.
+ * The events are consumed: a slot opens only as the week rolls, and by then
+ * this news is old — so a model-less wake row records what went unexamined.
+ *
+ * `spent` is the count that was actually measured, not the cap. A reader can
+ * be past it (an enrollment intro, or a wake the boundary let through on a
+ * race), and the rationale is read back by the next wake's decision log.
+ */
 async function skipCappedWake(
   db: PrismaClient,
   item: ClaimedItem,
   events: WakeEvent[],
+  spent: number,
 ): Promise<void> {
   const what =
     events.length === 1
@@ -1274,7 +1488,8 @@ async function skipCappedWake(
     db,
     item,
     events,
-    `(σύστημα) ${what} — ο χρήστης έχει ήδη ${WEEKLY_CAP} αυθόρμητα μηνύματα αυτή την εβδομάδα.`,
+    `(σύστημα) ${what} — ο χρήστης έχει ${spent} αναπάντητα μηνύματα προτύπου ` +
+      `αυτή την εβδομάδα (όριο ${WEEKLY_TEMPLATE_CAP}), οπότε δεν στέλνουμε άλλο.`,
   );
 }
 
@@ -1323,13 +1538,25 @@ export async function processItem(item: ClaimedItem, overrides: DrainDeps = {}):
         await deferItem(db, item.id, item.attempts, clamped);
         return;
       }
-      // The weekly cap, before the model for the same reason: a saturated
-      // reader's unprompted wake can only produce messages the boundary
-      // suppresses, so running it buys a decision entry the rails then have
-      // to contradict — and pays for it. Reply-continuations are exempt.
-      if (isCapCountable(events) && (await capUsage(db, item.subscriptionId)) >= WEEKLY_CAP) {
-        await skipCappedWake(db, item, events);
-        return;
+      // The proactive limit, before the model for the same reason: a wake
+      // the boundary would suppress whole can only buy a decision entry the
+      // rails then have to contradict — and pays for it.
+      //
+      // Only a cold push is capped, so the delivery mode decides whether to
+      // even ask. The window can shut between here and the boundary (a
+      // 30-60s model run, or an hour of sweeper retries), which is why the
+      // boundary re-reads both halves rather than trusting this.
+      const delivery = decideDelivery(
+        primaryEvent(events),
+        await lastWhatsAppInboundAt(db, item.subscriptionId),
+        new Date(),
+      );
+      if (delivery.mode === "template") {
+        const spent = await unrepliedTemplateSends(db, item.subscriptionId);
+        if (spent >= WEEKLY_TEMPLATE_CAP) {
+          await skipCappedWake(db, item, events, spent);
+          return;
+        }
       }
     }
 

--- a/services/notis/src/lib/queue.ts
+++ b/services/notis/src/lib/queue.ts
@@ -126,6 +126,11 @@ const eventsSchema = wakeEventsSchema.min(1);
 
 /** How long a paused item sleeps before the claim looks at it again. */
 export const PAUSE_DEFER_MS = 15 * 60_000;
+/** How long a wake waits when the proactive limit is only spent because
+ *  earlier sends have not settled. Shorter than the sweeper's hour-long
+ *  give-up, so the wake re-reads a few times before those rows resolve one
+ *  way or the other. */
+export const UNSETTLED_DEFER_MS = 5 * 60_000;
 /** Claim-time margin: a wake this close to quiet hours defers instead of
  *  racing the boundary with a 30-60s model run. */
 const QUIET_MARGIN_MS = 10 * 60_000;
@@ -948,42 +953,69 @@ function capGroupKey(row: CapRow): string {
   return row.wakeId ?? row.fallbackForId ?? row.id;
 }
 
+/** What the rule found for one reader. `unsettled` is the part of `unreplied`
+ *  that is only pending — written and not yet on any handset. */
+export interface CapUsage {
+  unreplied: number;
+  unsettled: number;
+}
+
 /**
  * The rule itself, over one reader's rows: how many of the rolling week's
  * template sends drew no answer.
  *
  * An occasion counts when it pushed a template AND something in it reached
- * the reader. The WhatsApp row and its SMS fallback share an occasion, so a
- * template that failed on WhatsApp and arrived as an SMS counts once — the
- * handset still buzzed with it, and the reader still owes no answer twice.
+ * the reader, or still will. The WhatsApp row and its SMS fallback share an
+ * occasion, so a template that failed on WhatsApp and arrived as an SMS
+ * counts once — the handset still buzzed with it, and the reader still owes
+ * no answer twice.
+ *
+ * A pending row counts. It is written, it holds an idempotency key, and the
+ * sweeper will deliver it: excluding it would let a Bird outage bank wake
+ * after wake, and the reader would get every one of them at once when Bird
+ * came back. But a pending occasion is not yet EVIDENCE of anything — the
+ * reader cannot ignore what has not arrived — so it is reported separately
+ * and the pre-model rail waits for it to settle rather than dropping a wake
+ * on it. Within the hour it is either `sent`, or `failed` and no longer
+ * counted at all.
  *
  * Replied means any inbound message, on either channel, inside
  * REPLY_WINDOW_MS of the moment the push reached them. An SMS reply is an
  * answer like any other here; only decideDelivery cares which channel opened
  * Meta's 24h window.
  */
-function countUnrepliedTemplateSends(outbound: CapRow[], inboundAt: Date[]): number {
-  const occasions = new Map<string, { template: boolean; reachedAt: Date | null }>();
+function countUnrepliedTemplateSends(outbound: CapRow[], inboundAt: Date[]): CapUsage {
+  interface Occasion {
+    template: boolean;
+    /** Earliest row that is on the handset. */
+    arrivedAt: Date | null;
+    /** Earliest row still in flight, used only when nothing has arrived. */
+    pendingAt: Date | null;
+  }
+  const occasions = new Map<string, Occasion>();
+  const earlier = (a: Date | null, b: Date) => (a === null || b < a ? b : a);
   for (const row of outbound) {
     const key = capGroupKey(row);
-    const occasion = occasions.get(key) ?? { template: false, reachedAt: null };
+    const occasion = occasions.get(key) ?? { template: false, arrivedAt: null, pendingAt: null };
     if (row.deliveryMode === "template") occasion.template = true;
-    if (row.status !== null && REACHED_STATUSES.includes(row.status)) {
-      if (occasion.reachedAt === null || row.createdAt < occasion.reachedAt) {
-        occasion.reachedAt = row.createdAt;
-      }
+    if (row.status === "pending") occasion.pendingAt = earlier(occasion.pendingAt, row.createdAt);
+    else if (row.status !== null && REACHED_STATUSES.includes(row.status)) {
+      occasion.arrivedAt = earlier(occasion.arrivedAt, row.createdAt);
     }
     occasions.set(key, occasion);
   }
 
-  let unreplied = 0;
-  for (const { template, reachedAt } of occasions.values()) {
+  const usage: CapUsage = { unreplied: 0, unsettled: 0 };
+  for (const { template, arrivedAt, pendingAt } of occasions.values()) {
+    const reachedAt = arrivedAt ?? pendingAt;
     if (!template || reachedAt === null) continue;
     const deadline = reachedAt.getTime() + REPLY_WINDOW_MS;
     const replied = inboundAt.some((at) => at > reachedAt && at.getTime() <= deadline);
-    if (!replied) unreplied++;
+    if (replied) continue;
+    usage.unreplied++;
+    if (arrivedAt === null) usage.unsettled++;
   }
-  return unreplied;
+  return usage;
 }
 
 /**
@@ -999,7 +1031,7 @@ export async function unrepliedTemplateSends(
   db: PrismaClient,
   subscriptionId: string,
   excludeIds: string[] = [],
-): Promise<number> {
+): Promise<CapUsage> {
   const since = new Date(Date.now() - WEEK_MS);
   const [outbound, inbound] = await Promise.all([
     db.notisMessage.findMany({
@@ -1066,8 +1098,8 @@ export async function subscriptionsAtTemplateCap(
 
   const spent: Array<{ subscriptionId: string; count: number }> = [];
   for (const [subscriptionId, rows] of outbound) {
-    const count = countUnrepliedTemplateSends(rows, inbound.get(subscriptionId) ?? []);
-    if (count >= WEEKLY_TEMPLATE_CAP) spent.push({ subscriptionId, count });
+    const { unreplied } = countUnrepliedTemplateSends(rows, inbound.get(subscriptionId) ?? []);
+    if (unreplied >= WEEKLY_TEMPLATE_CAP) spent.push({ subscriptionId, count: unreplied });
   }
   return spent.sort((a, b) => b.count - a.count);
 }
@@ -1410,8 +1442,8 @@ export async function sendProactiveMessages(
   // handset is worse than the whole story next week. decideDelivery gives
   // every row of a wake the same mode, so the template rows ARE the wake.
   if (rows.some((r) => r.deliveryMode === "template")) {
-    const spent = await unrepliedTemplateSends(db, sub.id, messageIds);
-    if (spent >= WEEKLY_TEMPLATE_CAP) {
+    const { unreplied } = await unrepliedTemplateSends(db, sub.id, messageIds);
+    if (unreplied >= WEEKLY_TEMPLATE_CAP) {
       await suppressMessages(db, messageIds, PROACTIVE_LIMIT_REASON);
       return;
     }
@@ -1552,9 +1584,19 @@ export async function processItem(item: ClaimedItem, overrides: DrainDeps = {}):
         new Date(),
       );
       if (delivery.mode === "template") {
-        const spent = await unrepliedTemplateSends(db, item.subscriptionId);
-        if (spent >= WEEKLY_TEMPLATE_CAP) {
-          await skipCappedWake(db, item, events, spent);
+        const { unreplied, unsettled } = await unrepliedTemplateSends(db, item.subscriptionId);
+        if (unreplied >= WEEKLY_TEMPLATE_CAP) {
+          // Dropping a wake is permanent — its events are consumed — so it
+          // must not rest on sends that are still in flight. A reader cannot
+          // ignore what has not arrived. When the budget only holds because
+          // of those, wait: within the hour each one is either on the handset
+          // (the budget was real) or failed (the slot is free and this wake
+          // runs). Every other rail already defers on transient state.
+          if (unreplied - unsettled < WEEKLY_TEMPLATE_CAP) {
+            await deferItem(db, item.id, item.attempts, new Date(Date.now() + UNSETTLED_DEFER_MS));
+            return;
+          }
+          await skipCappedWake(db, item, events, unreplied);
           return;
         }
       }


### PR DESCRIPTION
## Why

The weekly cap counted message ROWS marked `proactive`. That unit produced three defects:

- **A wake that wrote three bubbles spent the whole week.** The agent is told to call `send_message` once per bubble, and the prompt never tells it the budget, so it could not know.
- **The boundary delivered half a wake.** With one slot left, it sent the first bubble and suppressed the rest. The reader got a fragment of a story.
- **The wrong messages counted.** The enrollment intro spent a slot. A promised follow-up spent none, however cold it landed.

## What the rail is now

**At most 5 unreplied template sends per rolling week, per reader.** At the limit, no template goes out.

- **A template send** is a message that reaches a reader whose 24h WhatsApp window is shut — a cold push. Freeform sends are never capped, because only the reader can open that window.
- **The unit is the wake**, not the message row. One wake is one occasion the handset buzzed, however many bubbles the agent wrote for it. This also makes the rail all-or-nothing: a wake sends whole or is suppressed whole.
- **Replied** means any inbound message within 24 hours after the push reached the reader. A fresh send counts as unreplied immediately, and stops counting the moment the reader answers in time.

## SMS

The two SMS questions have opposite answers, and the code reflects that:

- **An SMS reply clears a send.** `handleSmsInbound` records real inbound SMS, and a reader who answers has engaged.
- **`decideDelivery` still reads WhatsApp inbound alone.** That is Meta's rule about when freeform is deliverable, not a measure of engagement. It is unchanged.
- **A template that failed on WhatsApp and arrived as an SMS counts once.** The two rows share a `wakeId`, so they collapse into one occasion. The enrollment intro carries no wake, so its fallback groups on `fallbackForId` instead.

## A held-back send now reaches the model

A send the limit stops is `suppressed` with `failureReason: "proactive limit"`. Unlike every other stopped send, it stays in the conversation window with `notSent` set, and the prompt renders it:

```
[2026-08-26T09:14:00Z] NOT SENT (proactive limit — they never received this, so they do not know it): «…»
```

The system prompt tells the agent to treat that story as untold and to write it fresh, not as an update. Failed and paused rows stay hidden, so nothing else can pass for delivered.

Showing those rows meant compaction saw them too, and compaction folds aged-out turns into `memory`, which never ages out. Its fold selected only `direction/body/createdAt` and rendered every outbound row as `you sent`. Left alone, a message the reader never received would have become a permanent claim that they were told, and every later wake would stay silent about news that never left. The filter, the row select and the row-to-turn mapping now live in `src/lib/conversation.ts`, and both the live prompt and the fold render a turn through one `conversationLine`. Two regression tests lock this down.

## Behaviour changes a reviewer should weigh

1. **A promised follow-up loses its exemption.** Outside the 24h window it buzzes a handset exactly like news does. In practice a reader who asks a question usually clears their own count by answering. If the limit does stop one, `firedAt` is already stamped, so that follow-up is not retried.
2. **Freeform proactive sends are no longer capped at all.** The old rail counted every `proactive` row regardless of delivery mode. Inside an open 24h window there is now no volume rail beyond quiet hours and the kill switch.
3. **A late reply reopens nothing.** Answer more than 24 hours after a push and that push stays counted.

All three are deliberate and were confirmed before implementation.

## Notes

- No schema migration. `proactive` keeps its column and its meaning (unprompted); it no longer decides the cap. The comment on it is updated.
- The suppression reason is renamed from `weekly cap` to `proactive limit`. The old key stays in `SUPPRESSION_REASONS` so the panel still labels existing rows.
- The panel measures the limit through the same exported function the boundary enforces, so the two cannot drift. Its copy of the rail vocabulary is deleted in favour of the exported set.
- Both cap reads are narrowed to template and SMS-fallback rows, and ask about replies only for the readers those found.

## Testing

- `npm test` (main): 1705 passed.
- `npm test -w notis`: 346 passed, including 21 rails tests and 2 new compaction regression tests.
- The compaction regression test was verified to fail against the old renderer (`you sent: «ΚΡΑΤΗΜΕΝΟ ΚΕΙΜΕΝΟ»`).
- The rails tests read `WEEKLY_TEMPLATE_CAP` rather than a hardcoded number. Verified green at cap 2 through 6. Their seeder spaces sends just over the 24h reply window, which is what lets one reply answer exactly one push; more than six such sends do not fit in a rolling week, so the seeder throws rather than placing them outside it, where they would go uncounted and pass every cap test for the wrong reason.
- `npm run build` passes for both apps. `npm run lint` is clean.
- Integration tests were not run: the Docker daemon is unavailable in this environment. `queue-core.ts` changed, but only by removing two exports that `tests/integration/notis-queue.test.ts` does not import, and `tsc -p tsconfig.jest.json` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqPum11sA96nFj3PFe6u2A

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqPum11sA96nFj3PFe6u2A)_





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the row-based proactive-message cap with a rolling limit on unreplied cold-template wakes.
- Counts one delivery occasion per wake, including SMS fallback, and clears it when the reader replies within 24 hours.
- Defers wakes while cap-occupying sends remain unsettled and suppresses an entire wake when the settled limit is reached.
- Preserves capped text as explicitly undelivered context across live prompting and conversation compaction.
- Uses the shared cap implementation and constant in administrative reporting.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| services/notis/src/lib/queue.ts | Implements wake-level unreplied-template accounting, unsettled-send deferral, whole-wake suppression, and shared administrative cap reporting. |
| services/notis/src/lib/conversation.ts | Centralizes the message filter, selected fields, and conversion of proactive-limit suppressions into explicitly undelivered conversation turns. |
| services/notis/src/lib/compaction.ts | Reuses the live conversation mapping and renderer so suppressed text cannot be folded into persistent memory as delivered. |
| services/notis/src/agent/prompt.ts | Renders held-back messages as NOT SENT and instructs the agent to treat their stories as untold. |
| services/notis/src/app/admin/(panel)/_lib/system.ts | Replaces the old proactive-row aggregation with the same unreplied-template calculation used by delivery enforcement. |
| services/notis/src/app/admin/(panel)/system/page.tsx | Fixes the stale badge denominator by rendering the shared enforced cap constant. |
| services/notis/src/lib/__tests__/queue-rails.test.ts | Adds coverage for wake grouping, replies, fallbacks, freeform delivery, unsettled deferral, and whole-wake suppression. |
| services/notis/src/lib/__tests__/compaction.test.ts | Verifies that limit-suppressed messages remain marked undelivered while suppressions from other rails remain hidden. |

<sub>Reviews (3): Last reviewed commit: ["fix(notis): read the cap constant in the..."](https://github.com/schemalabz/opencouncil/commit/7c3aa64cc9d42c1b3d6049ef1e62451c40ff5af8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57114665)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/schemalabz/opencouncil/blob/main/CLAUDE.md))

<!-- /greptile_comment -->