### PR TITLE
fix(seo): make subject pages readable by ai crawlers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -151,7 +151,10 @@ const nextConfig = {
     // streamed 404 still reaches it as HTTP 200.
     // Copied from next@16.2.6 (next/dist/shared/lib/router/utils/html-bots.js);
     // resync when upgrading Next in case upstream adds new crawlers.
-    htmlLimitedBots: /Googlebot|[\w-]+-Google|Google-[\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight/i,
+    // The AI-crawler section (GPTBot onward) is appended on purpose: these
+    // agents run no JavaScript, so they need blocking, fully rendered HTML
+    // and real 404s. Keep that section when resyncing with upstream.
+    htmlLimitedBots: /Googlebot|[\w-]+-Google|Google-[\w-]+|Chrome-Lighthouse|Slurp|DuckDuckBot|baiduspider|yandex|sogou|bitlybot|tumblr|vkShare|quora link preview|redditbot|ia_archiver|Bingbot|BingPreview|applebot|facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|Yeti|googleweblight|GPTBot|OAI-SearchBot|ChatGPT-User|ClaudeBot|Claude-User|Claude-SearchBot|anthropic-ai|PerplexityBot|Perplexity-User|CCBot|Amazonbot|Bytespider|meta-externalagent|DuckAssistBot/i,
 };
 
 export default withPostHogConfig(withNextIntl(nextConfig), {

--- a/packages/ui/src/__tests__/collapsible-card.ssr.test.tsx
+++ b/packages/ui/src/__tests__/collapsible-card.ssr.test.tsx
@@ -1,0 +1,33 @@
+/** @jest-environment node */
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { CollapsibleCard } from '../collapsible-card';
+
+describe('CollapsibleCard server rendering', () => {
+    const render = (props: Partial<React.ComponentProps<typeof CollapsibleCard>>) =>
+        renderToStaticMarkup(
+            <CollapsibleCard title="Απόφαση" {...props}>
+                <p>Κείμενο κάρτας</p>
+            </CollapsibleCard>
+        );
+
+    it('renders closed content into the markup when ssrContent is set', () => {
+        const html = render({ ssrContent: true });
+        expect(html).toContain('Κείμενο κάρτας');
+        expect(html).toContain('data-state="closed"');
+        expect(html).toContain('data-[state=closed]:hidden');
+    });
+
+    it('omits closed content without ssrContent', () => {
+        const html = render({});
+        expect(html).not.toContain('Κείμενο κάρτας');
+    });
+
+    it('renders open content without ssrContent when defaultOpen is set', () => {
+        const html = render({ defaultOpen: true });
+        expect(html).toContain('Κείμενο κάρτας');
+        expect(html).toContain('data-state="open"');
+    });
+});

--- a/packages/ui/src/collapsible-card.tsx
+++ b/packages/ui/src/collapsible-card.tsx
@@ -16,6 +16,8 @@ interface CollapsibleCardProps {
   defaultOpen?: boolean
   /** When set, the card gets an anchor id and auto-opens when the URL hash matches */
   id?: string
+  /** Server-render children while closed (hidden via CSS) so crawlers read the text */
+  ssrContent?: boolean
   className?: string
 }
 
@@ -28,6 +30,7 @@ export function CollapsibleCard({
   children,
   defaultOpen = false,
   id,
+  ssrContent = false,
   className,
 }: CollapsibleCardProps) {
   const [open, setOpen] = React.useState(defaultOpen)
@@ -88,7 +91,10 @@ export function CollapsibleCard({
                 )} />
               </button>
             </CollapsibleTrigger>
-            <CollapsibleContent className="border-t border-border">
+            <CollapsibleContent
+              forceMount={ssrContent ? true : undefined}
+              className={cn("border-t border-border", ssrContent && "data-[state=closed]:hidden")}
+            >
               {children}
             </CollapsibleContent>
           </div>

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
@@ -7,6 +7,8 @@ import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
 import { getLocalizedName } from "@/lib/formatters/name";
 import { localizeText } from "@/lib/serbian";
 import { compactMetadataDescription } from "@/lib/seo/metadataDescription";
+import { getRealmBaseUrlFromRequest } from "@/lib/realm.server";
+import { buildSubjectStructuredData, serializeStructuredData } from "@/lib/seo/subjectStructuredData";
 
 export async function generateMetadata(
     props: {
@@ -75,7 +77,7 @@ export async function generateMetadata(
 
 // Server component that renders the Subject component
 export default async function SubjectPage(
-    props: { params: Promise<{ cityId: string; meetingId: string; subjectId: string }> }
+    props: { params: Promise<{ cityId: string; meetingId: string; subjectId: string; locale: string }> }
 ) {
     const params = await props.params;
 
@@ -86,8 +88,41 @@ export default async function SubjectPage(
         notFound();
     }
 
+    const [meetingData, baseUrl] = await Promise.all([
+        getMeetingDataCached(params.cityId, params.meetingId),
+        getRealmBaseUrlFromRequest(),
+    ]);
+    if (!meetingData) {
+        notFound();
+    }
+
+    const structuredData = buildSubjectStructuredData({
+        canonicalUrl: `${baseUrl}/${params.cityId}/${params.meetingId}/subjects/${params.subjectId}`,
+        siteUrl: baseUrl,
+        locale: params.locale,
+        subjectName: localizeText(subject.name, params.locale),
+        subjectDescription: compactMetadataDescription(
+            localizeText(subject.description, params.locale),
+            500
+        ),
+        subjectCreatedAt: subject.createdAt,
+        subjectUpdatedAt: subject.updatedAt,
+        cityName: getLocalizedName(meetingData.city, params.locale),
+        meetingName: getLocalizedName(meetingData.meeting, params.locale),
+        meetingDate: meetingData.meeting.dateTime,
+        administrativeBodyName: meetingData.meeting.administrativeBody
+            ? getLocalizedName(meetingData.meeting.administrativeBody, params.locale)
+            : null,
+        topicName: subject.topic ? getLocalizedName(subject.topic, params.locale) : null,
+        citations: [...new Set(subject.contextCitationUrls)],
+    });
+
     return (
         <>
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: serializeStructuredData(structuredData) }}
+            />
             <SubjectReadTracker
                 cityId={params.cityId}
                 meetingId={params.meetingId}

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from "next/navigation";
 import { buildCanonicalAlternates } from "@/lib/utils/hreflang";
 import { getLocalizedName } from "@/lib/formatters/name";
 import { localizeText } from "@/lib/serbian";
+import { compactMetadataDescription } from "@/lib/seo/metadataDescription";
 
 export async function generateMetadata(
     props: {
@@ -51,7 +52,7 @@ export async function generateMetadata(
 
     // Create a meaningful description
     const description = subject.description
-        ? localizeText(subject.description, params.locale)
+        ? compactMetadataDescription(localizeText(subject.description, params.locale))
         : `Θέμα που συζητήθηκε | ${cityName} | ${new Date(meetingData.meeting.dateTime).toLocaleDateString("el-GR")}`;
 
     return {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -91,7 +91,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
     const cityEntries: MetadataRoute.Sitemap = cities.map(city => ({
         url: `${baseUrl}/${city.id}`,
-        lastModified: latestDate(city.updatedAt, ...city.councilMeetings.map(meeting => meeting.updatedAt)),
+        lastModified: latestDate(city.updatedAt, ...city.councilMeetings.flatMap(meeting => [meeting.updatedAt, ...meeting.subjects.map(subject => subject.updatedAt)])),
         changeFrequency: 'daily',
         priority: 0.9,
     }))

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -12,10 +12,16 @@ export const dynamic = 'force-dynamic'
 
 type SitemapCity = {
     id: string
+    updatedAt: Date
     councilMeetings: Array<{
         id: string
-        subjects: Array<{ id: string }>
+        updatedAt: Date
+        subjects: Array<{ id: string; updatedAt: Date }>
     }>
+}
+
+function latestDate(first: Date, ...rest: Date[]): Date {
+    return rest.reduce((max, date) => (date > max ? date : max), first)
 }
 
 async function fetchSitemapData(realm: Realm): Promise<SitemapCity[]> {
@@ -26,12 +32,14 @@ async function fetchSitemapData(realm: Realm): Promise<SitemapCity[]> {
         },
         select: {
             id: true,
+            updatedAt: true,
             councilMeetings: {
                 where: { released: true },
                 select: {
                     id: true,
+                    updatedAt: true,
                     subjects: {
-                        select: { id: true }
+                        select: { id: true, updatedAt: true }
                     }
                 }
             }
@@ -83,6 +91,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
     const cityEntries: MetadataRoute.Sitemap = cities.map(city => ({
         url: `${baseUrl}/${city.id}`,
+        lastModified: latestDate(city.updatedAt, ...city.councilMeetings.map(meeting => meeting.updatedAt)),
         changeFrequency: 'daily',
         priority: 0.9,
     }))
@@ -90,6 +99,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const meetingEntries: MetadataRoute.Sitemap = cities.flatMap(city =>
         city.councilMeetings.map(meeting => ({
             url: `${baseUrl}/${city.id}/${meeting.id}`,
+            lastModified: latestDate(meeting.updatedAt, ...meeting.subjects.map(subject => subject.updatedAt)),
             changeFrequency: 'weekly',
             priority: 0.7,
         }))
@@ -99,6 +109,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         city.councilMeetings.flatMap(meeting =>
             meeting.subjects.map(subject => ({
                 url: `${baseUrl}/${city.id}/${meeting.id}/subjects/${subject.id}`,
+                lastModified: subject.updatedAt,
                 changeFrequency: 'weekly',
                 priority: 0.6,
             }))

--- a/src/components/meetings/CouncilMeetingWrapper.tsx
+++ b/src/components/meetings/CouncilMeetingWrapper.tsx
@@ -1,9 +1,7 @@
 "use client"
 
 import { useState, useEffect, useMemo, createContext, useContext } from 'react'
-import { Loader } from 'lucide-react'
 import { VideoProvider } from './VideoProvider'
-import { motion } from 'framer-motion'
 import { TranscriptOptionsProvider } from './options/OptionsContext'
 import { CouncilMeetingDataProvider } from './CouncilMeetingDataContext'
 import { HighlightProvider } from './HighlightContext'
@@ -26,7 +24,6 @@ export const useLayout = () => useContext(LayoutContext);
 
 export default function CouncilMeetingWrapper({ meetingData, editable, canCreateHighlights, children }: CouncilMeetingWrapperProps) {
     const [isWide, setIsWide] = useState(false);
-    const [loading, setLoading] = useState(true);
 
     const memoizedUtterances = useMemo(() => {
         return meetingData.transcript.map((u) => u.utterances).flat()
@@ -41,21 +38,9 @@ export default function CouncilMeetingWrapper({ meetingData, editable, canCreate
 
         checkSize()
         window.addEventListener('resize', checkSize)
-        setLoading(false)
 
         return () => window.removeEventListener('resize', checkSize)
     }, [])
-
-    if (loading) return (
-        <motion.div
-            className="flex justify-center items-center h-screen"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-        >
-            <Loader className="animate-spin h-10 w-10" />
-        </motion.div>
-    )
 
     return (
         <LayoutContext.Provider value={{ isWide }}>

--- a/src/components/meetings/__tests__/CouncilMeetingWrapper.ssr.test.tsx
+++ b/src/components/meetings/__tests__/CouncilMeetingWrapper.ssr.test.tsx
@@ -1,0 +1,40 @@
+/** @jest-environment node */
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { MeetingData } from '@/lib/getMeetingData';
+
+const passthrough = ({ children }: { children: React.ReactNode }) => children;
+
+jest.mock('../VideoProvider', () => ({ VideoProvider: passthrough }));
+jest.mock('../options/OptionsContext', () => ({ TranscriptOptionsProvider: passthrough }));
+jest.mock('../CouncilMeetingDataContext', () => ({ CouncilMeetingDataProvider: passthrough }));
+jest.mock('../HighlightContext', () => ({ HighlightProvider: passthrough }));
+jest.mock('../subject/UtteranceExpansionContext', () => ({ UtteranceExpansionProvider: passthrough }));
+jest.mock('@/contexts/KeyboardShortcutsContext', () => ({ KeyboardShortcutsProvider: passthrough }));
+jest.mock('../EditingContext', () => ({ EditingProvider: passthrough }));
+jest.mock('../KeyboardShortcuts', () => ({ KeyboardShortcuts: () => null }));
+
+import CouncilMeetingWrapper from '../CouncilMeetingWrapper';
+
+describe('CouncilMeetingWrapper server rendering', () => {
+    it('renders the existing page content before client effects run', () => {
+        const meetingData = {
+            meeting: { id: 'meeting-1' },
+            transcript: [],
+        } as unknown as MeetingData;
+
+        const html = renderToStaticMarkup(
+            <CouncilMeetingWrapper
+                meetingData={meetingData}
+                editable={false}
+                canCreateHighlights={false}
+            >
+                <main>Existing meeting page</main>
+            </CouncilMeetingWrapper>
+        );
+
+        expect(html).toContain('<main>Existing meeting page</main>');
+        expect(html).not.toContain('animate-spin');
+    });
+});

--- a/src/components/meetings/subject/context.tsx
+++ b/src/components/meetings/subject/context.tsx
@@ -123,6 +123,7 @@ export function SubjectContext({ subject }: { subject: Subject }) {
         <CollapsibleCard
             icon={<Globe className="w-4 h-4" />}
             title={t("webInfo")}
+            ssrContent
         >
             <div className="space-y-3 p-4">
                 {subject.context && (

--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -181,6 +181,9 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                         {formatDate(new Date(meeting.dateTime), undefined, locale)}
                     </span>
                 </nav>
+                <h1 className="text-left text-3xl font-bold tracking-tight text-foreground md:text-4xl">
+                    {localize(name)}
+                </h1>
                 {isSuperAdmin && (
                     <div className="flex justify-end">
                         <SubjectAdminControls
@@ -282,6 +285,7 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                 {subject.nonAgendaReason !== 'beforeAgenda' && !subject.withdrawn && (
                     <CollapsibleCard
                         id="decision"
+                        ssrContent
                         icon={<Landmark className="w-4 h-4" />}
                         title={
                             decision ? (

--- a/src/lib/formatters/markdown.ts
+++ b/src/lib/formatters/markdown.ts
@@ -7,8 +7,9 @@ export function stripMarkdown(markdown: string): string {
     return markdown
         // Remove reference links [text](REF:TYPE:ID)
         .replace(/\[([^\]]+)\]\(REF:[^)]+\)/g, '$1')
-        // Remove regular links [text](url)
-        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+        // Remove regular links [text](url); the destination may contain one
+        // nesting level of balanced parentheses (e.g. Wikipedia URLs)
+        .replace(/\[([^\]]+)\]\((?:[^()]|\([^()]*\))*\)/g, '$1')
         // Remove bold **text** or __text__
         .replace(/\*\*([^*]+)\*\*/g, '$1')
         .replace(/__([^_]+)__/g, '$1')

--- a/src/lib/mcp/__tests__/server.test.ts
+++ b/src/lib/mcp/__tests__/server.test.ts
@@ -35,6 +35,7 @@ const CATEGORIES = ['discovery', 'directory', 'meetings', 'highlights'];
 type RecordedToolConfig = {
     annotations?: { readOnlyHint?: boolean };
     _meta?: { category?: string };
+    description?: string;
     inputSchema?: { parse: (value: unknown) => unknown };
 };
 type ToolHandler = (args: never, ctx: ServerContext) => Promise<unknown>;
@@ -112,6 +113,13 @@ describe('tool metadata', () => {
             typeof meta[name].annotations?.readOnlyHint !== 'boolean'
             || !CATEGORIES.includes(meta[name]._meta?.category ?? '')
         )).toEqual([]);
+    });
+
+    it('distinguishes rejected urgent subjects from withdrawn agenda subjects', () => {
+        const description = advertised(USER).meta.get_subject.description;
+
+        expect(description).toContain('did not approve it as urgent');
+        expect(description).toContain('withdrawn or postponed without discussion');
     });
 });
 

--- a/src/lib/mcp/data.ts
+++ b/src/lib/mcp/data.ts
@@ -463,6 +463,8 @@ export async function mcpGetSubject(subjectId: string, identity: McpIdentity) {
         meetingDate: isoDate(meetingDate),
         administrativeBody: meeting.administrativeBody?.name ?? null,
         agendaItemIndex: subject.agendaItemIndex,
+        withdrawn: subject.withdrawn,
+        nonAgendaReason: subject.nonAgendaReason,
         topic: subject.topic?.name ?? null,
         location: subject.location?.text ?? null,
         introducedBy: subject.introducedBy

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -326,10 +326,13 @@ export function registerOpenCouncilServer(server: McpServer) {
             annotations: { readOnlyHint: true, openWorldHint: false },
             _meta: category('meetings'),
             description:
-                'Get a subject (agenda item) in detail: description, per-speaker contribution summaries, ' +
+                'Get a subject (agenda item) in detail: status, description, per-speaker contribution summaries, ' +
                 'decision. Carries its meeting context (meetingName, meetingDate, and ' +
                 'administrativeBody — the body that met, e.g. «Δημοτική Επιτροπή», or null when the ' +
-                'record names none). Speaker `role` labels are resolved as of the meeting date (get_person ' +
+                'record names none). `withdrawn` means the subject did not proceed: when `nonAgendaReason` ' +
+                'is "outOfAgenda", the body did not approve it as urgent; otherwise the subject was ' +
+                'withdrawn or postponed without discussion. ' +
+                'Speaker `role` labels are resolved as of the meeting date (get_person ' +
                 'lists roles across all time). This tool does not report the vote tally; the subject page ' +
                 'at `url` shows it. For the verbatim discussion use get_subject_transcript.',
             inputSchema: z.object({ subjectId: z.string().min(1) }),

--- a/src/lib/seo/__tests__/metadataDescription.test.ts
+++ b/src/lib/seo/__tests__/metadataDescription.test.ts
@@ -9,23 +9,36 @@ describe("compactMetadataDescription", () => {
         ).toBe("Μείωση 3,3 εκατ. ευρώ στο τεχνικό πρόγραμμα.");
     });
 
-    it("strips markdown tokens", () => {
-        expect(compactMetadataDescription("## Τίτλος **έντονο** _πλάγιο_ `κώδικας` > παράθεση")).toBe(
-            "Τίτλος έντονο πλάγιο κώδικας παράθεση"
+    it("strips paired markdown and heading/list markers", () => {
+        expect(compactMetadataDescription("## Τίτλος\n**έντονο** _πλάγιο_ `κώδικας`\n- στοιχείο λίστας")).toBe(
+            "Τίτλος έντονο πλάγιο κώδικας στοιχείο λίστας"
+        );
+    });
+
+    it("preserves literal characters that are not markdown pairs", () => {
+        expect(compactMetadataDescription("Θέμα #5 και ΚΑΕ 15_7135 της υπ' αρ. 3*4 απόφασης")).toBe(
+            "Θέμα #5 και ΚΑΕ 15_7135 της υπ' αρ. 3*4 απόφασης"
         );
     });
 
     it("collapses whitespace and newlines", () => {
-        expect(compactMetadataDescription("πρώτη γραμμή\n\n- δεύτερη   γραμμή\n")).toBe(
-            "πρώτη γραμμή - δεύτερη γραμμή"
+        expect(compactMetadataDescription("πρώτη γραμμή\n\nδεύτερη   γραμμή\n")).toBe(
+            "πρώτη γραμμή δεύτερη γραμμή"
         );
     });
 
     it("caps long text with an ellipsis and no trailing space", () => {
         const out = compactMetadataDescription(`${"α".repeat(170)} ${"β".repeat(50)}`);
-        expect(out.length).toBeLessThanOrEqual(180);
+        expect(Array.from(out).length).toBeLessThanOrEqual(180);
         expect(out.endsWith("…")).toBe(true);
         expect(out).not.toMatch(/\s…$/);
+    });
+
+    it("does not split a surrogate pair at the truncation point", () => {
+        const out = compactMetadataDescription(`${"α".repeat(179)}🏗️${"β".repeat(20)}`);
+        expect(out.endsWith("…")).toBe(true);
+        expect(out).not.toMatch(/[\uD800-\uDBFF]…$/);
+        expect(out.isWellFormed()).toBe(true);
     });
 
     it("honors a custom maximum length", () => {

--- a/src/lib/seo/__tests__/metadataDescription.test.ts
+++ b/src/lib/seo/__tests__/metadataDescription.test.ts
@@ -1,0 +1,38 @@
+import { compactMetadataDescription } from "../metadataDescription";
+
+describe("compactMetadataDescription", () => {
+    it("keeps link labels and drops link targets, including REF markers", () => {
+        expect(
+            compactMetadataDescription(
+                "Μείωση [3,3 εκατ. ευρώ](REF:UTTERANCE:cmm4kznwy0f6lk2f1u6iun0rh) στο [τεχνικό πρόγραμμα](https://example.com/plan)."
+            )
+        ).toBe("Μείωση 3,3 εκατ. ευρώ στο τεχνικό πρόγραμμα.");
+    });
+
+    it("strips markdown tokens", () => {
+        expect(compactMetadataDescription("## Τίτλος **έντονο** _πλάγιο_ `κώδικας` > παράθεση")).toBe(
+            "Τίτλος έντονο πλάγιο κώδικας παράθεση"
+        );
+    });
+
+    it("collapses whitespace and newlines", () => {
+        expect(compactMetadataDescription("πρώτη γραμμή\n\n- δεύτερη   γραμμή\n")).toBe(
+            "πρώτη γραμμή - δεύτερη γραμμή"
+        );
+    });
+
+    it("caps long text with an ellipsis and no trailing space", () => {
+        const out = compactMetadataDescription(`${"α".repeat(170)} ${"β".repeat(50)}`);
+        expect(out.length).toBeLessThanOrEqual(180);
+        expect(out.endsWith("…")).toBe(true);
+        expect(out).not.toMatch(/\s…$/);
+    });
+
+    it("honors a custom maximum length", () => {
+        expect(compactMetadataDescription("αβγδεζηθικ", 5)).toBe("αβγδ…");
+    });
+
+    it("returns short input unchanged", () => {
+        expect(compactMetadataDescription("Σύντομη περιγραφή.")).toBe("Σύντομη περιγραφή.");
+    });
+});

--- a/src/lib/seo/__tests__/subjectStructuredData.test.ts
+++ b/src/lib/seo/__tests__/subjectStructuredData.test.ts
@@ -1,0 +1,80 @@
+import { buildSubjectStructuredData, serializeStructuredData } from "../subjectStructuredData";
+
+const BASE = {
+    canonicalUrl: "https://opencouncil.gr/athens/feb26_2026/subjects/subj1",
+    siteUrl: "https://opencouncil.gr",
+    locale: "el",
+    subjectName: "Οικόπεδα για σχολεία",
+    subjectDescription: "Το συμβούλιο συζήτησε την παραχώρηση οικοπέδων.",
+    subjectCreatedAt: "2026-02-27T10:00:00.000Z",
+    subjectUpdatedAt: new Date("2026-03-01T09:30:00.000Z"),
+    cityName: "Αθήνα",
+    meetingName: "Συνεδρίαση Δημοτικού Συμβουλίου",
+    meetingDate: new Date("2026-02-26T17:00:00.000Z"),
+    administrativeBodyName: "Δημοτικό Συμβούλιο",
+    topicName: "Παιδεία",
+    citations: ["https://example.com/source"],
+};
+
+describe("buildSubjectStructuredData", () => {
+    it("describes the subject as an Article about the meeting event", () => {
+        expect(buildSubjectStructuredData(BASE)).toMatchObject({
+            "@context": "https://schema.org",
+            "@type": "Article",
+            "@id": `${BASE.canonicalUrl}#article`,
+            headline: BASE.subjectName,
+            description: BASE.subjectDescription,
+            datePublished: "2026-02-27T10:00:00.000Z",
+            dateModified: "2026-03-01T09:30:00.000Z",
+            inLanguage: "el",
+            mainEntityOfPage: BASE.canonicalUrl,
+            url: BASE.canonicalUrl,
+            articleSection: "Παιδεία",
+            citation: ["https://example.com/source"],
+            author: { "@type": "Organization", name: "OpenCouncil", url: BASE.siteUrl },
+            publisher: { "@type": "Organization", name: "OpenCouncil", url: BASE.siteUrl },
+            about: [
+                {
+                    "@type": "Event",
+                    name: BASE.meetingName,
+                    startDate: "2026-02-26T17:00:00.000Z",
+                    location: { "@type": "Place", name: "Αθήνα" },
+                    organizer: { "@type": "GovernmentOrganization", name: "Δημοτικό Συμβούλιο" },
+                },
+                { "@type": "Thing", name: "Παιδεία" },
+            ],
+        });
+    });
+
+    it("falls back to the city as organizer and omits optional entries", () => {
+        const data = buildSubjectStructuredData({
+            ...BASE,
+            administrativeBodyName: null,
+            topicName: null,
+            citations: [],
+        });
+
+        expect(data.about).toHaveLength(1);
+        expect(data.about[0].organizer).toEqual({
+            "@type": "GovernmentOrganization",
+            name: "Αθήνα",
+        });
+        expect(data.articleSection).toBeUndefined();
+        expect(data.citation).toBeUndefined();
+    });
+
+    it("emits no decision or vote data", () => {
+        const serialized = serializeStructuredData(buildSubjectStructuredData(BASE));
+
+        expect(serialized).not.toContain("abstract");
+        expect(serialized).not.toContain("decision");
+        expect(serialized).not.toContain("vote");
+        expect(serialized).not.toContain("pdfUrl");
+    });
+});
+
+describe("serializeStructuredData", () => {
+    it("escapes markup-significant characters before embedding in HTML", () => {
+        expect(serializeStructuredData({ value: "</script>" })).toBe('{"value":"\\u003c/script>"}');
+    });
+});

--- a/src/lib/seo/metadataDescription.ts
+++ b/src/lib/seo/metadataDescription.ts
@@ -1,14 +1,16 @@
+import { stripMarkdown } from "@/lib/formatters/markdown";
+
 /**
- * Compact a markdown text (a subject description) into a metadata
- * description: keep link labels, drop link targets (including internal
- * REF:UTTERANCE markers), strip markdown tokens, collapse whitespace,
- * and cap the length with an ellipsis.
+ * Flatten a markdown subject description into a metadata description:
+ * strip markdown via the shared helper, then cap the length with an
+ * ellipsis. The cap counts code points, so an emoji at the boundary
+ * cannot leave a lone surrogate in the output.
  */
 export function compactMetadataDescription(value: string, maxLength = 180): string {
-    const compact = value
-        .replace(/\[([^\]]+)]\([^)]+\)/g, "$1")
-        .replace(/[#*_>`]/g, "")
-        .replace(/\s+/g, " ")
-        .trim();
-    return compact.length > maxLength ? `${compact.slice(0, maxLength - 1).trimEnd()}…` : compact;
+    const stripped = stripMarkdown(value);
+    const chars = Array.from(stripped);
+    if (chars.length <= maxLength) {
+        return stripped;
+    }
+    return `${chars.slice(0, maxLength - 1).join("").trimEnd()}…`;
 }

--- a/src/lib/seo/metadataDescription.ts
+++ b/src/lib/seo/metadataDescription.ts
@@ -1,0 +1,14 @@
+/**
+ * Compact a markdown text (a subject description) into a metadata
+ * description: keep link labels, drop link targets (including internal
+ * REF:UTTERANCE markers), strip markdown tokens, collapse whitespace,
+ * and cap the length with an ellipsis.
+ */
+export function compactMetadataDescription(value: string, maxLength = 180): string {
+    const compact = value
+        .replace(/\[([^\]]+)]\([^)]+\)/g, "$1")
+        .replace(/[#*_>`]/g, "")
+        .replace(/\s+/g, " ")
+        .trim();
+    return compact.length > maxLength ? `${compact.slice(0, maxLength - 1).trimEnd()}…` : compact;
+}

--- a/src/lib/seo/subjectStructuredData.ts
+++ b/src/lib/seo/subjectStructuredData.ts
@@ -1,0 +1,60 @@
+type SubjectStructuredDataInput = {
+    canonicalUrl: string;
+    siteUrl: string;
+    locale: string;
+    subjectName: string;
+    subjectDescription: string;
+    // Dates survive as strings when they cross an unstable_cache boundary.
+    subjectCreatedAt: Date | string;
+    subjectUpdatedAt: Date | string;
+    cityName: string;
+    meetingName: string;
+    meetingDate: Date | string;
+    administrativeBodyName: string | null;
+    topicName: string | null;
+    citations: string[];
+};
+
+/**
+ * Article JSON-LD for a subject page. The meeting appears as an Event
+ * inside `about` (not `isPartOf`, which only accepts CreativeWork).
+ * Decision and vote data stay out until the extraction pipeline earns
+ * trust.
+ */
+export function buildSubjectStructuredData(input: SubjectStructuredDataInput) {
+    return {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "@id": `${input.canonicalUrl}#article`,
+        headline: input.subjectName,
+        description: input.subjectDescription,
+        datePublished: new Date(input.subjectCreatedAt).toISOString(),
+        dateModified: new Date(input.subjectUpdatedAt).toISOString(),
+        inLanguage: input.locale,
+        mainEntityOfPage: input.canonicalUrl,
+        url: input.canonicalUrl,
+        articleSection: input.topicName ?? undefined,
+        citation: input.citations.length > 0 ? input.citations : undefined,
+        author: { "@type": "Organization", name: "OpenCouncil", url: input.siteUrl },
+        publisher: { "@type": "Organization", name: "OpenCouncil", url: input.siteUrl },
+        about: [
+            {
+                "@type": "Event",
+                name: input.meetingName,
+                startDate: new Date(input.meetingDate).toISOString(),
+                location: { "@type": "Place", name: input.cityName },
+                organizer: {
+                    "@type": "GovernmentOrganization",
+                    name: input.administrativeBodyName ?? input.cityName,
+                },
+            },
+            ...(input.topicName ? [{ "@type": "Thing", name: input.topicName }] : []),
+        ],
+    };
+}
+
+// The subject text is model-generated: escape `<` so a literal
+// `</script>` inside it cannot close the JSON-LD script element.
+export function serializeStructuredData(data: unknown): string {
+    return JSON.stringify(data).replace(/</g, "\\u003c");
+}

--- a/src/lib/utils/__tests__/references.test.ts
+++ b/src/lib/utils/__tests__/references.test.ts
@@ -20,6 +20,10 @@ describe('stripMarkdown', () => {
         expect(stripMarkdown('Δες [εδώ](https://example.com) για λεπτομέρειες.')).toBe('Δες εδώ για λεπτομέρειες.');
     });
 
+    it('handles link destinations with balanced parentheses', () => {
+        expect(stripMarkdown('Κατά το [άρθρο](https://el.wikipedia.org/wiki/Νόμος_(δίκαιο)) ισχύει.')).toBe('Κατά το άρθρο ισχύει.');
+    });
+
     it('strips bold, italic and inline code', () => {
         expect(stripMarkdown('**bold** and _italic_ and `code`')).toBe('bold and italic and code');
     });


### PR DESCRIPTION
## Problem

LLMs do not cite opencouncil.gr. The cause is visibility: a production subject page sends ~2.5 MB of HTML, and the only visible text is a loading spinner. AI crawlers (GPTBot, ClaudeBot, PerplexityBot, CCBot) do not run JavaScript. The sitemap lists 9,069 subject URLs, and all of them are blank for these crawlers. The one element they can read, the meta description, leaks ~1,295 characters of raw markdown with internal `REF:UTTERANCE` markers.

## Changes

One commit per change:

1. **Includes the commit from #697** — the page content renders on the server.
2. `htmlLimitedBots` gains fourteen AI user agents, so these crawlers receive blocking, fully rendered HTML and real 404s. The upstream section of the list stays byte-identical.
3. The subject meta description goes through `compactMetadataDescription`: link labels stay, link targets and markdown tokens go, and the text caps at 180 characters. No more `REF:UTTERANCE` markers.
4. The subject page gets an `h1` with the subject name. A new opt-in `ssrContent` prop on `CollapsibleCard` server-renders the closed decision and context cards; a `data-[state=closed]:hidden` rule keeps them visually hidden. Radix renders no content for closed cards without it.
5. Subject pages emit one Article JSON-LD node: headline, description, dates, topic, citation URLs from the web-context research, and the meeting as an Event inside `about` with a `GovernmentOrganization` organizer. The serializer escapes `<`, so model-generated text cannot close the script element.
6. Sitemap entries gain `lastModified` from the same query; a meeting entry rolls up the newest `updatedAt` of its subjects.
7. `get_subject` (MCP) reports `withdrawn` and `nonAgendaReason`, and the tool description explains that an out-of-agenda withdrawal means the urgency vote failed.

## Scope

- **No decision data and no vote data go into the metadata or the JSON-LD.** The extraction pipeline is not yet trusted. Decision text appears only inside the page HTML, where the site already shows it to users.
- The page design does not change. Closed cards stay closed and toggle as before.
- `robots.txt` does not change; training crawlers stay allowed.
- Dead subject IDs keep the documented noindex behavior.

## Verification

- Full Jest run passes: 129 suites, 1,725 tests. `npm run lint` passes. `npx tsc --project tsconfig.jest.json --noEmit` reports only the pre-existing `services/notis/generated/client` errors.
- `npm run build` completes.
- Against a seeded local database, a fetch with the GPTBot user agent returns: the `h1` with the subject name, a 180-character description without markdown, the Article JSON-LD, the decision number, the Diavgeia link, and the context text inside `data-state="closed"` markup. The visible DOM contains zero `REF:UTTERANCE` markers.
- A Chromium check against the production build confirms: closed cards are hidden, they open and close on click, and the console shows no hydration errors.
- The sitemap serves `lastmod` on every entry, and a dead subject ID still returns the noindex metadata.

## Follow-ups (out of scope)

- Page weight: 2.5–13 MB RSC payloads, `Cache-Control: private, no-store`, and an uncached full-transcript read per request. Many AI fetchers cap responses at 1–5 MB, so this is the next lever.
- Homepage `h1`; per-meeting meta descriptions; server-side crawler-traffic measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFnfsSSydA66CHM4TDr4gB

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFnfsSSydA66CHM4TDr4gB)_



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes subject pages readable to non-JavaScript crawlers and adds cleaner machine-readable metadata.
- It server-renders subject content and closed decision and context cards.
- It adds compact descriptions, Article JSON-LD, and subject headings.
- It adds sitemap modification dates and expands MCP subject status fields.
- The latest changes fix both previously reported issues.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/sitemap.ts | The city timestamp now includes updates from released meetings and their subjects, which resolves the previous stale-rollup issue. |
| src/lib/formatters/markdown.ts | The Markdown link matcher now supports balanced parentheses in destinations and resolves the previously reported punctuation leak. |
| src/lib/seo/metadataDescription.ts | The metadata compactor uses the shared Markdown stripper and applies a code-point-safe length limit. |
| src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx | The subject route now emits compact metadata and safely serialized Article JSON-LD. |
| packages/ui/src/collapsible-card.tsx | The optional force-mounted content supports crawler-readable closed cards while CSS preserves their closed visual state. |
| src/lib/mcp/data.ts | MCP subject output now includes withdrawal and non-agenda status information. |

<sub>Reviews (2): Last reviewed commit: ["fix(seo): roll subject updates into city..."](https://github.com/schemalabz/opencouncil/commit/5f9e4ae81be502fb73a634be02c1ffd70a63e851) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58391978)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Municipal council experience](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/municipal-council-experience.md)
- Knowledge Base — [Application presentation system](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/application-presentation-system.md)
- Knowledge Base — [AI and MCP integration](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/ai-and-mcp-integration.md)
- Knowledge Base — [Meeting publication and records](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/meeting-publication.md)
</details>


<!-- /greptile_comment -->