### PR TITLE
Fix hydration errors by pinning timezone and hour cycle in date formatters

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,4 +71,25 @@ export default defineConfig([{
             }],
         }],
     },
+}, {
+    // Date text must render identically on the server (UTC machine) and in the
+    // visitor's browser, or hydration breaks (React error #418) and printed
+    // days go wrong near midnight. Raw toLocaleDateString/Intl.DateTimeFormat
+    // default to the machine's timezone and locale, so they are confined to
+    // src/lib/formatters — everything else calls its helpers, which pin a
+    // timezone and an hour cycle.
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: ["src/lib/formatters/**"],
+    rules: {
+        "no-restricted-syntax": ["error", {
+            selector: "CallExpression[callee.property.name='toLocaleDateString']",
+            message: "toLocaleDateString renders in the machine's timezone and locale, which differ between server and browser. Use formatDate/formatNumericDate/localCalendarDate from @/lib/formatters/time.",
+        }, {
+            selector: "CallExpression[callee.property.name='toLocaleTimeString']",
+            message: "toLocaleTimeString renders in the machine's timezone and locale, which differ between server and browser. Use formatDateTime/formatNumericDateTime from @/lib/formatters/time.",
+        }, {
+            selector: "NewExpression[callee.object.name='Intl'][callee.property.name='DateTimeFormat']",
+            message: "Intl.DateTimeFormat defaults to the machine's timezone, which differs between server and browser. Use a formatter from @/lib/formatters/time.",
+        }],
+    },
 }]);

--- a/src/app/[locale]/(admin)/admin/qr/page.tsx
+++ b/src/app/[locale]/(admin)/admin/qr/page.tsx
@@ -6,6 +6,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { formatNumericDate } from '@/lib/formatters/time';
 
 type CampaignRow = { id: string; code: string; url: string; name: string | null; isActive: boolean; createdAt: Date };
 
@@ -203,11 +204,7 @@ export default function AdminQrPage() {
                                         )}
                                     </TableCell>
                                     <TableCell className="text-sm text-muted-foreground">
-                                        {new Date(c.createdAt).toLocaleDateString('en-US', { 
-                                            year: 'numeric', 
-                                            month: 'short', 
-                                            day: 'numeric' 
-                                        })}
+                                        {formatNumericDate(new Date(c.createdAt), undefined, 'en')}
                                     </TableCell>
                                     <TableCell className="text-center">
                                         <input

--- a/src/app/[locale]/(admin)/admin/settings/api-keys/page.tsx
+++ b/src/app/[locale]/(admin)/admin/settings/api-keys/page.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge"
 import { PlusIcon, Copy, Check, AlertTriangle } from "lucide-react"
 import { useState, useEffect } from "react"
 import { toast } from "@/hooks/use-toast"
+import { formatNumericDate } from '@/lib/formatters/time';
 
 interface ApiKey {
     id: string
@@ -149,10 +150,10 @@ export default function ApiKeysPage() {
                                         <TableCell>
                                             <code className="text-sm bg-muted px-2 py-1 rounded">{key.keyPrefix}...</code>
                                         </TableCell>
-                                        <TableCell>{new Date(key.createdAt).toLocaleDateString()}</TableCell>
+                                        <TableCell>{formatNumericDate(new Date(key.createdAt))}</TableCell>
                                         <TableCell>
                                             {key.lastUsedAt
-                                                ? new Date(key.lastUsedAt).toLocaleDateString()
+                                                ? formatNumericDate(new Date(key.lastUsedAt))
                                                 : <span className="text-muted-foreground">Never</span>
                                             }
                                         </TableCell>
@@ -197,8 +198,8 @@ export default function ApiKeysPage() {
                                         <TableCell>
                                             <code className="text-sm bg-muted px-2 py-1 rounded">{key.keyPrefix}...</code>
                                         </TableCell>
-                                        <TableCell>{new Date(key.createdAt).toLocaleDateString()}</TableCell>
-                                        <TableCell>{key.revokedAt ? new Date(key.revokedAt).toLocaleDateString() : '-'}</TableCell>
+                                        <TableCell>{formatNumericDate(new Date(key.createdAt))}</TableCell>
+                                        <TableCell>{key.revokedAt ? formatNumericDate(new Date(key.revokedAt)) : '-'}</TableCell>
                                         <TableCell><Badge variant="secondary">Revoked</Badge></TableCell>
                                     </TableRow>
                                 ))}

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/page.tsx
@@ -3,17 +3,14 @@ import MapView from "@/components/map/map";
 import { useCouncilMeetingData } from "@/components/meetings/CouncilMeetingDataContext";
 import { SubjectSection } from "@/components/meetings/subject-section";
 import { TopicFilter } from "@/components/TopicFilter";
-import { formatDate } from "date-fns";
 import { CalendarIcon, ExternalLink, FileIcon, FileText, Youtube } from "lucide-react";
 import { useNotificationPreference } from "@/contexts/NotificationPreferenceContext";
-import { formatDateTime, formatRelativeTime } from "@/lib/formatters/time";
+import { formatDate, formatDateTime, formatRelativeTime } from "@/lib/formatters/time";
 import { sortSubjectsBySpeakerContributionCount, sortSubjectsByAgendaIndex, subjectToMapFeature } from "@/lib/utils";
 import { categorizeSubjects, getSubjectCategories } from "@/lib/utils/subjects";
 import { calculateGeometryBounds } from "@/lib/geo";
 import { Link } from "@/i18n/routing";
 import { HighlightCards } from "@/components/meetings/highlight-cards";
-import { el } from "date-fns/locale";
-import { enUS } from "date-fns/locale";
 import { useLocale, useTranslations } from "next-intl";
 import { useState, useMemo, useEffect } from "react";
 import type { Topic } from "@prisma/client";
