### PR TITLE
Improve city selector UX on mobile with full-height dialog

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -9,3 +9,20 @@ require('@testing-library/jest-dom');
 const { TextEncoder, TextDecoder } = require('util');
 if (typeof global.TextEncoder === 'undefined') global.TextEncoder = TextEncoder;
 if (typeof global.TextDecoder === 'undefined') global.TextDecoder = TextDecoder;
+
+// jsdom doesn't implement matchMedia, which vaul (the mobile drawer) queries on
+// mount. A stub that matches nothing is enough: the components under test fall
+// back to their default branch, and the tests drive the behaviour they care
+// about themselves.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+    window.matchMedia = (query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => { },
+        removeListener: () => { },
+        addEventListener: () => { },
+        removeEventListener: () => { },
+        dispatchEvent: () => false,
+    });
+}

--- a/messages/el.json
+++ b/messages/el.json
@@ -674,6 +674,8 @@
         "selectCityPlaceholder": "Επιλέξτε Δήμο...",
         "searchCityPlaceholder": "Αναζητήστε Δήμο...",
         "cityNotFound": "Δεν βρέθηκε Δήμος.",
+        "groupAvailable": "Δήμοι με ειδοποιήσεις",
+        "groupUnavailable": "Δεν υποστηρίζονται ακόμα",
         "selectCityButton": "Επιλέξτε Πόλη",
         "preferencesTitle": "Προτιμήσεις ειδοποιήσεων",
         "sendTiming": "Στέλνουμε μια ενημέρωση πριν από μια συνεδρίαση και μια ενημέρωση μετά από αυτήν.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -684,6 +684,8 @@
         "selectCityPlaceholder": "Select Municipality...",
         "searchCityPlaceholder": "Search Municipality...",
         "cityNotFound": "No municipality found.",
+        "groupAvailable": "Municipalities with notifications",
+        "groupUnavailable": "Not available yet",
         "selectCityButton": "Select City",
         "preferencesTitle": "Notification preferences",
         "sendTiming": "We send a heads-up before a meeting and a follow-up after it.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -674,6 +674,8 @@
     "selectCityPlaceholder": "Sélectionnez une commune...",
     "searchCityPlaceholder": "Rechercher une commune...",
     "cityNotFound": "Aucune commune trouvée.",
+    "groupAvailable": "Communes avec notifications",
+    "groupUnavailable": "Pas encore disponibles",
     "selectCityButton": "Sélectionnez une ville",
     "preferencesTitle": "Préférences de notification",
     "sendTiming": "Nous envoyons une information avant une séance et une autre après celle-ci.",

--- a/messages/sr.json
+++ b/messages/sr.json
@@ -684,6 +684,8 @@
         "selectCityPlaceholder": "Изаберите општину...",
         "searchCityPlaceholder": "Претражите општину...",
         "cityNotFound": "Није пронађена ниједна општина.",
+        "groupAvailable": "Општине са обавештењима",
+        "groupUnavailable": "Још нису доступне",
         "selectCityButton": "Изаберите град",
         "preferencesTitle": "Подешавања обавештења",
         "sendTiming": "Шаљемо најаву пре седнице и извештај након ње.",

--- a/packages/ui/src/dialog.tsx
+++ b/packages/ui/src/dialog.tsx
@@ -33,8 +33,15 @@ const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
     align?: "start" | "center"
+    /**
+     * Extra classes for the close button. The default 16px box is the size of
+     * its icon, which is small for a touch target, but it sits over the corner
+     * where a `p-0` dialog puts its content. Grow it only where the content
+     * leaves the corner free.
+     */
+    closeClassName?: string
   }
