### PR TITLE
test(utils): drop virtual flag from greek-name-klitiki mock

### DIFF
--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -19,7 +19,11 @@ import {
 } from '../utils';
 import { calculateOfferTotals } from '../pricing';
 
-// Mock for Greek klitiki library
+// Mock for Greek klitiki library. Do not pass `{ virtual: true }` here: the
+// package is a real dependency, and a virtual mock registers under the bare
+// specifier while jest's per-worker resolver caches the resolved path per
+// importing file. When another test file loads ../utils first in the same
+// worker, a virtual mock misses that cache entry and the real package answers.
 jest.mock('greek-name-klitiki', () =>
   function mockKlitiki(name: string) {
     // Simple mock implementation for testing
@@ -44,8 +48,7 @@ jest.mock('greek-name-klitiki', () =>
     if (capitalized === 'Νικος') return 'Νίκο';
     
     return conversions[capitalized] || name;
-  },
-  { virtual: true }
+  }
 );
 
 describe('monthsBetween', () => {


### PR DESCRIPTION
## Problem

`klitiki › should handle mixed casing by normalizing to Sentence Case (or keeping as is)` in `src/lib/__tests__/utils.test.ts` failed intermittently in full `npm test` runs (3 of 10 runs on a clean checkout). The failure was `Expected: "Νίκο", Received: "Νικος"` — the output of the real library. The in-file `jest.mock('greek-name-klitiki', factory, { virtual: true })` did not apply in those runs. The file always passed in isolation.

## Root cause

Three jest internals combine into the failure:

1. jest-runner creates one `Resolver` per project in each worker process. Every test file that runs in that worker shares it (`testWorker.js`).
2. `Resolver.getModuleID` caches `(from, moduleName) → module ID` across test files. The cache key does not include the virtual-mock state, but the computed ID depends on it (`resolver.js`).
3. With `{ virtual: true }`, jest registers the mock factory under the bare-specifier ID (`greek-name-klitiki`). A plain require from `src/lib/utils.ts` computes the resolved `node_modules` path ID instead.

`src/components/landing/v2/__tests__/search.test.ts` imports `src/lib/utils.ts` without the mock. When it runs before `utils.test.ts` in the same worker, the shared resolver caches the real-path ID for the `(utils.ts, greek-name-klitiki)` lookup. The later `utils.test.ts` run registers its virtual mock under the bare-specifier ID. The require from `utils.ts` then reuses the cached real-path ID, finds no mock there, and loads the real package. Worker assignment and file order change between runs, so the failure was intermittent.

Only the `'ΝΙΚΟΣ'` assertion diverges: uppercase Greek input loses its accent, and only the mock restores it. The real library declines the other test names the same way the mock does.

## Fix

Drop `{ virtual: true }`. The package is a real dependency, so the flag is not needed. Without it, mock registration and module lookup both compute the real-path ID, and the mock applies under every test order. A comment at the mock now records this constraint.

## Verification

- A custom sequencer that forces `search.test.ts` before `utils.test.ts` under `--runInBand` (one shared resolver) reproduced the failure 3 of 3 runs before the fix, and passes 3 of 3 runs after.
- 10 consecutive full `npm test` runs pass after the fix (before: 3 of 10 runs failed).
- `npm run lint` passes with no findings on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bJ4o8yijnzS5kaDpL2Dc7

---
_Generated by [Claude Code](https://claude.ai/code/session_014bJ4o8yijnzS5kaDpL2Dc7)_

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the unnecessary virtual flag from the `greek-name-klitiki` Jest mock to prevent order-dependent resolver cache mismatches.
- Registers the mock using the real dependency’s resolved module ID.
- Documents why the mock must remain non-virtual.
- Leaves the mock implementation and production code unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The changed Jest mock uses the valid non-virtual form for an existing declared dependency, while preserving the mock factory and test behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/__tests__/utils.test.ts | Removes `{ virtual: true }` from a mock of an installed dependency, aligning mock registration with normal module resolution and addressing the documented intermittent test failure. |

<sub>Reviews (1): Last reviewed commit: ["test(utils): drop virtual flag from gree..."](https://github.com/schemalabz/opencouncil/commit/5f7655e9c2bc8ee1fa4b522eaadd8689c0928628) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58605434)</sub>

<!-- /greptile_comment -->