### PR TITLE
Fix Badge component to render as span instead of div

### DIFF
--- a/packages/ui/src/__tests__/badge.test.tsx
+++ b/packages/ui/src/__tests__/badge.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+
+import { Badge } from '../badge';
+
+describe('Badge', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('renders an inline element, so it is valid inside a paragraph', () => {
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => { });
+
+        const { container } = render(
+            <p>
+                Text with a <Badge variant="outline">party</Badge> reference.
+            </p>
+        );
+
+        const badge = container.querySelector('p > span');
+        expect(badge).not.toBeNull();
+        expect(badge).toHaveTextContent('party');
+        expect(consoleError).not.toHaveBeenCalled();
+    });
+
+    it('renders the child element with asChild', () => {
+        const { container } = render(
+            <Badge asChild className="custom">
+                <a href="/parties/1">party</a>
+            </Badge>
+        );
+
+        const link = container.querySelector('a');
+        expect(link).toHaveAttribute('href', '/parties/1');
+        expect(link).toHaveClass('custom');
+        expect(link).toHaveClass('rounded-full');
+    });
+});

--- a/packages/ui/src/badge.tsx
+++ b/packages/ui/src/badge.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "./lib/utils"
@@ -24,12 +25,18 @@ const badgeVariants = cva(
 )
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof badgeVariants> {
+  asChild?: boolean
+}
 
-function Badge({ className, variant, ...props }: BadgeProps) {
+// A badge renders a <span>, not a <div>, because badges appear inside
+// paragraphs (markdown output, for example). A <div> in a <p> is invalid HTML
+// and the browser reparents it, which breaks hydration.
+function Badge({ className, variant, asChild = false, ...props }: BadgeProps) {
+  const Comp = asChild ? Slot : "span"
   return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+    <Comp className={cn(badgeVariants({ variant }), className)} {...props} />
   )
 }
 

--- a/src/components/FormattedTextDisplay.tsx
+++ b/src/components/FormattedTextDisplay.tsx
@@ -5,6 +5,7 @@ import { useLocale } from "next-intl";
 import { ReferenceType } from "@/lib/utils/references";
 import { Badge } from "./ui/badge";
 import ReactMarkdown from 'react-markdown';
+import type { Element, ElementContent } from 'hast';
 import { UtteranceReferenceLink } from "./meetings/subject/UtteranceReferenceLink";
 import { serbianScriptForLocale, toScript, type SerbianScript } from "@/lib/serbian";
 
