### PR TITLE
perf(explain): pin the table of contents, defer the embeds

### DIFF
--- a/src/app/[locale]/(other)/explain/ExplainReader.tsx
+++ b/src/app/[locale]/(other)/explain/ExplainReader.tsx
@@ -87,6 +87,30 @@ export function ExplainReader({
                 ?.closest("[data-toc-group]")
                 ?.querySelector("[data-toc-grouphead]")
                 ?.setAttribute("aria-current", "true");
+
+            // The pinned column scrolls its own content on a short screen, so the
+            // active entry can sit outside it. Move the column to the entry, and
+            // move nothing else: scrollIntoView walks every scrollable ancestor,
+            // and on this sticky box it drags the page instead of the column.
+            //
+            // Stop at the neighbour past the active entry, so the entry the reader
+            // wants never sits flush against the edge of the column. Entries wrap
+            // to two lines, so their heights differ and a fixed margin would cut a
+            // wrapped neighbour in half.
+            const aside = activeLink?.closest<HTMLElement>("[data-toc]");
+            if (aside && activeLink) {
+                const entries = [...aside.querySelectorAll<HTMLElement>("a")];
+                const i = entries.indexOf(activeLink);
+                const box = aside.getBoundingClientRect();
+                const link = activeLink.getBoundingClientRect();
+                if (link.top < box.top) {
+                    const lead = (i > 0 ? entries[i - 1] : null) ?? activeLink;
+                    aside.scrollTop += lead.getBoundingClientRect().top - box.top;
+                } else if (link.bottom > box.bottom) {
+                    const lead = (i >= 0 ? entries[i + 1] : null) ?? activeLink;
+                    aside.scrollTop += lead.getBoundingClientRect().bottom - box.bottom;
+                }
+            }
         }
 
         if (active >= 0) {

--- a/src/app/[locale]/(other)/explain/ExplainReader.tsx
+++ b/src/app/[locale]/(other)/explain/ExplainReader.tsx
@@ -33,14 +33,10 @@ export function ExplainReader({
     // on mobile so the current subtitle stays visible while reading the content.
     const [stickyIdx, setStickyIdx] = useState(-1);
 
-    // Track the section in view and pin the desktop table of contents.
+    // Track the section in view. The ToC itself pins with CSS position: sticky.
     useEffect(() => {
         const els = sections.map((s) => document.getElementById(s.id));
-        const aside = document.querySelector<HTMLElement>("[data-toc]");
-        const grid = aside?.parentElement ?? null;
         const OFFSET = 120; // spy threshold, below the fixed header
-        const PIN_TOP = 96; // where the ToC pins (matches the header offset)
-        const LG = 1024;
         let raf = 0;
 
         const compute = () => {
@@ -60,19 +56,6 @@ export function ExplainReader({
             // the Substack "further reading" section shouldn't pin its title
             const show = idx >= 0 && passed && sections[idx].id !== "substack";
             setStickyIdx(show ? idx : -1);
-
-            // pin the ToC: position: sticky is broken by an overflow-hidden
-            // ancestor, so translate it to hold PIN_TOP while it's in range.
-            if (aside && grid) {
-                if (window.innerWidth < LG) {
-                    aside.style.transform = "";
-                } else {
-                    const gridTop = grid.getBoundingClientRect().top;
-                    const max = Math.max(0, grid.offsetHeight - aside.offsetHeight);
-                    const t = Math.min(Math.max(0, PIN_TOP - gridTop), max);
-                    aside.style.transform = `translateY(${t}px)`;
-                }
-            }
         };
         const onScroll = () => {
             if (!raf) raf = requestAnimationFrame(compute);
@@ -85,7 +68,6 @@ export function ExplainReader({
             window.removeEventListener("scroll", onScroll);
             window.removeEventListener("resize", onScroll);
             if (raf) cancelAnimationFrame(raf);
-            if (aside) aside.style.transform = "";
         };
     }, [sections]);
 

--- a/src/app/[locale]/(other)/explain/page.tsx
+++ b/src/app/[locale]/(other)/explain/page.tsx
@@ -204,10 +204,10 @@ export default async function ExplainPage() {
             <NeighborhoodIllustration subjects={neighborhoodSubjects} />
 
             <div className="mt-12 lg:grid lg:grid-cols-[16rem_minmax(0,1fr)] lg:gap-12 lg:items-start">
-                {/* table of contents (desktop) — pinned via ExplainReader, since a
-                    parent layout uses overflow-hidden which breaks position: sticky */}
+                {/* table of contents (desktop) — pinned with native sticky, which the
+                    compositor keeps in place; top-24 matches the fixed header offset */}
                 <aside
-                    className="hidden self-start lg:block lg:will-change-transform"
+                    className="hidden self-start lg:sticky lg:top-24 lg:block lg:max-h-[calc(100dvh-6rem)] lg:overflow-y-auto lg:overscroll-contain"
                     data-toc
                     aria-label="Περιεχόμενα"
                 >

--- a/src/components/embeds/AgendaViewer.tsx
+++ b/src/components/embeds/AgendaViewer.tsx
@@ -106,6 +106,7 @@ export function AgendaViewer({
                         <iframe
                             src={`${pdf}#view=FitH`}
                             title={title}
+                            loading="lazy"
                             className={`h-[600px] w-full border-0 bg-muted/40 ${
                                 mobileImage ? "hidden sm:block" : "block"
                             }`}

--- a/src/components/embeds/TikTokEmbed.tsx
+++ b/src/components/embeds/TikTokEmbed.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+
+const EMBED_SCRIPT = "https://www.tiktok.com/embed.js";
 
 /**
  * Embeds a TikTok video via TikTok's official embed.js, which replaces the
  * blockquote with an iframe once it loads. The blockquote (caption + links)
  * stays as accessible, indexable fallback until the script processes it.
+ *
+ * On a long page like /explain the video sits thousands of pixels below the
+ * fold, and booting the player at page load blocks the main thread while the
+ * reader is still reading the first sections. The script therefore loads once
+ * the reader comes within four viewports of the video. The player needs about
+ * two viewports of scrolling to appear on a slow device, so a shorter lead
+ * leaves the reader looking at the caption instead of the video.
  *
  * Reusable: pass the video id, its canonical URL (`cite`) and the caption
  * markup as children.
@@ -19,18 +28,53 @@ export function TikTokEmbed({
     cite: string;
     children: React.ReactNode;
 }) {
+    const holder = useRef<HTMLQuoteElement>(null);
+
     useEffect(() => {
-        const script = document.createElement("script");
-        script.src = "https://www.tiktok.com/embed.js";
-        script.async = true;
-        document.body.appendChild(script);
+        const el = holder.current;
+        if (!el) return;
+
+        // embed.js scans the document when it runs, and it does not watch for
+        // blockquotes added later. A client-side navigation back to this page
+        // mounts a blockquote the earlier run never saw, so each mount carries
+        // its own tag and takes it away again: appending a fresh element is
+        // what re-runs the script, and the file itself comes from the cache.
+        let script: HTMLScriptElement | null = null;
+        const load = () => {
+            script = document.createElement("script");
+            script.src = EMBED_SCRIPT;
+            script.async = true;
+            document.body.appendChild(script);
+        };
+
+        // Without an observer there is no way to tell how far the video is, and
+        // a reader who never gets the player is worse off than one who pays for
+        // it at load.
+        if (typeof IntersectionObserver === "undefined") {
+            load();
+            return () => script?.remove();
+        }
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries.some((e) => e.isIntersecting)) {
+                    load();
+                    observer.disconnect();
+                }
+            },
+            { rootMargin: "400% 0px" },
+        );
+        observer.observe(el);
+
         return () => {
-            script.remove();
+            observer.disconnect();
+            script?.remove();
         };
     }, []);
 
     return (
         <blockquote
+            ref={holder}
             className="tiktok-embed not-prose"
             cite={cite}
             data-video-id={videoId}

--- a/src/components/embeds/__tests__/AgendaViewer.test.tsx
+++ b/src/components/embeds/__tests__/AgendaViewer.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import { AgendaViewer } from '../AgendaViewer';
+
+// The lightbox and the localized Link are not under test here.
+jest.mock('../ZoomLightbox', () => ({ ZoomLightbox: () => null }));
+jest.mock('@/i18n/routing', () => ({
+    Link: ({ children }: { children: React.ReactNode }) => <a href="/">{children}</a>,
+}));
+
+describe('AgendaViewer', () => {
+    it('leaves the PDF to load as the reader approaches it', () => {
+        const { container } = render(
+            <AgendaViewer title="Ημερήσια Διάταξη" pdf="https://example.org/agenda.pdf" />,
+        );
+
+        expect(container.querySelector('iframe')).toHaveAttribute('loading', 'lazy');
+    });
+});

--- a/src/components/embeds/__tests__/TikTokEmbed.test.tsx
+++ b/src/components/embeds/__tests__/TikTokEmbed.test.tsx
@@ -1,0 +1,125 @@
+import { render, act, screen } from '@testing-library/react';
+import { TikTokEmbed } from '../TikTokEmbed';
+
+// jsdom has no IntersectionObserver. This stub keeps the observed callback, so
+// a test decides when the reader scrolls near the video.
+let triggers: IntersectionObserverCallback[] = [];
+const disconnect = jest.fn();
+
+class IntersectionObserverStub implements IntersectionObserver {
+    readonly root = null;
+    readonly rootMargin = "";
+    readonly thresholds: ReadonlyArray<number> = [];
+    private readonly callback: IntersectionObserverCallback;
+
+    constructor(callback: IntersectionObserverCallback) {
+        this.callback = callback;
+        triggers.push(callback);
+    }
+
+    observe() {}
+    unobserve() {}
+    takeRecords(): IntersectionObserverEntry[] {
+        return [];
+    }
+    // A disconnected observer hears nothing more. Without this, an unmounted
+    // component still answers a later scroll and loads a tag it cannot remove.
+    disconnect = () => {
+        triggers = triggers.filter((t) => t !== this.callback);
+        disconnect();
+    };
+}
+
+beforeEach(() => {
+    triggers = [];
+    disconnect.mockClear();
+    window.IntersectionObserver = IntersectionObserverStub;
+});
+
+const scripts = () => document.querySelectorAll('script[src="https://www.tiktok.com/embed.js"]');
+
+afterEach(() => scripts().forEach((s) => s.remove()));
+
+const renderEmbed = () =>
+    render(
+        <TikTokEmbed videoId="123" cite="https://www.tiktok.com/@opencouncil/video/123">
+            <a href="https://www.tiktok.com/@opencouncil">@opencouncil</a>
+        </TikTokEmbed>,
+    );
+
+/** The only field the component reads off an entry. */
+const entry = { isIntersecting: true } as IntersectionObserverEntry;
+const approach = () =>
+    act(() => triggers.forEach((t) => t([entry], {} as IntersectionObserver)));
+
+describe('TikTokEmbed', () => {
+    it('does not load embed.js while the video is far from the viewport', () => {
+        renderEmbed();
+
+        expect(scripts()).toHaveLength(0);
+    });
+
+    it('loads embed.js as the reader approaches the video', () => {
+        renderEmbed();
+
+        approach();
+
+        expect(scripts()).toHaveLength(1);
+        expect(disconnect).toHaveBeenCalled();
+    });
+
+    it('takes its own tag away on unmount, and leaves the rest alone', () => {
+        const first = renderEmbed();
+        renderEmbed();
+        approach();
+        expect(scripts()).toHaveLength(2);
+
+        first.unmount();
+
+        // embed.js guards its own library by element id, so the second tag costs
+        // a cached request. Removing a tag the component never created does not
+        // cost a request, it costs somebody else their player.
+        expect(scripts()).toHaveLength(1);
+    });
+
+    it('loads embed.js right away where there is no IntersectionObserver', () => {
+        Reflect.deleteProperty(window, 'IntersectionObserver');
+
+        const { unmount } = renderEmbed();
+
+        expect(scripts()).toHaveLength(1);
+
+        unmount();
+
+        expect(scripts()).toHaveLength(0);
+    });
+
+    it('runs embed.js again after a remount, so the new blockquote gets scanned', () => {
+        const first = renderEmbed();
+        approach();
+        const firstTag = scripts()[0];
+        first.unmount();
+
+        renderEmbed();
+        approach();
+
+        // embed.js scans the document when it runs, and the earlier run never saw
+        // this blockquote. Only a fresh element re-runs the script.
+        expect(scripts()).toHaveLength(1);
+        expect(scripts()[0]).not.toBe(firstTag);
+    });
+
+    it('gives embed.js the markup it looks for', () => {
+        const { container } = renderEmbed();
+        const quote = container.querySelector('blockquote');
+
+        expect(quote).toHaveClass('tiktok-embed');
+        expect(quote).toHaveAttribute('data-video-id', '123');
+    });
+
+    it('keeps the caption as visible fallback until the player replaces it', () => {
+        renderEmbed();
+
+        expect(screen.getByRole('link', { name: '@opencouncil' })).toBeVisible();
+    });
+});


### PR DESCRIPTION
## What this changes

Two things on `/explain`, both about how the page behaves while you read it.

The table of contents no longer jitters. It held its position with a `transform` written from a rAF scroll handler. Scrolling runs on the compositor thread, so the column lagged the page and snapped back on almost every frame. Sampling its position on each frame of a scripted scroll from 1200px to 8000px, it was off its pin on 78 of 80 frames, by up to 678px. `position: sticky` pins it on the compositor instead, which measures 0 of 84 frames off the pin on a production build. It also drops a layout read and a style write from every scroll frame.

The old comment said an `overflow-hidden` ancestor broke sticky. That wrapper went away with the aurora background, so the workaround was no longer needed.

The agenda PDF and the TikTok embed now load near the viewport instead of on mount. They sit far below the fold, so their third-party weight was landing in the initial load for nothing.

## Notes for review

The TikTok embed owns its script tag. Each mount appends a tag, and it removes that same tag on unmount. `embed.js` scans the document when it runs, and it does not watch for blockquotes added later, so a client-side navigation back to this page needs a fresh element to re-run the script.

Where the browser has no `IntersectionObserver`, the script loads at mount instead. A reader who never gets the player is worse off than a reader who pays for it at load.

The blockquote stays in the server HTML as the accessible, indexable fallback.

## Testing

`TikTokEmbed.test.tsx`: the script stays away while the video is far from the viewport, it loads as the reader approaches, a mount removes only its own tag, a remount re-runs the script, the path without `IntersectionObserver` loads at mount, and the caption stays visible.

`AgendaViewer.test.tsx`: the agenda iframe carries `loading="lazy"`.

`npm run build` passes.

Checked in a browser against the production build. Stepping the scroll from 1500px to 7000px in 250px increments and reading the pinned column two frames later, all 23 samples sat at 96px.






<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62029145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The pull request appears safe to merge, with no outstanding correctness or repository-rule issues.

<h3>Summary</h3>

- Makes the desktop table of contents sticky and independently scrollable on short screens.
- Keeps the active table-of-contents entry visible by adjusting only the column’s scroll position.
- Lazily loads agenda PDF iframes and TikTok’s embed script.
- Adds coverage for embed loading, cleanup, remounting, fallback behavior, and markup.

<sub>Reviews (7) · Last reviewed commit: ["fix(explain): keep active table of conte..."](https://github.com/schemalabz/opencouncil/commit/56fcaad4876c2edd302c39944c4f6080651fe46c)</sub>

<!-- /greptile_comment -->