### PR TITLE
feat(subjects): keep the verbatim agenda item title

### DIFF
--- a/docs/guides/meeting-minutes.md
+++ b/docs/guides/meeting-minutes.md
@@ -49,6 +49,9 @@ Minutes include utterances linked to each subject via `Utterance.discussionSubje
 
 This linking is currently AI-driven with no manual editing UI. Misclassified or unlinked utterances silently disappear from the minutes output.
 
+### Subject headings print the official agenda title
+`Subject.agendaItemTitle` holds the item as written on the official agenda. `processAgenda` fills it for new meetings. The minutes print it in the table of contents, in each subject heading, and in cross-references. A subject without a title, for example one that summarize created, prints its summary name instead. `agendaItemTitleOrName()` in `src/lib/utils/subjects.ts` holds that rule. Web pages keep showing the summary name. The Diavgeia decision matcher receives the same title as the subject text of the poll request. The official wording matches decision titles far better than the summary name (issue #616).
+
 ### Excerpt and references are markdown
 `Decision.excerpt` and `Decision.references` are stored as markdown to preserve PDF structure (bullet points, numbered lists). Richness varies by municipality — Vrilissia has 14+ numbered reference items per decision, while Zografou often uses a single generic phrase.
 

--- a/messages/el/admin.json
+++ b/messages/el/admin.json
@@ -264,7 +264,7 @@
       "tabDocument": "Έγγραφο",
       "tabExtraction": "Στοιχεία απόφασης",
       "close": "Κλείσιμο",
-      "subjectDescriptionLabel": "Περιγραφή θέματος:",
+      "subjectDescriptionLabel": "Σύνοψη θέματος:",
       "agendaItemTitleLabel": "Τίτλος στην ημερήσια διάταξη:",
       "reassignTitle": "Μεταφορά απόφασης",
       "reassignExplain": "Η απόφαση θα μεταφερθεί στο θέμα «{subject}». Το «{holder}» θα μείνει χωρίς απόφαση."

--- a/messages/el/admin.json
+++ b/messages/el/admin.json
@@ -265,6 +265,7 @@
       "tabExtraction": "Στοιχεία απόφασης",
       "close": "Κλείσιμο",
       "subjectDescriptionLabel": "Περιγραφή θέματος:",
+      "agendaItemTitleLabel": "Τίτλος στην ημερήσια διάταξη:",
       "reassignTitle": "Μεταφορά απόφασης",
       "reassignExplain": "Η απόφαση θα μεταφερθεί στο θέμα «{subject}». Το «{holder}» θα μείνει χωρίς απόφαση."
     },

--- a/messages/en/admin.json
+++ b/messages/en/admin.json
@@ -264,7 +264,7 @@
       "tabDocument": "Document",
       "tabExtraction": "Decision details",
       "close": "Close",
-      "subjectDescriptionLabel": "Subject description:",
+      "subjectDescriptionLabel": "Subject summary:",
       "agendaItemTitleLabel": "Agenda item title:",
       "reassignTitle": "Move decision",
       "reassignExplain": "The decision moves to “{subject}”. “{holder}” is left without a decision."

--- a/messages/en/admin.json
+++ b/messages/en/admin.json
@@ -265,6 +265,7 @@
       "tabExtraction": "Decision details",
       "close": "Close",
       "subjectDescriptionLabel": "Subject description:",
+      "agendaItemTitleLabel": "Agenda item title:",
       "reassignTitle": "Move decision",
       "reassignExplain": "The decision moves to “{subject}”. “{holder}” is left without a decision."
     },

--- a/messages/fr/admin.json
+++ b/messages/fr/admin.json
@@ -264,7 +264,7 @@
       "tabDocument": "Document",
       "tabExtraction": "Détails de la décision",
       "close": "Fermer",
-      "subjectDescriptionLabel": "Description du sujet :",
+      "subjectDescriptionLabel": "Résumé du sujet :",
       "agendaItemTitleLabel": "Intitulé à l'ordre du jour :",
       "reassignTitle": "Déplacer la décision",
       "reassignExplain": "La décision sera déplacée vers « {subject} ». « {holder} » restera sans décision."

--- a/messages/fr/admin.json
+++ b/messages/fr/admin.json
@@ -265,6 +265,7 @@
       "tabExtraction": "Détails de la décision",
       "close": "Fermer",
       "subjectDescriptionLabel": "Description du sujet :",
+      "agendaItemTitleLabel": "Intitulé à l'ordre du jour :",
       "reassignTitle": "Déplacer la décision",
       "reassignExplain": "La décision sera déplacée vers « {subject} ». « {holder} » restera sans décision."
     },

--- a/messages/sr/admin.json
+++ b/messages/sr/admin.json
@@ -265,6 +265,7 @@
             "tabExtraction": "Детаљи одлуке",
             "close": "Затвори",
             "subjectDescriptionLabel": "Опис тачке:",
+            "agendaItemTitleLabel": "Наслов тачке дневног реда:",
             "reassignTitle": "Премести одлуку",
             "reassignExplain": "Одлука се премешта на тачку „{subject}”. Тачка „{holder}” остаје без одлуке."
         },

--- a/messages/sr/admin.json
+++ b/messages/sr/admin.json
@@ -264,7 +264,7 @@
             "tabDocument": "Документ",
             "tabExtraction": "Детаљи одлуке",
             "close": "Затвори",
-            "subjectDescriptionLabel": "Опис тачке:",
+            "subjectDescriptionLabel": "Сажетак теме:",
             "agendaItemTitleLabel": "Наслов тачке дневног реда:",
             "reassignTitle": "Премести одлуку",
             "reassignExplain": "Одлука се премешта на тачку „{subject}”. Тачка „{holder}” остаје без одлуке."

--- a/prisma/migrations/20260904220052_add_subject_agenda_item_title/migration.sql
+++ b/prisma/migrations/20260904220052_add_subject_agenda_item_title/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Subject" ADD COLUMN     "agendaItemTitle" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -470,6 +470,9 @@ model Subject {
   councilMeetingId String
 
   agendaItemIndex Int?
+  // The item as written on the official agenda. processAgenda sets it; summarize never touches
+  // it. Null for non-agenda subjects, rows that predate the field, or an item with no printed text.
+  agendaItemTitle String?
   nonAgendaReason NonAgendaReason?
   withdrawn       Boolean          @default(false)
   topicId String?

--- a/src/components/meetings/decisions/ConfirmSheet.tsx
+++ b/src/components/meetings/decisions/ConfirmSheet.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { ExternalLink, Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { diavgeiaViewUrl, inlinePdfUrl } from './pdfUrl';
+import { AIGeneratedBadge } from '@/components/AIGeneratedBadge';
 
 interface ConfirmSheetProps {
     open: boolean;
@@ -50,7 +51,7 @@ export function ConfirmSheet({ open, onOpenChange, action, destructive, decision
         : t(`${action}Explain`, { subject: subjectName ?? '', holder: holderName ?? '' });
     return (
         <Sheet open={open} onOpenChange={onOpenChange}>
-            <SheetContent side="right" className="flex w-full flex-col sm:max-w-xl">
+            <SheetContent side="right" className="flex w-full flex-col overflow-y-auto sm:max-w-xl">
                 <SheetHeader>
                     <SheetTitle>{t(`${action}Title`)}</SheetTitle>
                     <SheetDescription>
@@ -60,13 +61,14 @@ export function ConfirmSheet({ open, onOpenChange, action, destructive, decision
                     {agendaItemTitle?.trim() && (
                         <div className="rounded-lg bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
                             <span className="font-medium text-foreground">{t('agendaItemTitleLabel')}</span>{' '}
-                            <span className="line-clamp-4">{agendaItemTitle}</span>
+                            <span>{agendaItemTitle}</span>
                         </div>
                     )}
                     {subjectDescription && (
                         <div className="rounded-lg bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
                             <span className="font-medium text-foreground">{t('subjectDescriptionLabel')}</span>{' '}
-                            <span className="line-clamp-4">{subjectDescription}</span>
+                            <span>{subjectDescription}</span>
+                            <AIGeneratedBadge className="mt-1 justify-end" />
                         </div>
                     )}
                     {(ada || meetingLink) && (
@@ -105,9 +107,9 @@ export function ConfirmSheet({ open, onOpenChange, action, destructive, decision
                     </div>
                 )}
                 {extraContent && pane === 'extraction' ? (
-                    <div className="min-h-0 flex-1 overflow-y-auto rounded border p-3">{extraContent}</div>
+                    <div className="h-[60vh] min-h-[320px] shrink-0 overflow-y-auto rounded border p-3">{extraContent}</div>
                 ) : (
-                    <iframe title={t('documentTitle')} src={inlinePdfUrl(pdfUrl)} className="min-h-0 w-full flex-1 rounded border" />
+                    <iframe title={t('documentTitle')} src={inlinePdfUrl(pdfUrl)} className="h-[60vh] min-h-[320px] w-full shrink-0 rounded border" />
                 )}
                 {action !== 'view' && (
                     <div className={`rounded-lg px-3 py-2.5 text-sm ${action === 'unlink' && destructive ? 'bg-red-50 dark:bg-red-950/30 text-red-900 dark:text-red-200' : 'bg-muted/60'}`}>

--- a/src/components/meetings/decisions/ConfirmSheet.tsx
+++ b/src/components/meetings/decisions/ConfirmSheet.tsx
@@ -21,6 +21,7 @@ interface ConfirmSheetProps {
     ada: string | null;
     /** The subject's own description — the context for judging the match. */
     subjectDescription?: string | null;
+    agendaItemTitle?: string | null;
     busy: boolean;
     onConfirm: () => void;
     /** Inspect mode: the confirm button assigns, and it needs a selected subject. */
@@ -40,7 +41,7 @@ interface ConfirmSheetProps {
  * at the document itself, not only at metadata. Inspect mode uses the same
  * surface read-first: the admin opens the document, then assigns or dismisses.
  */
-export function ConfirmSheet({ open, onOpenChange, action, destructive, decisionTitle, decisionNumber, subjectName, pdfUrl, ada, subjectDescription, busy, onConfirm, confirmDisabled, onDismiss, extraContent, meetingLink, holderName }: ConfirmSheetProps) {
+export function ConfirmSheet({ open, onOpenChange, action, destructive, decisionTitle, decisionNumber, subjectName, pdfUrl, ada, subjectDescription, agendaItemTitle, busy, onConfirm, confirmDisabled, onDismiss, extraContent, meetingLink, holderName }: ConfirmSheetProps) {
     const t = useTranslations('admin.decisionsPage.sheet');
     const [pane, setPane] = useState<'document' | 'extraction'>('document');
     useEffect(() => { if (open) setPane('document'); }, [open]);
@@ -56,6 +57,12 @@ export function ConfirmSheet({ open, onOpenChange, action, destructive, decision
                         {decisionNumber ? `${decisionNumber} — ` : ''}{decisionTitle ?? ''}
                         {action === 'view' && subjectName && <><br />{explain}</>}
                     </SheetDescription>
+                    {agendaItemTitle?.trim() && (
+                        <div className="rounded-lg bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+                            <span className="font-medium text-foreground">{t('agendaItemTitleLabel')}</span>{' '}
+                            <span className="line-clamp-4">{agendaItemTitle}</span>
+                        </div>
+                    )}
                     {subjectDescription && (
                         <div className="rounded-lg bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
                             <span className="font-medium text-foreground">{t('subjectDescriptionLabel')}</span>{' '}

--- a/src/components/meetings/decisions/MeetingDecisionsPage.tsx
+++ b/src/components/meetings/decisions/MeetingDecisionsPage.tsx
@@ -1292,6 +1292,9 @@ export function MeetingDecisionsPage({ isSuperAdmin }: { isSuperAdmin: boolean }
                     subjectDescription={'subjectId' in sheetAction && sheetAction.subjectId
                         ? subjects.find(s => s.id === sheetAction.subjectId)?.description ?? null
                         : null}
+                    agendaItemTitle={'subjectId' in sheetAction && sheetAction.subjectId
+                        ? subjects.find(s => s.id === sheetAction.subjectId)?.agendaItemTitle ?? null
+                        : null}
                     busy={sheetBusy}
                     extraContent={sheetAction.action === 'view' ? renderExtractedDetails(sheetAction.subjectId) : undefined}
                     onConfirm={confirmPending}

--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -175,6 +175,11 @@ export interface Subject {
     id?: string;  // Optional ID assigned by backend (used for mapping utteranceDiscussionStatuses)
     name: string;
     description: string;  // Markdown with special reference links: [text](REF:UTTERANCE:id), [text](REF:PERSON:id), [text](REF:PARTY:id)
+    /**
+     * The item as written on the official agenda (#616). processAgenda sets it for
+     * every subject. summarize never sets it. When the field is absent, the stored value stays as it is.
+     */
+    agendaItemTitle?: string | null;
     agendaItemIndex: number | "BEFORE_AGENDA" | "OUT_OF_AGENDA";
     introducedByPersonId: string | null;
 

--- a/src/lib/apiTypes.ts
+++ b/src/lib/apiTypes.ts
@@ -447,6 +447,7 @@ export interface PollDecisionsRequest extends TaskRequest {
     people: { id: string; name: string }[];
     subjects: Array<{
         subjectId: string;
+        /** The agenda item title when the subject has one, else the summary name. */
         name: string;
         agendaItemIndex: number | null;
         nonAgendaReason: string | null;

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -472,6 +472,8 @@ export async function saveSubjectsForMeeting(
                         ? incoming.agendaItemIndex
                         : null,
                     description: incoming.description,
+                    // undefined leaves the stored title alone; null clears it.
+                    agendaItemTitle: incoming.agendaItemTitle,
                     topicId,
                     locationId: locationId ?? null,
                     personId: validIntroducedBy ?? null,
@@ -537,6 +539,7 @@ export async function saveSubjectsForMeeting(
                 data: {
                     name: subject.name,
                     description: subject.description,
+                    agendaItemTitle: subject.agendaItemTitle,
                     councilMeeting: {
                         connect: { cityId_id: { cityId, id: councilMeetingId } }
                     },

--- a/src/lib/minutes/__tests__/getMinutesData.test.ts
+++ b/src/lib/minutes/__tests__/getMinutesData.test.ts
@@ -1,0 +1,134 @@
+/** @jest-environment node */
+
+/**
+ * Every place the minutes print a subject name must print the verbatim agenda
+ * title when the subject has one (#616): the section name, the "discussed with"
+ * cross-reference, the "discussed elsewhere" back-reference, and the
+ * cross-subject markers inside the transcript.
+ */
+
+const mockGetCouncilMeeting = jest.fn();
+const mockGetSubjectsForMeeting = jest.fn();
+const mockGetCity = jest.fn();
+const mockUtteranceFindMany = jest.fn();
+
+jest.mock('@/lib/db/meetings', () => ({ getCouncilMeeting: (...a: unknown[]) => mockGetCouncilMeeting(...a) }));
+jest.mock('@/lib/db/subject', () => ({ getSubjectsForMeeting: (...a: unknown[]) => mockGetSubjectsForMeeting(...a) }));
+jest.mock('@/lib/db/cities', () => ({ getCity: (...a: unknown[]) => mockGetCity(...a) }));
+jest.mock('@/lib/db/decisions', () => ({
+    getExtractedDataForMeeting: jest.fn().mockResolvedValue([]),
+    getMeetingAttendance: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('@/lib/db/people', () => ({ getPeopleForCity: jest.fn().mockResolvedValue([]) }));
+jest.mock('@/lib/sorting/people', () => ({ getElectedOrderForBody: () => null }));
+jest.mock('@/lib/db/prisma', () => ({
+    __esModule: true,
+    default: { utterance: { findMany: (...a: unknown[]) => mockUtteranceFindMany(...a) } },
+}));
+
+import { getMinutesData } from '@/lib/minutes/getMinutesData';
+import { MinutesCrossSubjectEntry } from '@/lib/minutes/types';
+
+const CITY_ID = 'city-1';
+const MEETING_ID = 'meeting-1';
+
+function subjectRow(o: {
+    id: string;
+    name: string;
+    agendaItemTitle: string | null;
+    agendaItemIndex: number;
+    discussedIn?: { id: string; name: string; agendaItemTitle: string | null; agendaItemIndex: number };
+}) {
+    return {
+        id: o.id,
+        name: o.name,
+        agendaItemTitle: o.agendaItemTitle,
+        agendaItemIndex: o.agendaItemIndex,
+        nonAgendaReason: null,
+        withdrawn: false,
+        discussedIn: o.discussedIn ?? null,
+        decision: null,
+        highlights: [],
+        contributions: [],
+        location: null,
+        topic: null,
+    };
+}
+
+function utterance(o: { id: string; start: number; end: number; subjectId: string }) {
+    return {
+        id: o.id,
+        text: `text ${o.id}`,
+        startTimestamp: o.start,
+        endTimestamp: o.end,
+        discussionSubjectId: o.subjectId,
+        discussionStatus: 'DISCUSSED',
+        speakerSegment: { speakerTag: { label: 'Ομιλητής', personId: null } },
+    };
+}
+
+describe('getMinutesData — subject names carry the agenda title', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetCity.mockResolvedValue({
+            name: 'Χανιά', name_municipality: 'Δήμος Χανίων', timezone: 'Europe/Athens', logoImage: null,
+        });
+        mockGetCouncilMeeting.mockResolvedValue({
+            id: MEETING_ID, cityId: CITY_ID, name: 'Συνεδρίαση', dateTime: new Date('2026-03-04T18:00:00Z'),
+            administrativeBody: null,
+        });
+        // s1 has a title, s2 does not, s3 has a title and is discussed with s1.
+        mockGetSubjectsForMeeting.mockResolvedValue([
+            subjectRow({ id: 's1', name: 'Περίληψη ενός', agendaItemTitle: 'ΤΙΤΛΟΣ ΕΝΑ', agendaItemIndex: 1 }),
+            subjectRow({ id: 's2', name: 'Περίληψη δύο', agendaItemTitle: null, agendaItemIndex: 2 }),
+            subjectRow({
+                id: 's3', name: 'Περίληψη τρία', agendaItemTitle: 'ΤΙΤΛΟΣ ΤΡΙΑ', agendaItemIndex: 3,
+                discussedIn: { id: 's1', name: 'Περίληψη ενός', agendaItemTitle: 'ΤΙΤΛΟΣ ΕΝΑ', agendaItemIndex: 1 },
+            }),
+        ]);
+        // u2 sits inside s1's window but is linked to s3 — a cross-subject utterance.
+        mockUtteranceFindMany.mockResolvedValue([
+            utterance({ id: 'u1', start: 0, end: 10, subjectId: 's1' }),
+            utterance({ id: 'u2', start: 20, end: 25, subjectId: 's3' }),
+            utterance({ id: 'u3', start: 30, end: 40, subjectId: 's1' }),
+            utterance({ id: 'u4', start: 100, end: 110, subjectId: 's2' }),
+        ]);
+    });
+
+    it('prints the title as the section name, and the summary name when there is none', async () => {
+        const data = await getMinutesData(CITY_ID, MEETING_ID);
+        const byId = new Map(data.subjects.map(s => [s.subjectId, s]));
+
+        expect(byId.get('s1')!.name).toBe('ΤΙΤΛΟΣ ΕΝΑ');
+        expect(byId.get('s2')!.name).toBe('Περίληψη δύο');
+        expect(byId.get('s3')!.name).toBe('ΤΙΤΛΟΣ ΤΡΙΑ');
+    });
+
+    it('prints the title in the discussedWith cross-reference', async () => {
+        const data = await getMinutesData(CITY_ID, MEETING_ID);
+        const s3 = data.subjects.find(s => s.subjectId === 's3')!;
+
+        expect(s3.discussedWith).toEqual({ id: 's1', name: 'ΤΙΤΛΟΣ ΕΝΑ', agendaItemIndex: 1 });
+    });
+
+    it('prints the title in the discussedElsewhere back-reference', async () => {
+        const data = await getMinutesData(CITY_ID, MEETING_ID);
+        const s3 = data.subjects.find(s => s.subjectId === 's3')!;
+
+        expect(s3.discussedElsewhere).toEqual([
+            { subjectId: 's1', name: 'ΤΙΤΛΟΣ ΕΝΑ', agendaItemIndex: 1 },
+        ]);
+    });
+
+    it('prints the title on the cross-subject markers inside the transcript', async () => {
+        const data = await getMinutesData(CITY_ID, MEETING_ID);
+        const s1 = data.subjects.find(s => s.subjectId === 's1')!;
+
+        const crossNames = s1.transcriptEntries
+            .filter((e): e is MinutesCrossSubjectEntry => e.type === 'cross-subject')
+            .map(e => e.subject.name);
+
+        expect(crossNames.length).toBeGreaterThan(0);
+        expect(new Set(crossNames)).toEqual(new Set(['ΤΙΤΛΟΣ ΤΡΙΑ']));
+    });
+});

--- a/src/lib/minutes/getMinutesData.ts
+++ b/src/lib/minutes/getMinutesData.ts
@@ -5,6 +5,7 @@ import { getPeopleForCity } from '@/lib/db/people';
 import { getCity } from '@/lib/db/cities';
 import { getElectedOrderForBody } from '@/lib/sorting/people';
 import { getSpeakerDisplayInfo, isRoleActiveAt, isMayorRole, simplifyRoleName } from '@/lib/utils/roles';
+import { agendaItemTitleOrName } from '@/lib/utils/subjects';
 import { PersonWithRelations } from '@/lib/db/people';
 import prisma from '@/lib/db/prisma';
 import {
@@ -89,8 +90,8 @@ export async function getMinutesData(
         orderBy: { startTimestamp: 'asc' },
     });
 
-    // Subject name map for cross-subject annotations (includes all subjects)
-    const subjectNameMap = new Map(subjects.map(s => [s.id, s.name]));
+    // Subject title map for cross-subject annotations (includes all subjects)
+    const subjectNameMap = new Map(subjects.map(s => [s.id, agendaItemTitleOrName(s)]));
 
     // Compute temporal windows from linked utterances
     const windows = computeTemporalWindows(allUtterances, activeSubjectIds);
@@ -230,7 +231,7 @@ export async function getMinutesData(
                     if (ownerSubject && !discussedElsewhere.some(d => d.subjectId === ownerSubjectId)) {
                         discussedElsewhere.push({
                             subjectId: ownerSubjectId,
-                            name: ownerSubject.name,
+                            name: agendaItemTitleOrName(ownerSubject),
                             agendaItemIndex: ownerSubject.agendaItemIndex,
                         });
                     }
@@ -243,10 +244,10 @@ export async function getMinutesData(
             agendaItemIndex: s.agendaItemIndex,
             nonAgendaReason: s.nonAgendaReason as 'beforeAgenda' | 'outOfAgenda' | null,
             withdrawn: s.withdrawn,
-            name: s.name,
+            name: agendaItemTitleOrName(s),
             discussedWith: s.discussedIn ? {
                 id: s.discussedIn.id,
-                name: s.discussedIn.name,
+                name: agendaItemTitleOrName(s.discussedIn),
                 agendaItemIndex: s.discussedIn.agendaItemIndex,
             } : null,
             discussedElsewhere,

--- a/src/lib/minutes/types.ts
+++ b/src/lib/minutes/types.ts
@@ -55,6 +55,13 @@ export interface MinutesCrossSubjectEntry {
 
 export type MinutesTranscriptEntry = MinutesSpeakerEntry | MinutesCrossSubjectEntry;
 
+/**
+ * Every subject name inside `MinutesData` is the item as written on the official
+ * agenda, when the subject has one. Otherwise it is the summary name. This
+ * includes the cross-reference names: `MinutesCrossSubjectEntry.subject.name`
+ * and `MinutesAttendanceChange.atSubject.name`. `getMinutesData` resolves the
+ * name once, through `agendaItemTitleOrName`.
+ */
 export interface MinutesSubject {
     subjectId: string;
     agendaItemIndex: number | null;
@@ -62,7 +69,11 @@ export interface MinutesSubject {
     withdrawn: boolean;
     name: string;
 
-    discussedWith: { id: string; name: string; agendaItemIndex: number | null } | null;
+    discussedWith: {
+        id: string;
+        name: string;
+        agendaItemIndex: number | null;
+    } | null;
 
     /** Subjects whose discussion partially occurred within another subject's section */
     discussedElsewhere: Array<{

--- a/src/lib/tasks/__tests__/pollDecisionsRequest.test.ts
+++ b/src/lib/tasks/__tests__/pollDecisionsRequest.test.ts
@@ -1,0 +1,120 @@
+/** @jest-environment node */
+
+/**
+ * The one text field the decision matcher reads per subject (#616): the
+ * verbatim agenda title when the subject has one, else the summary name.
+ */
+
+const mockCouncilMeetingFindUnique = jest.fn();
+const mockUtteranceGroupBy = jest.fn().mockResolvedValue([]);
+const mockDecisionFindMany = jest.fn().mockResolvedValue([]);
+const mockDecisionCandidateFindMany = jest.fn().mockResolvedValue([]);
+const mockStartTask = jest.fn().mockResolvedValue({ id: 'task-1' });
+const mockGetPeopleForMeeting = jest.fn().mockResolvedValue([]);
+
+jest.mock('@/lib/db/prisma', () => ({
+    __esModule: true,
+    default: {
+        councilMeeting: { findUnique: (...args: unknown[]) => mockCouncilMeetingFindUnique(...args) },
+        utterance: { groupBy: (...args: unknown[]) => mockUtteranceGroupBy(...args) },
+        decision: { findMany: (...args: unknown[]) => mockDecisionFindMany(...args) },
+        decisionCandidate: { findMany: (...args: unknown[]) => mockDecisionCandidateFindMany(...args) },
+        taskStatus: { findUnique: jest.fn(), findMany: jest.fn(), create: jest.fn(), update: jest.fn() },
+        subject: { findMany: jest.fn().mockResolvedValue([]), update: jest.fn(), updateMany: jest.fn() },
+        $transaction: jest.fn(),
+    },
+}));
+jest.mock('@/env.mjs', () => ({ env: { NEXTAUTH_URL: 'http://test', TASK_API_URL: 'http://test', TASK_API_KEY: 'key' } }));
+jest.mock('next/cache', () => ({ revalidateTag: jest.fn() }));
+jest.mock('@/lib/auth', () => ({ withUserAuthorizedToEdit: jest.fn(), getCurrentUser: jest.fn() }));
+jest.mock('@/lib/discord', () => ({
+    sendTaskAdminAlert: jest.fn(),
+    sendPollDecisionsBatchStartedAlert: jest.fn(),
+    sendPollDecisionsBatchCompletedAlert: jest.fn(),
+}));
+jest.mock('@/lib/tasks/registry', () => ({ taskHandlers: {}, taskTerminalHooks: {} }));
+jest.mock('@/lib/tasks/tasks', () => ({ startTask: (...args: unknown[]) => mockStartTask(...args) }));
+jest.mock('@/lib/db/people', () => ({ getPeopleForMeeting: (...args: unknown[]) => mockGetPeopleForMeeting(...args) }));
+
+import { pollDecisionsForMeeting } from '@/lib/tasks/pollDecisions';
+
+const CITY_ID = 'city-1';
+const MEETING_ID = 'meeting-1';
+
+type SubjectRow = {
+    id: string;
+    name: string;
+    agendaItemTitle: string | null;
+    agendaItemIndex: number | null;
+    nonAgendaReason: string | null;
+};
+
+function meetingWith(subjects: SubjectRow[]) {
+    return {
+        id: MEETING_ID,
+        cityId: CITY_ID,
+        dateTime: new Date('2026-03-04T18:00:00Z'),
+        city: { diavgeiaUid: 'uid-1', timezone: 'Europe/Athens' },
+        administrativeBody: { id: 'body-1', name: 'Δημοτικό Συμβούλιο', diavgeiaUnitIds: [] },
+        subjects: subjects.map(s => ({ ...s, discussedIn: null, decision: null })),
+    };
+}
+
+/** The `subjects` array of the request body handed to startTask. */
+async function requestSubjects(subjects: SubjectRow[]) {
+    mockCouncilMeetingFindUnique.mockResolvedValue(meetingWith(subjects));
+    await pollDecisionsForMeeting(CITY_ID, MEETING_ID);
+    expect(mockStartTask).toHaveBeenCalledTimes(1);
+    const [taskType, body] = mockStartTask.mock.calls[0];
+    expect(taskType).toBe('pollDecisions');
+    return (body as { subjects: Array<Record<string, unknown>> }).subjects;
+}
+
+describe('pollDecisionsForMeeting — subject text sent to the matcher', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUtteranceGroupBy.mockResolvedValue([]);
+        mockDecisionFindMany.mockResolvedValue([]);
+        mockDecisionCandidateFindMany.mockResolvedValue([]);
+        mockStartTask.mockResolvedValue({ id: 'task-1' });
+        mockGetPeopleForMeeting.mockResolvedValue([]);
+    });
+
+    it('sends the verbatim agenda title when the subject has one', async () => {
+        const sent = await requestSubjects([{
+            id: 's1',
+            name: 'Αποζημίωση ακινήτου Κόκκινο Μετόχι',
+            agendaItemTitle: 'ΕΓΚΡΙΣΗ ΕΝΑΡΞΗΣ ΔΙΑΔΙΚΑΣΙΩΝ ΠΛΗΡΩΜΗΣ ΑΠΟΖΗΜΙΩΣΗΣ ΑΚΙΝΗΤΟΥ',
+            agendaItemIndex: 1,
+            nonAgendaReason: null,
+        }]);
+
+        expect(sent).toHaveLength(1);
+        expect(sent[0].name).toBe('ΕΓΚΡΙΣΗ ΕΝΑΡΞΗΣ ΔΙΑΔΙΚΑΣΙΩΝ ΠΛΗΡΩΜΗΣ ΑΠΟΖΗΜΙΩΣΗΣ ΑΚΙΝΗΤΟΥ');
+    });
+
+    it('falls back to the summary name for a subject with no title', async () => {
+        const sent = await requestSubjects([{
+            id: 's1',
+            name: 'Αποζημίωση ακινήτου Κόκκινο Μετόχι',
+            agendaItemTitle: null,
+            agendaItemIndex: 1,
+            nonAgendaReason: null,
+        }]);
+
+        expect(sent[0].name).toBe('Αποζημίωση ακινήτου Κόκκινο Μετόχι');
+    });
+
+    it('chooses per subject, and never sends the description field', async () => {
+        const sent = await requestSubjects([
+            { id: 's1', name: 'Summary one', agendaItemTitle: 'ΤΙΤΛΟΣ ΕΝΑ', agendaItemIndex: 1, nonAgendaReason: null },
+            { id: 's2', name: 'Summary two', agendaItemTitle: null, agendaItemIndex: 2, nonAgendaReason: null },
+        ]);
+
+        expect(sent.map(s => s.name)).toEqual(['ΤΙΤΛΟΣ ΕΝΑ', 'Summary two']);
+        expect(sent.map(s => s.subjectId)).toEqual(['s1', 's2']);
+        for (const s of sent) {
+            expect(s).not.toHaveProperty('description');
+        }
+    });
+});

--- a/src/lib/tasks/pollDecisions.ts
+++ b/src/lib/tasks/pollDecisions.ts
@@ -17,6 +17,7 @@ import { isRoleActiveAt, isMayorRole } from "../utils/roles";
 import { shouldSkipPolling, getBackoffState, getPollableMeetingDateRange, isLogodosiaMeeting, LOGODOSIA_NAME_PATTERN, type BackoffTier } from "./pollDecisionsBackoff";
 import { interleaveByCity } from "./pollableMeetings";
 import { sendPollDecisionsBatchStartedAlert, sendPollDecisionsBatchCompletedAlert } from "../discord";
+import { agendaItemTitleOrName } from "@/lib/utils/subjects";
 
 export async function requestPollDecisions(
     cityId: string,
@@ -75,6 +76,7 @@ export async function pollDecisionsForMeeting(
                 select: {
                     id: true,
                     name: true,
+                    agendaItemTitle: true,
                     agendaItemIndex: true,
                     nonAgendaReason: true,
                     discussedIn: { select: { id: true } },
@@ -168,7 +170,7 @@ export async function pollDecisionsForMeeting(
         })),
         subjects: sortedSubjects.map(s => ({
             subjectId: s.id,
-            name: s.name,
+            name: agendaItemTitleOrName(s),
             agendaItemIndex: s.agendaItemIndex,
             nonAgendaReason: s.nonAgendaReason,
             ...(s.decision?.ada ? {

--- a/src/lib/utils/__tests__/subjects.test.ts
+++ b/src/lib/utils/__tests__/subjects.test.ts
@@ -1,4 +1,4 @@
-import { categorizeSubjects, getNonAgendaLabel, getWithdrawnLabel, getSubjectCategories, pickSummarySubjects } from '../subjects';
+import { categorizeSubjects, getNonAgendaLabel, getWithdrawnLabel, getSubjectCategories, pickSummarySubjects, agendaItemTitleOrName } from '../subjects';
 
 // Identity translator: returns the key so tests assert the resolved key path
 // without depending on message-file contents.
@@ -156,5 +156,27 @@ describe('pickSummarySubjects', () => {
 
     it('returns every subject when the cap is not reached', () => {
         expect(pickSummarySubjects([subject('a', 0)], 6).map(s => s.id)).toEqual(['a']);
+    });
+});
+
+describe('agendaItemTitleOrName', () => {
+    it('prefers the verbatim agenda item title', () => {
+        expect(agendaItemTitleOrName({
+            name: 'Αποζημίωση ακινήτου Κόκκινο Μετόχι',
+            agendaItemTitle: 'ΕΓΚΡΙΣΗ ΕΝΑΡΞΗΣ ΔΙΑΔΙΚΑΣΙΩΝ ΠΛΗΡΩΜΗΣ ΑΠΟΖΗΜΙΩΣΗΣ ΑΚΙΝΗΤΟΥ',
+        })).toBe('ΕΓΚΡΙΣΗ ΕΝΑΡΞΗΣ ΔΙΑΔΙΚΑΣΙΩΝ ΠΛΗΡΩΜΗΣ ΑΠΟΖΗΜΙΩΣΗΣ ΑΚΙΝΗΤΟΥ');
+    });
+
+    it('falls back to the summary name when no title is stored', () => {
+        expect(agendaItemTitleOrName({ name: 'Αποζημίωση ακινήτου Κόκκινο Μετόχι', agendaItemTitle: null }))
+            .toBe('Αποζημίωση ακινήτου Κόκκινο Μετόχι');
+    });
+
+    it('falls back to the summary name for an empty title', () => {
+        expect(agendaItemTitleOrName({ name: 'Περίληψη', agendaItemTitle: '' })).toBe('Περίληψη');
+    });
+
+    it('falls back to the summary name for a whitespace-only title', () => {
+        expect(agendaItemTitleOrName({ name: 'Περίληψη', agendaItemTitle: '   ' })).toBe('Περίληψη');
     });
 });

--- a/src/lib/utils/subjects.ts
+++ b/src/lib/utils/subjects.ts
@@ -95,3 +95,13 @@ export function getWithdrawnLabel(t: Translate, subject: { nonAgendaReason: stri
 export function pickSummarySubjects<T extends { name: string; _count?: { contributions?: number } }>(subjects: T[], max: number): T[] {
     return sortSubjectsByImportance(subjects, 'importance').slice(0, max);
 }
+
+/**
+ * The title the minutes print and the decision matcher reads: the item as written
+ * on the official agenda when processAgenda kept it, else the summary name (#616).
+ * The web pages keep showing `name`. A blank stored title reads as no title.
+ */
+export function agendaItemTitleOrName(subject: { name: string; agendaItemTitle: string | null }): string {
+    return subject.agendaItemTitle?.trim() ? subject.agendaItemTitle : subject.name;
+}
+

--- a/tests/integration/save-subjects.test.ts
+++ b/tests/integration/save-subjects.test.ts
@@ -324,4 +324,52 @@ describe('saveSubjectsForMeeting - integration', () => {
 
         expect(secondRunIds).toEqual(firstRunIds)
     })
+
+    test('agendaItemTitle: stored on create, kept when a later run omits it, replaced when present, cleared by null', async () => {
+        // processAgenda run: every subject carries the field.
+        const agendaRun: Subject[] = [
+            makeSubject({ name: 'Budget', agendaItemIndex: 1, agendaItemTitle: 'ΕΓΚΡΙΣΗ ΠΡΟΫΠΟΛΟΓΙΣΜΟΥ ΟΙΚΟΝΟΜΙΚΟΥ ΕΤΟΥΣ 2026' }),
+            makeSubject({ name: 'Roads', agendaItemIndex: 2, agendaItemTitle: 'ΣΥΝΤΗΡΗΣΗ ΟΔΙΚΟΥ ΔΙΚΤΥΟΥ' }),
+        ]
+        await saveSubjectsForMeeting(agendaRun, cityId, meetingId, undefined, { pruneUnmatched: true })
+
+        const afterAgenda = await prisma.subject.findMany({ where: { councilMeetingId: meetingId, cityId }, orderBy: { agendaItemIndex: 'asc' } })
+        expect(afterAgenda[0].agendaItemTitle).toBe('ΕΓΚΡΙΣΗ ΠΡΟΫΠΟΛΟΓΙΣΜΟΥ ΟΙΚΟΝΟΜΙΚΟΥ ΕΤΟΥΣ 2026')
+        expect(afterAgenda[1].agendaItemTitle).toBe('ΣΥΝΤΗΡΗΣΗ ΟΔΙΚΟΥ ΔΙΚΤΥΟΥ')
+
+        // summarize run: renames the subject and omits the field.
+        const summarizeRun: Subject[] = [
+            makeSubject({ name: 'Budget 2026 approved', agendaItemIndex: 1, description: 'Discussed at length' }),
+        ]
+        await saveSubjectsForMeeting(summarizeRun, cityId, meetingId)
+
+        const afterSummarize = await prisma.subject.findUnique({ where: { id: afterAgenda[0].id } })
+        expect(afterSummarize!.name).toBe('Budget 2026 approved')
+        expect(afterSummarize!.agendaItemTitle).toBe('ΕΓΚΡΙΣΗ ΠΡΟΫΠΟΛΟΓΙΣΜΟΥ ΟΙΚΟΝΟΜΙΚΟΥ ΕΤΟΥΣ 2026')
+
+        const roadsAfterSummarize = await prisma.subject.findUnique({ where: { id: afterAgenda[1].id } })
+        expect(roadsAfterSummarize!.agendaItemTitle).toBe('ΣΥΝΤΗΡΗΣΗ ΟΔΙΚΟΥ ΔΙΚΤΥΟΥ')
+
+        // A second agenda run replaces the title, and an explicit null clears it.
+        const secondAgendaRun: Subject[] = [
+            makeSubject({ name: 'Budget 2026 approved', agendaItemIndex: 1, agendaItemTitle: 'ΕΓΚΡΙΣΗ ΠΡΟΫΠΟΛΟΓΙΣΜΟΥ 2026 (ΟΡΘΗ ΕΠΑΝΑΛΗΨΗ)' }),
+            makeSubject({ name: 'Roads', agendaItemIndex: 2, agendaItemTitle: null }),
+        ]
+        await saveSubjectsForMeeting(secondAgendaRun, cityId, meetingId, undefined, { pruneUnmatched: true })
+
+        const afterSecond = await prisma.subject.findMany({ where: { councilMeetingId: meetingId, cityId }, orderBy: { agendaItemIndex: 'asc' } })
+        expect(afterSecond[0].id).toBe(afterAgenda[0].id)
+        expect(afterSecond[0].agendaItemTitle).toBe('ΕΓΚΡΙΣΗ ΠΡΟΫΠΟΛΟΓΙΣΜΟΥ 2026 (ΟΡΘΗ ΕΠΑΝΑΛΗΨΗ)')
+        expect(afterSecond[1].id).toBe(afterAgenda[1].id)
+        expect(afterSecond[1].agendaItemTitle).toBeNull()
+    })
+
+    test('agendaItemTitle: a subject created without the field stores null', async () => {
+        const run: Subject[] = [makeSubject({ name: 'Opening remarks', agendaItemIndex: 'BEFORE_AGENDA' })]
+        await saveSubjectsForMeeting(run, cityId, meetingId)
+
+        const rows = await prisma.subject.findMany({ where: { councilMeetingId: meetingId, cityId } })
+        expect(rows).toHaveLength(1)
+        expect(rows[0].agendaItemTitle).toBeNull()
+    })
 })


### PR DESCRIPTION
## Summary

Zografou asked that the generated minutes print the agenda items as written on the official agenda, not our shortened summaries. The task server now returns that text (schemalabz/opencouncil-tasks#96). This PR stores it, prints it in the minutes, sends it to the Diavgeia decision matcher, and shows it in the decisions sheet. Web pages keep showing the summary name.

## Changes

- `Subject.agendaItemTitle String?`, nullable, no index; additive migration.
- `saveSubjectsForMeeting` passes the field straight to Prisma: a summarize result omits it and keeps the stored title, an explicit null clears it. Integration test with five cases.
- Minutes: `agendaItemTitleOrName()` in `src/lib/utils/subjects.ts` resolves the display title once; `getMinutesData` uses it for the headings, the table of contents, and the cross-references. A subject without a title keeps its summary name, so existing meetings render as before. A blank stored title reads as no title.
- Decision matching: the poll request sends the title as the subject `name` when the subject has one. The task server does not change.
- Decisions page: the sheet shows the official title above the subject description, so an operator who debugs a non-match sees the text the matcher received.

## Evidence

End to end on a local app with a local task server: a Zografou meeting created with a real agenda PDF stored 7 of 7 titles; the minutes JSON and the DOCX table of contents carry them; a meeting without titles renders unchanged.

Matching A/B on Athens community sittings, read from production, same matcher code, subject text the only difference:

| sitting | summary name: right / wrong / missed | verbatim title: right / wrong / missed |
|---|---|---|
| 2η Δ.Κ. 9 Feb 2026 (19 subjects) | 5 / 7 / 5 | 18 / 0 / 0 |
| 2η Δ.Κ. 19 Jan 2026 (35) | 5 / 4 / 21 | 29 / 0 / 1 |
| 3η Δ.Κ. 18 Feb 2026 (22, control) | 0 / 0 / 0 | 0 / 0 / 0 |
| 7η Δ.Κ. 19 Feb 2026 (16, control) | 11 / 1 / 3 | 15 / 0 / 0 |

"Right" agrees with the street and house number that the agenda item and the Diavgeia title both carry. The existing 2η links in production are mostly protocol-order guesses (3 right, 9 wrong on 9 Feb) and need re-linking after the backfill.

## Public payloads

The column travels with every subject through the existing `include` queries, so the public meeting endpoint, search results, and the meeting page payload now carry `agendaItemTitle`. Nothing reads it there. Say if you want it stripped.

## Backfill

Existing meetings get the field through a one-time script pipeline that runs after both PRs deploy: export, align (in the tasks repo), a local review page, import with dry run, target guard, and rollback. The scripts live on [`feat/agenda-item-title-backfill`](https://github.com/kouloumos/opencouncil/tree/feat/agenda-item-title-backfill) (one commit on top of this branch), together with [`align-agenda-titles.ts`](https://github.com/kouloumos/opencouncil-tasks/blob/feat/agenda-item-title-backfill/scripts/align-agenda-titles.ts) on the matching branch of the tasks repo. Zografou first.

## Deploy

Either order with schemalabz/opencouncil-tasks#96; only the backfill needs both.

Refs #616

<!-- preview-link: tasks=96 -->












<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an optional verbatim agenda title to subjects and consistently uses it for minutes, decision matching, and administrative match diagnostics while preserving summary-name fallbacks.
- Adds the nullable `Subject.agendaItemTitle` field and migration.
- Preserves omitted titles during subject updates while allowing explicit replacement or clearing.
- Centralizes blank-title fallback behavior in `agendaItemTitleOrName()`.
- Uses official titles throughout generated minutes and decision-matcher requests.
- Displays official titles alongside AI-generated summaries in the decisions sheet.
- Adds unit and integration coverage for persistence, fallback, minutes, and matcher behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the latest change resolves the remaining documentation rule violation and no actionable new issue was found.

The agenda-title behavior is consistently implemented across storage, minutes, matching, and diagnostics, with blank-value fallbacks and focused tests. All previous review threads are resolved, and the current code addresses their reported concerns.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| prisma/schema.prisma | Adds the optional agenda-item title to the persistent Subject model. |
| src/lib/db/utils.ts | Persists supplied agenda titles while preserving existing values when the field is omitted. |
| src/lib/utils/subjects.ts | Centralizes official-title selection with fallback for null, empty, and whitespace-only values. |
| src/lib/minutes/getMinutesData.ts | Applies the resolved title consistently to minute headings and cross-subject references. |
| src/lib/tasks/pollDecisions.ts | Sends the official agenda title to decision matching when available. |
| src/components/meetings/decisions/ConfirmSheet.tsx | Shows nonblank official titles in the diagnostic sheet and labels summaries as AI-generated. |
| tests/integration/save-subjects.test.ts | Covers title creation, preservation, replacement, explicit clearing, and omitted-field creation. |

<sub>Reviews (6): Last reviewed commit: ["fix(decisions): keep the whole subject c..."](https://github.com/schemalabz/opencouncil/commit/d313787e71758b3bda6634140e31375e1cf07339) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60710251)</sub>

<!-- /greptile_comment -->
