### PR TITLE
fix(meetings): render page content on server

### DIFF
--- a/src/components/meetings/CouncilMeetingWrapper.tsx
+++ b/src/components/meetings/CouncilMeetingWrapper.tsx
@@ -1,9 +1,7 @@
 "use client"
 
 import { useState, useEffect, useMemo, createContext, useContext } from 'react'
-import { Loader } from 'lucide-react'
 import { VideoProvider } from './VideoProvider'
-import { motion } from 'framer-motion'
 import { TranscriptOptionsProvider } from './options/OptionsContext'
 import { CouncilMeetingDataProvider } from './CouncilMeetingDataContext'
 import { HighlightProvider } from './HighlightContext'
@@ -26,7 +24,6 @@ export const useLayout = () => useContext(LayoutContext);
 
 export default function CouncilMeetingWrapper({ meetingData, editable, canCreateHighlights, children }: CouncilMeetingWrapperProps) {
     const [isWide, setIsWide] = useState(false);
-    const [loading, setLoading] = useState(true);
 
     const memoizedUtterances = useMemo(() => {
         return meetingData.transcript.map((u) => u.utterances).flat()
@@ -41,21 +38,9 @@ export default function CouncilMeetingWrapper({ meetingData, editable, canCreate
 
         checkSize()
         window.addEventListener('resize', checkSize)
-        setLoading(false)
 
         return () => window.removeEventListener('resize', checkSize)
     }, [])
-
-    if (loading) return (
-        <motion.div
-            className="flex justify-center items-center h-screen"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-        >
-            <Loader className="animate-spin h-10 w-10" />
-        </motion.div>
-    )
 
     return (
         <LayoutContext.Provider value={{ isWide }}>

--- a/src/components/meetings/__tests__/CouncilMeetingWrapper.ssr.test.tsx
+++ b/src/components/meetings/__tests__/CouncilMeetingWrapper.ssr.test.tsx
@@ -1,0 +1,40 @@
+/** @jest-environment node */
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { MeetingData } from '@/lib/getMeetingData';
+
+const passthrough = ({ children }: { children: React.ReactNode }) => children;
+
+jest.mock('../VideoProvider', () => ({ VideoProvider: passthrough }));
+jest.mock('../options/OptionsContext', () => ({ TranscriptOptionsProvider: passthrough }));
+jest.mock('../CouncilMeetingDataContext', () => ({ CouncilMeetingDataProvider: passthrough }));
+jest.mock('../HighlightContext', () => ({ HighlightProvider: passthrough }));
+jest.mock('../subject/UtteranceExpansionContext', () => ({ UtteranceExpansionProvider: passthrough }));
+jest.mock('@/contexts/KeyboardShortcutsContext', () => ({ KeyboardShortcutsProvider: passthrough }));
+jest.mock('../EditingContext', () => ({ EditingProvider: passthrough }));
+jest.mock('../KeyboardShortcuts', () => ({ KeyboardShortcuts: () => null }));
+
+import CouncilMeetingWrapper from '../CouncilMeetingWrapper';
+
+describe('CouncilMeetingWrapper server rendering', () => {
+    it('renders the existing page content before client effects run', () => {
+        const meetingData = {
+            meeting: { id: 'meeting-1' },
+            transcript: [],
+        } as unknown as MeetingData;
+
+        const html = renderToStaticMarkup(
+            <CouncilMeetingWrapper
+                meetingData={meetingData}
+                editable={false}
+                canCreateHighlights={false}
+            >
+                <main>Existing meeting page</main>
+            </CouncilMeetingWrapper>
+        );
+
+        expect(html).toContain('<main>Existing meeting page</main>');
+        expect(html).not.toContain('animate-spin');
+    });
+});


### PR DESCRIPTION
## Summary

- Remove the client-only loading gate from `CouncilMeetingWrapper`.
- Render the existing meeting page content in the initial server response.
- Add one regression test for server-rendered child content.

## Scope

This PR does not change subject outcomes, decision data, vote handling, MCP responses, metadata, structured data, translations, or page design.

## Verification

- Targeted ESLint passes.
- The SSR regression test passes.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes the client-only loading gate from the meeting wrapper so that meeting content appears in server-rendered HTML.

- It renders meeting children inside the existing provider stack during SSR.
- It adds a focused test that verifies server-rendered content and the absence of the loading spinner.

<h3>Confidence Score: 4/5</h3>

The PR is not safe to merge until the previously reported MCP withdrawal-status fix is restored.

The current HEAD omits `withdrawn` and `nonAgendaReason` from `mcpGetSubject` and removes the explanation that distinguishes rejected urgent consideration from withdrawal or postponement. This is the residual counterexample to the reply that commit `e55358f2` fixed the issue.

**Files Needing Attention:** src/lib/mcp/data.ts and src/lib/mcp/server.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/meetings/CouncilMeetingWrapper.tsx | Removes the mount-time spinner while preserving the meeting provider hierarchy; no blocking issue was found in this file. |
| src/components/meetings/__tests__/CouncilMeetingWrapper.ssr.test.tsx | Adds focused coverage that confirms meeting children render in static server markup. |

<sub>Reviews (3): Last reviewed commit: ["fix(meetings): render page content on se..."](https://github.com/schemalabz/opencouncil/commit/2061b9e4220b0407c75188cad9490ab2d3f70d06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58222728)</sub>

<!-- /greptile_comment -->