### PR TITLE
fix(proxy): answer headerless multipart POSTs with 404

### DIFF
--- a/src/lib/__tests__/multipartPostGuard.test.ts
+++ b/src/lib/__tests__/multipartPostGuard.test.ts
@@ -1,0 +1,38 @@
+import { isHeaderlessMultipartPost } from '../multipartPostGuard';
+
+const MULTIPART = 'multipart/form-data; boundary=----WebKitFormBoundaryx8jO2oVc6SWP3Sad';
+const ACTION_ID = '7f8e9d0c1b2a3f4e5d6c7b8a9f0e1d2c3b4a5f6e7d';
+
+describe('isHeaderlessMultipartPost', () => {
+    it('flags a multipart POST that carries no Next-Action header', () => {
+        expect(isHeaderlessMultipartPost('POST', MULTIPART, null)).toBe(true);
+    });
+
+    it('lets a server action with a file argument through (multipart with the header)', () => {
+        expect(isHeaderlessMultipartPost('POST', MULTIPART, ACTION_ID)).toBe(false);
+    });
+
+    it('treats an empty Next-Action header as present, as Next does', () => {
+        expect(isHeaderlessMultipartPost('POST', MULTIPART, '')).toBe(false);
+    });
+
+    it('lets a plain server action through (text/plain with the header)', () => {
+        expect(isHeaderlessMultipartPost('POST', 'text/plain;charset=UTF-8', ACTION_ID)).toBe(false);
+    });
+
+    it('ignores non-multipart POSTs, which Next answers with the page', () => {
+        expect(isHeaderlessMultipartPost('POST', 'application/x-www-form-urlencoded', null)).toBe(false);
+        expect(isHeaderlessMultipartPost('POST', 'application/json', null)).toBe(false);
+        expect(isHeaderlessMultipartPost('POST', null, null)).toBe(false);
+    });
+
+    it('matches the media type case-sensitively, exactly as Next classifies it', () => {
+        // Next never routes `Multipart/Form-Data` to the action handler; it renders the page.
+        expect(isHeaderlessMultipartPost('POST', 'Multipart/Form-Data; boundary=x', null)).toBe(false);
+    });
+
+    it('ignores other methods regardless of content type', () => {
+        expect(isHeaderlessMultipartPost('GET', MULTIPART, null)).toBe(false);
+        expect(isHeaderlessMultipartPost('PUT', MULTIPART, null)).toBe(false);
+    });
+});

