### PR TITLE
perf(landing): reduce initial payload and map remounts

### DIFF
--- a/src/app/[locale]/(landing-immersive)/page.tsx
+++ b/src/app/[locale]/(landing-immersive)/page.tsx
@@ -10,6 +10,7 @@ import { getMapSubjectsCached, getGeneralSubjectsCached, getSubjectCountsByCityC
 import { getListedCitiesCached, getMapCitiesCached, getPetitionedMapCitiesCached } from '@/lib/db/cities';
 import { getUpcomingMeetingsCached } from '@/lib/db/meetings';
 import { DEFAULT_RANGE, rangeToSubjectFilters } from '@/lib/landing/landingCore';
+import { toLandingSubjectPreview } from '@/lib/landing/payload';
 
 export async function generateMetadata(props: {
     params: Promise<{ locale: string }>;
@@ -72,8 +73,13 @@ export default async function HomePage() {
             realm={realm}
             defaultView={getRealmDefaultMapView(realm)}
             initial={{
-                subjects,
-                generalRows,
+                // Cards never render the full transcript-linked markdown. Serialize a bounded
+                // plain-text preview instead, while cached DB rows retain their full descriptions.
+                subjects: subjects.map(toLandingSubjectPreview),
+                generalRows: generalRows.map((row) => ({
+                    ...row,
+                    subjects: row.subjects.map(toLandingSubjectPreview),
+                })),
                 cities: cities.map((c) => ({
                     id: c.id,
                     name: c.name,

--- a/src/components/landing/v2/LandingV2.tsx
+++ b/src/components/landing/v2/LandingV2.tsx
@@ -63,7 +63,8 @@ import { MobileLayout } from './MobileLayout';
 
 /**
  * The consolidated landing redesign (issue #208). Desktop (≥ lg): split-screen map + tabbed
- * side panel; mobile: immersive map-first layout. Only one <Map> is mounted at a time.
+ * side panel; mobile: immersive map-first layout. Only one <Map> is mounted at a time, after
+ * hydration has resolved which responsive tree owns it.
  *
  * Initial data is server-resolved in page.tsx (realm-scoped) and passed as typed props, so the
  * map renders real data on first paint. Only filter/geocode/cities-at lookups stay client-side.
@@ -128,6 +129,12 @@ export function LandingV2({ realm, defaultView, initial }: LandingV2Props) {
     // Default to desktop during SSR (matches=false until mounted) so desktop has no layout
     // flash; mobile flips in after hydration.
     const isMobile = useMediaQuery('(max-width: 1023px)');
+    // The server and first client render intentionally use the desktop tree. Do not put Mapbox in
+    // that temporary tree: on mobile it would initialize, immediately unmount, then initialize
+    // again inside MobileLayout after useMediaQuery resolves. The media-query effect is registered
+    // first, so React batches the responsive flip and this mount-ready update into one render.
+    const [mapMountReady, setMapMountReady] = useState(false);
+    useEffect(() => setMapMountReady(true), []);
 
     // On breakpoint cross, remap any stray 'home' (mobile-only leftover) to 'subjects' for
     // desktop; mobile keeps it. First run skipped — parseInitialUrlState already picked the view.
@@ -686,7 +693,7 @@ export function LandingV2({ realm, defaultView, initial }: LandingV2Props) {
         petitionBucketFor: (cityId) => petitionedCities.find((c) => c.id === cityId)?.bucket ?? null,
     });
 
-    const mapNode = (
+    const mapNode = mapMountReady ? (
         <Map
             // remount on basemap switch; the camera is restored from cameraRef
             key={mapStyle}
@@ -705,7 +712,7 @@ export function LandingV2({ realm, defaultView, initial }: LandingV2Props) {
             zoomToGeometry={flyTo}
             zoomPadding={isMobile ? 120 : 80}
         />
-    );
+    ) : null;
 
     /**
      * Frame every result of the committed search.

--- a/src/lib/landing/payload.test.ts
+++ b/src/lib/landing/payload.test.ts
@@ -1,0 +1,31 @@
+import {
+    LANDING_DESCRIPTION_PREVIEW_LENGTH,
+    toLandingDescriptionPreview,
+    toLandingSubjectPreview,
+} from './payload';
+
+describe('landing payload previews', () => {
+    it('flattens markdown before sending a description to the client', () => {
+        expect(toLandingDescriptionPreview('**Important** [decision](REF:UTTERANCE:123)')).toBe(
+            'Important decision',
+        );
+    });
+
+    it('caps long descriptions at the landing-card budget', () => {
+        const preview = toLandingDescriptionPreview('council '.repeat(100));
+
+        expect(preview.length).toBeLessThanOrEqual(LANDING_DESCRIPTION_PREVIEW_LENGTH);
+        expect(preview).toMatch(/…$/);
+    });
+
+    it('keeps the original row immutable and preserves every other field', () => {
+        const row = { id: 'subject-1', description: '**Short** summary', cityId: 'athens' };
+
+        expect(toLandingSubjectPreview(row)).toEqual({
+            id: 'subject-1',
+            description: 'Short summary',
+            cityId: 'athens',
+        });
+        expect(row.description).toBe('**Short** summary');
+    });
+});

--- a/src/lib/landing/payload.ts
+++ b/src/lib/landing/payload.ts
@@ -1,0 +1,34 @@
+import { stripMarkdown } from '@/lib/formatters/markdown';
+
+/**
+ * Landing cards only need a short plain-text summary. Keeping full markdown descriptions in the
+ * React Server Component payload makes the initial document much larger without improving the
+ * first-screen experience.
+ */
+export const LANDING_DESCRIPTION_PREVIEW_LENGTH = 240;
+
+export function toLandingDescriptionPreview(
+    description: string,
+    maxLength = LANDING_DESCRIPTION_PREVIEW_LENGTH,
+): string {
+    const plainText = stripMarkdown(description);
+    if (plainText.length <= maxLength) return plainText;
+    if (maxLength <= 0) return '';
+    if (maxLength === 1) return '…';
+
+    const contentLength = maxLength - 1;
+    const candidate = plainText.slice(0, contentLength + 1);
+    const wordBoundary = candidate.lastIndexOf(' ');
+    // Prefer a whole word, but do not let one unusually long token erase most of the preview.
+    const cutAt = wordBoundary >= Math.floor(contentLength * 0.75) ? wordBoundary : contentLength;
+
+    return `${plainText.slice(0, cutAt).trimEnd()}…`;
+}
+
+/** Preserve the database wire shape while replacing the one oversized field at serialization. */
+export function toLandingSubjectPreview<T extends { description: string }>(subject: T): T {
+    return {
+        ...subject,
+        description: toLandingDescriptionPreview(subject.description),
+    };
+}


### PR DESCRIPTION
## Summary

- serialize landing subject descriptions as 240-character plain-text previews at the page boundary, while leaving cached database rows and other consumers untouched
- hold the Mapbox node until responsive hydration has resolved, preventing the temporary desktop tree from initializing a map on mobile
- add focused tests for markdown flattening, preview bounds, and immutable row serialization

## Impact

A conservative replay against the captured production landing response reduced the decoded document from 2.58 MB to 2.20 MB. Gzip size fell from about 513 KB to 400 KB, saving about 113 KB across 1,194 matched subject rows.

The hydration change also avoids the initial mobile Mapbox initialize → destroy → initialize cycle.

## Verification

- `npm test -- --runInBand src/lib/landing/payload.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- targeted ESLint on all four changed files


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reduces the landing-page server payload by flattening and truncating initial subject descriptions, and defers Mapbox mounting until responsive hydration resolves.
- Adds immutable landing-description preview serialization and focused tests.
- Applies previews to direct and city-grouped initial subject rows.
- Delays map mounting to avoid mobile initialize–destroy–initialize cycles.

<h3>Confidence Score: 4/5</h3>

The expanded-subject content regression should be fixed before merging so payload reduction does not truncate a user-opened summary.

Initial descriptions are converted to 240-character previews before the same field feeds unclamped expanded desktop and mobile views, while later API refetches restore full descriptions.

**Files Needing Attention:** src/app/[locale]/(landing-immersive)/page.tsx, src/lib/landing/payload.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/[locale]/(landing-immersive)/page.tsx | Applies bounded previews to initial landing rows, but consequently truncates content consumed by expanded subject views. |
| src/components/landing/v2/LandingV2.tsx | Defers Mapbox creation until the responsive client state resolves, with no concrete lifecycle regression identified. |
| src/lib/landing/payload.ts | Adds immutable markdown flattening and bounded preview generation; its use for all initial rows contributes to the expanded-content regression. |
| src/lib/landing/payload.test.ts | Covers markdown flattening, preview bounds, and immutable row transformation. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20schemalabz%2Fopencouncil%20PR%20%23698%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=schemalabz%2Fopencouncil&pr=698&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fapp%2F%5Blocale%5D%2F%28landing-immersive%29%2Fpage.tsx%3A78-82%0A**Expanded%20summaries%20are%20truncated**%0A%0AWhen%20a%20user%20expands%20a%20subject%20longer%20than%20240%20characters%20before%20changing%20a%20landing%20filter%2C%20these%20serialized%20previews%20feed%20the%20unclamped%20desktop%20and%20mobile%20expanded%20views%2C%20causing%20incomplete%20content%20that%20later%20changes%20to%20the%20full%20summary%20after%20an%20API%20refetch.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=schemalabz%2Fopencouncil&pr=698&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/app/[locale]/(landing-immersive)/page.tsx:78-82
**Expanded summaries are truncated**

When a user expands a subject longer than 240 characters before changing a landing filter, these serialized previews feed the unclamped desktop and mobile expanded views, causing incomplete content that later changes to the full summary after an API refetch.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(landing): reduce initial payload an..."](https://github.com/schemalabz/opencouncil/commit/ee13e976dd4192b309b74a1c46d388ce241e7ec6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58228166)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->