### PR TITLE
Add meeting summary embed widget

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Deep dives into specific features — architecture, data flow, and implementatio
 - **[guides/consultations.md](./guides/consultations.md)** — Public consultation feature: regulation viewer, comments, geo-editor, JSON schema
 - **[guides/meeting-highlights.md](./guides/meeting-highlights.md)** — Video highlight generation: multi-page flow, video formats (16:9, 9:16), rendering
 - **[guides/qr-campaigns.md](./guides/qr-campaigns.md)** — QR code redirect system with UTM tracking and analytics
+- **[guides/embed-widgets.md](./guides/embed-widgets.md)** — Iframe widgets for external sites: the meetings, hot subjects and meeting summary widgets, their params, theming, caching and the configurator
 - **[guides/serbian-localization.md](./guides/serbian-localization.md)** — Serbian dual-script support: Cyrillic-canonical catalogs, generated Latin, render-time transliteration, glossary, and the native-review workflow gating the serbia realm launch
 
 ## Operations & Infrastructure

--- a/docs/guides/embed-widgets.md
+++ b/docs/guides/embed-widgets.md
@@ -1,0 +1,94 @@
+# Embed Widgets
+
+**Concept**
+
+Iframe widgets that show OpenCouncil content on an external website: the meetings of a municipality, its hottest subjects, or a summary of one or more meetings.
+
+**Architectural Overview**
+
+A site owner opens the configurator at `/{cityId}/widget`, chooses a widget type and its appearance, and copies an `<iframe>` snippet. The iframe loads a page under `/embed/`. Each embed page:
+
+1. Reads its configuration from the query string. `parseEmbedConfig` handles the params that every widget shares (accent color, dark mode, corner radius, card limit, administrative-body filter). Widget-specific params stay in the route.
+2. Loads data through the public cached queries in `src/lib/cache/queries.ts`. These queries return released meetings only and never call `headers()`, so a page can be served from the CDN.
+3. Renders plain HTML with a small stylesheet (`embed.css`) driven by `--embed-*` CSS variables from `generateThemeVars`. The pages are Server Components. The subjects widget is the exception: it renders the app's shared `SubjectCardContent`, so it also applies `generateAppThemeShim`.
+4. Links back to OpenCouncil with `embedBaseUrl(city.realm)`. In production the links use the realm's own domain (a Cypriot city links to opencouncil.cy). On a preview or local host the links keep `NEXTAUTH_URL`.
+
+The `(embed)` route group has a minimal layout with `robots: noindex`. `next.config.mjs` adds `Content-Security-Policy: frame-ancestors *` and a CDN `Cache-Control` header to every `/:locale/embed/:path*` response. `EMBED_PATH` in `src/lib/utils/embed.ts` keeps analytics, SEO redirects and the dev login bar out of the iframe.
+
+| Widget | Route | Own params | Shows |
+|---|---|---|---|
+| Meetings | `/embed/meetings` | `cityId`, `showSubjects` | Upcoming and recent meetings with their top subjects |
+| Hot subjects | `/embed/subjects` | `cityId` or `geohash` | The most discussed subjects of recent meetings, optionally near a location |
+| Meeting summary | `/embed/summary` | `cityId`, `meetingId`, `subjects` | One block per meeting: the body, the meeting, its most discussed subjects, and its stats |
+
+Shared params: `accent` (hex without `#`), `mode` (`light`/`dark`), `radius` (`sharp`/`rounded`/`pill`), `limit`, `bodies` (comma-separated body types), `bodyIds` (comma-separated body ids).
+
+`/api/embed/subjects` returns the subjects widget's data as JSON with open CORS, so an embedding site can hide the iframe when there is nothing to show.
+
+**Sequence Diagram**
+
+```mermaid
+sequenceDiagram
+    participant Site as Embedding site
+    participant Proxy as src/proxy.ts
+    participant Page as /embed/summary
+    participant Cache as Cached queries
+    participant DB as PostgreSQL
+    participant CDN
+
+    Site->>Proxy: GET /embed/summary?cityId=vouli&meetingId=…
+    Proxy->>Page: locale rewrite (no auth, no analytics)
+    Page->>Cache: getCityCached(cityId)
+    Page->>Cache: getMeetingSummaries(cityId, { meetingId | limit })
+    Cache->>DB: meeting + subjects, segment span, speaker count, first utterance per subject
+    DB-->>Cache: rows (cached per meeting, tags city:…:meeting:…)
+    Cache-->>Page: MeetingSummary[]
+    Page-->>CDN: HTML + frame-ancestors * + s-maxage=300
+    CDN-->>Site: iframe content
+```
+
+**Key Component Pointers**
+
+Routes and layout:
+- `EmbedLayout`: [`src/app/[locale]/(embed)/layout.tsx`](../../src/app/[locale]/(embed)/layout.tsx) (no navigation, no footer, noindex)
+- Meetings widget: [`src/app/[locale]/(embed)/embed/meetings/page.tsx`](../../src/app/[locale]/(embed)/embed/meetings/page.tsx)
+- Hot subjects widget: [`src/app/[locale]/(embed)/embed/subjects/page.tsx`](../../src/app/[locale]/(embed)/embed/subjects/page.tsx)
+- Meeting summary widget: [`src/app/[locale]/(embed)/embed/summary/page.tsx`](../../src/app/[locale]/(embed)/embed/summary/page.tsx)
+- Stylesheet: [`src/app/[locale]/(embed)/embed/meetings/embed.css`](../../src/app/[locale]/(embed)/embed/meetings/embed.css) (shared by all widgets)
+- Pre-flight JSON: [`src/app/api/embed/subjects/route.ts`](../../src/app/api/embed/subjects/route.ts)
+
+Configuration and theming:
+- `parseEmbedConfig`, `parseBoundedInt`, `EMBED_SUMMARY_LIMITS`, `embedLocalePrefix`: [`src/lib/utils/embedParams.ts`](../../src/lib/utils/embedParams.ts)
+- `embedBaseUrl`: [`src/lib/utils/embedBaseUrl.ts`](../../src/lib/utils/embedBaseUrl.ts) (realm-aware link base)
+- `generateThemeVars`, `generateAppThemeShim`: [`src/lib/utils/embedTheme.ts`](../../src/lib/utils/embedTheme.ts)
+- `EMBED_PATH`: [`src/lib/utils/embed.ts`](../../src/lib/utils/embed.ts)
+- Frame and cache headers: [`next.config.mjs`](../../next.config.mjs)
+
+Data:
+- `getCouncilMeetingsForCityPublicCached`, `getMeetingSummaryCached`: [`src/lib/cache/queries.ts`](../../src/lib/cache/queries.ts)
+- `getMeetingSummary`: [`src/lib/db/meetingSummary.ts`](../../src/lib/db/meetingSummary.ts) (four queries per meeting)
+- `MeetingSummary` types and select: [`src/lib/db/types/meetingSummary.ts`](../../src/lib/db/types/meetingSummary.ts)
+- `getMeetingSummaries`: [`src/lib/meetingSummaries.ts`](../../src/lib/meetingSummaries.ts) (one meeting, or the latest past ones)
+- `pickSummarySubjects`: [`src/lib/utils/subjects.ts`](../../src/lib/utils/subjects.ts)
+- `getHotSubjectCards`: [`src/lib/hotSubjectCards.ts`](../../src/lib/hotSubjectCards.ts)
+
+Components:
+- `EmbedMeetingCard`: [`src/components/embed/EmbedMeetingCard.tsx`](../../src/components/embed/EmbedMeetingCard.tsx)
+- `EmbedSubjectCard`: [`src/components/embed/EmbedSubjectCard.tsx`](../../src/components/embed/EmbedSubjectCard.tsx)
+- `EmbedMeetingSummary`, `EmbedSummarySubjectCard`: [`src/components/embed/EmbedMeetingSummary.tsx`](../../src/components/embed/EmbedMeetingSummary.tsx), [`src/components/embed/EmbedSummarySubjectCard.tsx`](../../src/components/embed/EmbedSummarySubjectCard.tsx)
+- `EmbedFooter`: [`src/components/embed/EmbedFooter.tsx`](../../src/components/embed/EmbedFooter.tsx) (OpenCouncil attribution)
+- `EmbedConfigurator`: [`src/components/embed/EmbedConfigurator.tsx`](../../src/components/embed/EmbedConfigurator.tsx), served by [`src/app/[locale]/(city)/[cityId]/(other)/(tabs)/widget/page.tsx`](../../src/app/[locale]/(city)/[cityId]/(other)/(tabs)/widget/page.tsx)
+
+**Business Rules & Assumptions**
+
+- Widgets show released meetings only. They need no session and read no request headers.
+- An unknown `cityId` returns 404. An unknown or unreleased `meetingId`, or a city without past meetings, renders the widget's empty state with HTTP 200, because a 404 inside an iframe looks broken.
+- The meeting summary widget shows the latest released past meetings (`limit` 1 to 5, default 1) or one meeting (`meetingId`). It ignores the body filter when a meeting is pinned.
+- Each summary block shows the most discussed subjects first (`subjects` 1 to 20, default 6). The footer counts every subject of the meeting.
+- The summary widget shows no votes, outcomes or attendance. The subject text is the AI summary (`Subject.description`), stripped of markdown and clamped to two lines.
+- A meeting's duration is the span from its first to its last speaker segment. The speaker count is the number of distinct people with a speaker segment. Both stats are hidden before transcription.
+- The subject timestamp is the first utterance tagged `SUBJECT_DISCUSSION` for that subject. Subjects without tagged utterances show no timestamp.
+- Every widget page revalidates every 5 minutes. `revalidateMeeting` busts the per-meeting cache as soon as summarization writes new subjects.
+- The configurator is visible to city editors only. Its meeting picker offers released past meetings only, because the widget is public.
+
+See also: [meeting-lifecycle.md](./meeting-lifecycle.md) for how subjects and summaries are produced, and [../infrastructure.md](../infrastructure.md) for the CDN in front of the app.

--- a/messages/el.json
+++ b/messages/el.json
@@ -297,7 +297,14 @@
         "recent": "Πρόσφατες Συνεδριάσεις",
         "watchLive": "Παρακολουθήστε ζωντανά",
         "noSubjects": "Δεν υπάρχουν διαθέσιμα θέματα.",