--- a/src/lib/multipartPostGuard.ts
+++ b/src/lib/multipartPostGuard.ts
@@ -1,0 +1,32 @@
+/**
+ * Decide whether a request is a multipart POST that carries no Next-Action
+ * header. Next.js treats such a request as a no-JavaScript submission of
+ * a server-action form: it parses the body for `$ACTION_ID_` fields and,
+ * when it finds none it recognises, throws instead of answering 404
+ * (vercel/next.js#90090). In production that throw is a 500 and an
+ * onRequestError alert. This app has no no-JavaScript server-action forms,
+ * so the request can never be legitimate; vulnerability scanners send it
+ * to `/` several times a day. The proxy answers 404 before anything renders.
+ *
+ * The match mirrors Next's own classification (case-sensitive method and
+ * media type) so the guard covers exactly the requests Next would throw
+ * on. A POST that carries the header, even empty, is a fetch-style server
+ * action that Next resolves itself (an unknown ID gets a quiet 404). Other
+ * content types never reach the throwing branch.
+ *
+ * Relax this guard before adding a `<form action={serverAction}>`,
+ * `formAction={serverAction}`, or `useActionState` form: a submit before
+ * hydration posts exactly this shape. Remove it once the upstream fix
+ * ships.
+ *
+ * Pure function so the proxy's decision is unit-testable.
+ */
+export function isHeaderlessMultipartPost(
+    method: string,
+    contentTypeHeader: string | null,
+    nextActionHeader: string | null,
+): boolean {
+    if (method !== 'POST') return false;
+    if (nextActionHeader !== null) return false;
+    return (contentTypeHeader ?? '').startsWith('multipart/form-data');
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,6 +7,7 @@ import { REALMS, REALM_OVERRIDE_COOKIE, isRealm, isRealmApexHost, realmForHost, 
 import { LOCALE_PREFIX_RE, SERBIAN_SCRIPT_COOKIE, foreignLocaleRedirectPath, serbianScriptAdoption, serbianScriptParamTarget, serbianScriptRedirectPath, wwwRedirectTarget } from './lib/seo-redirects';
 import { isSerbianScript } from './lib/serbian/transliterate';
 import { mcpRewriteTarget } from './lib/mcp/rewrite';
+import { isHeaderlessMultipartPost } from './lib/multipartPostGuard';
 import { applySessionMirror } from './lib/auth/sessionMirror';
 
 const i18nMiddleware = createIntlMiddleware(routing);
@@ -39,6 +40,12 @@ async function proxyInner(req: NextRequest): Promise<Response | undefined> {
     }
 
     if (JUNK_PATH.test(req.nextUrl.pathname)) {
+        return new NextResponse(null, { status: 404 });
+    }
+
+    // Scanner probes for server actions; see isHeaderlessMultipartPost for
+    // why Next itself would answer them with a 500 instead of a 404.
+    if (isHeaderlessMultipartPost(req.method, req.headers.get('content-type'), req.headers.get('next-action'))) {
         return new NextResponse(null, { status: 404 });
     }
 


### PR DESCRIPTION
## Problem

Since 2026-09-02 15:12 UTC, production sends Discord alerts for `POST /` on `/[locale]/(landing-immersive)/page`:

```
Error - App Router render
Error: Failed to find Server Action. This request might be from an older or newer deployment.
```

28 alerts arrived in the first 18 hours. Staging shows the same pattern from 15:08 UTC the same day.

The message points at deployment skew, but there is no skew. The requests are vulnerability-scanner probes, and a Next.js bug turns them into 500s.

## Mechanism

Next.js treats a `multipart/form-data` POST **without** a `Next-Action` header as a no-JavaScript submission of a server-action form. It parses the body for `$ACTION_ID_` fields. When it finds none that it recognises, `areAllActionIdsValid` returns false and the handler throws instead of answering 404. In production the throw is a 500 and reaches `onRequestError`, which posts to Discord. A POST **with** the header takes the fetch-action path and gets a quiet 404 with `x-nextjs-action-not-found: 1`.

Upstream: vercel/next.js#90090 (open; #95447 closed as its duplicate on 2026-08-31). Fix PRs #90101 and #91129 are unmerged. The throw is still present in v16.3.4 and in canary.

Reproduced on preview pr-694, which has no Discord webhook:

| Request to `/` | Result |
|---|---|
| multipart POST, plain field, no header | 500 |
| multipart POST, empty body | 500 |
| multipart POST, unknown `$ACTION_ID_` field | 500 |
| urlencoded POST | 200 |
| JSON POST | 200 |
| POST with a stale `Next-Action` header | 404 |

## Evidence that the sender is a scanner

- Every burst in the production logs follows, by 4 to 8 seconds, the warning `The Server Reference ID did not match the expected format` with a random 40-character ID. Next 16 expects 42 characters. Then two headerless multipart POSTs arrive about half a second apart. All 13 bursts match this shape; staging shows the identical shape.
- The served landing HTML contains no `<form>` tag and no `$ACTION_ID_` field, so no browser can submit this from that page. Nothing in the repo posts FormData to a page path, only to `/api` routes.
- The preview host's Caddy access log shows older React2Shell-style scanners (`Next-Action: x`, WebKitFormBoundary bodies, paths `/`, `/en`, `/_flight`, `/api/rsc`, `/_next/rsc`, `/rsc`) since Aug 21. Those carry the header, so they never alert. The headerless variant is new since Sep 2.
- Nothing relevant changed in the Sep 2 deploy. Next.js has been 16.2.12 since the Aug 26 deploy, `onRequestError` exists since May, and the proxy had no POST handling.

## Change

`isHeaderlessMultipartPost` is a pure helper with unit tests. The proxy answers 404 when it matches, right after the junk-path check and before any auth or rendering work. The app has no no-JavaScript server-action forms (no `<form action={`, `useActionState`, or `formAction=` anywhere in `src`), so the request is never legitimate. A future no-JavaScript form would need this guard relaxed; the helper's doc comment says so. Remove the guard when the upstream fix ships.

The Next.js upgrade in #707 does not change this behaviour.

## Verified on preview pr-708

Same request set as the reproduction above, sent at 2026-09-03 10:20 UTC. The preview journal logged no `Failed to find Server Action` and no `onRequestError` line during the window.

| Request to `/` | Before (pr-694) | After (pr-708) |
|---|---|---|
| multipart POST, plain field, no header | 500 | 404, empty body |
| multipart POST, empty body | 500 | 404, empty body |
| multipart POST, unknown `$ACTION_ID_` field | 500 | 404, empty body |
| urlencoded POST | 200 | 200 |
| JSON POST | 200 | 200 |
| POST with a stale `Next-Action` header | 404 | 404, `x-nextjs-action-not-found: 1` |
| GET | 200 | 200 |
| multipart POST to `/mcp`, no header | 500 | 404 |