@@ -143,7 +140,7 @@ export default function MeetingPage() {
 
 function MeetingInfo() {
     const tMeeting = useTranslations("CouncilMeeting");
-    const { meeting, subjects } = useCouncilMeetingData();
+    const { meeting, subjects, city } = useCouncilMeetingData();
     const locale = useLocale();
     return (
         <div className="absolute bottom-0 left-0 right-0 p-4 sm:p-6">
@@ -152,7 +149,7 @@ function MeetingInfo() {
                 <div className="flex flex-wrap items-center gap-4 sm:gap-6 text-xs sm:text-sm text-gray-600">
                     <div className="flex items-center">
                         <CalendarIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4 mr-2 sm:mr-2.5" />
-                        {formatDate(new Date(meeting.dateTime), 'PPP', { locale: locale === 'el' ? el : enUS })}
+                        {formatDate(new Date(meeting.dateTime), city.timezone, locale)}
                     </div>
 
                     {meeting.agendaUrl && (
@@ -256,8 +253,7 @@ function UpcomingMeetingCard() {
                 <>
                     <div className="flex items-center justify-center gap-2 mb-3">
                         <CalendarIcon className="w-5 h-5 text-primary" />
-                        {/* Relative to the render clock, so the server and the
-                            client can land either side of a minute boundary. */}
+                        {/* Clock-relative text — see formatRelativeTime. */}
                         <p className="font-medium" suppressHydrationWarning>
                             {tMeeting('scheduledFor', { when: formatRelativeTime(meetingDate, locale) })}
                         </p>

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/page.tsx
@@ -256,7 +256,9 @@ function UpcomingMeetingCard() {
                 <>
                     <div className="flex items-center justify-center gap-2 mb-3">
                         <CalendarIcon className="w-5 h-5 text-primary" />
-                        <p className="font-medium">
+                        {/* Relative to the render clock, so the server and the
+                            client can land either side of a minute boundary. */}
+                        <p className="font-medium" suppressHydrationWarning>
                             {tMeeting('scheduledFor', { when: formatRelativeTime(meetingDate, locale) })}
                         </p>
                     </div>

--- a/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(meetings)/[meetingId]/subjects/[subjectId]/page.tsx
@@ -9,6 +9,7 @@ import { localizeText } from "@/lib/serbian";
 import { compactMetadataDescription } from "@/lib/seo/metadataDescription";
 import { getRealmBaseUrlFromRequest } from "@/lib/realm.server";
 import { buildSubjectStructuredData, serializeStructuredData } from "@/lib/seo/subjectStructuredData";
+import { formatNumericDate } from '@/lib/formatters/time';
 
 export async function generateMetadata(
     props: {
@@ -55,7 +56,7 @@ export async function generateMetadata(
     // Create a meaningful description
     const description = subject.description
         ? compactMetadataDescription(localizeText(subject.description, params.locale))
-        : `Θέμα που συζητήθηκε | ${cityName} | ${new Date(meetingData.meeting.dateTime).toLocaleDateString("el-GR")}`;
+        : `Θέμα που συζητήθηκε | ${cityName} | ${formatNumericDate(new Date(meetingData.meeting.dateTime), meetingData.city.timezone)}`;
 
     return {
         title,

--- a/src/app/[locale]/(landing-immersive)/page.tsx
+++ b/src/app/[locale]/(landing-immersive)/page.tsx
@@ -95,6 +95,7 @@ export default async function HomePage() {
                         name: m.city.name,
                         name_municipality: m.city.name_municipality,
                         logoImage: m.city.logoImage,
+                        timezone: m.city.timezone,
                     },
                     administrativeBody: m.administrativeBody ? { name: m.administrativeBody.name } : null,
                 })),

--- a/src/app/[locale]/(other)/notifications/[id]/page.tsx
+++ b/src/app/[locale]/(other)/notifications/[id]/page.tsx
@@ -73,7 +73,10 @@ export default async function NotificationPage(props: { params: Promise<{ id: st
                                     {delivery.sentAt && (
                                         <>
                                             <span className="mx-0.5">•</span>
-                                            <span className="whitespace-nowrap">
+                                            {/* Relative to the render clock, so the server and
+                                                the client can land either side of a minute
+                                                boundary. */}
+                                            <span className="whitespace-nowrap" suppressHydrationWarning>
                                                 {formatDistanceToNow(new Date(delivery.sentAt), { addSuffix: true, locale: el })}
                                             </span>
                                         </>

--- a/src/app/[locale]/(other)/notifications/[id]/page.tsx
+++ b/src/app/[locale]/(other)/notifications/[id]/page.tsx
@@ -2,8 +2,9 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { MapPin, Calendar, Building2, ChevronRight, Bell, Mail, MessageSquare, Clock, Youtube } from 'lucide-react';
-import { format, formatDistanceToNow } from 'date-fns';
+import { formatDistanceToNow } from 'date-fns';
 import { el } from 'date-fns/locale';
+import { formatDate } from '@/lib/formatters/time';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { ReasonBadge } from '@/components/notifications/ReasonBadge';
@@ -73,10 +74,7 @@ export default async function NotificationPage(props: { params: Promise<{ id: st
                                     {delivery.sentAt && (
                                         <>
                                             <span className="mx-0.5">•</span>
-                                            {/* Relative to the render clock, so the server and
-                                                the client can land either side of a minute
-                                                boundary. */}
-                                            <span className="whitespace-nowrap" suppressHydrationWarning>
+                                            <span className="whitespace-nowrap">
                                                 {formatDistanceToNow(new Date(delivery.sentAt), { addSuffix: true, locale: el })}
                                             </span>
                                         </>
@@ -108,7 +106,7 @@ export default async function NotificationPage(props: { params: Promise<{ id: st
                         </div>
                         <div className="flex items-center gap-2">
                             <Calendar className="h-4 w-4 text-muted-foreground shrink-0" />
-                            <span className="text-sm">{format(meetingDate, 'PPP', { locale: el })}</span>
+                            <span className="text-sm">{formatDate(meetingDate)}</span>
                         </div>
                     </div>
                 </div>
@@ -230,7 +228,7 @@ export default async function NotificationPage(props: { params: Promise<{ id: st
                         <Card className="bg-muted/30">
                             <CardContent className="pt-4 pb-4">
                                 <p className="text-center text-xs sm:text-sm text-muted-foreground leading-relaxed">
-                                    Αυτή η συνεδρίαση είναι προγραμματισμένη για τις {format(meetingDate, 'PPP', { locale: el })}.
+                                    Αυτή η συνεδρίαση είναι προγραμματισμένη για τις {formatDate(meetingDate)}.
                                     {meeting.administrativeBody?.youtubeChannelUrl ? (
                                         <> Μπορείτε να τη δείτε{' '}
                                             <a

--- a/src/components/RelativeTime.tsx
+++ b/src/components/RelativeTime.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useReducer, useState } from "react";
+import { useLocale } from "next-intl";
+import { formatRelativeTime } from "@/lib/formatters/time";
+
+// The rendered strings have at best minute granularity.
+const REFRESH_MS = 60_000;
+
+/**
+ * Distance-to-now text ("περίπου 2 ώρες", "πριν από 5 λεπτά") that is safe to
+ * server-render. The string depends on the clock at render time, so the server
+ * and the hydrating client routinely disagree and React reports hydration
+ * error #418. suppressHydrationWarning keeps the server text instead of
+ * erroring, and the interval keeps the text fresh from the client's clock.
+ */
+export function RelativeTime({ date, addSuffix = true }: { date: Date | string; addSuffix?: boolean }) {
+    const locale = useLocale();
+    const [mounted, setMounted] = useState(false);
+    const [, tick] = useReducer((n: number) => n + 1, 0);
+
+    useEffect(() => {
+        setMounted(true);
+        const id = setInterval(tick, REFRESH_MS);
+        return () => clearInterval(id);
+    }, []);
+
+    // The key swaps the node once after mount. Hydration adopted the server
+    // string (suppressed above), but React diffs later renders against its own
+    // client string — while the two stay equal it never writes the DOM, so an
+    // adopted stale string could survive until the next wording change.
+    // Remounting guarantees the client's value from the first paint after
+    // hydration.
+    return (
+        <span key={mounted ? "live" : "ssr"} suppressHydrationWarning>
+            {formatRelativeTime(new Date(date), locale, { addSuffix })}
+        </span>
+    );
+}

--- a/src/components/admin/consultations/consultations.tsx
+++ b/src/components/admin/consultations/consultations.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Upload, ExternalLink, Pencil, Check, X } from 'lucide-react';
 import { ConsultationForAdmin } from '@/lib/db/consultations';
+import { formatDateTime } from '@/lib/formatters/time';
 
 type CityOption = { id: string; name: string };
 
@@ -396,13 +397,7 @@ export default function Consultations({ initialConsultations, initialCities }: C
                                             )}
                                         </TableCell>
                                         <TableCell className="text-sm text-muted-foreground">
-                                            {new Date(c.endDate).toLocaleDateString('en-US', {
-                                                year: 'numeric',
-                                                month: 'short',
-                                                day: 'numeric',
-                                                hour: '2-digit',
-                                                minute: '2-digit'
-                                            })}
+                                            {formatDateTime(new Date(c.endDate), undefined, 'medium', 'en')}
                                         </TableCell>
                                         <TableCell className="text-sm">{c._count.comments}</TableCell>
                                         <TableCell className="text-center">

--- a/src/components/admin/conversations/SendTemplateDialog.tsx
+++ b/src/components/admin/conversations/SendTemplateDialog.tsx
@@ -35,6 +35,7 @@ import {
     type MeetingOption,
 } from '@/app/[locale]/(admin)/admin/conversations/actions';
 import type { SendStatus } from './types';
+import { formatNumericDate } from '@/lib/formatters/time';
 
 /**
  * Top-right "Send test message" button on the admin Conversations page.
@@ -333,7 +334,7 @@ export function SendTemplateDialog() {
                                     <SelectContent>
                                         {meetings.map((m) => (
                                             <SelectItem key={m.id} value={m.id}>
-                                                {new Date(m.dateTime).toLocaleDateString('el-GR')} — {m.name}
+                                                {formatNumericDate(new Date(m.dateTime))} — {m.name}
                                             </SelectItem>
                                         ))}
                                     </SelectContent>

--- a/src/components/admin/diavgeia/PollingStats.tsx
+++ b/src/components/admin/diavgeia/PollingStats.tsx
@@ -33,7 +33,7 @@ import {
 import { Search, Clock, Activity, CalendarClock, ArrowUpDown, ChevronDown, Eye, Copy, Check, ExternalLink, Loader2, AlertTriangle } from 'lucide-react';
 import { resolveCandidateConflict } from '@/lib/tasks/pollDecisions';
 import { useUrlParams } from '@/hooks/useUrlParams';
-import { formatRelativeTime } from '@/lib/formatters/time';
+import { formatNumericDate, formatRelativeTime } from '@/lib/formatters/time';
 
 interface BackoffTier {
   afterDays: number;
@@ -654,7 +654,7 @@ export function PollingStats({ stats, pollCities, cityFilter, pollMeetings, meet
                       {m.firstPollAt ? (
                         <Tooltip>
                           <TooltipTrigger asChild>
-                            <span className="block cursor-default">{new Date(m.firstPollAt).toLocaleDateString()}</span>
+                            <span className="block cursor-default">{formatNumericDate(new Date(m.firstPollAt))}</span>
                           </TooltipTrigger>
                           <TooltipContent side="bottom">{new Date(m.firstPollAt).toLocaleString()}</TooltipContent>
                         </Tooltip>
@@ -826,7 +826,7 @@ export function PollingStats({ stats, pollCities, cityFilter, pollMeetings, meet
                       <td className="px-4 py-2 whitespace-nowrap font-mono text-xs">{d.ada ?? '—'}</td>
                       <td className="px-4 py-2 whitespace-nowrap">{d.publishDate ?? '—'}</td>
                       <td className="px-4 py-2 whitespace-nowrap">
-                        {new Date(d.discoveredAt).toLocaleDateString()}
+                        {formatNumericDate(new Date(d.discoveredAt))}
                       </td>
                       <td className="px-4 py-2 whitespace-nowrap">{formatDays(d.discoveryDelayDays)}</td>
                       <td className="px-4 py-2 whitespace-nowrap">{formatDays(d.publishDelayDays)}</td>

--- a/src/components/admin/meetings/ExpandableMeetingRow.tsx
+++ b/src/components/admin/meetings/ExpandableMeetingRow.tsx
@@ -27,6 +27,7 @@ import { MeetingStatusBadge } from "@/components/meetings/MeetingStatusBadge";
 import Link from "next/link";
 import { MeetingTimeline } from "@/components/meetings/MeetingTimeline";
 import { getPollingHistoryForMeeting } from "@/lib/tasks/pollDecisions";
+import { formatNumericDate } from '@/lib/formatters/time';
 
 interface ExpandableMeetingRowProps {
     meeting: CouncilMeetingWithAdminBodyAndSubjects;
@@ -181,10 +182,10 @@ export function ExpandableMeetingRow({
                                 <div>{pollingStatus.currentTierLabel}</div>
                             )}
                             {pollingStatus.lastPollAt && (
-                                <div>Last: {new Date(pollingStatus.lastPollAt).toLocaleDateString()}</div>
+                                <div>Last: {formatNumericDate(new Date(pollingStatus.lastPollAt))}</div>
                             )}
                             {pollingStatus.nextPollEligible ? (
-                                <div>Next: {new Date(pollingStatus.nextPollEligible).toLocaleDateString()}</div>
+                                <div>Next: {formatNumericDate(new Date(pollingStatus.nextPollEligible))}</div>
                             ) : pollingStatus.currentTierLabel?.startsWith('Stopped') ? (
                                 <div>Automatic polling stopped</div>
                             ) : null}

--- a/src/components/admin/offers/offers.tsx
+++ b/src/components/admin/offers/offers.tsx
@@ -28,6 +28,7 @@ import { Offer } from "@prisma/client";
 import OfferForm from "./offer-form";
 import { getOffers } from "@/lib/db/offers";
 import { calculateOfferTotals, formatCurrency } from "@/lib/utils";
+import { formatDate } from "@/lib/formatters/time";
 import {
     categorizeCities,
     calculateARR,
@@ -172,8 +173,8 @@ function OfferLine({
                 {showMissingAdamWarning && <MissingAdamBadge />}
                 <DiscountBadge discount={offer.discountPercentage} />
                 <span className="text-xs text-muted-foreground">
-                    {offer.startDate.toLocaleDateString()} →{" "}
-                    {offer.endDate.toLocaleDateString()}
+                    {formatDate(offer.startDate)} →{" "}
+                    {formatDate(offer.endDate)}
                 </span>
             </div>
             <div className="flex items-center gap-3">

--- a/src/components/admin/reviews/ReviewsTable.tsx
+++ b/src/components/admin/reviews/ReviewsTable.tsx
@@ -6,7 +6,7 @@ import { Progress } from '@/components/ui/progress';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
-import { formatDurationMs } from '@/lib/formatters/time';
+import { formatDurationMs, formatNumericDate } from '@/lib/formatters/time';
 import { ExternalLink, AlertCircle, Clock, Info, Eye, CheckCircle, Loader2 } from 'lucide-react';
 import {
   Table,
@@ -135,7 +135,7 @@ export function ReviewsTable({ reviews }: ReviewsTableProps) {
                 <div>
                   <div className="font-medium">{review.meetingName}</div>
                   <div className="text-sm text-muted-foreground">
-                    {new Date(review.meetingDate).toLocaleDateString()}
+                    {formatNumericDate(new Date(review.meetingDate))}
                   </div>
                 </div>
               </TableCell>
@@ -299,7 +299,7 @@ export function ReviewsTable({ reviews }: ReviewsTableProps) {
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <div className="text-sm text-muted-foreground mb-1">Meeting Date</div>
-                <div className="font-medium">{new Date(selectedReviewDetail.meetingDate).toLocaleDateString()}</div>
+                <div className="font-medium">{formatNumericDate(new Date(selectedReviewDetail.meetingDate))}</div>
               </div>
               <div>
                 <div className="text-sm text-muted-foreground mb-1">Status</div>

--- a/src/components/consultations/CommentSection.tsx
+++ b/src/components/consultations/CommentSection.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils";
 import { getSafeHtmlContent } from "@/lib/utils/sanitize";
 import { ConsultationCommentWithUpvotes } from "@/lib/db/consultations";
 import posthog from "posthog-js";
+import { formatDateTime } from '@/lib/formatters/time';
 
 // Dynamically import ReactQuill to avoid SSR issues
 const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
@@ -282,13 +283,7 @@ export default function CommentSection({
                                                                     {comment.user.name || 'Ανώνυμος'}
                                                                 </span>
                                                                 <span className="text-xs text-muted-foreground">
-                                                                    {new Date(comment.createdAt).toLocaleDateString('el-GR', {
-                                                                        day: 'numeric',
-                                                                        month: 'short',
-                                                                        year: 'numeric',
-                                                                        hour: '2-digit',
-                                                                        minute: '2-digit'
-                                                                    })}
+                                                                    {formatDateTime(new Date(comment.createdAt), undefined, 'medium')}
                                                                 </span>
                                                             </div>
 

--- a/src/components/landing/v2/MobileLayout.tsx
+++ b/src/components/landing/v2/MobileLayout.tsx
@@ -646,7 +646,7 @@ function MunicipalityCard({
                     <CalendarDays className="h-3 w-3 shrink-0" />
                     <span className="truncate">
                         <span className="font-medium text-foreground/80">{t('municipality.nextMeeting')}</span>{' '}
-                        {formatDateTime(new Date(next.dateTime), undefined, 'long', locale)}
+                        {formatDateTime(new Date(next.dateTime), next.city.timezone, 'long', locale)}
                     </span>
                 </div>
             )}
@@ -720,7 +720,7 @@ function StripCard({ subject, active, onClick }: { subject: LandingSubject; acti
                     )}
                     {subject.date && (
                         <span className="flex items-center gap-1">
-                            <CalendarDays className="h-3 w-3 shrink-0" /> {formatDate(new Date(subject.date), undefined, locale)}
+                            <CalendarDays className="h-3 w-3 shrink-0" /> {formatDate(new Date(subject.date), subject.cityTimezone, locale)}
                         </span>
                     )}
                     {locationLine && (
@@ -800,7 +800,7 @@ function MobileSubjectExpanded({
                     )}
                     {subject.date && (
                         <div className="flex items-center gap-1 text-xs font-medium text-foreground/80">
-                            <CalendarDays className="h-3 w-3 shrink-0" /> {formatDate(new Date(subject.date), undefined, locale)}
+                            <CalendarDays className="h-3 w-3 shrink-0" /> {formatDate(new Date(subject.date), subject.cityTimezone, locale)}
                         </div>
                     )}
                     {locationLine && (

--- a/src/components/landing/v2/MunicipalitiesList.tsx
+++ b/src/components/landing/v2/MunicipalitiesList.tsx
@@ -212,7 +212,7 @@ function MuniPanelCard({
                         <CalendarDays className="h-3.5 w-3.5 shrink-0" />
                         <span className="truncate">
                             <span className="font-medium text-foreground/80">{t('municipality.nextMeeting')}</span>{' '}
-                            {formatDateTime(new Date(next.dateTime), undefined, 'long', locale)}
+                            {formatDateTime(new Date(next.dateTime), next.city.timezone, 'long', locale)}
                         </span>
                     </div>
                 </>

--- a/src/components/landing/v2/NotifyPrompt.tsx
+++ b/src/components/landing/v2/NotifyPrompt.tsx
@@ -82,7 +82,7 @@ export function NotifyPrompt({
                         <CalendarDays className="h-5 w-5 shrink-0 text-primary" />
                         <span className="text-foreground/80">
                             <span className="font-semibold text-primary">{t('municipality.nextMeeting')}</span>{' '}
-                            {formatDateTime(new Date(nextMeeting.dateTime), undefined, 'long', locale)}
+                            {formatDateTime(new Date(nextMeeting.dateTime), nextMeeting.city.timezone, 'long', locale)}
                         </span>
                     </div>
                 )}

--- a/src/components/landing/v2/SubjectCard.tsx
+++ b/src/components/landing/v2/SubjectCard.tsx
@@ -184,7 +184,7 @@ export function SubjectCard({
                     )}
                     {subject.date && (
                         <div className="flex items-center gap-1 text-xs font-medium text-foreground/80">
-                            <CalendarDays className="h-3 w-3 shrink-0" /> {formatDate(new Date(subject.date))}
+                            <CalendarDays className="h-3 w-3 shrink-0" /> {formatDate(new Date(subject.date), subject.cityTimezone)}
                         </div>
                     )}
 

--- a/src/components/meetings/HighlightView.tsx
+++ b/src/components/meetings/HighlightView.tsx
@@ -179,7 +179,8 @@ export function HighlightView({ highlight }: HighlightViewProps) {
                 )}
                 <div className="flex items-center space-x-1 text-sm text-muted-foreground">
                   <Calendar className="h-4 w-4" />
-                  <span>{t('highlightView.lastUpdated', { relativeTime: formatRelativeTime(highlight.updatedAt, locale) })}</span>
+                  {/* Clock-relative text — see formatRelativeTime. */}
+                  <span suppressHydrationWarning>{t('highlightView.lastUpdated', { relativeTime: formatRelativeTime(highlight.updatedAt, locale) })}</span>
                 </div>
                 {creatorName && (
                   <div className="flex items-center space-x-1 text-sm text-muted-foreground">

--- a/src/components/meetings/MeetingCard.tsx
+++ b/src/components/meetings/MeetingCard.tsx
@@ -2,12 +2,13 @@
 import { useRouter, usePathname } from '../../i18n/routing';
 import { Card, CardContent } from "../ui/card";
 import { useLocale, useTranslations } from 'next-intl';
-import React, { useEffect, useState, useMemo } from 'react';
-import { format, formatDistanceToNow, isFuture } from 'date-fns';
+import React, { useEffect, useState, useMemo, useReducer } from 'react';
+import { isFuture } from 'date-fns';
 import { getLocalizedName } from '@/lib/formatters/name';
 import { CalendarIcon, Clock, Loader2, ChevronRight, Building } from 'lucide-react';
 import { sortSubjectsByImportance, IS_DEV } from '@/lib/utils';
-import { formatDateTime, getDateFnsLocale } from '@/lib/formatters/time';
+import { formatDateTime, localCalendarDate } from '@/lib/formatters/time';
+import { RelativeTime } from '@/components/RelativeTime';
 import SubjectBadge from '../subject-badge';
 import { cn } from '@/lib/utils';
 import { Link } from '@/i18n/routing';
@@ -91,7 +92,34 @@ export default function MeetingCard({ item: meeting, editable, cityTimezone }: M
 
     const remainingSubjectsCount = meeting.subjects.length - 3;
     const isUpcoming = isFuture(meeting.dateTime);
-    const isToday = format(meeting.dateTime, 'yyyy-MM-dd') === format(new Date(), 'yyyy-MM-dd');
+    // Compare calendar days in the city's timezone: the machine's local day is
+    // UTC on the server and the visitor's zone in the browser, so the two ends
+    // disagreed on which meetings are "today" (and both could be wrong for the
+    // city).
+    const isToday = localCalendarDate(new Date(meeting.dateTime), cityTimezone)
+        === localCalendarDate(new Date(), cityTimezone);
+
+    // Re-render just after the start so the badge flips from the ticking
+    // countdown to the "today" label instead of counting upward into the past.
+    const [, rerenderAtStart] = useReducer((n: number) => n + 1, 0);
+    useEffect(() => {
+        if (!isUpcoming) return;
+        // setTimeout overflows (and fires immediately) past 2^31-1 ms, so for
+        // a meeting further out than that, chain timers until the start is
+        // within one timeout's range.
+        const startMs = new Date(meeting.dateTime).getTime() + 1000;
+        const MAX_DELAY = 2 ** 31 - 1;
+        let id: ReturnType<typeof setTimeout>;
+        const schedule = () => {
+            const remaining = Math.max(startMs - Date.now(), 0);
+            id = setTimeout(
+                remaining > MAX_DELAY ? schedule : rerenderAtStart,
+                Math.min(remaining, MAX_DELAY),
+            );
+        };
+        schedule();
+        return () => clearTimeout(id);
+    }, [isUpcoming, meeting.dateTime]);
     const isTodayWithoutVideo = isToday && !meeting.videoUrl;
 
     // Ensure we have subjects to display
@@ -138,7 +166,9 @@ export default function MeetingCard({ item: meeting, editable, cityTimezone }: M
                                     <span className="relative z-10 flex items-center gap-1.5">
                                         <Clock className="w-3.5 h-3.5" />
                                         {isUpcoming ? (
-                                            <>{t('upcoming')}: {formatDistanceToNow(meeting.dateTime, { locale: getDateFnsLocale(locale) })}</>
+                                            // One span, so the flex gap of the parent does not
+                                            // replace the space between label and countdown.
+                                            <span>{t('upcoming')}: <RelativeTime date={meeting.dateTime} addSuffix={false} /></span>
                                         ) : (
                                             t('today')
                                         )}

--- a/src/components/meetings/__tests__/MeetingCard.test.tsx
+++ b/src/components/meetings/__tests__/MeetingCard.test.tsx
@@ -74,8 +74,8 @@ describe('MeetingCard date line (#514)', () => {
 
     it('shows the time on a past meeting, in the city timezone', () => {
         renderCard();
-        // 14:30Z -> 16:30 Athens. Greek formatting renders this as "4:30 μ.μ.".
-        expect(screen.getByText(/15 Ιανουαρίου 2024/)).toHaveTextContent(/4:30/);
+        // 14:30Z -> 16:30 Athens, rendered in the pinned 24-hour clock.
+        expect(screen.getByText(/15 Ιανουαρίου 2024/)).toHaveTextContent(/16:30/);
     });
 
     it('does not fall back to a date-only render', () => {
@@ -95,6 +95,6 @@ describe('MeetingCard date line (#514)', () => {
     it('follows the active locale', () => {
         mockLocale = 'en';
         renderCard();
-        expect(screen.getByText(/January 15, 2024/)).toHaveTextContent(/4:30/);
+        expect(screen.getByText(/January 15, 2024/)).toHaveTextContent(/16:30/);
     });
 });

--- a/src/components/meetings/subject/subject.tsx
+++ b/src/components/meetings/subject/subject.tsx
@@ -347,7 +347,8 @@ export default function Subject({ subjectId }: { subjectId?: string }) {
                                         {t("viewDecision")}
                                     </a>
                                     {decision.updatedAt && (
-                                        <span className="text-xs text-muted-foreground">
+                                        // Clock-relative text — see formatRelativeTime.
+                                        <span className="text-xs text-muted-foreground" suppressHydrationWarning>
                                             {t("lastUpdated", { time: formatRelativeTime(new Date(decision.updatedAt), locale) })}
                                         </span>
                                     )}

--- a/src/components/offer-letter/docx/shared.ts
+++ b/src/components/offer-letter/docx/shared.ts
@@ -28,6 +28,7 @@ import {
 } from "docx";
 import type { Offer } from "@prisma/client";
 import { offerGrammar, type ProcurementLine } from "@/lib/offers/display";
+import { formatDate, formatWeekday } from "@/lib/formatters/time";
 
 // ─── Typography ─────────────────────────────────────────────────────────────
 
@@ -135,13 +136,7 @@ export const LOGO_H = Math.round((LOGO_W * 1354) / 1606);
 
 /** "Τρίτη, 21 Ιουλίου 2026" */
 function greekLetterheadDate(d: Date = new Date()): string {
-    const weekday = new Intl.DateTimeFormat("el-GR", { weekday: "long" }).format(d);
-    const rest = new Intl.DateTimeFormat("el-GR", {
-        day: "numeric",
-        month: "long",
-        year: "numeric",
-    }).format(d);
-    return `${weekday}, ${rest}`;
+    return `${formatWeekday(d)}, ${formatDate(d)}`;
 }
 
 const letterheadLine = (text: string) =>

--- a/src/components/offer-letter/offer-pdf.tsx
+++ b/src/components/offer-letter/offer-pdf.tsx
@@ -20,6 +20,7 @@ import {
     getOfferCostBreakdown,
 } from "@/lib/offers/display";
 import { ASSET_BASE, Brand, C, greekUpper, LucideIcon, QRCode } from "@/components/pdf/shared";
+import { formatDate } from "@/lib/formatters/time";
 
 const MARGIN_X = 48;
 
@@ -31,8 +32,7 @@ const fmtEur = (n: number) =>
         minimumFractionDigits: 2,
     }).format(n);
 
-const fmtDate = (d: Date) =>
-    new Intl.DateTimeFormat("el-GR", { day: "numeric", month: "long", year: "numeric" }).format(d);
+const fmtDate = (d: Date) => formatDate(d);
 
 // ─── Text styles (fontSize + lineHeight always paired) ──────────────────────
 const T = {

--- a/src/components/og/story-templates/classic.tsx
+++ b/src/components/og/story-templates/classic.tsx
@@ -1,14 +1,15 @@
-import { format } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { OpenCouncilWatermark } from "../shared-components";
-import { formatDate } from "@/lib/formatters/time";
+import { DEFAULT_TIMEZONE, formatDate, formatWeekday } from "@/lib/formatters/time";
 import type { PreviewData } from "./types";
 import { SectionLabel, SubjectRow, RemainderLine, STORY_FONT_FAMILY } from "./shared";
 
 // T1 — Classic (cream / clean)
 export const Template1Classic = (data: PreviewData) => {
     const { preAgenda, agenda, preAgendaShown, agendaShown, preAgendaRemaining, agendaRemaining } = data;
-    // Greek long-form weekday name, e.g. "Δευτέρα", "Τρίτη", ...
-    const weekday = data.meetingDate.toLocaleDateString("el-GR", { weekday: "long" });
+    // Greek long-form weekday name, e.g. "Δευτέρα", "Τρίτη", ... All the dates
+    // on the image render in the same timezone so weekday and date agree.
+    const weekday = formatWeekday(data.meetingDate);
 
     return (
         <div
@@ -62,7 +63,7 @@ export const Template1Classic = (data: PreviewData) => {
                     Συνεδρίαση
                 </span>
                 <span style={{ display: "flex", fontSize: 92, fontWeight: 800, color: "#111827", lineHeight: 1.05 }}>
-                    {format(data.meetingDate, "dd.MM.yy")}
+                    {formatInTimeZone(data.meetingDate, DEFAULT_TIMEZONE, "dd.MM.yy")}
                 </span>
             </div>
 

--- a/src/components/og/story-templates/dark.tsx
+++ b/src/components/og/story-templates/dark.tsx
@@ -1,6 +1,7 @@
-import { format } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { el } from "date-fns/locale";
 import { OpenCouncilWatermark } from "../shared-components";
+import { DEFAULT_TIMEZONE, formatWeekday } from "@/lib/formatters/time";
 import type { PreviewData } from "./types";
 import { SectionLabel, SubjectRow, RemainderLine, STORY_FONT_FAMILY, uppercaseGreek } from "./shared";
 
@@ -8,9 +9,11 @@ import { SectionLabel, SubjectRow, RemainderLine, STORY_FONT_FAMILY, uppercaseGr
 export const Template2Dark = (data: PreviewData) => {
     const { preAgenda, agenda, preAgendaShown, agendaShown, preAgendaRemaining, agendaRemaining } = data;
 
-    const month = format(data.meetingDate, "LLLL", { locale: el });
+    // All the dates on the image render in the same timezone so weekday,
+    // day number, month and year agree.
+    const month = formatInTimeZone(data.meetingDate, DEFAULT_TIMEZONE, "LLLL", { locale: el });
     // Greek long-form weekday name, e.g. "Δευτέρα", "Τρίτη", ...
-    const weekday = data.meetingDate.toLocaleDateString("el-GR", { weekday: "long" });
+    const weekday = formatWeekday(data.meetingDate);
 
     return (
         <div
@@ -87,7 +90,7 @@ export const Template2Dark = (data: PreviewData) => {
                         letterSpacing: "-0.04em",
                     }}
                 >
-                    {String(data.meetingDate.getDate()).padStart(2, "0")}
+                    {formatInTimeZone(data.meetingDate, DEFAULT_TIMEZONE, "dd")}
                 </span>
                 <div style={{ display: "flex", flexDirection: "column", marginLeft: 28, marginBottom: 18 }}>
                     <span
@@ -115,7 +118,7 @@ export const Template2Dark = (data: PreviewData) => {
                         {month}
                     </span>
                     <span style={{ display: "flex", fontSize: 36, color: "#9CA3AF", marginTop: 8, whiteSpace: "nowrap" }}>
-                        {data.meetingDate.getFullYear()}
+                        {formatInTimeZone(data.meetingDate, DEFAULT_TIMEZONE, "yyyy")}
                     </span>
                 </div>
             </div>

--- a/src/components/profile/UserInfoForm.tsx
+++ b/src/components/profile/UserInfoForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useTranslations, useLocale } from "next-intl";
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { signOut } from "next-auth/react";
 import type { User } from "@prisma/client";
@@ -16,8 +16,7 @@ import { PhoneField, PhoneFieldValidity } from "@/components/ui/phone-field";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { NotificationPreferencesSection } from "@/components/profile/NotificationPreferencesSection";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { format } from "date-fns";
-import { getDateFnsLocale } from "@/lib/formatters/time";
+import { formatNumericDateTime } from "@/lib/formatters/time";
 
 interface UserInfoFormProps {
     user: User;
@@ -26,7 +25,6 @@ interface UserInfoFormProps {
 
 export function UserInfoForm({ user, isOnboarded }: UserInfoFormProps) {
     const t = useTranslations("Profile");
-    const dateLocale = getDateFnsLocale(useLocale());
     const router = useRouter();
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
@@ -173,7 +171,7 @@ export function UserInfoForm({ user, isOnboarded }: UserInfoFormProps) {
 
                                 <div className="flex flex-col justify-between gap-2">
                                     <p className="text-xs text-muted-foreground">
-                                        {t("lastUpdated", { date: format(new Date(user.updatedAt), 'dd/MM/yyyy HH:mm', { locale: dateLocale }) })}
+                                        {t("lastUpdated", { date: formatNumericDateTime(new Date(user.updatedAt), undefined, 'el', false) })}
                                     </p>
                                     <Button
                                         type="submit"
@@ -238,7 +236,7 @@ export function UserInfoForm({ user, isOnboarded }: UserInfoFormProps) {
                                 </div>
                                 <div className="flex flex-col gap-2">
                                     <p className="text-xs text-muted-foreground">
-                                        {t("lastUpdated", { date: format(new Date(user.updatedAt), 'dd/MM/yyyy HH:mm', { locale: dateLocale }) })}
+                                        {t("lastUpdated", { date: formatNumericDateTime(new Date(user.updatedAt), undefined, 'el', false) })}
                                     </p>
                                     <div className="flex items-center justify-between">
                                         <Button type="submit" disabled={isSubmitting} className="whitespace-normal h-auto">

--- a/src/components/user/sign-in.tsx
+++ b/src/components/user/sign-in.tsx
@@ -5,7 +5,7 @@ import { Card, CardHeader, CardContent, CardFooter } from "@/components/ui/card"
 import { useSearchParams } from "next/navigation"
 import { useTranslations } from "next-intl"
 import { signInWithEmail } from "@/lib/serverSignIn"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import posthog from "posthog-js"
 
 export function SignIn() {
@@ -15,6 +15,17 @@ export function SignIn() {
     const callbackUrl = searchParams.get("callbackUrl")
     const [error, setError] = useState<string | null>(null)
     const [isLoading, setIsLoading] = useState(false)
+
+    // The success path keeps isLoading true while the page navigates away. A
+    // Back navigation can restore the page from bfcache with that state
+    // intact, which would leave the form disabled.
+    useEffect(() => {
+        const onPageShow = (e: PageTransitionEvent) => {
+            if (e.persisted) setIsLoading(false)
+        }
+        window.addEventListener("pageshow", onPageShow)
+        return () => window.removeEventListener("pageshow", onPageShow)
+    }, [])
 
     async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
         e.preventDefault()
@@ -26,12 +37,20 @@ export function SignIn() {
         posthog.capture("sign_in_requested", { has_callback_url: !!callbackUrl })
 
         try {
-            await signInWithEmail(formData)
+            const verifyRequestUrl = await signInWithEmail(formData)
+            // The email is sent; show Auth.js's "check your email" page. The
+            // action returns the URL instead of redirecting (see serverSignIn),
+            // so only real failures reach the catch below. Navigate to the
+            // path on the current origin: Auth.js builds the URL on
+            // NEXTAUTH_URL's origin, which is the primary domain — a visitor
+            // on another realm domain must stay on it, and the same app
+            // serves /api/auth everywhere.
+            const { pathname, search } = new URL(verifyRequestUrl)
+            window.location.assign(`${pathname}${search}`)
         } catch (err) {
             posthog.captureException(err)
             setError(t("error"))
             console.error("Sign in error:", err)
-        } finally {
             setIsLoading(false)
         }
     }

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -93,6 +93,13 @@ describe('formatDate', () => {
     expect(formatDate(new Date('2024-01-15'))).toMatch(/15.*Ιανουαρίου.*2024/);
   });
 
+  it('should default to the app timezone, not the machine timezone', () => {
+    // 23:30Z on the 15th is already the 16th in Europe/Athens. A machine-local
+    // default would make the server (UTC) and the browser render different
+    // dates and break hydration.
+    expect(formatDate(new Date('2024-01-15T23:30:00Z'))).toMatch(/16.*Ιανουαρίου.*2024/);
+  });
+
   it('should throw error for invalid date', () => {
     // @ts-ignore - Testing invalid input
     expect(() => formatDate(null)).toThrow('Invalid date');
@@ -101,17 +108,18 @@ describe('formatDate', () => {
 
 describe('formatDateTime', () => {
   it('should format date and time in Greek locale', () => {
-    const date = new Date('2024-01-15T14:30:00');
-    // The output might contain either 24-hour format or AM/PM (μ.μ.)
+    const date = new Date('2024-01-15T14:30:00Z');
+    // Without an explicit timezone the formatter renders the app default
+    // (Europe/Athens, UTC+2 in January), in the pinned 24-hour clock.
     expect(formatDateTime(date)).toMatch(/15.*Ιανουαρίου.*2024/);
-    expect(formatDateTime(date)).toMatch(/2:30|14:30/);
+    expect(formatDateTime(date)).toMatch(/16:30/);
   });
 
   it('should render the time in the given timezone', () => {
     const date = new Date('2024-01-15T14:30:00Z');
     // January is EET (UTC+2), so Athens runs two hours ahead of the UTC baseline.
-    expect(formatDateTime(date, 'Europe/Athens')).toMatch(/4:30/);
-    expect(formatDateTime(date, 'UTC')).toMatch(/2:30/);
+    expect(formatDateTime(date, 'Europe/Athens')).toMatch(/16:30/);
+    expect(formatDateTime(date, 'UTC')).toMatch(/14:30/);
   });
 
   it('should follow the locale parameter', () => {
@@ -121,12 +129,12 @@ describe('formatDateTime', () => {
   });
 
   it('should use a compact month with dateStyle medium', () => {
-    const date = new Date('2024-01-15T14:30:00');
+    const date = new Date('2024-01-15T14:30:00Z');
     const result = formatDateTime(date, undefined, 'medium');
     // The full month name only appears with the default 'long' dateStyle
     expect(result).not.toMatch(/Ιανουαρίου/);
     expect(result).toMatch(/2024/);
-    expect(result).toMatch(/2:30|14:30/);
+    expect(result).toMatch(/16:30/);
   });
 
   it('should throw error for invalid date', () => {

--- a/src/lib/auth/signInResult.ts
+++ b/src/lib/auth/signInResult.ts
@@ -1,0 +1,17 @@
+/**
+ * Auth.js's server `signIn` (raw mode) rethrows `AuthError` instances, but
+ * every other failure — `sendVerificationRequest` throwing on a Resend
+ * outage, a misconfigured deploy — comes back as a redirect URL on Auth.js's
+ * own error or sign-in endpoints. Callers that pass `redirect: false` must
+ * treat those URLs as failures, not as the verify-request success URL.
+ *
+ * Returns the failing path with its query (e.g.
+ * "/api/auth/error?error=Configuration"), or null for a success URL.
+ */
+export function signInFailurePath(url: string): string | null {
+    const { pathname, search } = new URL(url);
+    if (pathname.startsWith("/api/auth/error") || pathname.startsWith("/api/auth/signin")) {
+        return `${pathname}${search}`;
+    }
+    return null;
+}

--- a/src/lib/db/meetings.ts
+++ b/src/lib/db/meetings.ts
@@ -175,7 +175,7 @@ export async function getCouncilMeetingsForCity(cityId: string, { includeUnrelea
 }
 
 const upcomingMeetingInclude = {
-    city: { select: { id: true, name: true, name_municipality: true, logoImage: true } },
+    city: { select: { id: true, name: true, name_municipality: true, logoImage: true, timezone: true } },
     administrativeBody: true,
 } satisfies Prisma.CouncilMeetingInclude;
 

--- a/src/lib/db/notifications.ts
+++ b/src/lib/db/notifications.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { NotificationPreference, Petition, City, Topic, User, Location, Prisma } from '@prisma/client';
 import { auth, signIn } from "@/auth";
+import { signInFailurePath } from "@/lib/auth/signInResult";
 import { getCurrentUser, withUserAuthorizedToEdit } from "@/lib/auth";
 import { classifyDeliveries, deliveriesWhereForStatus } from '@/lib/notifications/deliveryStatus';
 import { attachGeometryToCities } from "./cities";
@@ -68,8 +69,16 @@ async function requireSelfOrSuperadmin(userId: string): Promise<void> {
 async function sendMagicLink(email: string) {
     try {
         // Use the existing signIn function with the resend provider
-        // This will create the user if they don't exist and send a magic link
-        await signIn("resend", { email }, { redirectTo: "/" });
+        // This will create the user if they don't exist and send a magic link.
+        // redirect: false — with the default, Auth.js throws NEXT_REDIRECT on
+        // success, so every sent magic link landed in the catch below and was
+        // logged as a failure.
+        const url: string = await signIn("resend", { email, redirect: false });
+        const failurePath = signInFailurePath(url);
+        if (failurePath) {
+            console.error(`Magic link not sent to ${email} (redirected to ${failurePath})`);
+            return false;
+        }
         console.log(`Magic link sent to ${email}`);
         return true;
     } catch (error) {

--- a/src/lib/db/subject.ts
+++ b/src/lib/db/subject.ts
@@ -217,6 +217,8 @@ export type MapSubjectRow = {
     cityName: string;
     nameMunicipality: string;
     logoImage: string | null;
+    /** IANA timezone of the city, so meeting dates render in the city's local day */
+    cityTimezone: string;
     councilMeetingId: string;
     meetingDate?: string;
     meetingName?: string;
@@ -258,7 +260,7 @@ const mapSubjectInclude = {
             administrativeBody: { select: { name: true, type: true } },
             // City display fields travel on every row so the client needn't reconcile against
             // the loaded city list (Subject reaches City only through councilMeeting).
-            city: { select: { name: true, name_municipality: true, logoImage: true } },
+            city: { select: { name: true, name_municipality: true, logoImage: true, timezone: true } },
         },
     },
     topic: { select: { name: true, name_en: true, colorHex: true, icon: true } },
@@ -320,6 +322,7 @@ function toGeneralSubjectRow(s: MapSubjectPayload, discussionSeconds: Map<string
         cityName: s.councilMeeting.city.name,
         nameMunicipality: s.councilMeeting.city.name_municipality,
         logoImage: s.councilMeeting.city.logoImage,
+        cityTimezone: s.councilMeeting.city.timezone,
         councilMeetingId: s.councilMeetingId,
         meetingDate: s.councilMeeting?.dateTime?.toISOString(),
         meetingName: s.councilMeeting?.name,

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -6,6 +6,7 @@
  */
 
 import { env } from '@/env.mjs';
+import { formatDate, formatDateTime, formatWeekday } from '@/lib/formatters/time';
 import { formatDurationMs } from '@/lib/formatters/time';
 import type { ReviewerInfo } from '@/lib/db/reviews';
 import type { PollDecisionsMeetingResult } from '@/lib/tasks/pollDecisions';
@@ -118,14 +119,7 @@ export async function sendMeetingCreatedAdminAlert(data: {
 }): Promise<void> {
     await sendAdminAlert({
         title: `🆕 ${data.cityId}: ${data.meetingId}`,
-        description: `Scheduled for ${data.meetingDate.toLocaleDateString('el-GR', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-            weekday: 'long',
-            hour: '2-digit',
-            minute: '2-digit'
-        })}`,
+        description: `Scheduled for ${formatWeekday(data.meetingDate)}, ${formatDateTime(data.meetingDate)}`,
         color: 0x00ff00, // Green
         fields: [
             {
@@ -140,11 +134,7 @@ export async function sendMeetingCreatedAdminAlert(data: {
             },
             {
                 name: 'Date',
-                value: data.meetingDate.toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                }),
+                value: formatDate(data.meetingDate, undefined, 'en'),
                 inline: false,
             },
             {

--- a/src/lib/email/templates/NotificationEmail.tsx
+++ b/src/lib/email/templates/NotificationEmail.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Section, Heading, Text, Button, Container } from '@react-email/components';
 import { BaseTemplate } from '../components/BaseTemplate';
+import { formatDate } from '@/lib/formatters/time';
 
 interface NotificationSubject {
     id: string;
@@ -35,11 +36,7 @@ export const NotificationEmail = ({
         ? 'Ειδοποίηση επερχόμενης συνεδρίασης'
         : 'Ειδοποίηση πρόσφατης συνεδρίασης';
 
-    const meetingDateFormatted = meetingDate.toLocaleDateString('el-GR', {
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric'
-    });
+    const meetingDateFormatted = formatDate(meetingDate);
 
     return (
         <BaseTemplate previewText={typeLabel}>

--- a/src/lib/formatters/time.ts
+++ b/src/lib/formatters/time.ts
@@ -33,6 +33,16 @@ export function getIntlLocale(locale: string): string {
 }
 
 /**
+ * The timezone that `formatDate`/`formatDateTime`/`formatNumericDateTime` use
+ * when the caller does not pass one. An omitted timezone must never mean "the
+ * machine's": the server renders in UTC and the browser in the visitor's zone,
+ * so the same call would produce different text on each side and break
+ * hydration (React error #418). Callers with a better zone in scope (a city's
+ * timezone) should still pass it.
+ */
+const DEFAULT_TIMEZONE = 'Europe/Athens';
+
+/**
  * Formats time in seconds to a human-readable string
  * @param time - Time in seconds
  * @returns Formatted string like "5:30" or "1:23:45"
@@ -102,16 +112,34 @@ export function formatDurationMs(ms: number): string {
 }
 
 /**
- * Formats a date to a relative time string (e.g., "2 hours ago", "3 days ago")
+ * Formats a date to a relative time string (e.g., "2 hours ago", "3 days ago").
+ *
+ * The output depends on the clock at render time, so the server and the
+ * hydrating client routinely produce different strings. A server-rendered
+ * element whose text comes from this function needs `suppressHydrationWarning`
+ * (or the `RelativeTime` component, which also keeps the text fresh).
+ *
  * @param date - The date to format
  * @param locale - The locale to use for formatting (defaults to 'el')
+ * @param options - `addSuffix` controls the "ago"/"in" wording (defaults to true)
  * @returns Formatted relative time string in the specified locale
  */
-export function formatRelativeTime(date: Date, locale: string = 'el'): string {
+export function formatRelativeTime(date: Date, locale: string = 'el', options?: { addSuffix?: boolean }): string {
   return formatDistanceToNow(date, {
-    addSuffix: true,
+    addSuffix: options?.addSuffix ?? true,
     locale: getDateFnsLocale(locale)
   });
+}
+
+/**
+ * The calendar date of a moment in a timezone, as `YYYY-MM-DD`. Documents and
+ * badges work in local dates, and a meeting stored at local midnight is stored
+ * before midnight UTC — the UTC (or machine) date would off-by-one every
+ * comparison for it. Always pass City.timezone; realms make Athens an
+ * assumption, not a fact.
+ */
+export function localCalendarDate(d: Date, timeZone: string): string {
+    return d.toLocaleDateString('en-CA', { timeZone });
 }
 
 /**
@@ -123,9 +151,7 @@ export function formatRelativeTime(date: Date, locale: string = 'el'): string {
 export function formatDate(date: Date, timezone?: string, locale: string = 'el'): string {
   const options: Intl.DateTimeFormatOptions = { dateStyle: 'long' };
 
-  if (timezone) {
-    options.timeZone = timezone;
-  }
+  options.timeZone = timezone || DEFAULT_TIMEZONE;
 
   const intlLocale = getIntlLocale(locale);
   if (date instanceof Date) {
@@ -144,19 +170,20 @@ export function formatDate(date: Date, timezone?: string, locale: string = 'el')
  * @param date - The date to format
  * @param timezone - Optional timezone
  * @param locale - 'el' (default) or 'en'; both produce day-first numeric output
+ * @param withSeconds - Include the seconds component (default: true)
  * @returns e.g. "04/05/2026 10:07:30"
  */
-export function formatNumericDateTime(date: Date, timezone?: string, locale: string = 'el'): string {
+export function formatNumericDateTime(date: Date, timezone?: string, locale: string = 'el', withSeconds: boolean = true): string {
     const options: Intl.DateTimeFormatOptions = {
         day: '2-digit',
         month: '2-digit',
         year: 'numeric',
         hour: '2-digit',
         minute: '2-digit',
-        second: '2-digit',
+        ...(withSeconds ? { second: '2-digit' as const } : {}),
         hour12: false,
     };
-    if (timezone) options.timeZone = timezone;
+    options.timeZone = timezone || DEFAULT_TIMEZONE;
 
     // en-GB rather than en-US so English output stays day-first numeric.
     const intlLocale = locale === 'en' ? 'en-GB' : getIntlLocale(locale);
@@ -174,12 +201,15 @@ export function formatNumericDateTime(date: Date, timezone?: string, locale: str
 export function formatDateTime(date: Date, timezone?: string, dateStyle: 'long' | 'medium' | 'short' = 'long', locale: string = 'el'): string {
   const options: Intl.DateTimeFormatOptions = {
     dateStyle,
-    timeStyle: 'short'
+    timeStyle: 'short',
+    // Pin the hour cycle. CLDR defaults Greek to 12-hour ("2:00 μ.μ."), but
+    // WebKit overrides the default with the device's 24-Hour Time setting, so
+    // server HTML and Safari/iOS in-app browsers disagreed on every rendered
+    // time and broke hydration (React error #418).
+    hour12: false,
   };
 
-  if (timezone) {
-    options.timeZone = timezone;
-  }
+  options.timeZone = timezone || DEFAULT_TIMEZONE;
 
   const intlLocale = getIntlLocale(locale);
   if (date instanceof Date) {

--- a/src/lib/formatters/time.ts
+++ b/src/lib/formatters/time.ts
@@ -40,7 +40,7 @@ export function getIntlLocale(locale: string): string {
  * hydration (React error #418). Callers with a better zone in scope (a city's
  * timezone) should still pass it.
  */
-const DEFAULT_TIMEZONE = 'Europe/Athens';
+export const DEFAULT_TIMEZONE = 'Europe/Athens';
 
 /**
  * Formats time in seconds to a human-readable string
@@ -140,6 +140,41 @@ export function formatRelativeTime(date: Date, locale: string = 'el', options?: 
  */
 export function localCalendarDate(d: Date, timeZone: string): string {
     return d.toLocaleDateString('en-CA', { timeZone });
+}
+
+/**
+ * Numeric date, compact for tables and message strings: `DD/MM/YYYY`.
+ * The date-only counterpart of `formatNumericDateTime`.
+ *
+ * @param date - The date to format
+ * @param timezone - Optional timezone
+ * @param locale - 'el' (default) or 'en'; both produce day-first numeric output
+ * @returns e.g. "04/05/2026"
+ */
+export function formatNumericDate(date: Date, timezone?: string, locale: string = 'el'): string {
+    const options: Intl.DateTimeFormatOptions = {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        timeZone: timezone || DEFAULT_TIMEZONE,
+    };
+    // en-GB rather than en-US so English output stays day-first numeric.
+    const intlLocale = locale === 'en' ? 'en-GB' : getIntlLocale(locale);
+    return new Intl.DateTimeFormat(intlLocale, options).format(date);
+}
+
+/**
+ * The long weekday name of a moment ("Δευτέρα", "Monday").
+ *
+ * @param date - The date to format
+ * @param timezone - Optional timezone
+ * @param locale - Optional locale (defaults to 'el')
+ */
+export function formatWeekday(date: Date, timezone?: string, locale: string = 'el'): string {
+    return new Intl.DateTimeFormat(getIntlLocale(locale), {
+        weekday: 'long',
+        timeZone: timezone || DEFAULT_TIMEZONE,
+    }).format(date);
 }
 
 /**

--- a/src/lib/landing/landingData.ts
+++ b/src/lib/landing/landingData.ts
@@ -33,7 +33,7 @@ export type LandingListCity = Pick<
 /** A serialized (Date → string) view of UpcomingMeetingWithCity, derived so it tracks the schema. */
 export type UpcomingMeeting = Pick<UpcomingMeetingWithCity, 'id' | 'cityId' | 'name'> & {
     dateTime: string;
-    city: Pick<UpcomingMeetingWithCity['city'], 'id' | 'name' | 'name_municipality' | 'logoImage'>;
+    city: Pick<UpcomingMeetingWithCity['city'], 'id' | 'name' | 'name_municipality' | 'logoImage' | 'timezone'>;
     administrativeBody: { name: string } | null;
 };
 
@@ -56,6 +56,8 @@ export type LandingSubject = {
     lng: number;
     /** meeting date as ISO string (missing for unscheduled data) */
     date: string | null;
+    /** IANA timezone of the city, so `date` renders as the city's local day */
+    cityTimezone: string;
     /** the street/area the subject refers to (Location.text) */
     where: string;
     /** the administrative body (όργανο) name, e.g. "Δημοτικό Συμβούλιο"; null when unknown */
@@ -227,6 +229,7 @@ export function toGeneralCities(
             lat: row.lat,
             lng: row.lng,
             date: s.meetingDate ?? null,
+            cityTimezone: s.cityTimezone,
             where: '',
             bodyName: s.bodyName ?? null,
             adminBodyType: s.adminBodyType ?? null,
@@ -275,6 +278,7 @@ export function toLandingSubjects(
                 lat,
                 lng,
                 date: s.meetingDate ?? null,
+                cityTimezone: s.cityTimezone,
                 where: s.locationText ?? '',
                 bodyName: s.bodyName ?? null,
                 adminBodyType: s.adminBodyType ?? null,

--- a/src/lib/notifications/content.ts
+++ b/src/lib/notifications/content.ts
@@ -5,6 +5,7 @@ import { NotificationEmail } from '@/lib/email/templates/NotificationEmail';
 import { env } from '@/env.mjs';
 import { stripMarkdown } from '@/lib/formatters/markdown';
 import { buildUnsubscribeUrl } from '@/lib/notifications/tokens';
+import { formatNumericDate } from '@/lib/formatters/time';
 
 interface NotificationSubject {
     id: string;
@@ -41,7 +42,7 @@ export async function generateEmailContent(notification: NotificationData): Prom
     body: string;
 }> {
     const meetingDate = new Date(notification.meeting.dateTime);
-    const meetingDateFormatted = meetingDate.toLocaleDateString('el-GR');
+    const meetingDateFormatted = formatNumericDate(meetingDate);
 
     const title = `${notification.city.name_municipality}: ${notification.meeting.administrativeBody?.name || 'Συνεδρίαση'} - ${meetingDateFormatted}`;
 
@@ -70,7 +71,7 @@ export async function generateEmailContent(notification: NotificationData): Prom
  */
 export async function generateSmsContent(notification: NotificationData): Promise<string> {
     const meetingDate = new Date(notification.meeting.dateTime);
-    const meetingDateFormatted = meetingDate.toLocaleDateString('el-GR');
+    const meetingDateFormatted = formatNumericDate(meetingDate);
     const subjectCount = notification.subjects.length;
 
     const adminBody = notification.meeting.administrativeBody?.name || 'συνεδρίαση';

--- a/src/lib/notifications/deliver.ts
+++ b/src/lib/notifications/deliver.ts
@@ -7,6 +7,7 @@ import {
     sendSMSMessage,
 } from './bird';
 import { sendAndPersistOutbound } from './outbound';
+import { formatDate } from '@/lib/formatters/time';
 import { env } from '@/env.mjs';
 
 /**
@@ -144,7 +145,7 @@ async function sendMessageDelivery(delivery: any): Promise<boolean> {
 
         // Prepare WhatsApp template parameters
         const templateParams = {
-            date: meeting.dateTime.toLocaleDateString('el-GR', { day: 'numeric', month: 'long', year: 'numeric' }),
+            date: formatDate(meeting.dateTime),
             cityName: notification.city.name,
             subjectsSummary: notification.subjects.slice(0, 3).map((ns: any) => ns.subject.name).join(', '),
             adminBody: meeting.administrativeBody?.name || 'Συνεδρίαση',

--- a/src/lib/serverSignIn.ts
+++ b/src/lib/serverSignIn.ts
@@ -2,10 +2,23 @@
 
 import { signIn } from "@/auth"
 import { safeRedirectPath } from "@/lib/safeRedirect"
+import { signInFailurePath } from "@/lib/auth/signInResult"
 
-export async function signInWithEmail(formData: FormData) {
+export async function signInWithEmail(formData: FormData): Promise<string> {
     const email = formData.get("email")
     const redirectTo = safeRedirectPath(formData.get("callbackUrl"))
     console.log(`Sign-in requested (redirectTo: ${redirectTo})`)
-    await signIn("resend", { email, redirectTo })
+    // redirect: false — with the default, Auth.js finishes by throwing Next's
+    // NEXT_REDIRECT through the caller's await, and the sign-in form reported
+    // every successful request as an error. Instead, return the verify-request
+    // URL and let the caller navigate to it.
+    const url: string = await signIn("resend", { email, redirectTo, redirect: false })
+    // Auth.js rethrows AuthError instances on its own; every other failure
+    // comes back as an error URL (see signInFailurePath). Throw so the form
+    // shows its error state instead of navigating there.
+    const failurePath = signInFailurePath(url)
+    if (failurePath) {
+        throw new Error(`Sign-in did not complete (redirected to ${failurePath})`)
+    }
+    return url
 }

--- a/src/lib/tasks/decisionWindow.ts
+++ b/src/lib/tasks/decisionWindow.ts
@@ -13,15 +13,6 @@ const MAX_WINDOW_DAYS = 45;
 const MIN_SAMPLE = 10;
 const HEADROOM = 1.5;
 
-/**
- * The city-local calendar date of a moment. Documents print local dates, and a
- * meeting stored at local midnight is stored before midnight UTC — using the
- * UTC date would off-by-one every declared-session comparison for it. Always
- * pass City.timezone; realms make Athens an assumption, not a fact.
- */
-export function localCalendarDate(d: Date, timeZone: string): string {
-    return d.toLocaleDateString('en-CA', { timeZone });
-}
 
 /** p95 of the city's publish-lag history (days), with headroom, clamped. */
 export function deriveWindowDays(lagsDays: number[]): number {

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -10,7 +10,8 @@ import { upsertDecision, deleteDecision, getDecisionForSubject, DECISION_ELIGIBL
 export { getDecisionForSubject };
 import { getCurrentUser, withUserAuthorizedToEdit } from "../auth";
 import { getPeopleForMeeting } from "../db/people";
-import { deriveWindowDays, localCalendarDate } from "./decisionWindow";
+import { deriveWindowDays } from "./decisionWindow";
+import { localCalendarDate } from "@/lib/formatters/time";
 import { getConflictingCandidates, applyCandidateConflictResolution, getUnresolvedCandidatesForMeeting } from "../db/decisionCandidates";
 import { isRoleActiveAt, isMayorRole } from "../utils/roles";
 import { shouldSkipPolling, getBackoffState, getPollableMeetingDateRange, BACKOFF_SCHEDULE, MAX_POLLING_DAYS, LOGODOSIA_NAME_PATTERN } from "./pollDecisionsBackoff";

--- a/src/lib/utils/meetingId.ts
+++ b/src/lib/utils/meetingId.ts
@@ -3,6 +3,10 @@
  * Example: 2026-04-20 → "apr20_2026"
  */
 export function formatDateAsMeetingId(date: Date): string {
+    // Deterministic despite the raw toLocaleDateString: locale and timezone are
+    // pinned. The produced strings are persisted meeting IDs, so a formatter
+    // swap would change the IDs.
+    // eslint-disable-next-line no-restricted-syntax
     return date
         .toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'Europe/Athens' })
         .toLowerCase()


### PR DESCRIPTION
## Summary

This PR fixes hydration mismatches (React error #418) caused by date formatting functions rendering differently on the server (UTC) and in the browser (visitor's timezone). The solution pins a default timezone (`Europe/Athens`) and hour cycle (24-hour) across all date formatters, ensuring consistent output between server and client.

## Key Changes

- **New `DEFAULT_TIMEZONE` constant**: All date formatters now use `Europe/Athens` as the default timezone instead of the machine's local timezone, preventing server/browser disagreement.

- **New formatter functions**:
  - `localCalendarDate()`: Returns calendar date in a given timezone as `YYYY-MM-DD` for local date comparisons (e.g., "is today?")
  - `formatNumericDate()`: Compact date format `DD/MM/YYYY` for tables and messages
  - `formatWeekday()`: Long weekday name ("Δευτέρα", "Monday")

- **Enhanced `formatNumericDateTime()`**: Added optional `withSeconds` parameter to control seconds display; now always uses `DEFAULT_TIMEZONE` when none provided.

- **Pinned hour cycle in `formatDateTime()`**: Added `hour12: false` to force 24-hour format, preventing WebKit from overriding with device settings (which broke hydration on Safari/iOS).

- **New `RelativeTime` component**: Client component that safely renders relative time strings ("2 hours ago") with `suppressHydrationWarning` and auto-refreshes every minute to keep text current.

- **Updated `formatRelativeTime()`**: Added optional `addSuffix` parameter; documented that output depends on render-time clock and requires `suppressHydrationWarning` or the `RelativeTime` component.

- **ESLint rules**: Added restrictions on raw `toLocaleDateString()`, `toLocaleTimeString()`, and `Intl.DateTimeFormat` outside `src/lib/formatters/` to enforce use of centralized formatters.

- **Auth flow improvements**:
  - `signInWithEmail()` now returns the verify-request URL instead of throwing; caller navigates to it
  - New `signInFailurePath()` utility to distinguish Auth.js error URLs from success URLs
  - Fixed bfcache issue in sign-in form by resetting `isLoading` on page restore

- **Widespread formatter adoption**: Updated 20+ components and utilities to use the new timezone-aware formatters instead of raw `toLocaleDateString()` or `date-fns` functions without timezone context.

## Notable Implementation Details

- `MeetingCard` now compares calendar dates in the city's timezone to correctly determine "isToday" across server/browser
- Meeting cards re-render at the meeting start time to flip from countdown to "today" label
- OG image templates use `formatInTimeZone` from `date-fns-tz` to ensure all dates on the image render in the same timezone
- All timezone-dependent comparisons (documents, badges, notifications) now use `localCalendarDate()` with the city's timezone
- Test updates reflect the pinned 24-hour clock and `Europe/Athens` default (e.g., `14:30Z` → `16:30` in Athens, not `4:30 μ.μ.`)

https://claude.ai/code/session_01Bb7iQH26UG2Kmw3oqvTqWr



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes timezone-aware date formatting to prevent server/client hydration mismatches and updates affected presentation, notification, task, and authentication paths.
- Pins the default timezone and 24-hour clock behavior in shared formatters.
- Adds calendar-date, numeric-date, weekday, and self-refreshing relative-time helpers.
- Migrates date rendering across public, administrative, document, notification, and social-image surfaces.
- Chains long meeting-start timers so cards transition correctly even when meetings are more than one platform timeout interval away.
- Improves email sign-in result handling and restores loading state after browser history navigation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported long-delay meeting timer now reschedules until the meeting start and triggers the required render transition.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/formatters/time.ts | Centralizes deterministic timezone-aware date, time, weekday, calendar-date, and relative-time formatting. |
| src/components/meetings/MeetingCard.tsx | Uses city-local calendar comparisons and chained start-time scheduling; the previously reported capped-timer failure is resolved. |
| src/components/RelativeTime.tsx | Provides hydration-safe client-side relative-time rendering with periodic refresh. |
| src/lib/auth/signInResult.ts | Separates Auth.js failure destinations from successful sign-in redirect URLs. |
| src/components/user/sign-in.tsx | Navigates using the returned sign-in destination and resets loading state when restored from browser history. |
| eslint.config.mjs | Restricts direct locale-sensitive date APIs outside the centralized formatter module. |

<sub>Reviews (2): Last reviewed commit: ["chore(lint): confine raw date formatting..."](https://github.com/schemalabz/opencouncil/commit/075f9c3233a907b29fb019c11b2d1fe722ea392e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58605753)</sub>

<!-- /greptile_comment -->