### PR TITLE
revert(people): let the numbers carry the party blocks again

### DIFF
--- a/src/lib/sorting/__tests__/people.test.ts
+++ b/src/lib/sorting/__tests__/people.test.ts
@@ -28,7 +28,6 @@ function role(fields: Partial<OrderedRole> & { body?: BodyRef }): OrderedRole {
         partyId: null,
         administrativeBodyId: body?.id ?? null,
         administrativeBody: body ?? null,
-        party: null,
         electedOrder: null,
         ...OPEN,
         ...rest,
@@ -38,7 +37,7 @@ function role(fields: Partial<OrderedRole> & { body?: BodyRef }): OrderedRole {
 const seat = (body: BodyRef, electedOrder: number | null = null, extra: Partial<OrderedRole> = {}) =>
     role({ body, electedOrder, ...extra });
 const partyRole = (partyId: string, isHead = false, dates: Partial<OrderedRole> = OPEN) =>
-    role({ partyId, party: { id: partyId, name: partyId }, isHead, ...dates });
+    role({ partyId, isHead, ...dates });
 const mayorRole = () => role({ cityId: 'athens', isHead: true });
 
 function person(id: string, name: string, roles: OrderedRole[]): OrderedPerson {
@@ -88,41 +87,17 @@ describe('sortBodyMembers', () => {
         expect(names(sortBodyMembers(people, COUNCIL.id))).toEqual(['mayor', 'chair', 'second', 'third', 'early', 'late']);
     });
 
-    it('groups the members by party, the first-elected party first', () => {
-        // The shape a Greek council carries: the order of election runs across
-        // the parties, so the numbers alone would interleave them.
+    it('follows the numbers across parties, because the fill carries the blocks', () => {
+        // The party a member belongs to changes nothing here. A municipality
+        // that wants its members in party blocks, or an officer above them,
+        // writes that into the numbers; see the note on this module.
         const people = [
-            person('a1', 'Άλφα Ένα', [partyRole('alpha'), seat(COUNCIL, 1)]),
             person('b1', 'Βήτα Ένα', [partyRole('beta'), seat(COUNCIL, 2)]),
-            person('a2', 'Άλφα Δύο', [partyRole('alpha'), seat(COUNCIL, 3)]),
+            person('a1', 'Άλφα Ένα', [partyRole('alpha'), seat(COUNCIL, 1)]),
             person('b2', 'Βήτα Δύο', [partyRole('beta'), seat(COUNCIL, 4)]),
+            person('a2', 'Άλφα Δύο', [partyRole('alpha'), seat(COUNCIL, 3)]),
         ];
-        expect(names(sortBodyMembers(people, COUNCIL.id))).toEqual(['a1', 'a2', 'b1', 'b2']);
-    });
-
-    it('closes the list with the members who hold no party', () => {
-        const people = [
-            person('independent', 'Άλφα Άλφα', [seat(COUNCIL, 1)]),
-            person('member', 'Ωμέγα Ωμέγα', [partyRole('alpha'), seat(COUNCIL, 2)]),
-        ];
-        expect(names(sortBodyMembers(people, COUNCIL.id))).toEqual(['member', 'independent']);
-    });
-
-    it('sorts a party whose members carry no number after the parties that do', () => {
-        const people = [
-            person('unnumbered', 'Άλφα Άλφα', [partyRole('beta'), seat(COUNCIL)]),
-            person('numbered', 'Ωμέγα Ωμέγα', [partyRole('alpha'), seat(COUNCIL, 9)]),
-        ];
-        expect(names(sortBodyMembers(people, COUNCIL.id))).toEqual(['numbered', 'unnumbered']);
-    });
-
-    it('keeps the mayor and the chair before the party blocks', () => {
-        const people = [
-            person('member', 'Άλφα Άλφα', [partyRole('alpha'), seat(COUNCIL, 1)]),
-            person('chair', 'Βήτα Βήτα', [partyRole('beta'), seat(COUNCIL, 8, { isHead: true })]),
-            person('mayor', 'Ωμέγα Ωμέγα', [mayorRole(), partyRole('beta'), seat(COUNCIL, 5)]),
-        ];
-        expect(names(sortBodyMembers(people, COUNCIL.id))).toEqual(['mayor', 'chair', 'member']);
+        expect(names(sortBodyMembers(people, COUNCIL.id))).toEqual(['a1', 'b1', 'a2', 'b2']);
     });
 
     it('puts every member, numbered or not, before someone with no seat on the body', () => {

--- a/src/lib/sorting/people.ts
+++ b/src/lib/sorting/people.ts
@@ -1,4 +1,4 @@
-import type { AdministrativeBody, AdministrativeBodyType, Party, Role } from '@prisma/client';
+import type { AdministrativeBody, AdministrativeBodyType, Role } from '@prisma/client';
 import { administrativeBodyTypeRank, compareAdministrativeBodies } from '@/lib/utils/administrativeBodies';
 import { getSurname } from '@/lib/formatters/name';
 import { filterActiveRoles, isActivePartyRole, isMayor } from '@/lib/utils/roles';
@@ -9,8 +9,7 @@ import { filterActiveRoles, isActivePartyRole, isMayor } from '@/lib/utils/roles
  * One field decides the order: `Role.electedOrder`, the elected order of a seat
  * on an administrative body. The rules read it the same way on every surface:
  *
- * - In one body: the mayor, then the chair, then the parties in turn, then
- *   elected order inside the party, then surname.
+ * - In one body: the mayor, then the chair, then elected order, then surname.
  * - In one party: the mayor, then the party head, then the members by the body
  *   they sit on (council, committee, community, none), then elected order in
  *   that body, then surname.
@@ -19,13 +18,23 @@ import { filterActiveRoles, isActivePartyRole, isMayor } from '@/lib/utils/roles
  *   sit on. With a body type selected, only the bodies of that type place
  *   people, so a page filtered to the committees lists them in committee order.
  *
- * A body's list groups the members by party, because that is how a municipality
- * publishes its council. The grouping is a rule here, not a property of the
- * numbers: `electedOrder` stays the seat's own order of election, which in a
- * Greek municipal election runs across the parties rather than inside one.
+ * `electedOrder` carries the whole order of a body's list, and this module adds
+ * nothing to it beyond the mayor and the chair. A municipality publishes its
+ * council in party blocks, so the fill that writes these numbers puts the blocks
+ * in them. Two rules are deliberately absent here:
+ *
+ * - Grouping by party. A rule could group the members, but it could not place an
+ *   Αντιπρόεδρος or a Γραμματέας, who belong to a party and yet sit above every
+ *   block. `Role.isHead` marks the chair alone, no other field marks an officer,
+ *   and the role's name is text a municipality writes, not a signal to match on.
+ *   A grouping rule would therefore fix one half of the order and break the
+ *   other. The numbers hold both.
+ * - Any ordering of the parties. The fill decides it, so a municipality that
+ *   publishes an order of its own keeps it.
  *
  * The minutes read `electedOrder` through {@link getElectedOrderForBody} and
- * {@link compareRanks}. They print one order of election, without the grouping.
+ * {@link compareRanks} and nothing else, so the order a page shows and the
+ * order the minutes print come from the same numbers.
  */
 
 /**
@@ -39,7 +48,6 @@ export type OrderedRole = Pick<
     'isHead' | 'cityId' | 'partyId' | 'administrativeBodyId' | 'electedOrder' | 'startDate' | 'endDate'
 > & {
     administrativeBody: Pick<AdministrativeBody, 'id' | 'name' | 'type'> | null;
-    party: Pick<Party, 'id' | 'name'> | null;
 };
 
 export interface OrderedPerson {
@@ -91,38 +99,6 @@ const activeRoles = (person: OrderedPerson): OrderedRole[] => filterActiveRoles(
 const bodyRole = (person: OrderedPerson, administrativeBodyId: string): OrderedRole | null =>
     activeRoles(person).find(role => role.administrativeBodyId === administrativeBodyId) ?? null;
 
-/** The party a person belongs to now, or null. */
-const activePartyRole = (person: OrderedPerson): OrderedRole | null =>
-    activeRoles(person).find(role => role.partyId) ?? null;
-
-/**
- * Where each party's block sits in one body's list.
- *
- * The party whose first-elected member comes first opens the list, so the order
- * of the blocks follows the election rather than a count this function would
- * have to take. A party whose members carry no number sorts after the parties
- * that do, by name. Everyone with no party sorts after every party, which is
- * where a municipality puts its independents.
- */
-function partyBlockRanks(people: OrderedPerson[], administrativeBodyId: string): Map<string, number> {
-    const blocks = new Map<string, { order: number | null; name: string }>();
-    for (const person of people) {
-        const role = activePartyRole(person);
-        if (!role?.partyId) continue;
-        const order = bodyRole(person, administrativeBodyId)?.electedOrder ?? null;
-        const seen = blocks.get(role.partyId);
-        if (!seen) {
-            blocks.set(role.partyId, { order, name: role.party?.name ?? role.partyId });
-        } else if (compareRanks(order, seen.order) < 0) {
-            seen.order = order;
-        }
-    }
-    const ordered = [...blocks.entries()].sort(
-        ([, a], [, b]) => compareRanks(a.order, b.order) || a.name.localeCompare(b.name, 'el'),
-    );
-    return new Map(ordered.map(([partyId], index) => [partyId, index]));
-}
-
 /**
  * The seat that places a person, and their elected order on it.
  *
@@ -156,26 +132,24 @@ function sortWithKeys<T, K>(items: T[], key: (item: T) => K, compare: (a: K, b: 
 }
 
 /**
- * The members of one administrative body: the mayor, then the chair, then the
- * parties in turn, then elected order inside each party, then surname. Someone
- * in the list without a seat on the body (a deputy mayor listed with the
- * council) sorts after the members.
+ * The members of one administrative body: the mayor, then the chair, then
+ * elected order, then surname. Someone in the list without a seat on the body
+ * (a deputy mayor listed with the council) sorts after the members.
+ *
+ * The elected order carries the party blocks, so two members of one party are
+ * adjacent because their numbers are adjacent, not because this function put
+ * them together.
  */
 export function sortBodyMembers<T extends OrderedPerson>(people: T[], administrativeBodyId: string): T[] {
-    const blocks = partyBlockRanks(people, administrativeBodyId);
     return sortWithKeys(
         people,
         person => {
             const role = bodyRole(person, administrativeBodyId);
-            const partyId = activePartyRole(person)?.partyId;
-            const block = partyId ? blocks.get(partyId) : undefined;
             return {
                 person,
                 mayor: isMayor(person),
                 member: role !== null,
                 chair: role?.isHead ?? false,
-                // No party sorts after every party, so the independents close the list.
-                block: block ?? blocks.size,
                 electedOrder: role?.electedOrder ?? null,
             };
         },
@@ -183,7 +157,6 @@ export function sortBodyMembers<T extends OrderedPerson>(people: T[], administra
             compareFlags(a.mayor, b.mayor)
             || compareFlags(a.member, b.member)
             || compareFlags(a.chair, b.chair)
-            || a.block - b.block
             || compareRanks(a.electedOrder, b.electedOrder)
             || compareByLastName(a.person, b.person),
     );


### PR DESCRIPTION
Follows #724, which is merged. This reverses one decision from it: a body's list stops grouping its members by party in the sort, and the grouping goes back into `electedOrder`, which the fill writes.

## Why

The sort could group the members. It could not place an Αντιπρόεδρος or a Γραμματέας.

Papagos-Cholargos asked for «Δήμαρχος, Πρόεδρος, Αντιπρόεδρος, Γραμματέας και στη συνέχεια τα μέλη ανά παράταξη σύμφωνα με τη σειρά εκλογής». Those two officers belong to a party and still sit above every block. Nothing on `Role` marks them: `isHead` marks the chair alone, and the role's name is text a municipality writes, not a signal to match on. A grouping rule therefore fixed one half of that request and broke the other, and closing the gap needed a new field.

One number holds both. The fill writes the officers first, then the blocks, and the sort reads the result.

## What this costs

The pages now need a fill that writes the blocks. The order of election taken from an election result does not: seats are awarded across the parties, so it interleaves them. On Orestiada it read Νέα Ξανά 1, an independent 2, Νέα Ξανά 3–8, ΠΡΩΤΗ ΓΡΑΜΜΗ 9 — every number right, the page still wrong. That is the case #724 grouped around, and it comes back until the fill is re-run.

So this change and the data go together. The per-city runbook is ready.

## Changes

`sortBodyMembers` loses the party-block key and the two helpers behind it. `OrderedRole` loses `party`, which only the blocks used. The rule is again: the mayor, then the chair, then elected order, then surname.

The module comment now records why the two absent rules — grouping, and any ordering of the parties — are absent, so the next reader does not add them back. One test pins the contract: members of different parties interleave by number, which is what a grouping rule would break.

## Verification

Type check, lint, 165 test suites and the production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbuxmSdnZVX23fJQELSi33

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbuxmSdnZVX23fJQELSi33)_

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61757402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/schema-labs/-/pull-requests/schemalabz/opencouncil/732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not safe to merge without a deployment mechanism that ensures every required `electedOrder` fill completes before the new comparator serves public pages.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Flib%2Fsorting%2Fpeople.ts%3A160%0AIf%20this%20code%20deploys%20before%20every%20required%20data%20fill%20completes%2C%20the%20comparator%20treats%20existing%20election%20ranks%20as%20the%20final%20display%20order.%20Those%20ranks%20can%20interleave%20parties%2C%20as%20the%20Orestiada%20case%20in%20the%20PR%20description%20shows.%20Public%20body%20pages%20then%20display%20members%20in%20the%20wrong%20order.%20Couple%20this%20change%20to%20the%20data%20rollout%2C%20or%20keep%20a%20compatibility%20path%20until%20the%20fill%20completes.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=schemalabz%2Fopencouncil&pr=732&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Data rollout can misorder members** <a href="https://github.com/schemalabz/opencouncil/pull/732#discussion_r3961465479">▶</a>

<details><summary><h3>Summary</h3></summary>

- Removes the party relation from `OrderedRole`.
- Removes party-block rank calculation.
- Updates the sorting contract and its tests.
- Introduces a rollout dependency on completed display-order fills.
</details>

<!-- /greptile_comment -->