### PR TITLE
fix(analytics): report google places failures to posthog

### DIFF
--- a/src/lib/__tests__/google-maps.test.ts
+++ b/src/lib/__tests__/google-maps.test.ts
@@ -1,0 +1,246 @@
+import posthog from 'posthog-js';
+import { getPlaceSuggestions, getPlaceDetails } from '@/lib/google-maps';
+import { getPlaceSuggestions as fetchPlaceSuggestions, getPlaceDetails as fetchPlaceDetails } from '@/lib/actions';
+
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: {
+        __loaded: true,
+        captureException: jest.fn(),
+    },
+}));
+
+jest.mock('@/lib/actions', () => ({
+    getPlaceSuggestions: jest.fn(),
+    getPlaceDetails: jest.fn(),
+}));
+
+const mockedPosthog = posthog as jest.Mocked<typeof posthog>;
+const suggestionsAction = fetchPlaceSuggestions as jest.MockedFunction<typeof fetchPlaceSuggestions>;
+const detailsAction = fetchPlaceDetails as jest.MockedFunction<typeof fetchPlaceDetails>;
+
+describe('google-maps failure reporting', () => {
+    beforeEach(() => {
+        // resetAllMocks, not clearAllMocks: the action stubs and any
+        // captureException implementation set by one test must not reach the
+        // next one. restoreAllMocks below only covers the console spy.
+        jest.resetAllMocks();
+        mockedPosthog.__loaded = true;
+        jest.spyOn(console, 'error').mockImplementation(() => { });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('reports an expired API key with the Google status attached', async () => {
+        // What the action returns for an expired key: Google answers 200 with
+        // REQUEST_DENIED, so the status reaches the caller.
+        suggestionsAction.mockResolvedValue({
+            success: true,
+            data: {
+                status: 'REQUEST_DENIED',
+                error_message: 'The provided API key is expired.',
+            },
+        });
+
+        const result = await getPlaceSuggestions('Πατησίων 100');
+
+        // The status drives the user-facing message in LocationSelector.
+        expect(result.error).toMatchObject({ type: 'API_ERROR', status: 'REQUEST_DENIED' });
+        expect(mockedPosthog.captureException).toHaveBeenCalledTimes(1);
+        const [error, props] = mockedPosthog.captureException.mock.calls[0];
+        expect((error as Error).message).toContain('The provided API key is expired.');
+        expect(props).toMatchObject({
+            places_operation: 'suggestions',
+            places_status: 'REQUEST_DENIED',
+        });
+    });
+
+    it('reports a non-OK Google status with the status attached', async () => {
+        suggestionsAction.mockResolvedValue({
+            success: true,
+            data: { status: 'OVER_QUERY_LIMIT' },
+        });
+
+        const result = await getPlaceSuggestions('Πατησίων 100');
+
+        expect(result.error).toMatchObject({ type: 'API_ERROR', status: 'OVER_QUERY_LIMIT' });
+        expect(mockedPosthog.captureException).toHaveBeenCalledTimes(1);
+        expect(mockedPosthog.captureException.mock.calls[0][1]).toMatchObject({
+            places_operation: 'suggestions',
+            places_status: 'OVER_QUERY_LIMIT',
+        });
+    });
+
+    it('reports a failed suggestions action without a Google status', async () => {
+        // A failed Result means the action itself failed (no API key, network
+        // throw), so there is no Google status to attach.
+        suggestionsAction.mockResolvedValue({ success: false, error: 'API configuration error' });
+
+        const result = await getPlaceSuggestions('Πατησίων 100');
+
+        expect(result.error).toMatchObject({ type: 'API_ERROR', status: 'UNKNOWN' });
+        expect(mockedPosthog.captureException).toHaveBeenCalledTimes(1);
+        const [error, props] = mockedPosthog.captureException.mock.calls[0];
+        expect((error as Error).message).toContain('API configuration error');
+        expect(props).toMatchObject({ places_operation: 'suggestions' });
+        expect(props).not.toHaveProperty('places_status');
+    });
+
+    it('does not report ZERO_RESULTS', async () => {
+        suggestionsAction.mockResolvedValue({
+            success: true,
+            data: { status: 'ZERO_RESULTS' },
+        });
+
+        const result = await getPlaceSuggestions('Πατησίων 100');
+
+        expect(result).toEqual({ data: [] });
+        expect(mockedPosthog.captureException).not.toHaveBeenCalled();
+    });
+
+    it('does not report a successful lookup', async () => {
+        suggestionsAction.mockResolvedValue({
+            success: true,
+            data: {
+                status: 'OK',
+                predictions: [{ place_id: 'abc', description: 'Πατησίων 100, Αθήνα' }],
+            },
+        });
+
+        const result = await getPlaceSuggestions('Πατησίων 100');
+
+        expect(result.data).toHaveLength(1);
+        expect(mockedPosthog.captureException).not.toHaveBeenCalled();
+    });
+
+    it('reports a failed details action to PostHog', async () => {
+        detailsAction.mockResolvedValue({ success: false, error: 'API configuration error' });
+
+        const result = await getPlaceDetails('abc');
+
+        expect(result).toBeNull();
+        expect(mockedPosthog.captureException).toHaveBeenCalledTimes(1);
+        expect(mockedPosthog.captureException.mock.calls[0][1]).toMatchObject({
+            places_operation: 'details',
+        });
+    });
+
+    it('reports a non-OK details status with the status attached', async () => {
+        detailsAction.mockResolvedValue({ success: true, data: { status: 'NOT_FOUND' } });
+
+        const result = await getPlaceDetails('abc');
+
+        expect(result).toBeNull();
+        expect(mockedPosthog.captureException).toHaveBeenCalledTimes(1);
+        expect(mockedPosthog.captureException.mock.calls[0][1]).toMatchObject({
+            places_operation: 'details',
+            places_status: 'NOT_FOUND',
+        });
+    });
+
+    // The message assertions below separate each guard from the catch block,
+    // which reports the same props and also returns null.
+    it('reports an OK details response with no result', async () => {
+        detailsAction.mockResolvedValue({ success: true, data: { status: 'OK' } });
+
+        const result = await getPlaceDetails('abc');
+
+        expect(result).toBeNull();
+        expect(mockedPosthog.captureException).toHaveBeenCalledTimes(1);
+        const [error, props] = mockedPosthog.captureException.mock.calls[0];
+        expect((error as Error).message).toContain('Result missing in place details');
+        expect(props).toMatchObject({ places_operation: 'details' });
+    });
+
+    it('reports place details with no geometry', async () => {
+        detailsAction.mockResolvedValue({
+            success: true,
+            data: { status: 'OK', result: { formatted_address: 'Πατησίων 100, Αθήνα' } },
+        });
+
+        const result = await getPlaceDetails('abc');
+
+        expect(result).toBeNull();
+        const [error] = mockedPosthog.captureException.mock.calls[0];
+        expect((error as Error).message).toContain('Location geometry missing in place details');
+    });
+
+    it('reports place details with no formatted address', async () => {
+        detailsAction.mockResolvedValue({
+            success: true,
+            data: { status: 'OK', result: { geometry: { location: { lat: 37.99, lng: 23.73 } } } },
+        });
+
+        const result = await getPlaceDetails('abc');
+
+        expect(result).toBeNull();
+        const [error] = mockedPosthog.captureException.mock.calls[0];
+        expect((error as Error).message).toContain('Formatted address missing in place details');
+    });
+
+    it('returns the address and [lng, lat] coordinates for a complete result', async () => {
+        detailsAction.mockResolvedValue({
+            success: true,
+            data: {
+                status: 'OK',
+                result: {
+                    formatted_address: 'Πατησίων 100, Αθήνα',
+                    geometry: { location: { lat: 37.99, lng: 23.73 } },
+                },
+            },
+        });
+
+        const result = await getPlaceDetails('abc');
+
+        expect(result).toEqual({ text: 'Πατησίων 100, Αθήνα', coordinates: [23.73, 37.99] });
+        expect(mockedPosthog.captureException).not.toHaveBeenCalled();
+    });
+
+    it('reports an OK response that carries no prediction list', async () => {
+        suggestionsAction.mockResolvedValue({ success: true, data: { status: 'OK' } });
+
+        const result = await getPlaceSuggestions('Πατησίων 100');
+
+        expect(result).toEqual({ data: [] });
+        const [error] = mockedPosthog.captureException.mock.calls[0];
+        expect((error as Error).message).toContain('Predictions missing in place suggestions');
+    });
+
+    it('reports the same failure once per page load', async () => {
+        suggestionsAction.mockResolvedValue({ success: true, data: { status: 'UNKNOWN_ERROR' } });
+
+        await getPlaceSuggestions('Πατησίων 100');
+        await getPlaceSuggestions('Πατησίων 100');
+        await getPlaceSuggestions('Σταδίου 5');
+
+        // The autocomplete calls the action on every debounced keystroke, so an
+        // outage would otherwise send one exception per keypress.
+        expect(mockedPosthog.captureException).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the API error when PostHog itself throws', async () => {
+        mockedPosthog.captureException.mockImplementation(() => {
+            throw new Error('posthog is broken');
+        });
+        suggestionsAction.mockResolvedValue({ success: true, data: { status: 'INVALID_REQUEST' } });
+
+        const result = await getPlaceSuggestions('Πατησίων 100');
+
+        // Reporting happens inside the caller's try block. A throw there would
+        // be caught as a network error and mislabel the failure.
+        expect(result.error).toMatchObject({ type: 'API_ERROR', status: 'INVALID_REQUEST' });
+    });
+
+    it('stays silent when PostHog is not initialised', async () => {
+        mockedPosthog.__loaded = false;
+        // A cause no earlier test used: the dedupe set lives for the module's
+        // lifetime, so a repeated cause would mask the guard under test.
+        suggestionsAction.mockResolvedValue({ success: false, error: 'Action failed while posthog is off' });
+
+        await getPlaceSuggestions('Πατησίων 100');
+
+        expect(mockedPosthog.captureException).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -60,14 +60,15 @@ export async function getPlaceSuggestions(data: {
         });
         console.log('Response status:', response.data.status);
 
-        // Handle different Google API response statuses
-        if (response.data.status === 'ZERO_RESULTS') {
-            // ZERO_RESULTS is not an error, it's a valid response with no results
-            return createSuccess({ status: 'ZERO_RESULTS', predictions: [] });
-        } else if (response.data.status !== 'OK') {
+        // Pass the Google status through instead of collapsing it into an
+        // error. The caller needs the status: it selects the user-facing
+        // message (REQUEST_DENIED and OVER_QUERY_LIMIT read differently) and it
+        // tags the PostHog report. A failed Result now means that this action
+        // failed, not that Google refused the request.
+        //
+        // ZERO_RESULTS is a valid empty answer, so it is not logged.
+        if (response.data.status !== 'OK' && response.data.status !== 'ZERO_RESULTS') {
             console.error('Google Places API returned non-OK status:', response.data.status);
-            const errorMsg = `Google API error: ${response.data.status}${response.data.error_message ? ': ' + response.data.error_message : ''}`;
-            return createError(errorMsg);
         }
 
         return createSuccess(response.data);
@@ -105,10 +106,9 @@ export async function getPlaceDetails(data: { placeId: string; language?: string
             timeout: 5000 // Set timeout to 5 seconds
         });
 
+        // Pass the status through, for the same reason as getPlaceSuggestions.
         if (response.data.status !== 'OK') {
             console.error('Google Places Details API returned non-OK status:', response.data.status);
-            const errorMsg = `Google API error: ${response.data.status}${response.data.error_message ? ': ' + response.data.error_message : ''}`;
-            return createError(errorMsg);
         }
 
         return createSuccess(response.data);

--- a/src/lib/google-maps.ts
+++ b/src/lib/google-maps.ts
@@ -1,3 +1,4 @@
+import posthog from 'posthog-js';
 import { getPlaceSuggestions as fetchPlaceSuggestions, getPlaceDetails as fetchPlaceDetails } from './actions';
 import { ApiResult } from '@/lib/result';
 
@@ -22,6 +23,62 @@ export type PlaceSuggestionsError = {
 
 // Result type that can either be suggestions or an error
 export type PlaceSuggestionsResult = ApiResult<PlaceSuggestion[], PlaceSuggestionsError>;
+
+type PlacesOperation = 'suggestions' | 'details';
+
+// The fields of a Google autocomplete prediction that this module reads. The
+// server action passes Google's body through untyped, so this is the contract
+// the mapping below relies on.
+type PlacePrediction = {
+    place_id: string;
+    description: string;
+};
+
+// One PostHog report per distinct failure per page load. getPlaceSuggestions
+// runs on every debounced keystroke, so an outage that lasts a session sends
+// one exception per keypress without this. The set stays empty on the server,
+// where the guard below returns first.
+const reportedPlacesFailures = new Set<string>();
+
+/**
+ * Log a Google Places failure and report it to PostHog.
+ *
+ * These failures never throw: the server action returns a Result, and the
+ * functions below turn it into an empty list or null. Nothing reaches
+ * window.onerror, so PostHog's exception autocapture never sees them. An
+ * expired API key broke the notification signup with no trace in PostHog.
+ *
+ * PostHog is initialised only when the project token is set and outside embed
+ * routes, so the guard follows the analytics helpers (captureHighlight,
+ * SubjectReadTracker). It also swallows every server-side call, where this
+ * module runs for search filter extraction and PostHog never loads. The
+ * console line runs before the guard, so those failures still reach the server
+ * log.
+ *
+ * Nothing in here throws. The callers report from inside their own try block,
+ * where a throw becomes a caught network error and mislabels the failure.
+ */
+function reportPlacesFailure(operation: PlacesOperation, cause: unknown, status?: string): void {
+    console.error(`Google Places ${operation} failed${status ? ` (${status})` : ''}:`, cause);
+    try {
+        if (!posthog.__loaded) return;
+
+        const description = cause instanceof Error ? cause.message : String(cause);
+        const key = `${operation}:${status ?? ''}:${description}`;
+        if (reportedPlacesFailures.has(key)) return;
+        reportedPlacesFailures.add(key);
+
+        const error = cause instanceof Error
+            ? cause
+            : new Error(`Google Places ${operation} failed: ${description}`);
+        posthog.captureException(error, {
+            ...(status && { places_status: status }),
+            places_operation: operation
+        });
+    } catch (reportingError) {
+        console.error('Failed to report a Google Places failure:', reportingError);
+    }
+}
 
 /**
  * Get place suggestions based on input text
@@ -51,7 +108,7 @@ export async function getPlaceSuggestions(
 
         // Check if the server action failed
         if (!result.success) {
-            console.error('Error getting place suggestions:', result.error);
+            reportPlacesFailure('suggestions', result.error);
             return {
                 data: [],
                 error: {
@@ -71,19 +128,24 @@ export async function getPlaceSuggestions(
                 return { data: [] };
             }
 
+            // Google names the field error_message, and sends it only for some
+            // statuses (REQUEST_DENIED carries the reason, OVER_QUERY_LIMIT does not).
+            const message = `Google API error: ${response.status}${response.error_message ? `: ${response.error_message}` : ''}`;
+            reportPlacesFailure('suggestions', message, response.status);
             return {
                 data: [],
                 error: {
                     type: 'API_ERROR',
-                    message: response.error || `Google API error: ${response.status}`,
+                    message,
                     status: response.status
                 }
             };
         }
 
         // Check if we have valid predictions
-        if (response.predictions && Array.isArray(response.predictions)) {
-            const suggestions = response.predictions.map((prediction: any) => ({
+        if (Array.isArray(response.predictions)) {
+            const predictions: PlacePrediction[] = response.predictions;
+            const suggestions = predictions.map((prediction) => ({
                 id: prediction.place_id,
                 placeId: prediction.place_id,
                 text: prediction.description
@@ -91,9 +153,13 @@ export async function getPlaceSuggestions(
             return { data: suggestions };
         }
 
+        // An OK status with no prediction list is indistinguishable from a real
+        // empty result for the caller, so report it rather than let it pass as
+        // "no matches in this municipality".
+        reportPlacesFailure('suggestions', 'Predictions missing in place suggestions', response.status);
         return { data: [] };
     } catch (error) {
-        console.error('Error fetching place suggestions:', error);
+        reportPlacesFailure('suggestions', error);
         return {
             data: [],
             error: {
@@ -118,7 +184,7 @@ export async function getPlaceDetails(placeId: string, language?: string): Promi
 
         // Check if the server action failed
         if (!result.success) {
-            console.error('Error getting place details:', result.error);
+            reportPlacesFailure('details', result.error);
             return null;
         }
 
@@ -126,28 +192,40 @@ export async function getPlaceDetails(placeId: string, language?: string): Promi
 
         // Check for Google API error status
         if (response.status !== 'OK') {
-            console.error('Error getting place details:', response.status);
+            const message = `Google API error: ${response.status}${response.error_message ? `: ${response.error_message}` : ''}`;
+            reportPlacesFailure('details', message, response.status);
             return null;
         }
 
-        // Check if we have a valid result
-        if (response.result && response.status === 'OK') {
-            const { formatted_address, geometry } = response.result;
-
-            if (!geometry || !geometry.location) {
-                console.error('Location geometry missing in place details');
-                return null;
-            }
-
-            return {
-                text: formatted_address,
-                coordinates: [geometry.location.lng, geometry.location.lat]
-            };
+        // An OK status does not guarantee a body, and the server action passes
+        // the response through without reading it, so an empty result reaches
+        // this point.
+        if (!response.result) {
+            reportPlacesFailure('details', 'Result missing in place details');
+            return null;
         }
 
-        return null;
+        const { formatted_address, geometry } = response.result;
+
+        if (!geometry || !geometry.location) {
+            reportPlacesFailure('details', 'Location geometry missing in place details');
+            return null;
+        }
+
+        // Google omits formatted_address for some place types. Returning it
+        // unchecked puts `text: undefined` behind a `text: string` type, and the
+        // caller stores that as the location's label.
+        if (!formatted_address) {
+            reportPlacesFailure('details', 'Formatted address missing in place details');
+            return null;
+        }
+
+        return {
+            text: formatted_address,
+            coordinates: [geometry.location.lng, geometry.location.lat]
+        };
     } catch (error) {
-        console.error('Error fetching place details:', error);
+        reportPlacesFailure('details', error);
         return null;
     }
 } 


### PR DESCRIPTION
## Problem

An expired `GOOGLE_API_KEY` broke the location step of the notification signup on production. PostHog showed no trace of it. Two separate causes hid the failure.

**A Google Places failure never throws.** The error is a value at every level: `src/lib/actions.ts` returns a `Result`, `src/lib/google-maps.ts` turns that into an empty list or `null`, and `LocationSelector` puts the message in `setError()` state.

`instrumentation-client.ts` sets `capture_exceptions: true`. In posthog-js that resolves to `capture_unhandled_errors: true`, `capture_unhandled_rejections: true`, `capture_console_errors: false`. PostHog hooks `window.onerror` and `window.onunhandledrejection` only. It does not read `console.error`. Nothing threw, so PostHog saw a normal session. The Discord alert stayed quiet for the same reason: `onRequestError` in `src/instrumentation.ts` fires only on thrown errors.

**The server action discarded the Google status.** `src/lib/actions.ts` collapsed every non-OK status into an error string, so a successful `Result` could only carry `OK` or `ZERO_RESULTS`. The `status !== 'OK'` branches in `src/lib/google-maps.ts` were therefore unreachable, and the reachable path hardcoded `status: 'UNKNOWN'`.

That cost the user too. `LocationSelector` selects its message from `REQUEST_DENIED` and `OVER_QUERY_LIMIT`. Both branches were dead, so during the incident a user saw "Location search error (UNKNOWN). Please try again." for a permanently broken service. The correct string was already translated in all four locales.

## Change

**`src/lib/actions.ts`** passes the Google response through instead of collapsing the status. A failed `Result` now means that the action failed, not that Google refused the request. This makes the status branches live and lights up the existing translations.

**`src/lib/google-maps.ts`** gains a `reportPlacesFailure` helper that calls `posthog.captureException`. It:

- owns the `console.error`, so the log and the report cannot diverge;
- sends one report per distinct failure per page load, because the autocomplete calls the action on every debounced keystroke;
- cannot throw — the callers report from inside a try block, where a throw would mislabel an API error as a network error;
- reads `error_message`, which is the field Google sends (the previous code read `error`, which does not exist).

Every failure exit reports: a failed action, a non-OK Google status, a thrown request, and four malformed-response cases. `ZERO_RESULTS` and successful lookups stay silent. Each event carries `places_operation`, plus `places_status` where Google supplies one.

Two paths that passed silently before now report: a suggestions response with no prediction list, and a place details result with no `formatted_address`. The second one previously put `text: undefined` behind a `text: string` signature.

## Notes for the reviewer

- The `if (!posthog.__loaded) return` guard follows `src/lib/highlights/analytics.ts`. It covers a contributor setup with no project token, and the server, where PostHog never loads.
- This PR adds a `posthog-js` import to a module that server code imports through `src/lib/search/filters.ts`. The import is inert on the server, but it does enter the server bundle: `.next/server/chunks/src_lib_0bdx5s1._.js` measures 240,877 bytes and carries the browser SDK.

## Open, and out of scope here

- **The server path reports nothing.** `src/lib/search/filters.ts` calls both functions on the server, where `posthog.__loaded` is always false. An expired key silently drops every location filter from search. Closing this, and the bundle note above, means reporting from the server action with `posthog-node` (already used in `src/lib/mcp/analytics.ts`) or with `sendErrorAdminAlert`. That placement would also cover the embed surface, where analytics is off by design. It is a larger change than this PR.
- **The onboarding flow emits no step events.** `OnboardingContext.tsx` captures `notification_signup_completed` on success only, so a drop shows as completions falling to zero.

## Verification

- `npm test` — 137 suites, 1816 tests, including 15 in `src/lib/__tests__/google-maps.test.ts`.
- `npx tsc --noEmit`, `npx tsc --project tsconfig.jest.json --noEmit` — clean for `src/`.
- `npx eslint --max-warnings 0` on the changed files — clean.
- `npm run build` — passes.
- Each new guard is mutation-tested: removing the dedupe, the try/catch, the `__loaded` guard, the predictions report, or a `PlacePrediction` field each fails a test or the typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJhiSBc3W2aPDkjgrdTFTs