@@ -20,6 +21,17 @@ const makeRehypeTransliterate = (script: SerbianScript) => () => (tree: { type: 
         node.children?.forEach((child) => walk(child as { type: string; value?: string; children?: unknown[] }));
     };
     walk(tree);
+};
+
+// True when the subtree holds an utterance reference. Such a reference expands
+// into a mini transcript, which is block content.
+const hasUtteranceReference = (node: Element | ElementContent | undefined): boolean => {
+    if (!node || node.type !== 'element') return false;
+    if (node.tagName === 'a' && typeof node.properties.href === 'string'
+        && node.properties.href.startsWith('REF:UTTERANCE:')) {
+        return true;
+    }
+    return node.children.some(hasUtteranceReference);
 };
 
 interface FormattedTextDisplayProps {
@@ -80,6 +92,16 @@ export const FormattedTextDisplay = memo(function FormattedTextDisplay({
                 urlTransform={(url) => url} // Pass through all URLs unchanged
                 rehypePlugins={rehypePlugins}
                 components={{
+                    // A block element inside a <p> is invalid HTML. Only a paragraph
+                    // that can hold the block-level mini transcript renders as a <div>.
+                    // Every other paragraph stays a <p> and keeps the `prose` styles.
+                    // The margin repeats the paragraph spacing of `prose-sm`.
+                    p: ({ node, children }) => (
+                        !disableUtteranceExpansion && hasUtteranceReference(node)
+                            ? <div className="my-4">{children}</div>
+                            : <p>{children}</p>
+                    ),
+
                     // Custom link renderer to handle REF:TYPE:ID links
                     a: ({ href, children }) => {
                         if (!href || !href.startsWith('REF:')) {

--- a/src/components/meetings/subject/UtteranceReferenceLink.tsx
+++ b/src/components/meetings/subject/UtteranceReferenceLink.tsx
@@ -68,8 +68,10 @@ const UtteranceReferenceLinkComponent = function UtteranceReferenceLink({
     return <span className="text-muted-foreground">{children}</span>;
   }
 
+  // No wrapping element: the expansion below is block content, and a wrapper
+  // <span> around it would be invalid HTML.
   return (
-    <span className="inline">
+    <>
       <a
         onClick={handleClick}
         className={cn(
@@ -93,7 +95,7 @@ const UtteranceReferenceLinkComponent = function UtteranceReferenceLink({
           />
         </div>
       )}
-    </span>
+    </>
   );
 };
 

--- a/src/components/meetings/subject/__tests__/UtteranceReferenceLink.test.tsx
+++ b/src/components/meetings/subject/__tests__/UtteranceReferenceLink.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+jest.mock('../UtteranceExpansionContext', () => ({
+    useUtteranceExpansion: () => ({ toggleExpansion: jest.fn(), isExpanded: () => true }),
+}));
+jest.mock('@/components/meetings/CouncilMeetingDataContext', () => ({
+    useCouncilMeetingData: () => ({ meeting: { cityId: 'athens' } }),
+}));
+jest.mock('@/hooks/useUtteranceData', () => ({
+    useUtteranceData: () => ({
+        utterance: { id: 'utt-1' },
+        utteranceIndex: 0,
+        segment: { id: 'segment-1', speakerTag: { id: 'tag-1' }, utterances: [{ id: 'utt-1' }] },
+    }),
+}));
+jest.mock('../UtteranceMiniTranscript', () => ({
+    UtteranceMiniTranscript: () => <div data-testid="mini-transcript" />,
+}));
+
+import { UtteranceReferenceLink } from '../UtteranceReferenceLink';
+
+describe('UtteranceReferenceLink', () => {
+    // The expansion is block content. The reference sits in a text flow, so the
+    // component must not wrap the link and the expansion in an inline element.
+    it('renders the expansion as a sibling of the link, with no wrapper element', () => {
+        const { container } = render(
+            <UtteranceReferenceLink utteranceId="utt-1">κείμενο</UtteranceReferenceLink>
+        );
+
+        expect(Array.from(container.children).map((el) => el.tagName)).toEqual(['A', 'DIV']);
+        expect(container.querySelector('[data-testid="mini-transcript"]')).not.toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
Changed the Badge component to render as a `<span>` instead of a `<div>` to ensure valid HTML when badges appear inside paragraphs (e.g., in markdown output). Added support for the `asChild` prop to allow rendering custom child elements with badge styling.

## Changes
- **Changed root element**: Badge now renders as `<span>` instead of `<div>` to maintain valid HTML structure when used inside `<p>` tags
- **Added `asChild` prop**: Integrated Radix UI's `Slot` component to support rendering custom child elements while preserving badge styling
- **Updated TypeScript types**: Changed `BadgeProps` to extend `React.HTMLAttributes<HTMLSpanElement>` and added `asChild?: boolean`
- **Added test coverage**: Created comprehensive tests verifying:
  - Badge renders as an inline element valid inside paragraphs
  - `asChild` prop correctly renders child elements with badge classes applied

## Implementation Details
- A `<div>` inside a `<p>` is invalid HTML and causes the browser to reparent it, which breaks hydration
- The `asChild` prop uses Radix UI's `Slot` component to merge props and classes onto the child element
- Added explanatory comment in the source code documenting why `<span>` is used instead of `<div>`

https://claude.ai/code/session_016pkPccpBkF8Vu1s1PTjKXo





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes badges to use inline HTML and supports custom child elements. It also adjusts utterance-reference markup to prevent invalid block content inside paragraphs.
- `Badge` now renders a `<span>` by default and supports Radix `Slot` through `asChild`.
- Markdown paragraphs remain `<p>` elements unless they can contain an expanded utterance reference.
- Expanded utterance content renders beside its link without an invalid inline wrapper.
- Focused tests cover badge markup, mock cleanup, and utterance expansion structure.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no outstanding correctness or repository-rule issue remains.

The console-spy cleanup fixes the first previous finding. The conditional paragraph renderer addresses the second previous finding while preserving normal paragraph markup. Both previous threads were also manually resolved without explanation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/badge.tsx | Changes the badge root from `div` to `span` and adds `asChild` composition. |
| packages/ui/src/__tests__/badge.test.tsx | Tests inline badge markup and `asChild`, with reliable mock cleanup. |
| src/components/FormattedTextDisplay.tsx | Preserves normal paragraph markup while allowing block-level utterance expansion. |
| src/components/meetings/subject/UtteranceReferenceLink.tsx | Removes the inline wrapper around the link and block transcript expansion. |
| src/components/meetings/subject/__tests__/UtteranceReferenceLink.test.tsx | Verifies that the link and expanded transcript render as sibling elements. |

<sub>Reviews (3): Last reviewed commit: ["fix(subject): keep the mini transcript o..."](https://github.com/schemalabz/opencouncil/commit/9e8d6f0978b5cdfa02c438388c0d666b3bd6a99b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60922762)</sub>

**Context used:**

- Knowledge Base — [Application presentation system](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/application-presentation-system.md)
- Knowledge Base — [Meeting publication and records](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/meeting-publication.md)

<!-- /greptile_comment -->