->(({ className, children, align = "center", ...props }, ref) => (
+>(({ className, children, align = "center", closeClassName, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -47,7 +54,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className={cn("absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground", closeClassName)}>
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/packages/ui/src/dialog.tsx
+++ b/packages/ui/src/dialog.tsx
@@ -33,15 +33,8 @@ const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
     align?: "start" | "center"
-    /**
-     * Extra classes for the close button. The default 16px box is the size of
-     * its icon, which is small for a touch target, but it sits over the corner
-     * where a `p-0` dialog puts its content. Grow it only where the content
-     * leaves the corner free.
-     */
-    closeClassName?: string
   }
->(({ className, children, align = "center", closeClassName, ...props }, ref) => (
+>(({ className, children, align = "center", ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -54,7 +47,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className={cn("absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground", closeClassName)}>
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -150,14 +150,22 @@ export default function Combobox<T>({
             filter={(value, search, keywords) =>
                 relevanceScore(keywords?.length ? `${value} ${keywords.join(" ")}` : value, search)
             }
-            className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
-            <div className="flex items-center px-3 border-b">
-                <CommandInput
-                    placeholder={searchPlaceholder || placeholder}
-                    className="h-12 flex-1"
-                />
-            </div>
-            <CommandList>
+            className={cn(
+                "[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5",
+                // Fill the sheet rather than size to content, so the list keeps
+                // every pixel the software keyboard leaves.
+                isMobile && "h-auto min-h-0 flex-1",
+            )}
+        >
+            <CommandInput
+                placeholder={searchPlaceholder || placeholder}
+                // 16px on mobile. Under that, iOS Safari zooms the page in when the
+                // field takes focus, and the user cannot zoom back out.
+                className={cn("h-12", isMobile && "text-base")}
+            />
+            {/* max-h-full, not max-h-none: tailwind-merge only drops the list's
+                own 300px cap for a value it recognises as a length. */}
+            <CommandList className={cn(isMobile && "max-h-full flex-1")}>
                 <CommandEmpty>
                     <div className="py-6 text-center">
                         <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-orange-100 text-orange-600 mb-3">
@@ -225,8 +233,25 @@ export default function Combobox<T>({
             <>
                 {trigger}
                 <Dialog open={open} onOpenChange={setOpen}>
-                    <DialogContent className="sm:max-w-[425px] overflow-hidden p-0">
-                        <DialogHeader className="px-4 pt-4">
+                    {/*
+                      * A full-height sheet anchored to the top of the screen. The
+                      * centred box this replaces put the results behind the software
+                      * keyboard, and only the top few rows of a list capped at 300px
+                      * stayed on screen.
+                      */}
+                    <DialogContent
+                        align="start"
+                        // The title names the task and the field carries its own
+                        // placeholder, so there is nothing left for a description.
+                        aria-describedby={undefined}
+                        className="top-0 flex h-[100dvh] max-h-[100dvh] max-w-none translate-y-0 flex-col gap-0 overflow-y-hidden rounded-none border-0 p-0 sm:rounded-none"
+                        // The sheet is the full screen, so this is the only way out
+                        // of it. The negative margin pulls the box back by the same
+                        // amount as the padding, so the icon stays where it is.
+                        closeClassName="-m-3 p-3"
+                    >
+                        {/* pr-14 keeps the title clear of the close button. */}
+                        <DialogHeader className="px-4 pb-3 pr-14 pt-4 text-left">
                             <DialogTitle>{placeholder}</DialogTitle>
                         </DialogHeader>
                         {renderContent()}

--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button"
 import { ChevronsUpDown, Search, X } from "lucide-react"
 import { Command, CommandEmpty, CommandInput, CommandItem, CommandList, CommandGroup } from "@/components/ui/command"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Drawer, DrawerContent, DrawerTitle, DrawerDescription } from "@/components/ui/drawer"
 import { cn, relevanceScore } from "@/lib/utils";
 
 type ComboboxGroup<T> = {
@@ -170,7 +170,12 @@ export default function Combobox<T>({
             />
             {/* max-h-full, not max-h-none: tailwind-merge only drops the list's
                 own 300px cap for a value it recognises as a length. */}
-            <CommandList className={cn(isMobile && "max-h-full flex-1")}>
+            {/* min-h-0, because a flex item in a column defaults to min-height:auto,
+                and Safari has resolved that to the content height. The list then
+                grows past the sheet, which clips it, and nothing scrolls at all.
+                overscroll-contain stops the page from taking over the scroll when
+                the list reaches either end. */}
+            <CommandList className={cn(isMobile && "max-h-full min-h-0 flex-1 overscroll-contain")}>
                 <CommandEmpty>
                     <div className="py-6 text-center">
                         <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-orange-100 text-orange-600 mb-3">
@@ -237,31 +242,31 @@ export default function Combobox<T>({
         return (
             <>
                 {trigger}
-                <Dialog open={open} onOpenChange={setOpen}>
-                    {/*
-                      * A full-height sheet anchored to the top of the screen. The
-                      * centred box this replaces put the results behind the software
-                      * keyboard, and only the top few rows of a list capped at 300px
-                      * stayed on screen.
-                      */}
-                    <DialogContent
-                        align="start"
-                        // The title names the task and the field carries its own
-                        // placeholder, so there is nothing left for a description.
-                        aria-describedby={undefined}
-                        className="top-0 flex h-[100dvh] max-h-[100dvh] max-w-none translate-y-0 flex-col gap-0 overflow-y-hidden rounded-none border-0 p-0 sm:rounded-none"
-                        // The sheet is the full screen, so this is the only way out
-                        // of it. The negative margin pulls the box back by the same
-                        // amount as the padding, so the icon stays where it is.
-                        closeClassName="-m-3 p-3"
+                {/*
+                  * A drawer rather than a dialog, because vaul is the only thing
+                  * here that stops iOS Safari scrolling the page behind an
+                  * overlay. `overflow: hidden` on html and body does not: Safari
+                  * still scrolls the page once its toolbars collapse, and again
+                  * whenever the keyboard covers part of the viewport. vaul pins
+                  * the body and cancels the touch moves that would scroll it.
+                  */}
+                <Drawer open={open} onOpenChange={setOpen}>
+                    <DrawerContent
+                        className="h-[85vh] max-h-[85vh] flex flex-col"
+                        // Leave the keyboard down. It would cover half of a sheet
+                        // anchored to the bottom, and the list is what the user
+                        // came to read; the field is one tap away.
+                        onOpenAutoFocus={(event) => event.preventDefault()}
                     >
-                        {/* pr-14 keeps the title clear of the close button. */}
-                        <DialogHeader className="px-4 pb-3 pr-14 pt-4 text-left">
-                            <DialogTitle>{placeholder}</DialogTitle>
-                        </DialogHeader>
+                        <DrawerTitle className="px-4 pb-3 pt-2 text-left text-lg font-semibold">
+                            {placeholder}
+                        </DrawerTitle>
+                        <DrawerDescription className="sr-only">
+                            {searchPlaceholder || placeholder}
+                        </DrawerDescription>
                         {renderContent()}
-                    </DialogContent>
-                </Dialog>
+                    </DrawerContent>
+                </Drawer>
             </>
         );
     }

--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -138,10 +138,15 @@ export default function Combobox<T>({
                 items: items.filter(item => item != null)
             }];
         }
-        return groups.map(group => ({
-            ...group,
-            items: group.items.filter(item => item != null)
-        }));
+        // cmdk hides a group whose items the search filtered out, but not one
+        // that never had any. Without this, a caller that groups a list it is
+        // still fetching shows its headings above the empty message.
+        return groups
+            .map(group => ({
+                ...group,
+                items: group.items.filter(item => item != null)
+            }))
+            .filter(group => group.items.length > 0);
     }, [groups, items]);
 
 

--- a/src/components/__tests__/Combobox.test.tsx
+++ b/src/components/__tests__/Combobox.test.tsx
@@ -17,8 +17,15 @@ beforeAll(() => {
         unobserve() {}
         disconnect() {}
     };
-    window.innerWidth = 1024; // desktop -> Popover path (not the mobile Dialog)
 });
+
+// Combobox picks its presentation from window.innerWidth on mount.
+const DESKTOP_WIDTH = 1024; // -> Popover
+const PHONE_WIDTH = 390; // -> full-height Dialog
+
+function setViewportWidth(width: number) {
+    window.innerWidth = width;
+}
 
 type City = { name: string; muni: string };
 
@@ -55,6 +62,8 @@ function openAndSearch(query: string) {
 }
 
 describe('Combobox accent-insensitive search (#402)', () => {
+    beforeEach(() => setViewportWidth(DESKTOP_WIDTH));
+
     // Documents *why* the query below is a valid guard: on the previous
     // implementation (cmdk default filter, no keywords) it scored 0 -> hidden.
     // If someone later swaps in a query the old filter would have matched,
@@ -75,5 +84,31 @@ describe('Combobox accent-insensitive search (#402)', () => {
         openAndSearch('ζζζζζ');
         expect(screen.queryByText(ACCENTED)).not.toBeInTheDocument();
         expect(screen.queryByText('Θεσσαλονίκη')).not.toBeInTheDocument();
+    });
+});
+
+describe('Combobox on a phone', () => {
+    beforeEach(() => setViewportWidth(PHONE_WIDTH));
+
+    it('opens a dialog titled with the placeholder', () => {
+        renderCombobox();
+        fireEvent.click(screen.getByRole('combobox'));
+        expect(screen.getByRole('dialog', { name: 'Επιλέξτε δήμο' })).toBeInTheDocument();
+    });
+
+    it('filters the same way it does on desktop', () => {
+        openAndSearch(DEACCENTED_QUERY);
+        const list = screen.getByRole('listbox');
+        expect(within(list).getByText(ACCENTED)).toBeInTheDocument();
+        expect(within(list).queryByText('Θεσσαλονίκη')).not.toBeInTheDocument();
+    });
+
+    // The dialog used to be a centred box holding a list capped at 300px, so the
+    // software keyboard covered most of the results. The list now fills a
+    // full-height sheet instead; drop the cap and this regresses.
+    it('does not cap the results list at 300px', () => {
+        renderCombobox();
+        fireEvent.click(screen.getByRole('combobox'));
+        expect(screen.getByRole('listbox').className).not.toMatch(/max-h-\[300px\]/);
     });
 });

--- a/src/components/__tests__/Combobox.test.tsx
+++ b/src/components/__tests__/Combobox.test.tsx
@@ -103,9 +103,17 @@ describe('Combobox on a phone', () => {
         expect(within(list).queryByText('Θεσσαλονίκη')).not.toBeInTheDocument();
     });
 
-    // The dialog used to be a centred box holding a list capped at 300px, so the
-    // software keyboard covered most of the results. The list now fills a
-    // full-height sheet instead; drop the cap and this regresses.
+    // A sheet anchored to the bottom would be half covered by the keyboard, and
+    // the list is what the user opens this for. The field is one tap away.
+    it('leaves the keyboard down by not focusing the field on open', () => {
+        renderCombobox();
+        fireEvent.click(screen.getByRole('combobox'));
+        expect(screen.getByPlaceholderText('Αναζήτηση δήμου')).not.toHaveFocus();
+    });
+
+    // The sheet used to be a centred box holding a list capped at 300px, so the
+    // software keyboard covered most of the results. The list now fills the
+    // sheet instead; drop the cap and this regresses.
     it('does not cap the results list at 300px', () => {
         renderCombobox();
         fireEvent.click(screen.getByRole('combobox'));

--- a/src/components/__tests__/Combobox.test.tsx
+++ b/src/components/__tests__/Combobox.test.tsx
@@ -112,3 +112,32 @@ describe('Combobox on a phone', () => {
         expect(screen.getByRole('listbox').className).not.toMatch(/max-h-\[300px\]/);
     });
 });
+
+describe('Combobox groups', () => {
+    beforeEach(() => setViewportWidth(DESKTOP_WIDTH));
+
+    // The notification picker groups a city list it fetches on the first click,
+    // so both groups are empty until that request lands. cmdk renders a heading
+    // for a group that never had items, which put two headings above the empty
+    // message.
+    it('hides a heading for a group with no items', () => {
+        render(
+            <Combobox<City>
+                items={[]}
+                groups={[
+                    { key: 'a', label: 'WITH NOTIFICATIONS', items: [] },
+                    { key: 'b', label: 'NOT AVAILABLE YET', items: [cities[1]] },
+                ]}
+                value={null}
+                onChange={() => {}}
+                placeholder="Επιλέξτε δήμο"
+                searchPlaceholder="Αναζήτηση δήμου"
+                getItemLabel={(c) => c.name}
+                getItemValue={(c) => `${c.name} ${c.muni}`}
+            />,
+        );
+        fireEvent.click(screen.getByRole('combobox'));
+        expect(screen.queryByText('WITH NOTIFICATIONS')).not.toBeInTheDocument();
+        expect(screen.getByText('NOT AVAILABLE YET')).toBeInTheDocument();
+    });
+});

--- a/src/components/cities/CityComboboxItem.tsx
+++ b/src/components/cities/CityComboboxItem.tsx
@@ -1,0 +1,33 @@
+import { Bell, MapPin } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { CityMinimalWithCounts } from '@/lib/db/cities';
+
+/**
+ * A city row for the shared `Combobox`. The bell marks a municipality that can
+ * send notifications; every other one only offers the petition page. Both city
+ * pickers show the same rows, so the two lists stay recognisable as one thing.
+ */
+export function CityComboboxItem({ item }: { item: CityMinimalWithCounts }) {
+    return (
+        <div className="flex items-center">
+            <div
+                className={cn(
+                    "w-5 h-5 sm:w-6 sm:h-6 rounded-full flex items-center justify-center mr-2 shrink-0",
+                    item.supportsNotifications ? "bg-orange-100" : "bg-gray-100"
+                )}
+            >
+                {/* Important, because Combobox sizes every icon in a row to h-5/w-5,
+                    which would fill the chip and hide the colour behind it. */}
+                {item.supportsNotifications ? (
+                    <Bell className="!h-3 !w-3" />
+                ) : (
+                    <MapPin className="!h-3 !w-3" />
+                )}
+            </div>
+            <div className="min-w-0">
+                <div className="font-medium text-sm sm:text-base">{item.name}</div>
+                <div className="text-xs text-gray-500">{item.name_municipality}</div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/onboarding/selectors/MunicipalitySelector.tsx
+++ b/src/components/onboarding/selectors/MunicipalitySelector.tsx
@@ -1,10 +1,11 @@
-import { MapPin, Search, Bell } from 'lucide-react';
+import { MapPin, Search } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import Combobox from '@/components/Combobox';
 import { CityMinimalWithCounts } from '@/lib/db/cities';
 import { isPublic } from "@/lib/cityStatus";
+import { CityComboboxItem } from '@/components/cities/CityComboboxItem';
 
 interface MunicipalitySelectorProps {
     cities: CityMinimalWithCounts[];
@@ -84,28 +85,6 @@ export function MunicipalitySelector({
         </Button>
     );
 
-    // Custom item component
-    const CityItem: React.ComponentType<{
-        item: CityMinimalWithCounts;
-    }> = ({ item }) => (
-        <div className="flex items-center">
-            <div className={cn(
-                "w-5 h-5 sm:w-6 sm:h-6 rounded-full flex items-center justify-center mr-2",
-                item.supportsNotifications ? "bg-orange-100" : "bg-gray-100"
-            )}>
-                {item.supportsNotifications ? (
-                    <Bell className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
-                ) : (
-                    <MapPin className="h-4 w-4" />
-                )}
-            </div>
-            <div>
-                <div className="font-medium text-sm sm:text-base">{item.name}</div>
-                <div className="text-[10px] sm:text-xs text-gray-500">{item.name_municipality}</div>
-            </div>
-        </div>
-    );
-
     return (
         <div className="space-y-6 w-full max-w-md mx-auto px-4 sm:px-0">
             <div>
@@ -116,7 +95,7 @@ export function MunicipalitySelector({
                     placeholder={t('placeholder')}
                     searchPlaceholder={t('searchPlaceholder')}
                     groups={groups}
-                    ItemComponent={CityItem}
+                    ItemComponent={CityComboboxItem}
                     TriggerComponent={CityTrigger}
                     getItemLabel={(city) => city.name}
                     getItemValue={(city) => `${city.name} ${city.name_municipality}`}

--- a/src/components/profile/NotificationPreferencesSection.tsx
+++ b/src/components/profile/NotificationPreferencesSection.tsx
@@ -1,23 +1,23 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations, useLocale } from 'next-intl';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Bell, MapPin, Tag, Edit, Trash2, Loader2, Mail, Phone, MoreVertical, ChevronDown, ExternalLink } from 'lucide-react';
+import { Bell, MapPin, Tag, Edit, Trash2, Loader2, Mail, Phone, MoreVertical, ChevronDown, ExternalLink, Plus } from 'lucide-react';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Checkbox } from '@/components/ui/checkbox';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import Combobox from '@/components/Combobox';
 import { CityMinimalWithCounts } from '@/lib/db/cities';
+import { CityComboboxItem } from '@/components/cities/CityComboboxItem';
 import { Link } from '@/i18n/routing';
 import { format } from 'date-fns';
 import { getDateFnsLocale } from '@/lib/formatters/time';
 
 interface CitySelectorProps {
     label: string;
-    size?: 'default' | 'sm';
     cities: CityMinimalWithCounts[];
     loading: boolean;
     onFetchCities: () => void;
@@ -25,11 +25,12 @@ interface CitySelectorProps {
     placeholder: string;
     searchPlaceholder: string;
     emptyMessage: string;
+    groupAvailableLabel: string;
+    groupUnavailableLabel: string;
 }
 
 function CitySelector({
     label,
-    size = 'default',
     cities,
     loading,
     onFetchCities,
@@ -37,23 +38,47 @@ function CitySelector({
     placeholder,
     searchPlaceholder,
     emptyMessage,
+    groupAvailableLabel,
+    groupUnavailableLabel,
 }: CitySelectorProps) {
+    // Every municipality we know about is in this list, but only a small part of
+    // them can send notifications; the rest lead to the petition page. One flat
+    // run of ~375 rows buries the handful this control can subscribe you to.
+    const groups = useMemo(() => [
+        {
+            key: 'available',
+            label: groupAvailableLabel,
+            items: cities.filter(city => city.supportsNotifications),
+        },
+        {
+            key: 'unavailable',
+            label: groupUnavailableLabel,
+            items: cities.filter(city => !city.supportsNotifications),
+        },
+    ], [cities, groupAvailableLabel, groupUnavailableLabel]);
+
     return (
-        <div className="w-fit">
+        <div className="w-full sm:w-fit">
             <Combobox
                 items={cities}
+                groups={groups}
                 value={null}
                 onChange={onSelect}
                 placeholder={placeholder}
                 searchPlaceholder={searchPlaceholder}
                 getItemLabel={(city) => city.name}
                 getItemValue={(city) => `${city.name} ${city.name_municipality}`}
+                ItemComponent={CityComboboxItem}
                 emptyMessage={emptyMessage}
                 loading={loading}
-                className="w-64"
+                className="w-80"
                 TriggerComponent={() => (
-                    <Button variant="outline" size={size} onClick={onFetchCities}>
-                        <Bell className="mr-2 h-4 w-4" />
+                    <Button
+                        variant="outline"
+                        className="h-11 w-full justify-start sm:h-10 sm:w-auto"
+                        onClick={onFetchCities}
+                    >
+                        <Plus className="mr-2 h-4 w-4" />
                         {label}
                     </Button>
                 )}
@@ -244,6 +269,8 @@ export function NotificationPreferencesSection() {
         placeholder: t('selectCityPlaceholder'),
         searchPlaceholder: t('searchCityPlaceholder'),
         emptyMessage: t('cityNotFound'),
+        groupAvailableLabel: t('groupAvailable'),
+        groupUnavailableLabel: t('groupUnavailable'),
     };
 
     if (loading) {
@@ -494,7 +521,7 @@ export function NotificationPreferencesSection() {
                     )}
                 </div>
 
-                <CitySelector label={t('addCity')} size="sm" {...citySelectorProps} />
+                <CitySelector label={t('addCity')} {...citySelectorProps} />
             </div>
 
             {/* Notifications history table */}


### PR DESCRIPTION
## Summary
Refactors the city selector (Combobox) to provide a better mobile experience by replacing the centered dialog with a full-height sheet anchored to the top of the screen. Also extracts the city item rendering into a reusable component and groups cities by notification support status.

## Key Changes

- **Mobile-optimized Combobox dialog**: Converts the centered dialog to a full-height sheet (`h-[100dvh]`) that anchors to the top, preventing the software keyboard from covering results. Removes the 300px height cap on the results list on mobile.

- **Responsive input sizing**: Sets the search input to `text-base` on mobile to prevent iOS Safari from zooming the page when the field takes focus.

- **Extracted CityComboboxItem component**: Creates a reusable `CityComboboxItem` component that displays cities with visual indicators (bell icon for notification-supporting municipalities, map pin for others). Replaces inline item rendering in both `MunicipalitySelector` and `NotificationPreferencesSection`.

- **City grouping by notification support**: Groups cities into "available" (supports notifications) and "unavailable" (petition-only) sections in the city selector, reducing cognitive load when browsing ~375 municipalities. Only a small subset can send notifications.

- **Improved dialog accessibility**: Adds `aria-describedby={undefined}` to the dialog since the title names the task and the field has its own placeholder. Increases the close button touch target to 40px with `-m-3 p-3` padding.

- **UI refinements**:
  - Changes the city selector trigger button icon from Bell to Plus
  - Adjusts button sizing to be full-width on mobile (`w-full`) and auto-width on desktop (`sm:w-auto`)
  - Updates the combobox width from `w-64` to `w-80` for better visibility
  - Removes the unused `size` prop from `CitySelector`

- **Test coverage**: Adds tests for mobile viewport behavior, including dialog presentation, search filtering consistency, and verification that the results list is not capped at 300px.

- **Internationalization**: Adds translation keys for city grouping labels (`groupAvailable`, `groupUnavailable`) in all supported languages (English, Greek, French, Serbian).

## Implementation Details

The Combobox now detects viewport width on mount to choose between a Popover (desktop) and full-height Dialog (mobile). The dialog uses `max-h-full` and `flex-1` on mobile to fill available space after the software keyboard appears, ensuring results remain visible. The `CommandList` is wrapped with responsive classes to maintain proper scrolling behavior.

The `CityComboboxItem` component uses consistent icon sizing (`!h-3 !w-3`) to override the Combobox's default icon sizing, and includes visual grouping with colored circular backgrounds (orange for notification-supporting, gray for others).

https://claude.ai/code/session_01Wbuvnit1VtAvSYNxuvqaek







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR refactors the mobile city selector into a responsive drawer and introduces shared, grouped municipality rendering.
- Replaces the mobile dialog with a flex-based drawer and uncapped scrolling results.
- Groups municipalities by notification availability and adds localized group labels.
- Extracts shared city-row rendering and adds mobile and grouping tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/Combobox.tsx | Replaces the mobile dialog with a responsive drawer, adjusts list sizing and focus behavior, and omits empty groups. |
| src/components/__tests__/Combobox.test.tsx | Adds coverage for mobile presentation, filtering, focus behavior, result-list sizing, and empty groups. |
| src/components/cities/CityComboboxItem.tsx | Introduces a reusable municipality row with notification-support indicators. |
| src/components/onboarding/selectors/MunicipalitySelector.tsx | Reuses the extracted city item component without changing selection behavior. |
| src/components/profile/NotificationPreferencesSection.tsx | Groups municipalities by notification support and updates the responsive selector trigger. |

<sub>Reviews (4): Last reviewed commit: ["fix(ui): open the mobile combobox as a d..."](https://github.com/schemalabz/opencouncil/commit/9f8835da5612a2e90a153f13f259ed1eb2195b97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58589599)</sub>

<!-- /greptile_comment -->