-        "hotSubjects": "Επίκαιρα Θέματα"
+        "hotSubjects": "Επίκαιρα Θέματα",
+        "aiSummary": "Αυτόματη σύνοψη",
+        "fullMeeting": "Ολόκληρη η συνεδρίαση",
+        "noMeeting": "Η συνεδρίαση δεν βρέθηκε.",
+        "subjectsCount": "{count, plural, one {# θέμα} other {# θέματα}}",
+        "speakersCount": "{count, plural, one {# ομιλητής} other {# ομιλητές}}",
+        "hoursCount": "{count, plural, one {# ώρα} other {# ώρες}}",
+        "minutesCount": "{count, plural, one {# λεπτό} other {# λεπτά}}"
     },
     "AddMeetingForm": {
         "meetingName": "Όνομα Συνεδρίασης",

--- a/messages/el.json
+++ b/messages/el.json
@@ -287,7 +287,12 @@
         "troubleshootingTitle": "Σημειώσεις εγκατάστασης",
         "troubleshootingCSP": "Αν το widget δεν εμφανίζεται, ελέγξτε ότι το Content Security Policy (CSP) του site σας επιτρέπει frame-src από opencouncil.gr.",
         "troubleshootingWordPress": "Σε WordPress, χρησιμοποιήστε Custom HTML block. Σε Joomla, χρησιμοποιήστε module τύπου \"Custom / mod_custom\" με editor σε code view.",
-        "troubleshootingHeight": "Ρυθμίστε το height στον κώδικα ανάλογα με τον αριθμό συνεδριάσεων. Για 5 συνεδριάσεις, 600px είναι καλή αρχή."
+        "troubleshootingHeight": "Ρυθμίστε το height στον κώδικα ανάλογα με τον αριθμό συνεδριάσεων. Για 5 συνεδριάσεις, 600px είναι καλή αρχή.",
+        "typeSummary": "Σύνοψη συνεδρίασης",
+        "summaryMeeting": "Ποια συνεδρίαση",
+        "summaryLatest": "Οι πιο πρόσφατες συνεδριάσεις",
+        "subjectsPerMeeting": "Θέματα ανά συνεδρίαση",
+        "troubleshootingHeightSummary": "Για τη σύνοψη συνεδρίασης υπολογίστε περίπου 450px ύψος ανά συνεδρίαση."
     },
     "EmbedWidget": {
         "subjects": "Θέματα",

--- a/messages/en.json
+++ b/messages/en.json
@@ -273,7 +273,12 @@
         "troubleshootingTitle": "Installation notes",
         "troubleshootingCSP": "If the widget doesn't load, check that your site's Content Security Policy (CSP) allows frame-src from opencouncil.gr.",
         "troubleshootingWordPress": "In WordPress, use a Custom HTML block. In Joomla, use a \"Custom / mod_custom\" module with the editor in code view.",
-        "troubleshootingHeight": "Adjust the height value in the code based on the number of meetings. For 5 meetings, 600px is a good starting point."
+        "troubleshootingHeight": "Adjust the height value in the code based on the number of meetings. For 5 meetings, 600px is a good starting point.",
+        "typeSummary": "Meeting summary",
+        "summaryMeeting": "Which meeting",
+        "summaryLatest": "The latest meetings",
+        "subjectsPerMeeting": "Subjects per meeting",
+        "troubleshootingHeightSummary": "For the meeting summary, allow about 450px of height per meeting."
     },
     "EmbedWidget": {
         "subjects": "Subjects",

--- a/messages/en.json
+++ b/messages/en.json
@@ -283,7 +283,14 @@
         "recent": "Recent Meetings",
         "watchLive": "Watch live",
         "noSubjects": "No subjects available.",
-        "hotSubjects": "Hot Subjects"
+        "hotSubjects": "Hot Subjects",
+        "aiSummary": "Automatic summary",
+        "fullMeeting": "Full meeting",
+        "noMeeting": "Meeting not found.",
+        "subjectsCount": "{count, plural, one {# subject} other {# subjects}}",
+        "speakersCount": "{count, plural, one {# speaker} other {# speakers}}",
+        "hoursCount": "{count, plural, one {# hour} other {# hours}}",
+        "minutesCount": "{count, plural, one {# minute} other {# minutes}}"
     },
     "AddMeetingForm": {
         "meetingName": "Meeting Name",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -287,7 +287,12 @@
     "numberOfSubjects": "Nombre de sujets à afficher",
     "typeMeetings": "Séances",
     "typeSubjects": "Sujets marquants",
-    "widgetType": "Contenu à afficher"
+    "widgetType": "Contenu à afficher",
+    "typeSummary": "Résumé de séance",
+    "summaryMeeting": "Quelle séance",
+    "summaryLatest": "Les dernières séances",
+    "subjectsPerMeeting": "Points par séance",
+    "troubleshootingHeightSummary": "Pour le résumé de séance, prévoyez environ 450px de hauteur par séance."
   },
   "EmbedWidget": {
     "subjects": "Points",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -297,7 +297,14 @@
     "recent": "Séances récentes",
     "watchLive": "Regarder en direct",
     "hotSubjects": "Sujets marquants",
-    "noSubjects": "Aucun sujet disponible."
+    "noSubjects": "Aucun sujet disponible.",
+    "aiSummary": "Résumé automatique",
+    "fullMeeting": "Séance complète",
+    "noMeeting": "Séance introuvable.",
+    "subjectsCount": "{count, plural, one {# point} other {# points}}",
+    "speakersCount": "{count, plural, one {# intervenant} other {# intervenants}}",
+    "hoursCount": "{count, plural, one {# heure} other {# heures}}",
+    "minutesCount": "{count, plural, one {# minute} other {# minutes}}"
   },
   "AddMeetingForm": {
     "meetingName": "Nom de la séance",

--- a/messages/sr.json
+++ b/messages/sr.json
@@ -273,7 +273,12 @@
         "troubleshootingTitle": "Напомене за инсталацију",
         "troubleshootingCSP": "Ако се виџет не учитава, проверите да ли Content Security Policy (CSP) вашег сајта дозвољава frame-src са opencouncil.gr.",
         "troubleshootingWordPress": "У WordPress-у користите блок Custom HTML. У Joomla-и користите модул \"Custom / mod_custom\" са уређивачем у приказу кода.",
-        "troubleshootingHeight": "Прилагодите вредност висине у коду према броју седница. За 5 седница, 600px је добра почетна вредност."
+        "troubleshootingHeight": "Прилагодите вредност висине у коду према броју седница. За 5 седница, 600px је добра почетна вредност.",
+        "typeSummary": "Сажетак седнице",
+        "summaryMeeting": "Која седница",
+        "summaryLatest": "Најновије седнице",
+        "subjectsPerMeeting": "Теме по седници",
+        "troubleshootingHeightSummary": "За сажетак седнице предвидите око 450px висине по седници."
     },
     "EmbedWidget": {
         "subjects": "Теме",

--- a/messages/sr.json
+++ b/messages/sr.json
@@ -283,7 +283,14 @@
         "recent": "Недавне седнице",
         "watchLive": "Гледајте уживо",
         "noSubjects": "Нема доступних тема.",
-        "hotSubjects": "Актуелне теме"
+        "hotSubjects": "Актуелне теме",
+        "aiSummary": "Аутоматски сажетак",
+        "fullMeeting": "Цела седница",
+        "noMeeting": "Седница није пронађена.",
+        "subjectsCount": "{count, plural, one {# тема} few {# теме} other {# тема}}",
+        "speakersCount": "{count, plural, one {# говорник} few {# говорника} other {# говорника}}",
+        "hoursCount": "{count, plural, one {# сат} few {# сата} other {# сати}}",
+        "minutesCount": "{count, plural, one {# минут} few {# минута} other {# минута}}"
     },
     "AddMeetingForm": {
         "meetingName": "Назив седнице",

--- a/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/widget/page.tsx
+++ b/src/app/[locale]/(city)/[cityId]/(other)/(tabs)/widget/page.tsx
@@ -1,8 +1,8 @@
 import { notFound } from 'next/navigation';
 import { isUserAuthorizedToEdit } from '@/lib/auth';
-import { getCityCached, getAdministrativeBodiesWithPublicMeetingsCached } from '@/lib/cache';
+import { getCityCached, getAdministrativeBodiesWithPublicMeetingsCached, getCouncilMeetingsForCityPublicCached } from '@/lib/cache';
 import { AdministrativeBodyType } from '@prisma/client';
-import { EmbedConfigurator, type EmbedBodyGroup } from '@/components/embed/EmbedConfigurator';
+import { EmbedConfigurator, type EmbedBodyGroup, type EmbedRecentMeeting } from '@/components/embed/EmbedConfigurator';
 import { Metadata } from 'next';
 
 // Embed configurator for city admins — nothing to index.
@@ -11,6 +11,9 @@ export const metadata: Metadata = {
 };
 
 const ADMIN_BODY_TYPE_ORDER: AdministrativeBodyType[] = ['council', 'committee', 'community'];
+
+/** Choices offered by the summary widget's meeting picker. */
+const RECENT_MEETINGS_LIMIT = 20;
 
 export default async function WidgetPage(
     props: {
@@ -22,11 +25,13 @@ export default async function WidgetPage(
     const canEdit = await isUserAuthorizedToEdit({ cityId });
     if (!canEdit) notFound();
 
-    const [city, bodies] = await Promise.all([
+    const [city, bodies, pastMeetings] = await Promise.all([
         getCityCached(cityId),
         // Only bodies that have released meetings — the widget is public, so the
         // filter shouldn't offer bodies a visitor can't see any meetings for.
         getAdministrativeBodiesWithPublicMeetingsCached(cityId),
+        // Same rule for the summary widget's meeting picker: released past meetings only.
+        getCouncilMeetingsForCityPublicCached(cityId, { limit: RECENT_MEETINGS_LIMIT, timeFilter: 'past' }),
     ]);
 
     const bodyGroups: EmbedBodyGroup[] = ADMIN_BODY_TYPE_ORDER
@@ -38,5 +43,20 @@ export default async function WidgetPage(
         }))
         .filter(group => group.bodies.length > 0);
 
-    return <EmbedConfigurator cityId={cityId} cityName={city?.name} bodyGroups={bodyGroups} />;
+    const recentMeetings: EmbedRecentMeeting[] = pastMeetings.map(meeting => ({
+        id: meeting.id,
+        name: meeting.name,
+        name_en: meeting.name_en,
+        dateTime: new Date(meeting.dateTime).toISOString(),
+    }));
+
+    return (
+        <EmbedConfigurator
+            cityId={cityId}
+            cityName={city?.name}
+            cityTimezone={city?.timezone}
+            bodyGroups={bodyGroups}
+            recentMeetings={recentMeetings}
+        />
+    );
 }

--- a/src/app/[locale]/(embed)/embed/meetings/embed.css
+++ b/src/app/[locale]/(embed)/embed/meetings/embed.css
@@ -197,3 +197,135 @@
     height: 24px;
     object-fit: contain;
 }
+
+/* ── Meeting summary widget: one block per meeting ── */
+.embed-summary {
+    padding: 16px;
+    border: 1px solid var(--embed-border);
+    background: var(--embed-card-bg);
+}
+.embed-summary-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+.embed-summary-title {
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1.35;
+    color: var(--embed-text);
+}
+.embed-summary-subtitle {
+    margin-top: 2px;
+    font-size: 13px;
+    color: var(--embed-text-muted);
+}
+.embed-summary-badge {
+    flex-shrink: 0;
+    padding: 3px 9px;
+    border: 1px solid var(--embed-border);
+    border-radius: 999px;
+    background: var(--embed-card-hover);
+    font-size: 11px;
+    font-weight: 600;
+    white-space: nowrap;
+    color: var(--embed-accent);
+}
+
+/* Cards fill the row; each is at least 220px wide. */
+.embed-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 10px;
+}
+.embed-summary-card,
+.embed-summary-card:hover,
+.embed-summary-card:visited {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px;
+    border: 1px solid var(--embed-border);
+    background: var(--embed-bg);
+    color: inherit;
+    text-decoration: none;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+.embed-summary-card:hover {
+    border-color: var(--embed-accent);
+    box-shadow: 0 2px 12px rgba(0,0,0,0.06);
+}
+.embed-summary-topic {
+    align-self: flex-start;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1.4;
+}
+.embed-summary-card-title {
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.35;
+    color: var(--embed-text);
+    transition: color 0.15s;
+}
+.embed-summary-card:hover .embed-summary-card-title {
+    color: var(--embed-accent);
+}
+.embed-summary-desc {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    font-size: 12.5px;
+    line-height: 1.45;
+    color: var(--embed-text-muted);
+}
+.embed-summary-time {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: auto;
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    color: var(--embed-accent);
+}
+
+/* ── Stats footer with the block's single link ── */
+.embed-summary-footer {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px 16px;
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid var(--embed-border);
+}
+.embed-summary-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    font-size: 12px;
+    color: var(--embed-text-muted);
+}
+.embed-summary-stat {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+.embed-summary-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--embed-accent);
+    text-decoration: none;
+}
+.embed-summary-link:hover {
+    text-decoration: underline;
+}

--- a/src/app/[locale]/(embed)/embed/meetings/page.tsx
+++ b/src/app/[locale]/(embed)/embed/meetings/page.tsx
@@ -4,6 +4,7 @@ import { getCityCached, getCouncilMeetingsForCityPublicCached } from '@/lib/cach
 import { EmbedMeetingCard } from '@/components/embed/EmbedMeetingCard';
 import { EmbedFooter } from '@/components/embed/EmbedFooter';
 import { parseEmbedConfig, type EmbedSearchParams } from '@/lib/utils/embedParams';
+import { embedBaseUrl } from '@/lib/utils/embedBaseUrl';
 import './embed.css';
 
 // Cache the page for 5 minutes at the CDN, serve stale for up to 1 hour while revalidating
@@ -28,7 +29,8 @@ export default async function EmbedMeetingsPage(props: EmbedMeetingsPageProps) {
     const city = await getCityCached(cityId);
     if (!city) notFound();
 
-    const { limit, administrativeBodyTypes, administrativeBodyIds, themeVars, baseUrl } = parseEmbedConfig(searchParams);
+    const { limit, administrativeBodyTypes, administrativeBodyIds, themeVars } = parseEmbedConfig(searchParams);
+    const baseUrl = embedBaseUrl(city.realm);
     const showSubjects = searchParams.showSubjects !== 'false';
 
     // Fetch upcoming (ASC, nearest first) and past (DESC, most recent first) in parallel.

--- a/src/app/[locale]/(embed)/embed/subjects/page.tsx
+++ b/src/app/[locale]/(embed)/embed/subjects/page.tsx
@@ -4,6 +4,7 @@ import { getCityCached, getCityIdForGeohashCached } from '@/lib/cache';
 import { EmbedSubjectCard } from '@/components/embed/EmbedSubjectCard';
 import { EmbedFooter } from '@/components/embed/EmbedFooter';
 import { parseEmbedConfig, type EmbedSearchParams } from '@/lib/utils/embedParams';
+import { embedBaseUrl } from '@/lib/utils/embedBaseUrl';
 import { getHotSubjectCards } from '@/lib/hotSubjectCards';
 import { isValidGeohash } from '@/lib/geo';
 import { cn } from '@/lib/utils';
@@ -37,7 +38,8 @@ export default async function EmbedSubjectsPage(props: EmbedSubjectsPageProps) {
     // An explicitly provided cityId must exist (unchanged behavior).
     if (searchParams.cityId && !city) notFound();
 
-    const { limit, administrativeBodyTypes, administrativeBodyIds, themeVars, appThemeShim, baseUrl } = parseEmbedConfig(searchParams);
+    const { limit, administrativeBodyTypes, administrativeBodyIds, themeVars, appThemeShim } = parseEmbedConfig(searchParams);
+    const baseUrl = embedBaseUrl(city?.realm);
 
     const cards = city
         ? await getHotSubjectCards(city.id, { limit, administrativeBodyTypes, administrativeBodyIds, geohash })

--- a/src/app/[locale]/(embed)/embed/summary/page.tsx
+++ b/src/app/[locale]/(embed)/embed/summary/page.tsx
@@ -1,0 +1,82 @@
+import { notFound } from 'next/navigation';
+import { getTranslations } from 'next-intl/server';
+import { getCityCached } from '@/lib/cache';
+import { EmbedMeetingSummary, type EmbedSummaryTranslations } from '@/components/embed/EmbedMeetingSummary';
+import { EmbedFooter } from '@/components/embed/EmbedFooter';
+import { parseEmbedConfig, parseBoundedInt, EMBED_SUMMARY_LIMITS, type EmbedSearchParams } from '@/lib/utils/embedParams';
+import { embedBaseUrl } from '@/lib/utils/embedBaseUrl';
+import { getMeetingSummaries } from '@/lib/meetingSummaries';
+import '../meetings/embed.css';
+
+// Cache the page for 5 minutes at the CDN, serve stale for up to 1 hour while revalidating
+export const revalidate = 300;
+
+interface EmbedSummaryPageProps {
+    params: Promise<{ locale: string }>;
+    searchParams: Promise<EmbedSearchParams & {
+        cityId?: string;
+        /** One specific meeting. Without it, `limit` latest past meetings are stacked. */
+        meetingId?: string;
+        /** Subject cards per meeting. */
+        subjects?: string;
+    }>;
+}
+
+/**
+ * Meeting summary widget: one block per meeting with its most discussed
+ * subjects, the meeting's stats and a single link to the full meeting page.
+ */
+export default async function EmbedSummaryPage(props: EmbedSummaryPageProps) {
+    const searchParams = await props.searchParams;
+    const { locale } = await props.params;
+    const { cityId, meetingId } = searchParams;
+
+    if (!cityId) notFound();
+
+    const city = await getCityCached(cityId);
+    if (!city) notFound();
+
+    const { limit, administrativeBodyTypes, administrativeBodyIds, themeVars } =
+        parseEmbedConfig(searchParams, { limit: EMBED_SUMMARY_LIMITS.meetings });
+    const maxSubjects = parseBoundedInt(searchParams.subjects, EMBED_SUMMARY_LIMITS.subjects);
+    const baseUrl = embedBaseUrl(city.realm);
+
+    const summaries = await getMeetingSummaries(cityId, { meetingId, limit, administrativeBodyTypes, administrativeBodyIds });
+
+    const t = await getTranslations('EmbedWidget');
+    const translations: EmbedSummaryTranslations = {
+        aiSummary: t('aiSummary'),
+        fullMeeting: t('fullMeeting'),
+        noSubjects: t('noSubjects'),
+        subjectsCount: (count) => t('subjectsCount', { count }),
+        speakersCount: (count) => t('speakersCount', { count }),
+        hoursCount: (count) => t('hoursCount', { count }),
+        minutesCount: (count) => t('minutesCount', { count }),
+    };
+    // A missing specific meeting and a city without past meetings read differently.
+    const emptyText = meetingId ? t('noMeeting') : t('noMeetings');
+
+    return (
+        <div className="embed-widget" style={themeVars as React.CSSProperties}>
+            {summaries.length === 0 ? (
+                <div className="embed-empty">{emptyText}</div>
+            ) : (
+                <div className="embed-list">
+                    {summaries.map((summary) => (
+                        <EmbedMeetingSummary
+                            key={summary.meeting.id}
+                            summary={summary}
+                            maxSubjects={maxSubjects}
+                            locale={locale}
+                            baseUrl={baseUrl}
+                            cityTimezone={city.timezone}
+                            translations={translations}
+                        />
+                    ))}
+                </div>
+            )}
+
+            <EmbedFooter baseUrl={baseUrl} cityId={cityId} />
+        </div>
+    );
+}

--- a/src/app/api/embed/subjects/route.ts
+++ b/src/app/api/embed/subjects/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { env } from '@/env.mjs';
 import { getCityCached, getCityIdForGeohashCached } from '@/lib/cache';
 import { parseEmbedConfig } from '@/lib/utils/embedParams';
+import { embedBaseUrl } from '@/lib/utils/embedBaseUrl';
 import { getRecentHotSubjects, getHotSubjectsNearGeohash, withDistances, type HotSubject, type HotSubjectWithDistance } from '@/lib/hotSubjects';
 import { isValidGeohash, decodeGeohashToCenter } from '@/lib/geo';
 
@@ -51,7 +51,7 @@ export async function GET(req: NextRequest) {
     }
 
     const { limit, administrativeBodyTypes, administrativeBodyIds } = parseEmbedConfig(params);
-    const baseUrl = env.NEXTAUTH_URL.replace(/\/$/, '');
+    const baseUrl = embedBaseUrl(city?.realm);
 
     const top: HotSubject[] = city
         ? geohash

--- a/src/components/embed/EmbedConfigurator.tsx
+++ b/src/components/embed/EmbedConfigurator.tsx
@@ -11,10 +11,13 @@ import { urlPrefixForLocale } from '@/i18n/config';
 import { Switch } from '@/components/ui/switch';
 import { Slider } from '@/components/ui/slider';
 import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { AdminBodyPicker, type AdminBodyGroup } from '@/components/ui/admin-body-picker';
 import { EmbedLocationInput, type EmbedLocation } from '@/components/embed/EmbedLocationInput';
 import { Check, Copy, Code, Sun, Moon } from 'lucide-react';
 import { type EmbedRadius } from '@/lib/utils/embedTheme';
+import { EMBED_SUMMARY_LIMITS } from '@/lib/utils/embedParams';
+import { formatDate } from '@/lib/formatters/time';
 
 /** An admin-body type and its individual bodies that have public meetings. */
 export interface EmbedBodyGroup {
@@ -22,26 +25,48 @@ export interface EmbedBodyGroup {
     bodies: { id: string; name: string; name_en: string }[];
 }
 
+/** A released past meeting the summary widget can be pinned to. */
+export interface EmbedRecentMeeting {
+    id: string;
+    name: string;
+    name_en: string;
+    /** ISO string: crosses the server/client boundary as text. */
+    dateTime: string;
+}
+
+type EmbedWidgetType = 'meetings' | 'subjects' | 'summary';
+
+/** Select value for "the latest meetings" in the summary widget's meeting picker. */
+const LATEST_MEETINGS = 'latest';
+
 interface EmbedConfiguratorProps {
     cityId: string;
     /** City name — biases the location-filter address search. */
     cityName?: string;
+    /** For the dates in the summary widget's meeting picker. */
+    cityTimezone?: string;
     /** Only types/bodies that have released meetings — pre-filtered server-side. */
     bodyGroups: EmbedBodyGroup[];
+    /** Released past meetings, newest first — choices for the summary widget's meeting picker. */
+    recentMeetings: EmbedRecentMeeting[];
 }
 
-export function EmbedConfigurator({ cityId, cityName, bodyGroups }: EmbedConfiguratorProps) {
+export function EmbedConfigurator({ cityId, cityName, cityTimezone, bodyGroups, recentMeetings }: EmbedConfiguratorProps) {
     const t = useTranslations('EmbedConfigurator');
     const tCommon = useTranslations('Common');
     const locale = useLocale();
 
     // Configuration state
-    const [widgetType, setWidgetType] = useState<'meetings' | 'subjects'>('meetings');
+    const [widgetType, setWidgetType] = useState<EmbedWidgetType>('meetings');
     const [accent, setAccent] = useState('#3b82f6');
     const [mode, setMode] = useState<'light' | 'dark'>('light');
     const [limit, setLimit] = useState(5);
     const [showSubjects, setShowSubjects] = useState(true);
     const [radius, setRadius] = useState<EmbedRadius>('rounded');
+    // Summary widget: a pinned meeting (null = the latest ones), how many of those, and cards per meeting.
+    const [summaryMeetingId, setSummaryMeetingId] = useState<string | null>(null);
+    const [summaryLimit, setSummaryLimit] = useState<number>(EMBED_SUMMARY_LIMITS.meetings.default);
+    const [subjectsPerMeeting, setSubjectsPerMeeting] = useState<number>(EMBED_SUMMARY_LIMITS.subjects.default);
     // Body filter: a single type (level 1) plus an optional specific body (level 2).
     const [selectedType, setSelectedType] = useState<AdministrativeBodyType | null>(null);
     const [selectedBodyId, setSelectedBodyId] = useState<string | null>(null);
@@ -70,6 +95,9 @@ export function EmbedConfigurator({ cityId, cityName, bodyGroups }: EmbedConfigu
         return () => clearTimeout(timer);
     }, [copied]);
 
+    // A pinned meeting is shown whatever its body; the body filter only narrows "the latest meetings".
+    const bodyFilterApplies = widgetType !== 'summary' || summaryMeetingId === null;
+
     // Build the embed URL
     const embedUrl = useMemo(() => {
         if (!origin) return '';
@@ -77,21 +105,35 @@ export function EmbedConfigurator({ cityId, cityName, bodyGroups }: EmbedConfigu
         params.set('cityId', cityId);
         if (accent !== '#3b82f6') params.set('accent', accent.replace('#', ''));
         if (mode !== 'light') params.set('mode', mode);
-        if (limit !== 5) params.set('limit', String(limit));
+        if (widgetType === 'summary') {
+            if (summaryMeetingId) {
+                params.set('meetingId', summaryMeetingId);
+            } else if (summaryLimit !== EMBED_SUMMARY_LIMITS.meetings.default) {
+                params.set('limit', String(summaryLimit));
+            }
+            if (subjectsPerMeeting !== EMBED_SUMMARY_LIMITS.subjects.default) {
+                params.set('subjects', String(subjectsPerMeeting));
+            }
+        } else if (limit !== 5) {
+            params.set('limit', String(limit));
+        }
         if (widgetType === 'meetings' && !showSubjects) params.set('showSubjects', 'false');
-        if (widgetType === 'meetings' && radius !== 'rounded') params.set('radius', radius);
+        // The subjects widget's cards have fixed corners.
+        if (widgetType !== 'subjects' && radius !== 'rounded') params.set('radius', radius);
         // A specific body (id) wins over the broader type filter.
-        if (selectedBodyId) {
-            params.set('bodyIds', selectedBodyId);
-        } else if (selectedType) {
-            params.set('bodies', selectedType);
+        if (bodyFilterApplies) {
+            if (selectedBodyId) {
+                params.set('bodyIds', selectedBodyId);
+            } else if (selectedType) {
+                params.set('bodies', selectedType);
+            }
         }
         // Location filter is subjects-only.
         if (widgetType === 'subjects' && geoLocation) {
             params.set('geohash', geoLocation.geohash);
         }
         return `${origin}/${urlPrefixForLocale(locale)}/embed/${widgetType}?${params.toString()}`;
-    }, [origin, locale, cityId, widgetType, accent, mode, limit, showSubjects, radius, selectedType, selectedBodyId, geoLocation]);
+    }, [origin, locale, cityId, widgetType, accent, mode, limit, showSubjects, radius, selectedType, selectedBodyId, geoLocation, bodyFilterApplies, summaryMeetingId, summaryLimit, subjectsPerMeeting]);
 
     const embedCode = `<iframe\n  src="${embedUrl}"\n  width="100%"\n  height="600"\n  frameborder="0"\n  style="border-radius: 8px; border: 1px solid #e5e7eb;"\n  title="OpenCouncil"\n></iframe>`;
 
@@ -126,6 +168,7 @@ export function EmbedConfigurator({ cityId, cityName, bodyGroups }: EmbedConfigu
                         {([
                             { value: 'meetings', label: t('typeMeetings') },
                             { value: 'subjects', label: t('typeSubjects') },
+                            { value: 'summary', label: t('typeSummary') },
                         ] as const).map((opt) => (
                             <button
                                 key={opt.value}
@@ -178,20 +221,76 @@ export function EmbedConfigurator({ cityId, cityName, bodyGroups }: EmbedConfigu
                     />
                 </div>
 
-                {/* Number of cards */}
-                <div className="space-y-3">
-                    <div className="flex items-center justify-between">
-                        <Label>{widgetType === 'subjects' ? t('numberOfSubjects') : t('numberOfMeetings')}</Label>
-                        <span className="text-sm font-medium tabular-nums">{limit}</span>
+                {/* Meeting picker — summary widget only */}
+                {widgetType === 'summary' && (
+                    <div className="space-y-2">
+                        <Label>{t('summaryMeeting')}</Label>
+                        <Select
+                            value={summaryMeetingId ?? LATEST_MEETINGS}
+                            onValueChange={(value) => setSummaryMeetingId(value === LATEST_MEETINGS ? null : value)}
+                        >
+                            <SelectTrigger>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value={LATEST_MEETINGS}>{t('summaryLatest')}</SelectItem>
+                                {recentMeetings.map((meeting) => (
+                                    <SelectItem key={meeting.id} value={meeting.id}>
+                                        {getLocalizedName(meeting, locale)} · {formatDate(new Date(meeting.dateTime), cityTimezone, locale)}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
                     </div>
-                    <Slider
-                        value={[limit]}
-                        onValueChange={([v]) => setLimit(v)}
-                        min={1}
-                        max={10}
-                        step={1}
-                    />
-                </div>
+                )}
+
+                {/* Number of cards — for the summary widget, how many of the latest meetings */}
+                {widgetType !== 'summary' ? (
+                    <div className="space-y-3">
+                        <div className="flex items-center justify-between">
+                            <Label>{widgetType === 'subjects' ? t('numberOfSubjects') : t('numberOfMeetings')}</Label>
+                            <span className="text-sm font-medium tabular-nums">{limit}</span>
+                        </div>
+                        <Slider
+                            value={[limit]}
+                            onValueChange={([v]) => setLimit(v)}
+                            min={1}
+                            max={10}
+                            step={1}
+                        />
+                    </div>
+                ) : summaryMeetingId === null && (
+                    <div className="space-y-3">
+                        <div className="flex items-center justify-between">
+                            <Label>{t('numberOfMeetings')}</Label>
+                            <span className="text-sm font-medium tabular-nums">{summaryLimit}</span>
+                        </div>
+                        <Slider
+                            value={[summaryLimit]}
+                            onValueChange={([v]) => setSummaryLimit(v)}
+                            min={EMBED_SUMMARY_LIMITS.meetings.min}
+                            max={EMBED_SUMMARY_LIMITS.meetings.max}
+                            step={1}
+                        />
+                    </div>
+                )}
+
+                {/* Subject cards per meeting — summary widget only */}
+                {widgetType === 'summary' && (
+                    <div className="space-y-3">
+                        <div className="flex items-center justify-between">
+                            <Label>{t('subjectsPerMeeting')}</Label>
+                            <span className="text-sm font-medium tabular-nums">{subjectsPerMeeting}</span>
+                        </div>
+                        <Slider
+                            value={[subjectsPerMeeting]}
+                            onValueChange={([v]) => setSubjectsPerMeeting(v)}
+                            min={EMBED_SUMMARY_LIMITS.subjects.min}
+                            max={EMBED_SUMMARY_LIMITS.subjects.max}
+                            step={1}
+                        />
+                    </div>
+                )}
 
                 {/* Location filter — subjects widget only */}
                 {widgetType === 'subjects' && (
@@ -218,8 +317,8 @@ export function EmbedConfigurator({ cityId, cityName, bodyGroups }: EmbedConfigu
                     </div>
                 )}
 
-                {/* Border radius — subjects cards have fixed corners, so meetings-only */}
-                {widgetType === 'meetings' && (
+                {/* Border radius — subjects cards have fixed corners, so not for that widget */}
+                {widgetType !== 'subjects' && (
                 <div className="space-y-2">
                     <Label>{t('borderRadius')}</Label>
                     <div className="flex gap-2">
@@ -241,16 +340,18 @@ export function EmbedConfigurator({ cityId, cityName, bodyGroups }: EmbedConfigu
                 )}
 
                 {/* Administrative body filter — type (level 1) + specific body (level 2) */}
-                <AdminBodyPicker
-                    groups={bodyPickerGroups}
-                    selectedType={selectedType}
-                    onTypeChange={type => { setSelectedType(type); setSelectedBodyId(null); }}
-                    selectedBodyId={selectedBodyId}
-                    onBodyChange={setSelectedBodyId}
-                    allTypesLabel={tCommon('allMeetings')}
-                    allBodiesLabel={tCommon('allBodies')}
-                    label={t('administrativeBodies')}
-                />
+                {bodyFilterApplies && (
+                    <AdminBodyPicker
+                        groups={bodyPickerGroups}
+                        selectedType={selectedType}
+                        onTypeChange={type => { setSelectedType(type); setSelectedBodyId(null); }}
+                        selectedBodyId={selectedBodyId}
+                        onBodyChange={setSelectedBodyId}
+                        allTypesLabel={tCommon('allMeetings')}
+                        allBodiesLabel={tCommon('allBodies')}
+                        label={t('administrativeBodies')}
+                    />
+                )}
 
                 {/* Embed code */}
                 <div className="space-y-2">
@@ -290,7 +391,7 @@ export function EmbedConfigurator({ cityId, cityName, bodyGroups }: EmbedConfigu
                     <ul className="list-disc pl-4 space-y-1 text-xs">
                         <li>{t('troubleshootingCSP')}</li>
                         <li>{t('troubleshootingWordPress')}</li>
-                        <li>{t('troubleshootingHeight')}</li>
+                        <li>{widgetType === 'summary' ? t('troubleshootingHeightSummary') : t('troubleshootingHeight')}</li>
                     </ul>
                 </div>
             </div>

--- a/src/components/embed/EmbedMeetingSummary.tsx
+++ b/src/components/embed/EmbedMeetingSummary.tsx
@@ -1,0 +1,107 @@
+import { ArrowRight, Clock, FileText, Users } from 'lucide-react';
+import { formatDate } from '@/lib/formatters/time';
+import { getLocalizedName } from '@/lib/formatters/name';
+import { embedLocalePrefix } from '@/lib/utils/embedParams';
+import { pickSummarySubjects } from '@/lib/utils/subjects';
+import type { MeetingSummary } from '@/lib/db/types';
+import { EmbedSummarySubjectCard } from '@/components/embed/EmbedSummarySubjectCard';
+
+export interface EmbedSummaryTranslations {
+    aiSummary: string;
+    fullMeeting: string;
+    noSubjects: string;
+    subjectsCount: (count: number) => string;
+    speakersCount: (count: number) => string;
+    hoursCount: (count: number) => string;
+    minutesCount: (count: number) => string;
+}
+
+interface EmbedMeetingSummaryProps {
+    summary: MeetingSummary;
+    /** Subject cards to show; the footer still counts every subject. */
+    maxSubjects: number;
+    locale: string;
+    baseUrl: string;
+    cityTimezone?: string;
+    translations: EmbedSummaryTranslations;
+}
+
+/** "3 ώρες 41 λεπτά" — the hours part only from one hour on, the minutes part only when non-zero. */
+function formatDurationText(seconds: number, t: EmbedSummaryTranslations): string {
+    const totalMinutes = Math.round(seconds / 60);
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    if (hours === 0) return t.minutesCount(minutes);
+    if (minutes === 0) return t.hoursCount(hours);
+    return `${t.hoursCount(hours)} ${t.minutesCount(minutes)}`;
+}
+
+/**
+ * One meeting block of the summary widget: body and meeting in the header, the
+ * most discussed subjects as cards, and a stats footer with the block's only
+ * link to the meeting page. Hook-free, so the iframe stays a Server Component.
+ */
+export function EmbedMeetingSummary({ summary, maxSubjects, locale, baseUrl, cityTimezone, translations: t }: EmbedMeetingSummaryProps) {
+    const { meeting, durationSeconds, speakerCount, subjectStartSeconds } = summary;
+    const meetingUrl = `${baseUrl}${embedLocalePrefix(locale)}/${meeting.cityId}/${meeting.id}`;
+    const subjects = pickSummarySubjects(meeting.subjects, maxSubjects);
+
+    const meetingName = getLocalizedName(meeting, locale);
+    // The cached payload revives dates as ISO strings; normalize before formatting.
+    const date = formatDate(new Date(meeting.dateTime), cityTimezone, locale);
+    const title = meeting.administrativeBody ? getLocalizedName(meeting.administrativeBody, locale) : meetingName;
+    const subtitle = meeting.administrativeBody ? `${meetingName}, ${date}` : date;
+
+    return (
+        <section className="embed-summary" style={{ borderRadius: 'var(--embed-radius)' }}>
+            <header className="embed-summary-header">
+                <div>
+                    <div className="embed-summary-title">{title}</div>
+                    <div className="embed-summary-subtitle">{subtitle}</div>
+                </div>
+                <span className="embed-summary-badge">{t.aiSummary}</span>
+            </header>
+
+            {subjects.length > 0 ? (
+                <div className="embed-summary-grid">
+                    {subjects.map((subject) => (
+                        <EmbedSummarySubjectCard
+                            key={subject.id}
+                            subject={subject}
+                            startSeconds={subjectStartSeconds[subject.id] ?? null}
+                            href={`${meetingUrl}/subjects/${subject.id}`}
+                            locale={locale}
+                        />
+                    ))}
+                </div>
+            ) : (
+                <div className="embed-empty">{t.noSubjects}</div>
+            )}
+
+            <footer className="embed-summary-footer">
+                <div className="embed-summary-stats">
+                    {durationSeconds != null && (
+                        <span className="embed-summary-stat">
+                            <Clock size={13} />
+                            {formatDurationText(durationSeconds, t)}
+                        </span>
+                    )}
+                    <span className="embed-summary-stat">
+                        <FileText size={13} />
+                        {t.subjectsCount(meeting.subjects.length)}
+                    </span>
+                    {speakerCount > 0 && (
+                        <span className="embed-summary-stat">
+                            <Users size={13} />
+                            {t.speakersCount(speakerCount)}
+                        </span>
+                    )}
+                </div>
+                <a href={meetingUrl} target="_blank" rel="noopener noreferrer" className="embed-summary-link">
+                    {t.fullMeeting}
+                    <ArrowRight size={14} />
+                </a>
+            </footer>
+        </section>
+    );
+}

--- a/src/components/embed/EmbedSubjectCard.tsx
+++ b/src/components/embed/EmbedSubjectCard.tsx
@@ -7,7 +7,7 @@ import { SubjectCardContent } from '@/components/subject/SubjectCardContent';
 import { SubjectCardFooter } from '@/components/subject/SubjectCardFooter';
 import type { SubjectCardStats } from '@/lib/subjectCardStats';
 import type { PersonWithRelations } from '@/lib/db/people';
-import { routing, urlPrefixForLocale } from '@/i18n/routing';
+import { embedLocalePrefix } from '@/lib/utils/embedParams';
 import { localizeText } from '@/lib/serbian';
 import { useTranslations } from 'next-intl';
 
@@ -35,10 +35,7 @@ interface EmbedSubjectCardProps {
  */
 export function EmbedSubjectCard({ subject, meeting, locationText, speakers, stats, locale, baseUrl, cityTimezone }: EmbedSubjectCardProps) {
     const t = useTranslations('Subject');
-    // next-intl uses `as-needed` prefixing: the default locale has no prefix.
-    // Keeping the locale here makes English iframes link to English pages.
-    const localePrefix = locale === routing.defaultLocale ? '' : `/${urlPrefixForLocale(locale)}`;
-    const subjectUrl = `${baseUrl}${localePrefix}/${meeting.cityId}/${meeting.id}/subjects/${subject.id}`;
+    const subjectUrl = `${baseUrl}${embedLocalePrefix(locale)}/${meeting.cityId}/${meeting.id}/subjects/${subject.id}`;
 
     return (
         <a href={subjectUrl} target="_blank" rel="noopener noreferrer" className="block hover:no-underline">

--- a/src/components/embed/EmbedSummarySubjectCard.tsx
+++ b/src/components/embed/EmbedSummarySubjectCard.tsx
@@ -1,0 +1,56 @@
+import { Play } from 'lucide-react';
+import { compactMetadataDescription } from '@/lib/seo/metadataDescription';
+import { formatTimestamp } from '@/lib/formatters/time';
+import { getLocalizedName } from '@/lib/formatters/name';
+import { localizeText } from '@/lib/serbian';
+import type { MeetingSummarySubject } from '@/lib/db/types';
+
+interface EmbedSummarySubjectCardProps {
+    subject: MeetingSummarySubject;
+    /** Seconds into the recording where the discussion starts; null when untagged. */
+    startSeconds: number | null;
+    /** Subject page URL; the whole card is the link. */
+    href: string;
+    locale: string;
+}
+
+/** Enough text for the two-line clamp on a wide card; the rest never reaches the iframe. */
+const DESCRIPTION_MAX_CHARS = 240;
+
+/**
+ * Subject card of the summary widget: topic badge, title, a two-line summary
+ * and the discussion's start time. One anchor per card (HTML forbids nesting
+ * them); the subject page it opens already plays that discussion.
+ */
+export function EmbedSummarySubjectCard({ subject, startSeconds, href, locale }: EmbedSummarySubjectCardProps) {
+    const description = subject.description
+        ? localizeText(compactMetadataDescription(subject.description, DESCRIPTION_MAX_CHARS), locale)
+        : null;
+
+    return (
+        <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="embed-summary-card"
+            style={{ borderRadius: 'var(--embed-radius)' }}
+        >
+            {subject.topic && (
+                <span
+                    className="embed-summary-topic"
+                    style={{ color: subject.topic.colorHex, backgroundColor: `${subject.topic.colorHex}20` }}
+                >
+                    {getLocalizedName(subject.topic, locale)}
+                </span>
+            )}
+            <span className="embed-summary-card-title">{localizeText(subject.name, locale)}</span>
+            {description && <span className="embed-summary-desc">{description}</span>}
+            {startSeconds != null && (
+                <span className="embed-summary-time">
+                    <Play size={12} />
+                    {formatTimestamp(startSeconds)}
+                </span>
+            )}
+        </a>
+    );
+}

--- a/src/components/embed/__tests__/EmbedMeetingSummary.test.tsx
+++ b/src/components/embed/__tests__/EmbedMeetingSummary.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import { EmbedMeetingSummary, type EmbedSummaryTranslations } from '../EmbedMeetingSummary';
+import type { MeetingSummary, MeetingSummarySubject } from '@/lib/db/types';
+
+const t: EmbedSummaryTranslations = {
+    aiSummary: 'Αυτόματη σύνοψη',
+    fullMeeting: 'Ολόκληρη η συνεδρίαση',
+    noSubjects: 'Δεν υπάρχουν διαθέσιμα θέματα.',
+    subjectsCount: (count) => `${count} θέματα`,
+    speakersCount: (count) => `${count} ομιλητές`,
+    hoursCount: (count) => `${count} ώρες`,
+    minutesCount: (count) => `${count} λεπτά`,
+};
+
+function subject(id: string, name: string, contributions: number, description = 'Περίληψη'): MeetingSummarySubject {
+    return {
+        id,
+        name,
+        description,
+        agendaItemIndex: null,
+        nonAgendaReason: null,
+        topic: { name: 'Δικαιοσύνη', name_en: 'Justice', colorHex: '#112233', icon: 'scale' },
+        _count: { contributions },
+    };
+}
+
+function summary(overrides: Partial<MeetingSummary> = {}): MeetingSummary {
+    return {
+        meeting: {
+            id: 'apr6_2026',
+            cityId: 'vouli',
+            name: '25η συνεδρίαση',
+            name_en: '25th session',
+            dateTime: new Date('2026-04-06T10:00:00Z'),
+            administrativeBody: { name: 'Ολομέλεια της Βουλής', name_en: 'Plenary' },
+            subjects: [
+                subject('quiet', 'Ήσυχο θέμα', 0),
+                subject('penal', 'Ποινικός Κώδικας', 9),
+                subject('waste', 'Διαχείριση αποβλήτων', 4),
+            ],
+        },
+        durationSeconds: 3 * 3600 + 41 * 60,
+        speakerCount: 28,
+        subjectStartSeconds: { penal: 872 },
+        ...overrides,
+    };
+}
+
+describe('EmbedMeetingSummary', () => {
+    it('shows the body, the meeting, the most discussed subjects and the stats', () => {
+        render(<EmbedMeetingSummary summary={summary()} maxSubjects={2} locale="el" baseUrl="https://opencouncil.cy" translations={t} />);
+
+        expect(screen.getByText('Ολομέλεια της Βουλής')).toBeInTheDocument();
+        expect(screen.getByText(/25η συνεδρίαση, .*2026/)).toBeInTheDocument();
+        expect(screen.getByText('Αυτόματη σύνοψη')).toBeInTheDocument();
+
+        const cards = screen.getAllByRole('link', { name: /Ποινικός Κώδικας|Διαχείριση αποβλήτων|Ήσυχο θέμα/ });
+        expect(cards.map(card => card.textContent)).toEqual([
+            expect.stringContaining('Ποινικός Κώδικας'),
+            expect.stringContaining('Διαχείριση αποβλήτων'),
+        ]);
+        expect(cards[0]).toHaveAttribute('href', 'https://opencouncil.cy/vouli/apr6_2026/subjects/penal');
+        expect(cards[0]).toHaveTextContent('00:14:32');
+        expect(cards[1]).not.toHaveTextContent(/\d\d:\d\d:\d\d/);
+
+        expect(screen.getByText('3 ώρες 41 λεπτά')).toBeInTheDocument();
+        expect(screen.getByText('3 θέματα')).toBeInTheDocument();
+        expect(screen.getByText('28 ομιλητές')).toBeInTheDocument();
+
+        const fullMeeting = screen.getByRole('link', { name: /Ολόκληρη η συνεδρίαση/ });
+        expect(fullMeeting).toHaveAttribute('href', 'https://opencouncil.cy/vouli/apr6_2026');
+        expect(fullMeeting).toHaveAttribute('target', '_blank');
+    });
+
+    it('prefixes links and picks English names for an English iframe', () => {
+        render(<EmbedMeetingSummary summary={summary()} maxSubjects={1} locale="en" baseUrl="https://opencouncil.cy" translations={t} />);
+
+        expect(screen.getByText('Plenary')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /Ολόκληρη η συνεδρίαση/ }))
+            .toHaveAttribute('href', 'https://opencouncil.cy/en/vouli/apr6_2026');
+    });
+
+    it('hides the stats that do not exist before transcription', () => {
+        render(<EmbedMeetingSummary summary={summary({ durationSeconds: null, speakerCount: 0 })} maxSubjects={6} locale="el" baseUrl="https://opencouncil.cy" translations={t} />);
+
+        expect(screen.queryByText(/λεπτά/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/ομιλητές/)).not.toBeInTheDocument();
+        expect(screen.getByText('3 θέματα')).toBeInTheDocument();
+    });
+
+    it('keeps the header and link for a meeting without subjects', () => {
+        const withoutSubjects = summary();
+        withoutSubjects.meeting.subjects = [];
+        render(<EmbedMeetingSummary summary={withoutSubjects} maxSubjects={6} locale="el" baseUrl="https://opencouncil.cy" translations={t} />);
+
+        expect(screen.getByText('Δεν υπάρχουν διαθέσιμα θέματα.')).toBeInTheDocument();
+        expect(screen.getByText('0 θέματα')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /Ολόκληρη η συνεδρίαση/ })).toBeInTheDocument();
+    });
+});

--- a/src/lib/__tests__/meetingSummaries.test.ts
+++ b/src/lib/__tests__/meetingSummaries.test.ts
@@ -1,0 +1,66 @@
+/** @jest-environment node */
+const mockGetMeetingSummaryCached = jest.fn();
+const mockGetCouncilMeetingsForCityPublicCached = jest.fn();
+
+jest.mock('@/lib/cache', () => ({
+    __esModule: true,
+    getMeetingSummaryCached: (...args: unknown[]) => mockGetMeetingSummaryCached(...args),
+    getCouncilMeetingsForCityPublicCached: (...args: unknown[]) => mockGetCouncilMeetingsForCityPublicCached(...args),
+}));
+
+import { getMeetingSummaries } from '@/lib/meetingSummaries';
+import type { MeetingSummary } from '@/lib/db/types';
+
+function summary(meetingId: string): MeetingSummary {
+    return {
+        meeting: {
+            id: meetingId,
+            cityId: 'vouli',
+            name: meetingId,
+            name_en: meetingId,
+            dateTime: new Date('2026-04-06T10:00:00Z'),
+            administrativeBody: null,
+            subjects: [],
+        },
+        durationSeconds: 60,
+        speakerCount: 1,
+        subjectStartSeconds: {},
+    };
+}
+
+describe('getMeetingSummaries', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns the requested meeting without consulting the meeting list', async () => {
+        mockGetMeetingSummaryCached.mockResolvedValue(summary('m1'));
+
+        const result = await getMeetingSummaries('vouli', { meetingId: 'm1', limit: 3, administrativeBodyIds: ['b1'] });
+
+        expect(result.map(s => s.meeting.id)).toEqual(['m1']);
+        expect(mockGetMeetingSummaryCached).toHaveBeenCalledWith('vouli', 'm1');
+        expect(mockGetCouncilMeetingsForCityPublicCached).not.toHaveBeenCalled();
+    });
+
+    it('yields an empty list for an unknown or unreleased meeting', async () => {
+        mockGetMeetingSummaryCached.mockResolvedValue(null);
+
+        expect(await getMeetingSummaries('vouli', { meetingId: 'nope', limit: 1 })).toEqual([]);
+    });
+
+    it('takes the latest released past meetings with the body filters, newest first', async () => {
+        mockGetCouncilMeetingsForCityPublicCached.mockResolvedValue([{ id: 'm3' }, { id: 'm2' }, { id: 'm1' }]);
+        mockGetMeetingSummaryCached.mockImplementation((_cityId: string, meetingId: string) =>
+            Promise.resolve(meetingId === 'm2' ? null : summary(meetingId)));
+
+        const result = await getMeetingSummaries('vouli', {
+            limit: 3, administrativeBodyTypes: ['council'], administrativeBodyIds: ['b1'],
+        });
+
+        expect(mockGetCouncilMeetingsForCityPublicCached).toHaveBeenCalledWith('vouli', {
+            limit: 3, administrativeBodyTypes: ['council'], administrativeBodyIds: ['b1'], timeFilter: 'past',
+        });
+        expect(result.map(s => s.meeting.id)).toEqual(['m3', 'm1']);
+    });
+});

--- a/src/lib/__tests__/meetingSummary.test.ts
+++ b/src/lib/__tests__/meetingSummary.test.ts
@@ -1,0 +1,107 @@
+/** @jest-environment node */
+jest.mock('@/lib/db/prisma', () => ({
+    __esModule: true,
+    default: {
+        councilMeeting: { findUnique: jest.fn() },
+        speakerSegment: { aggregate: jest.fn() },
+        person: { count: jest.fn() },
+        utterance: { groupBy: jest.fn() },
+    },
+}));
+
+import prisma from '@/lib/db/prisma';
+import { getMeetingSummary } from '@/lib/db/meetingSummary';
+
+const mockFindUnique = prisma.councilMeeting.findUnique as jest.MockedFunction<typeof prisma.councilMeeting.findUnique>;
+const mockAggregate = prisma.speakerSegment.aggregate as jest.MockedFunction<typeof prisma.speakerSegment.aggregate>;
+const mockPersonCount = prisma.person.count as jest.MockedFunction<typeof prisma.person.count>;
+const mockGroupBy = prisma.utterance.groupBy as jest.MockedFunction<typeof prisma.utterance.groupBy>;
+
+function subject(id: string, contributions: number) {
+    return {
+        id,
+        name: `Θέμα ${id}`,
+        description: 'Περίληψη',
+        agendaItemIndex: 1,
+        nonAgendaReason: null,
+        topic: null,
+        _count: { contributions },
+    };
+}
+
+const MEETING = {
+    id: 'apr6_2026',
+    cityId: 'vouli',
+    name: '25η συνεδρίαση',
+    name_en: '25th session',
+    dateTime: new Date('2026-04-06T10:00:00Z'),
+    administrativeBody: { name: 'Ολομέλεια', name_en: 'Plenary' },
+    subjects: [subject('s1', 3), subject('s2', 0)],
+};
+
+describe('getMeetingSummary', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockAggregate.mockResolvedValue({ _min: { startTimestamp: 12 }, _max: { endTimestamp: 13272 } } as never);
+        mockPersonCount.mockResolvedValue(28 as never);
+        mockGroupBy.mockResolvedValue([
+            { discussionSubjectId: 's1', _min: { startTimestamp: 872.5 } },
+            { discussionSubjectId: 's2', _min: { startTimestamp: null } },
+            { discussionSubjectId: null, _min: { startTimestamp: 5 } },
+        ] as never);
+    });
+
+    it('reads released meetings only and stops when there is none', async () => {
+        mockFindUnique.mockResolvedValue(null as never);
+
+        expect(await getMeetingSummary('vouli', 'missing')).toBeNull();
+
+        expect(mockFindUnique).toHaveBeenCalledWith(expect.objectContaining({
+            where: { cityId_id: { cityId: 'vouli', id: 'missing' }, released: true },
+        }));
+        expect(mockAggregate).not.toHaveBeenCalled();
+        expect(mockPersonCount).not.toHaveBeenCalled();
+        expect(mockGroupBy).not.toHaveBeenCalled();
+    });
+
+    it('maps the segment span, speaker count and first discussion utterance per subject', async () => {
+        mockFindUnique.mockResolvedValue(MEETING as never);
+
+        const summary = await getMeetingSummary('vouli', 'apr6_2026');
+
+        expect(summary).toEqual({
+            meeting: MEETING,
+            durationSeconds: 13260,
+            speakerCount: 28,
+            subjectStartSeconds: { s1: 872.5 },
+        });
+        expect(mockPersonCount).toHaveBeenCalledWith({
+            where: { speakerTags: { some: { speakerSegments: { some: { cityId: 'vouli', meetingId: 'apr6_2026' } } } } },
+        });
+        expect(mockGroupBy).toHaveBeenCalledWith(expect.objectContaining({
+            where: { discussionSubjectId: { in: ['s1', 's2'] }, discussionStatus: 'SUBJECT_DISCUSSION' },
+        }));
+    });
+
+    it('has no duration before transcription', async () => {
+        mockFindUnique.mockResolvedValue(MEETING as never);
+        mockAggregate.mockResolvedValue({ _min: { startTimestamp: null }, _max: { endTimestamp: null } } as never);
+        mockPersonCount.mockResolvedValue(0 as never);
+        mockGroupBy.mockResolvedValue([] as never);
+
+        const summary = await getMeetingSummary('vouli', 'apr6_2026');
+
+        expect(summary?.durationSeconds).toBeNull();
+        expect(summary?.speakerCount).toBe(0);
+        expect(summary?.subjectStartSeconds).toEqual({});
+    });
+
+    it('skips the utterance query for a meeting without subjects', async () => {
+        mockFindUnique.mockResolvedValue({ ...MEETING, subjects: [] } as never);
+
+        const summary = await getMeetingSummary('vouli', 'apr6_2026');
+
+        expect(mockGroupBy).not.toHaveBeenCalled();
+        expect(summary?.subjectStartSeconds).toEqual({});
+    });
+});

--- a/src/lib/cache/queries.ts
+++ b/src/lib/cache/queries.ts
@@ -5,6 +5,7 @@ import { decodeGeohashToCenter } from "@/lib/geo";
 import { getGitHubStats } from "@/lib/github";
 import { getCityMessage } from "@/lib/db/cityMessages";
 import { getCouncilMeetingsForCity } from "@/lib/db/meetings";
+import { getMeetingSummary } from "@/lib/db/meetingSummary";
 import { getPartiesForCity } from "@/lib/db/parties";
 import { getPeopleForCity } from "@/lib/db/people";
 import { getSubjectsForMeeting, SubjectWithRelations } from "@/lib/db/subject";
@@ -86,6 +87,21 @@ export async function getCouncilMeetingsForCityPublicCached(
     () => getCouncilMeetingsForCity(cityId, { includeUnreleased: false, limit, administrativeBodyTypes, administrativeBodyIds, timeFilter }),
     ['city', cityId, 'meetings', 'onlyReleased', limit ? `limit:${limit}` : 'all', typeKey, idKey, timeKey],
     { tags: ['city', `city:${cityId}`, `city:${cityId}:meetings`] }
+  )();
+}
+
+/**
+ * Cached data for one block of the meeting summary widget. Keyed per meeting,
+ * so every widget configuration shares one entry; `revalidateMeeting` busts it
+ * once summarization writes new subjects. Transcript edits (speaker tags,
+ * segment boundaries) bust no tag, so the entry also expires hourly: the
+ * duration and speaker count then catch up without a manual revalidation.
+ */
+export async function getMeetingSummaryCached(cityId: string, meetingId: string) {
+  return createCache(
+    () => getMeetingSummary(cityId, meetingId),
+    ['city', cityId, 'meeting', meetingId, 'summary'],
+    { tags: ['city', `city:${cityId}`, `city:${cityId}:meetings`, `city:${cityId}:meeting:${meetingId}`], revalidate: 3600 }
   )();
 }
 

--- a/src/lib/db/meetingSummary.ts
+++ b/src/lib/db/meetingSummary.ts
@@ -1,0 +1,49 @@
+import 'server-only';
+import prisma from '@/lib/db/prisma';
+import { meetingSummarySelect, type MeetingSummary } from '@/lib/db/types/meetingSummary';
+
+/**
+ * The data one meeting block of the summary widget needs, from four cheap
+ * queries: the meeting with its subjects, the span of its speaker segments,
+ * the number of distinct speakers, and the first discussion utterance per
+ * subject. Released meetings only; null otherwise.
+ */
+export async function getMeetingSummary(cityId: string, meetingId: string): Promise<MeetingSummary | null> {
+    const meeting = await prisma.councilMeeting.findUnique({
+        where: { cityId_id: { cityId, id: meetingId }, released: true },
+        select: meetingSummarySelect,
+    });
+    if (!meeting) return null;
+
+    const subjectIds = meeting.subjects.map(subject => subject.id);
+    const [segments, speakerCount, firstUtterances] = await Promise.all([
+        prisma.speakerSegment.aggregate({
+            where: { cityId, meetingId },
+            _min: { startTimestamp: true },
+            _max: { endTimestamp: true },
+        }),
+        prisma.person.count({
+            where: { speakerTags: { some: { speakerSegments: { some: { cityId, meetingId } } } } },
+        }),
+        subjectIds.length > 0
+            ? prisma.utterance.groupBy({
+                by: ['discussionSubjectId'],
+                where: { discussionSubjectId: { in: subjectIds }, discussionStatus: 'SUBJECT_DISCUSSION' },
+                _min: { startTimestamp: true },
+            })
+            : [],
+    ]);
+
+    const subjectStartSeconds: Record<string, number> = {};
+    for (const row of firstUtterances) {
+        if (row.discussionSubjectId && row._min.startTimestamp != null) {
+            subjectStartSeconds[row.discussionSubjectId] = row._min.startTimestamp;
+        }
+    }
+
+    const start = segments._min.startTimestamp;
+    const end = segments._max.endTimestamp;
+    const durationSeconds = start != null && end != null ? Math.max(0, end - start) : null;
+
+    return { meeting, durationSeconds, speakerCount, subjectStartSeconds };
+}

--- a/src/lib/db/types/index.ts
+++ b/src/lib/db/types/index.ts
@@ -15,6 +15,7 @@ import { CouncilMeetingWithAdminBodyAndSubjects } from '../meetings';
 // Re-export db types
 export * from './roles';
 export * from './contribution';
+export * from './meetingSummary';
 
 // Pagination
 export type { PaginationParams } from "../../../../packages/ui/src/lib/pagination";

--- a/src/lib/db/types/meetingSummary.ts
+++ b/src/lib/db/types/meetingSummary.ts
@@ -1,0 +1,44 @@
+import type { Prisma } from '@prisma/client';
+
+/**
+ * Lean read for the meeting summary widget: the meeting, its body and its
+ * subjects with the fields a card shows. No transcript, votes, attendance or
+ * location — the widget renders none of those.
+ */
+export const meetingSummarySelect = {
+    id: true,
+    cityId: true,
+    name: true,
+    name_en: true,
+    dateTime: true,
+    administrativeBody: { select: { name: true, name_en: true } },
+    subjects: {
+        select: {
+            id: true,
+            name: true,
+            description: true,
+            agendaItemIndex: true,
+            nonAgendaReason: true,
+            topic: { select: { name: true, name_en: true, colorHex: true, icon: true } },
+            _count: { select: { contributions: true } },
+        },
+    },
+} satisfies Prisma.CouncilMeetingSelect;
+
+export type MeetingSummaryMeeting = Prisma.CouncilMeetingGetPayload<{ select: typeof meetingSummarySelect }>;
+export type MeetingSummarySubject = MeetingSummaryMeeting['subjects'][number];
+
+/**
+ * Everything one meeting block of the summary widget renders. Plain data only
+ * (no Map, no class instances): it crosses `unstable_cache`, which revives a
+ * hit from JSON — so `meeting.dateTime` may arrive as an ISO string.
+ */
+export interface MeetingSummary {
+    meeting: MeetingSummaryMeeting;
+    /** Seconds from the first to the last speaker segment; null before transcription. */
+    durationSeconds: number | null;
+    /** Distinct people with at least one speaker segment in the meeting. */
+    speakerCount: number;
+    /** Seconds into the recording where each subject's discussion starts, by subject id. */
+    subjectStartSeconds: Record<string, number>;
+}

--- a/src/lib/meetingSummaries.ts
+++ b/src/lib/meetingSummaries.ts
@@ -1,0 +1,33 @@
+import type { AdministrativeBodyType } from '@prisma/client';
+import { getCouncilMeetingsForCityPublicCached, getMeetingSummaryCached } from '@/lib/cache';
+import type { MeetingSummary } from '@/lib/db/types';
+
+export interface MeetingSummariesArgs {
+    /** One specific meeting; body filters do not apply. */
+    meetingId?: string | null;
+    /** Without `meetingId`: how many of the latest released past meetings to show. */
+    limit: number;
+    administrativeBodyTypes?: AdministrativeBodyType[];
+    administrativeBodyIds?: string[];
+}
+
+/**
+ * The meetings the summary widget shows, newest first: the requested meeting,
+ * or the latest released past meetings of the city. An unknown or unreleased
+ * `meetingId` yields an empty list, so the iframe renders its empty state
+ * rather than a 404.
+ */
+export async function getMeetingSummaries(
+    cityId: string,
+    { meetingId, limit, administrativeBodyTypes, administrativeBodyIds }: MeetingSummariesArgs,
+): Promise<MeetingSummary[]> {
+    if (meetingId) {
+        const summary = await getMeetingSummaryCached(cityId, meetingId);
+        return summary ? [summary] : [];
+    }
+    const meetings = await getCouncilMeetingsForCityPublicCached(cityId, {
+        limit, administrativeBodyTypes, administrativeBodyIds, timeFilter: 'past',
+    });
+    const summaries = await Promise.all(meetings.map(meeting => getMeetingSummaryCached(cityId, meeting.id)));
+    return summaries.filter((summary): summary is MeetingSummary => summary !== null);
+}

--- a/src/lib/utils/__tests__/embedBaseUrl.test.ts
+++ b/src/lib/utils/__tests__/embedBaseUrl.test.ts
@@ -1,0 +1,32 @@
+const mockEnv = { NEXTAUTH_URL: 'https://opencouncil.gr' };
+
+jest.mock('@/env.mjs', () => ({ env: mockEnv }));
+
+import { embedBaseUrl } from '../embedBaseUrl';
+
+describe('embedBaseUrl', () => {
+    beforeEach(() => {
+        mockEnv.NEXTAUTH_URL = 'https://opencouncil.gr';
+    });
+
+    it("uses the city's realm domain when the configured host is a realm apex", () => {
+        expect(embedBaseUrl('cyprus')).toBe('https://opencouncil.cy');
+        expect(embedBaseUrl('greece')).toBe('https://opencouncil.gr');
+    });
+
+    it('keeps a preview host so links stay on the host under review', () => {
+        mockEnv.NEXTAUTH_URL = 'https://pr-12.opencouncil.dev';
+        expect(embedBaseUrl('cyprus')).toBe('https://pr-12.opencouncil.dev');
+    });
+
+    it('keeps localhost, port included', () => {
+        mockEnv.NEXTAUTH_URL = 'http://localhost:3000/';
+        expect(embedBaseUrl('cyprus')).toBe('http://localhost:3000');
+    });
+
+    it('falls back to the configured URL without a realm, trailing slash stripped', () => {
+        mockEnv.NEXTAUTH_URL = 'https://opencouncil.gr/';
+        expect(embedBaseUrl(null)).toBe('https://opencouncil.gr');
+        expect(embedBaseUrl()).toBe('https://opencouncil.gr');
+    });
+});

--- a/src/lib/utils/__tests__/embedParams.test.ts
+++ b/src/lib/utils/__tests__/embedParams.test.ts
@@ -1,0 +1,37 @@
+import { parseEmbedConfig, parseBoundedInt, embedLocalePrefix, EMBED_SUMMARY_LIMITS } from '../embedParams';
+
+describe('parseBoundedInt', () => {
+    const spec = { default: 6, min: 1, max: 20 };
+
+    it('falls back to the default for a missing, invalid or zero value', () => {
+        expect(parseBoundedInt(undefined, spec)).toBe(6);
+        expect(parseBoundedInt('abc', spec)).toBe(6);
+        expect(parseBoundedInt('0', spec)).toBe(6);
+    });
+
+    it('clamps to the bounds', () => {
+        expect(parseBoundedInt('3', spec)).toBe(3);
+        expect(parseBoundedInt('99', spec)).toBe(20);
+        expect(parseBoundedInt('-4', spec)).toBe(1);
+    });
+});
+
+describe('parseEmbedConfig limit', () => {
+    it('keeps the meetings and subjects widgets at default 5, cap 10', () => {
+        expect(parseEmbedConfig({}).limit).toBe(5);
+        expect(parseEmbedConfig({ limit: '50' }).limit).toBe(10);
+    });
+
+    it('uses the summary widget bounds when given', () => {
+        expect(parseEmbedConfig({}, { limit: EMBED_SUMMARY_LIMITS.meetings }).limit).toBe(1);
+        expect(parseEmbedConfig({ limit: '3' }, { limit: EMBED_SUMMARY_LIMITS.meetings }).limit).toBe(3);
+        expect(parseEmbedConfig({ limit: '50' }, { limit: EMBED_SUMMARY_LIMITS.meetings }).limit).toBe(5);
+    });
+});
+
+describe('embedLocalePrefix', () => {
+    it('is empty for the default locale and a path segment otherwise', () => {
+        expect(embedLocalePrefix('el')).toBe('');
+        expect(embedLocalePrefix('en')).toBe('/en');
+    });
+});

--- a/src/lib/utils/__tests__/subjects.test.ts
+++ b/src/lib/utils/__tests__/subjects.test.ts
@@ -1,4 +1,4 @@
-import { categorizeSubjects, getNonAgendaLabel, getWithdrawnLabel, getSubjectCategories } from '../subjects';
+import { categorizeSubjects, getNonAgendaLabel, getWithdrawnLabel, getSubjectCategories, pickSummarySubjects } from '../subjects';
 
 // Identity translator: returns the key so tests assert the resolved key path
 // without depending on message-file contents.
@@ -143,5 +143,18 @@ describe('getWithdrawnLabel', () => {
 
     it('returns long label for OUT_OF_AGENDA withdrawn', () => {
         expect(getWithdrawnLabel(t, { nonAgendaReason: 'outOfAgenda' }, 'long')).toBe('notApprovedLong');
+    });
+});
+
+describe('pickSummarySubjects', () => {
+    const subject = (id: string, contributions: number) => ({ id, name: id, _count: { contributions } });
+
+    it('keeps the most discussed subjects, most discussed first', () => {
+        const picked = pickSummarySubjects([subject('a', 1), subject('b', 5), subject('c', 3)], 2);
+        expect(picked.map(s => s.id)).toEqual(['b', 'c']);
+    });
+
+    it('returns every subject when the cap is not reached', () => {
+        expect(pickSummarySubjects([subject('a', 0)], 6).map(s => s.id)).toEqual(['a']);
     });
 });

--- a/src/lib/utils/embedBaseUrl.ts
+++ b/src/lib/utils/embedBaseUrl.ts
@@ -1,0 +1,18 @@
+import type { Realm } from '@prisma/client';
+import { env } from '@/env.mjs';
+import { getRealmBaseUrl, isRealmApexHost } from '@/lib/realm';
+
+/**
+ * Base URL for the links a widget renders (trailing slash stripped).
+ *
+ * In production `NEXTAUTH_URL` is one realm's apex (opencouncil.gr), but a
+ * widget for a city of another realm must link to that realm's own domain: a
+ * `vouli` iframe on a Cypriot site pointing visitors at opencouncil.gr would
+ * cross the tenant boundary. On a preview or local host `NEXTAUTH_URL` is kept
+ * as is, so links stay on the host under review.
+ */
+export function embedBaseUrl(realm?: Realm | null): string {
+    const configured = env.NEXTAUTH_URL.replace(/\/$/, '');
+    if (!realm) return configured;
+    return isRealmApexHost(new URL(configured).hostname) ? getRealmBaseUrl(realm) : configured;
+}

--- a/src/lib/utils/embedParams.ts
+++ b/src/lib/utils/embedParams.ts
@@ -1,4 +1,5 @@
 import { AdministrativeBodyType } from '@prisma/client';
+import { DEFAULT_LOCALE, urlPrefixForLocale } from '@/i18n/config';
 import {
     generateThemeVars,
     generateAppThemeShim,
@@ -10,6 +11,38 @@ import {
 } from '@/lib/utils/embedTheme';
 
 const VALID_BODY_TYPES = new Set<string>(['council', 'committee', 'community']);
+
+export interface BoundedIntSpec {
+    default: number;
+    min: number;
+    max: number;
+}
+
+/** Cards shown by the meetings and subjects widgets. */
+const DEFAULT_LIMIT: BoundedIntSpec = { default: 5, min: 1, max: 10 };
+
+/** Bounds of the meeting summary widget's own params; the configurator reads the same values. */
+export const EMBED_SUMMARY_LIMITS = {
+    /** Latest past meetings shown when no `meetingId` is given. */
+    meetings: { default: 1, min: 1, max: 5 },
+    /** Subject cards per meeting. */
+    subjects: { default: 6, min: 1, max: 20 },
+} as const satisfies Record<string, BoundedIntSpec>;
+
+/** A query integer clamped to `[min, max]`; missing, invalid or zero falls back to the default. */
+export function parseBoundedInt(raw: string | undefined, { default: fallback, min, max }: BoundedIntSpec): number {
+    const parsed = parseInt(raw || '', 10) || fallback;
+    return Math.min(Math.max(parsed, min), max);
+}
+
+/**
+ * URL prefix for a locale under next-intl's `as-needed` prefixing: empty for
+ * the default locale, so a Greek iframe links to unprefixed Greek pages and an
+ * English one to `/en/...`.
+ */
+export function embedLocalePrefix(locale: string): string {
+    return locale === DEFAULT_LOCALE ? '' : `/${urlPrefixForLocale(locale)}`;
+}
 
 /** Raw query params shared by every embed widget variant. */
 export interface EmbedSearchParams {
@@ -26,7 +59,7 @@ export interface EmbedSearchParams {
 export interface ParsedEmbedConfig {
     mode: EmbedMode;
     radius: EmbedRadius;
-    /** Clamped to 1–10 — number of cards to show. */
+    /** Number of cards to show, clamped to the widget's bounds (1–10 unless overridden). */
     limit: number;
     administrativeBodyTypes?: AdministrativeBodyType[];
     administrativeBodyIds?: string[];
@@ -41,10 +74,10 @@ export interface ParsedEmbedConfig {
  * Variant-specific params (e.g. `showSubjects`) stay in their own routes. The
  * base URL for links is realm-dependent, see `embedBaseUrl`.
  */
-export function parseEmbedConfig(searchParams: EmbedSearchParams): ParsedEmbedConfig {
+export function parseEmbedConfig(searchParams: EmbedSearchParams, options: { limit?: BoundedIntSpec } = {}): ParsedEmbedConfig {
     const accent = parseAccentColor(searchParams.accent);
     const mode: EmbedMode = searchParams.mode === 'dark' ? 'dark' : 'light';
-    const limit = Math.min(Math.max(parseInt(searchParams.limit || '5', 10) || 5, 1), 10);
+    const limit = parseBoundedInt(searchParams.limit, options.limit ?? DEFAULT_LIMIT);
     const radius: EmbedRadius =
         searchParams.radius === 'sharp' || searchParams.radius === 'pill'
             ? searchParams.radius

--- a/src/lib/utils/embedParams.ts
+++ b/src/lib/utils/embedParams.ts
@@ -1,5 +1,4 @@
 import { AdministrativeBodyType } from '@prisma/client';
-import { env } from '@/env.mjs';
 import {
     generateThemeVars,
     generateAppThemeShim,
@@ -34,14 +33,13 @@ export interface ParsedEmbedConfig {
     themeVars: EmbedThemeVars;
     /** App design-token overrides for the shared SubjectCardContent in the subjects widget. */
     appThemeShim: AppThemeShim;
-    /** Trailing-slash-free base URL for building card links. */
-    baseUrl: string;
 }
 
 /**
  * Parse the appearance/filter query params common to all embed widgets
- * (`/embed/meetings`, `/embed/subjects`, …) and derive the theme vars + base
- * URL. Variant-specific params (e.g. `showSubjects`) stay in their own routes.
+ * (`/embed/meetings`, `/embed/subjects`, …) and derive the theme vars.
+ * Variant-specific params (e.g. `showSubjects`) stay in their own routes. The
+ * base URL for links is realm-dependent, see `embedBaseUrl`.
  */
 export function parseEmbedConfig(searchParams: EmbedSearchParams): ParsedEmbedConfig {
     const accent = parseAccentColor(searchParams.accent);
@@ -66,6 +64,5 @@ export function parseEmbedConfig(searchParams: EmbedSearchParams): ParsedEmbedCo
         administrativeBodyIds,
         themeVars: generateThemeVars(accent, mode, radius),
         appThemeShim: generateAppThemeShim(accent, mode, radius),
-        baseUrl: env.NEXTAUTH_URL.replace(/\/$/, ''),
     };
 }

--- a/src/lib/utils/subjects.ts
+++ b/src/lib/utils/subjects.ts
@@ -1,4 +1,4 @@
-import { sortSubjectsBySpeakerContributionCount } from "@/lib/utils";
+import { sortSubjectsBySpeakerContributionCount, sortSubjectsByImportance } from "@/lib/utils";
 import type { Statistics } from "@/lib/statistics";
 
 interface CategorizableSubject {
@@ -88,3 +88,10 @@ export function getWithdrawnLabel(t: Translate, subject: { nonAgendaReason: stri
     return mode === 'short' ? t('withdrawnShort') : t('withdrawnLong');
 }
 
+/**
+ * The subjects a block of the meeting summary widget shows: the `max` most
+ * discussed ones, most discussed first — the same ranking as the meetings widget.
+ */
+export function pickSummarySubjects<T extends { name: string; _count?: { contributions?: number } }>(subjects: T[], max: number): T[] {
+    return sortSubjectsByImportance(subjects, 'importance').slice(0, max);
+}


### PR DESCRIPTION
## Summary

Introduces a new "meeting summary" embed widget that displays one or more meetings with their most discussed subjects, speaker stats, and duration. Site owners can pin a specific meeting or show the latest released past meetings. The widget complements the existing meetings and subjects widgets.

## Key Changes

**New Widget Type**
- Added `/embed/summary` route that renders meeting blocks with subject cards, stats footer, and a link to the full meeting page
- Configurator now supports three widget types: meetings, subjects, and summary
- Summary widget has its own parameters: `meetingId` (optional, pins one meeting), `limit` (1-5 latest meetings), `subjects` (1-20 cards per meeting)

**Data Layer**
- `getMeetingSummary()` queries a released meeting with its subjects, speaker segment span, distinct speaker count, and first discussion utterance per subject
- `getMeetingSummaries()` fetches either a pinned meeting or the latest released past meetings, respecting body filters
- New `MeetingSummary` type captures the lean read needed for the widget (no transcript, votes, or attendance)

**UI Components**
- `EmbedMeetingSummary` renders the meeting block with header (body + date), subject grid, and stats footer
- `EmbedSummarySubjectCard` displays each subject as a card with topic badge, title, description clamp, and discussion start time
- Added `embed.css` styles for the summary widget's grid layout, cards, and footer

**Configurator Updates**
- Added meeting picker dropdown in the configurator to select a pinned meeting or "latest meetings"
- New controls for subjects-per-meeting and latest-meetings limit
- Body filter now only applies when showing "latest meetings" (not when a specific meeting is pinned)
- Radius control now applies to summary and meetings widgets (subjects widget has fixed corners)

**Utilities & Helpers**
- `parseBoundedInt()` clamps query integers to a spec's min/max bounds
- `embedLocalePrefix()` returns the locale prefix for next-intl's as-needed strategy (empty for default locale)
- `embedBaseUrl()` resolves the correct domain for widget links (realm apex in production, preview/localhost as-is)
- `pickSummarySubjects()` sorts subjects by importance then contribution count, returning the top N

**Translations**
- Added EmbedConfigurator strings for summary widget type, meeting picker, and subjects-per-meeting
- Added EmbedWidget strings for AI summary badge, full meeting link, duration formatting, and empty states
- Updated troubleshooting height guidance for the summary widget

**Tests**
- `getMeetingSummary.test.ts` — verifies meeting fetch, segment span, speaker count, and first utterance per subject
- `getMeetingSummaries.test.ts` — tests pinned meeting vs. latest meetings, body filters, and empty states
- `EmbedMeetingSummary.test.tsx` — renders header, subject cards, stats, and links correctly
- `embedParams.test.ts` — `parseBoundedInt()` and `parseEmbedConfig()` with summary bounds
- `embedBaseUrl.test.ts` — realm domain resolution and preview/localhost handling
- `subjects.test.ts` — `pickSummarySubjects()` sorting and limiting

## Implementation Details

- The summary widget's meeting picker is populated server-side in the configurator page, showing the 5 most recent released meetings
- Meeting dates in the configurator use the city's timezone for accurate display
- Subject cards link to the subject page with `target="_blank"` and `rel="noopener noreferrer"`
- The widget respects the same theme variables (accent, mode, radius) as other embed widgets
- Body filters do not apply when a specific meeting is pinned, allowing the widget to show any meeting regardless of administrative body
- Duration is calculated from speaker segment timestamps; null before transcription
- The footer displays subject count, speaker count, duration, and a single link to the full meeting page

https://claude.ai/code/session_01H1gDk8J8VW5QTYV7FScSRm



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The latest revision addresses the previous review feedback for the meeting summary embed widget.
- It adds hourly expiry to cached meeting statistics.
- It updates source imports to use the repository alias.
- It removes an unnecessary subject field from the summary query.
- It corrects the Greek full-meeting label.

<h3>Confidence Score: 5/5</h3>

The revision appears safe to merge because no new actionable failure remains.

The new cache expiry bounds stale transcript statistics, and the alias imports now comply with the repository rule. The three previous threads were manually resolved without explanatory replies.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/cache/queries.ts | Adds hourly expiry so transcript-derived summary statistics cannot remain stale indefinitely. |
| src/lib/utils/subjects.ts | Uses the existing importance sorter to select summary subjects. |
| src/lib/db/types/meetingSummary.ts | Removes an unused subject field from the lean meeting summary select. |
| src/components/embed/EmbedMeetingSummary.tsx | Replaces the relative component import with the required source alias. |
| messages/el.json | Corrects the Greek translation for the full-meeting link. |

<sub>Reviews (2): Last reviewed commit: ["docs(embed): document the embed widgets"](https://github.com/schemalabz/opencouncil/commit/7af1e5a83ec055f4dfee9547928057e5e2b4a866) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60938063)</sub>

<!-- /greptile_comment -->