### PR TITLE
Add public API endpoints for subjects

### DIFF
--- a/src/app/api/cities/[cityId]/meetings/[meetingId]/subjects/[subjectId]/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/[meetingId]/subjects/[subjectId]/route.ts
@@ -1,9 +1,39 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { revalidatePath, revalidateTag } from 'next/cache';
-import { getCurrentUser } from '@/lib/auth';
+import { getCurrentUser, withServiceOrUserAuth } from '@/lib/auth';
 import prisma from '@/lib/db/prisma';
 import { handleApiError } from '@/lib/api/errors';
+import { getApiSubject } from '@/lib/db/subjectsApi';
+import { getRealm } from '@/lib/realm.server';
 import { z } from 'zod';
+
+export async function GET(
+    req: NextRequest,
+    props: { params: Promise<{ cityId: string; meetingId: string; subjectId: string }> }
+) {
+    const params = await props.params;
+    try {
+        const includeUnreleased = req.nextUrl.searchParams.get('includeUnreleased') === 'true';
+        if (includeUnreleased) {
+            await withServiceOrUserAuth(req, { cityId: params.cityId });
+        }
+
+        const subject = await getApiSubject(
+            await getRealm(),
+            params.cityId,
+            params.meetingId,
+            params.subjectId,
+            { includeUnreleased }
+        );
+        if (!subject) {
+            return NextResponse.json({ error: 'Subject not found' }, { status: 404 });
+        }
+
+        return NextResponse.json(subject);
+    } catch (error) {
+        return handleApiError(error, 'Failed to fetch subject');
+    }
+}
 
 const patchSchema = z.object({
     nonAgendaReason: z.enum(['beforeAgenda', 'outOfAgenda']).nullable().optional(),

--- a/src/app/api/cities/[cityId]/meetings/[meetingId]/subjects/route.ts
+++ b/src/app/api/cities/[cityId]/meetings/[meetingId]/subjects/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getApiSubjects } from '@/lib/db/subjectsApi';
+import { getRealm } from '@/lib/realm.server';
+import { meetingSubjectListQuerySchema } from '@/lib/zod-schemas/subject';
+import { withServiceOrUserAuth } from '@/lib/auth';
+import { handleApiError } from '@/lib/api/errors';
+
+export async function GET(
+    request: NextRequest,
+    props: { params: Promise<{ cityId: string; meetingId: string }> }
+) {
+    const params = await props.params;
+    try {
+        const query = Object.fromEntries(request.nextUrl.searchParams.entries());
+        const { introducerId, limit, includeUnreleased } = meetingSubjectListQuerySchema.parse(query);
+
+        // includeUnreleased requires auth (service key or authorized user)
+        if (includeUnreleased) {
+            await withServiceOrUserAuth(request, { cityId: params.cityId });
+        }
+
+        const subjects = await getApiSubjects(await getRealm(), params.cityId, {
+            meetingId: params.meetingId,
+            introducerId,
+            limit,
+            includeUnreleased,
+        });
+
+        return NextResponse.json(subjects);
+    } catch (error) {
+        if (error instanceof z.ZodError) {
+            return NextResponse.json({ error: error.errors }, { status: 400 });
+        }
+        return handleApiError(error, 'Failed to fetch subjects');
+    }
+}

--- a/src/app/api/cities/[cityId]/subjects/route.ts
+++ b/src/app/api/cities/[cityId]/subjects/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getApiSubjects } from '@/lib/db/subjectsApi';
+import { getRealm } from '@/lib/realm.server';
+import { subjectListQuerySchema } from '@/lib/zod-schemas/subject';
+import { withServiceOrUserAuth } from '@/lib/auth';
+import { handleApiError } from '@/lib/api/errors';
+
+export async function GET(request: NextRequest, props: { params: Promise<{ cityId: string }> }) {
+    const params = await props.params;
+    try {
+        const query = Object.fromEntries(request.nextUrl.searchParams.entries());
+        const { introducerId, from, to, limit, includeUnreleased } = subjectListQuerySchema.parse(query);
+
+        // includeUnreleased requires auth (service key or authorized user)
+        if (includeUnreleased) {
+            await withServiceOrUserAuth(request, { cityId: params.cityId });
+        }
+
+        const subjects = await getApiSubjects(await getRealm(), params.cityId, {
+            introducerId,
+            from,
+            to,
+            limit,
+            includeUnreleased,
+        });
+
+        return NextResponse.json(subjects);
+    } catch (error) {
+        if (error instanceof z.ZodError) {
+            return NextResponse.json({ error: error.errors }, { status: 400 });
+        }
+        return handleApiError(error, 'Failed to fetch subjects');
+    }
+}

--- a/src/lib/db/__tests__/subjectsApi.test.ts
+++ b/src/lib/db/__tests__/subjectsApi.test.ts
@@ -1,0 +1,81 @@
+// buildApiSubjectWhere is a pure filter builder; mock the prisma singleton so
+// importing subjectsApi.ts doesn't pull in the real client (→ env.mjs, which
+// the jest transform doesn't handle).
+jest.mock('../prisma', () => ({ __esModule: true, default: {} }));
+
+import { Realm } from '@prisma/client';
+import { buildApiSubjectWhere } from '@/lib/db/subjectsApi';
+import { PUBLIC_CITY_WHERE } from '@/lib/cityStatus';
+
+describe('buildApiSubjectWhere', () => {
+    describe('the public view', () => {
+        it('serves released meetings of a published city in the realm of the request', () => {
+            const where = buildApiSubjectWhere(Realm.greece, 'athens', {});
+
+            expect(where).toEqual({
+                cityId: 'athens',
+                councilMeeting: {
+                    released: true,
+                    city: { ...PUBLIC_CITY_WHERE, realm: Realm.greece },
+                },
+            });
+        });
+
+        it('excludes a city that is not published', () => {
+            // A city ID is public: /api/cities/all lists pending cities too. The
+            // status constraint is what keeps their meetings out of the API.
+            const { councilMeeting } = buildApiSubjectWhere(Realm.greece, 'pending-city', {});
+
+            expect(councilMeeting).toMatchObject({ city: { status: { in: ['demo', 'supported'] } } });
+        });
+
+        it('scopes to the realm of the request', () => {
+            const { councilMeeting } = buildApiSubjectWhere(Realm.france, 'paris', {});
+
+            expect(councilMeeting).toMatchObject({ city: { realm: Realm.france } });
+        });
+    });
+
+    describe('the authorized view', () => {
+        it('drops the release, status and realm constraints', () => {
+            // The routes authorize for the city before they pass this, so an
+            // admin of a city we do not publish still reads their own city.
+            const where = buildApiSubjectWhere(Realm.greece, 'athens', { includeUnreleased: true });
+
+            expect(where).toEqual({ cityId: 'athens' });
+        });
+
+        it('keeps a date range while it drops the visibility constraints', () => {
+            const to = new Date('2025-12-31T23:59:59.999Z');
+            const where = buildApiSubjectWhere(Realm.greece, 'athens', { includeUnreleased: true, to });
+
+            expect(where.councilMeeting).toEqual({ dateTime: { lte: to } });
+        });
+    });
+
+    describe('filters', () => {
+        it('restricts to one meeting', () => {
+            expect(buildApiSubjectWhere(Realm.greece, 'athens', { meetingId: 'm1' }))
+                .toMatchObject({ councilMeetingId: 'm1' });
+        });
+
+        it('restricts to one introducer', () => {
+            expect(buildApiSubjectWhere(Realm.greece, 'athens', { introducerId: 'p1' }))
+                .toMatchObject({ personId: 'p1' });
+        });
+
+        it('applies each end of the date range', () => {
+            const from = new Date('2025-01-01T00:00:00.000Z');
+            const to = new Date('2025-12-31T23:59:59.999Z');
+            const { councilMeeting } = buildApiSubjectWhere(Realm.greece, 'athens', { from, to });
+
+            expect(councilMeeting).toMatchObject({ dateTime: { gte: from, lte: to } });
+        });
+
+        it('omits the date filter when the caller names no range', () => {
+            const { councilMeeting } = buildApiSubjectWhere(Realm.greece, 'athens', {});
+
+            expect(councilMeeting).not.toHaveProperty('dateTime');
+        });
+    });
+});

--- a/src/lib/db/subjectsApi.ts
+++ b/src/lib/db/subjectsApi.ts
@@ -1,0 +1,224 @@
+// Server-only (NOT a "use server" action module). Every function here takes
+// `includeUnreleased` from its caller, so as exported actions they would hand
+// subjects of unreleased meetings to anyone who posted the right argument. The
+// API routes authorize first. Same reason as meetingsList.ts.
+import "server-only";
+import { Prisma, NonAgendaReason, LocationType, Realm } from '@prisma/client';
+import prisma from '@/lib/db/prisma';
+import { PUBLIC_CITY_WHERE } from '@/lib/cityStatus';
+import { DEFAULT_SUBJECT_LIMIT, MAX_SUBJECT_LIMIT } from '@/lib/zod-schemas/subject';
+
+/**
+ * The wire shape of a subject in the REST API.
+ *
+ * Deliberately smaller than {@link import('@/lib/db/subject').SubjectWithRelations}:
+ * the API contract carries the agenda record and the entities a subject points
+ * at, not the discussion itself. Contributions, votes, attendance, highlights
+ * and the decision stay out — they are large, they change shape as the
+ * extraction pipeline improves, and an API contract must stay stable.
+ */
+const apiSubjectSelect = {
+    id: true,
+    name: true,
+    description: true,
+    cityId: true,
+    councilMeetingId: true,
+    agendaItemIndex: true,
+    agendaItemTitle: true,
+    nonAgendaReason: true,
+    withdrawn: true,
+    topic: {
+        select: { id: true, name: true, name_en: true, colorHex: true, icon: true },
+    },
+    location: {
+        select: { id: true, type: true, text: true },
+    },
+    introducedBy: {
+        select: { id: true, name: true, name_en: true },
+    },
+    councilMeeting: {
+        select: { id: true, name: true, name_en: true, dateTime: true },
+    },
+} satisfies Prisma.SubjectSelect;
+
+type ApiSubjectRow = Prisma.SubjectGetPayload<{ select: typeof apiSubjectSelect }>;
+
+export interface ApiSubject {
+    id: string;
+    name: string;
+    description: string;
+    cityId: string;
+    meetingId: string;
+    meetingName: string;
+    meetingNameEn: string;
+    meetingDate: string;
+    agendaItemIndex: number | null;
+    agendaItemTitle: string | null;
+    nonAgendaReason: NonAgendaReason | null;
+    withdrawn: boolean;
+    topic: {
+        id: string;
+        name: string;
+        name_en: string;
+        colorHex: string;
+        icon: string | null;
+    } | null;
+    location: {
+        type: LocationType;
+        text: string;
+        coordinates: { lat: number; lng: number } | null;
+    } | null;
+    introducedBy: {
+        id: string;
+        name: string;
+        name_en: string;
+    } | null;
+}
+
+export interface ApiSubjectFilters {
+    /** Restrict to one meeting of the city. */
+    meetingId?: string;
+    /** Restrict to subjects introduced by this person. */
+    introducerId?: string;
+    /** Earliest meeting date, inclusive. */
+    from?: Date;
+    /** Latest meeting date, inclusive. */
+    to?: Date;
+    /** Callers must authorize before they pass true. */
+    includeUnreleased?: boolean;
+    limit?: number;
+}
+
+function meetingWhere(realm: Realm, filters: ApiSubjectFilters): Prisma.CouncilMeetingWhereInput {
+    const where: Prisma.CouncilMeetingWhereInput = {};
+
+    // The public view carries three constraints, not one. A city ID is not a
+    // secret — /api/cities/all hands out every ID, `pending` ones included — so
+    // the released flag alone would serve a city we do not publish, and would
+    // serve one realm's councils on another realm's domain.
+    if (!filters.includeUnreleased) {
+        where.released = true;
+        where.city = { ...PUBLIC_CITY_WHERE, realm };
+    }
+
+    if (filters.from || filters.to) {
+        where.dateTime = {
+            ...(filters.from && { gte: filters.from }),
+            ...(filters.to && { lte: filters.to }),
+        };
+    }
+    return where;
+}
+
+/**
+ * The subject filter behind every listing here. Exported so the visibility
+ * rules can be asserted without a database.
+ *
+ * `includeUnreleased` drops the public-city and realm constraints as well as
+ * the release constraint: the callers that pass it have authorized for this
+ * city (or hold a service key), so they see their own city whatever its status.
+ */
+export function buildApiSubjectWhere(
+    realm: Realm,
+    cityId: string,
+    filters: ApiSubjectFilters
+): Prisma.SubjectWhereInput {
+    const meeting = meetingWhere(realm, filters);
+    return {
+        cityId,
+        ...(filters.meetingId && { councilMeetingId: filters.meetingId }),
+        ...(filters.introducerId && { personId: filters.introducerId }),
+        ...(Object.keys(meeting).length > 0 && { councilMeeting: meeting }),
+    };
+}
+
+/**
+ * Centroids of the locations these subjects point at, keyed by location id.
+ *
+ * Centroids, not ST_X/ST_Y of the raw geometry: a location can be a line or a
+ * polygon. Raw SQL because the geometry column is an Unsupported() type.
+ */
+async function locationCentroids(rows: ApiSubjectRow[]): Promise<Map<string, { lat: number; lng: number }>> {
+    const locationIds = [...new Set(rows.map(row => row.location?.id).filter((id): id is string => id != null))];
+    const centroids = new Map<string, { lat: number; lng: number }>();
+    if (locationIds.length === 0) return centroids;
+
+    const coordinates = await prisma.$queryRaw<Array<{ id: string; lng: number; lat: number }>>`
+        SELECT id, ST_X(ST_Centroid(coordinates)) AS lng, ST_Y(ST_Centroid(coordinates)) AS lat
+        FROM "Location" WHERE id IN (${Prisma.join(locationIds)})`;
+    for (const row of coordinates) centroids.set(row.id, { lat: row.lat, lng: row.lng });
+    return centroids;
+}
+
+function toApiSubject(
+    row: ApiSubjectRow,
+    centroids: Map<string, { lat: number; lng: number }>
+): ApiSubject {
+    return {
+        id: row.id,
+        name: row.name,
+        description: row.description,
+        cityId: row.cityId,
+        meetingId: row.councilMeetingId,
+        meetingName: row.councilMeeting.name,
+        meetingNameEn: row.councilMeeting.name_en,
+        meetingDate: row.councilMeeting.dateTime.toISOString(),
+        agendaItemIndex: row.agendaItemIndex,
+        agendaItemTitle: row.agendaItemTitle,
+        nonAgendaReason: row.nonAgendaReason,
+        withdrawn: row.withdrawn,
+        topic: row.topic,
+        location: row.location
+            ? {
+                type: row.location.type,
+                text: row.location.text,
+                coordinates: centroids.get(row.location.id) ?? null,
+            }
+            : null,
+        introducedBy: row.introducedBy,
+    };
+}
+
+/**
+ * Subjects of a city, newest meeting first, in agenda order within a meeting.
+ */
+export async function getApiSubjects(
+    realm: Realm,
+    cityId: string,
+    filters: ApiSubjectFilters = {}
+): Promise<ApiSubject[]> {
+    const rows = await prisma.subject.findMany({
+        where: buildApiSubjectWhere(realm, cityId, filters),
+        select: apiSubjectSelect,
+        orderBy: [
+            { councilMeeting: { dateTime: 'desc' } },
+            { agendaItemIndex: 'asc' },
+            { name: 'asc' },
+        ],
+        take: Math.min(filters.limit ?? DEFAULT_SUBJECT_LIMIT, MAX_SUBJECT_LIMIT),
+    });
+
+    const centroids = await locationCentroids(rows);
+    return rows.map(row => toApiSubject(row, centroids));
+}
+
+/** One subject of one meeting, or null when it does not exist or is not visible. */
+export async function getApiSubject(
+    realm: Realm,
+    cityId: string,
+    meetingId: string,
+    subjectId: string,
+    { includeUnreleased = false }: { includeUnreleased?: boolean } = {}
+): Promise<ApiSubject | null> {
+    const row = await prisma.subject.findFirst({
+        where: {
+            id: subjectId,
+            ...buildApiSubjectWhere(realm, cityId, { meetingId, includeUnreleased }),
+        },
+        select: apiSubjectSelect,
+    });
+    if (!row) return null;
+
+    const centroids = await locationCentroids([row]);
+    return toApiSubject(row, centroids);
+}

--- a/src/lib/openapi/__tests__/coverage.test.ts
+++ b/src/lib/openapi/__tests__/coverage.test.ts
@@ -29,6 +29,10 @@ const EXPECTED_OPERATIONS = [
     'GET /api/cities/{cityId}/people/{personId}',
     'PUT /api/cities/{cityId}/people/{personId}',
     'DELETE /api/cities/{cityId}/people/{personId}',
+    'GET /api/cities/{cityId}/subjects',
+    'GET /api/cities/{cityId}/meetings/{meetingId}/subjects',
+    'GET /api/cities/{cityId}/meetings/{meetingId}/subjects/{subjectId}',
+    'PATCH /api/cities/{cityId}/meetings/{meetingId}/subjects/{subjectId}',
     'POST /api/search',
     'GET /api/utterance/{utteranceId}/context',
 ].sort();

--- a/src/lib/openapi/index.ts
+++ b/src/lib/openapi/index.ts
@@ -5,6 +5,7 @@ import './routes/meetings';
 import './routes/search';
 import './routes/parties';
 import './routes/people';
+import './routes/subjects';
 import './routes/utterances';
 
 import { registry, generateSpec } from './registry';

--- a/src/lib/openapi/routes/subjects.ts
+++ b/src/lib/openapi/routes/subjects.ts
@@ -1,0 +1,226 @@
+import { z } from 'zod';
+import { LocationType, NonAgendaReason } from '@prisma/client';
+import { registry, sessionAuth, ValidationErrorSchema, ErrorResponseSchema, cityIdParam } from '@/lib/openapi/registry';
+import { MAX_SUBJECT_LIMIT, DEFAULT_SUBJECT_LIMIT } from '@/lib/zod-schemas/subject';
+
+// --- Response Schemas ---
+
+// Matches ApiSubject in src/lib/db/subjectsApi.ts — the trimmed wire shape.
+// The discussion itself (contributions, votes, attendance, highlights, the
+// decision) is not part of this contract.
+const SubjectTopicSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    name_en: z.string(),
+    colorHex: z.string(),
+    icon: z.string().nullable(),
+}).openapi('SubjectTopic');
+
+const SubjectLocationSchema = z.object({
+    type: z.nativeEnum(LocationType),
+    text: z.string(),
+    coordinates: z.object({
+        lat: z.number(),
+        lng: z.number(),
+    }).nullable().openapi({ description: 'Centroid of the location geometry. Null when the geometry is missing.' }),
+}).openapi('SubjectLocation');
+
+const SubjectIntroducerSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    name_en: z.string(),
+}).openapi('SubjectIntroducer');
+
+const SubjectSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string(),
+    cityId: z.string(),
+    meetingId: z.string(),
+    meetingName: z.string(),
+    meetingNameEn: z.string(),
+    meetingDate: z.string().datetime(),
+    agendaItemIndex: z.number().int().nullable().openapi({ description: 'Position on the official agenda. Null for a non-agenda subject.' }),
+    agendaItemTitle: z.string().nullable().openapi({ description: 'The item as written on the official agenda.' }),
+    nonAgendaReason: z.nativeEnum(NonAgendaReason).nullable(),
+    withdrawn: z.boolean(),
+    topic: SubjectTopicSchema.nullable(),
+    location: SubjectLocationSchema.nullable(),
+    introducedBy: SubjectIntroducerSchema.nullable(),
+}).openapi('Subject');
+
+registry.register('SubjectTopic', SubjectTopicSchema);
+registry.register('SubjectLocation', SubjectLocationSchema);
+registry.register('SubjectIntroducer', SubjectIntroducerSchema);
+registry.register('Subject', SubjectSchema);
+
+// --- Shared query parameters ---
+
+const limitQuery = z.string().optional().openapi({
+    description: `Maximum number of subjects to return (1-${MAX_SUBJECT_LIMIT}). Defaults to ${DEFAULT_SUBJECT_LIMIT}.`,
+    example: '20',
+});
+
+const introducerIdQuery = z.string().optional().openapi({
+    description: 'Return only subjects introduced by this person.',
+});
+
+const includeUnreleasedQuery = z.string().optional().openapi({
+    description: 'Include subjects of unreleased meetings, and of a city that is not published. '
+        + 'Requires an authorized session for the city, or a service key.',
+    example: 'true',
+});
+
+const listResponses = {
+    200: {
+        description: 'List of subjects',
+        content: { 'application/json': { schema: z.array(SubjectSchema) } },
+    },
+    400: {
+        description: 'Invalid query parameters',
+        content: { 'application/json': { schema: ValidationErrorSchema } },
+    },
+    401: {
+        description: 'includeUnreleased requested without authorization',
+        content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
+    500: {
+        description: 'Server error',
+        content: { 'application/json': { schema: ErrorResponseSchema } },
+    },
+};
+
+// --- Routes ---
+
+const meetingIdParam = cityIdParam.extend({
+    meetingId: z.string().openapi({ description: 'Meeting ID' }),
+});
+
+const subjectIdParam = meetingIdParam.extend({
+    subjectId: z.string().openapi({ description: 'Subject ID' }),
+});
+
+registry.registerPath({
+    method: 'get',
+    path: '/api/cities/{cityId}/subjects',
+    summary: 'List subjects for a city',
+    description: 'Returns subjects of released meetings of the given city, newest meeting first, '
+        + 'in agenda order within a meeting. The city must be published, and it must belong to the '
+        + 'realm of the host that serves the request. Filter by introducer and by meeting date.',
+    tags: ['Subjects'],
+    request: {
+        params: cityIdParam,
+        query: z.object({
+            introducerId: introducerIdQuery,
+            from: z.string().optional().openapi({ description: 'Earliest meeting date, inclusive (ISO 8601).', example: '2025-01-01' }),
+            to: z.string().optional().openapi({
+                description: 'Latest meeting date, inclusive (ISO 8601). A date with no time of day covers the whole day.',
+                example: '2025-12-31',
+            }),
+            limit: limitQuery,
+            includeUnreleased: includeUnreleasedQuery,
+        }),
+    },
+    responses: listResponses,
+});
+
+registry.registerPath({
+    method: 'get',
+    path: '/api/cities/{cityId}/meetings/{meetingId}/subjects',
+    summary: 'List subjects for a meeting',
+    description: 'Returns the subjects of one meeting, in agenda order. The meeting must be released, '
+        + 'and its city must be published in the realm of the host that serves the request.',
+    tags: ['Subjects'],
+    request: {
+        params: meetingIdParam,
+        query: z.object({
+            introducerId: introducerIdQuery,
+            limit: limitQuery,
+            includeUnreleased: includeUnreleasedQuery,
+        }),
+    },
+    responses: listResponses,
+});
+
+registry.registerPath({
+    method: 'get',
+    path: '/api/cities/{cityId}/meetings/{meetingId}/subjects/{subjectId}',
+    summary: 'Get a subject',
+    tags: ['Subjects'],
+    request: {
+        params: subjectIdParam,
+        query: z.object({
+            includeUnreleased: includeUnreleasedQuery,
+        }),
+    },
+    responses: {
+        200: {
+            description: 'The subject',
+            content: { 'application/json': { schema: SubjectSchema } },
+        },
+        401: {
+            description: 'includeUnreleased requested without authorization',
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+        },
+        404: {
+            description: 'Subject not found',
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+        },
+        500: {
+            description: 'Server error',
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+        },
+    },
+});
+
+// --- Admin routes ---
+
+const UpdateSubjectSchema = z.object({
+    nonAgendaReason: z.nativeEnum(NonAgendaReason).nullable().optional(),
+    withdrawn: z.boolean().optional(),
+}).openapi('UpdateSubject');
+
+registry.register('UpdateSubject', UpdateSubjectSchema);
+
+registry.registerPath({
+    method: 'patch',
+    path: '/api/cities/{cityId}/meetings/{meetingId}/subjects/{subjectId}',
+    summary: 'Update the agenda flags of a subject',
+    description: 'Updates `nonAgendaReason` and `withdrawn`. Requires superadmin access.',
+    tags: ['Subjects'],
+    security: [{ [sessionAuth.name]: [] }],
+    'x-access-level': 'superadmin',
+    request: {
+        params: subjectIdParam,
+        body: {
+            required: true,
+            content: { 'application/json': { schema: UpdateSubjectSchema } },
+        },
+    },
+    responses: {
+        200: {
+            description: 'The updated agenda flags',
+            content: {
+                'application/json': {
+                    schema: z.object({
+                        id: z.string(),
+                        nonAgendaReason: z.nativeEnum(NonAgendaReason).nullable(),
+                        withdrawn: z.boolean(),
+                    }),
+                },
+            },
+        },
+        400: {
+            description: 'Invalid request body',
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+        },
+        403: {
+            description: 'Superadmin access required',
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+        },
+        404: {
+            description: 'Subject not found',
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+        },
+    },
+});

--- a/src/lib/zod-schemas/__tests__/subject.test.ts
+++ b/src/lib/zod-schemas/__tests__/subject.test.ts
@@ -1,0 +1,70 @@
+import {
+    subjectListQuerySchema,
+    meetingSubjectListQuerySchema,
+    DEFAULT_SUBJECT_LIMIT,
+    MAX_SUBJECT_LIMIT,
+} from '../subject';
+
+describe('subjectListQuerySchema', () => {
+    it('applies the default limit when the caller names none', () => {
+        expect(subjectListQuerySchema.parse({})).toEqual({
+            introducerId: undefined,
+            from: undefined,
+            to: undefined,
+            limit: DEFAULT_SUBJECT_LIMIT,
+            includeUnreleased: false,
+        });
+    });
+
+    it('parses the date range into Date objects', () => {
+        const parsed = subjectListQuerySchema.parse({ from: '2025-01-01', to: '2025-12-31' });
+        expect(parsed.from).toEqual(new Date('2025-01-01T00:00:00.000Z'));
+        // The upper bound covers the whole day. Midnight at the start of the
+        // 31st would drop every meeting held on the 31st.
+        expect(parsed.to).toEqual(new Date('2025-12-31T23:59:59.999Z'));
+    });
+
+    it('keeps a full timestamp in the upper bound as written', () => {
+        const parsed = subjectListQuerySchema.parse({ to: '2025-12-31T09:00:00.000Z' });
+        expect(parsed.to).toEqual(new Date('2025-12-31T09:00:00.000Z'));
+    });
+
+    it('rejects an unparseable date', () => {
+        expect(() => subjectListQuerySchema.parse({ from: 'yesterday' })).toThrow(/Invalid 'from' date/);
+    });
+
+    it('rejects a limit outside the allowed range', () => {
+        expect(() => subjectListQuerySchema.parse({ limit: '0' })).toThrow();
+        expect(() => subjectListQuerySchema.parse({ limit: String(MAX_SUBJECT_LIMIT + 1) })).toThrow();
+        expect(() => subjectListQuerySchema.parse({ limit: 'many' })).toThrow();
+    });
+
+    it('rejects a limit that is not a whole number', () => {
+        // parseInt alone reads these as 10 and 1, and serves a page of data.
+        expect(() => subjectListQuerySchema.parse({ limit: '10abc' })).toThrow();
+        expect(() => subjectListQuerySchema.parse({ limit: '1.5' })).toThrow();
+        expect(() => subjectListQuerySchema.parse({ limit: ' 10' })).toThrow();
+        expect(() => subjectListQuerySchema.parse({ limit: '-5' })).toThrow();
+    });
+
+    it('accepts a well-formed limit', () => {
+        expect(subjectListQuerySchema.parse({ limit: '20' }).limit).toBe(20);
+    });
+
+    it('treats includeUnreleased as true only for the exact string', () => {
+        expect(subjectListQuerySchema.parse({ includeUnreleased: 'true' }).includeUnreleased).toBe(true);
+        expect(subjectListQuerySchema.parse({ includeUnreleased: '1' }).includeUnreleased).toBe(false);
+    });
+
+    it('keeps introducerId', () => {
+        expect(subjectListQuerySchema.parse({ introducerId: 'person-1' }).introducerId).toBe('person-1');
+    });
+});
+
+describe('meetingSubjectListQuerySchema', () => {
+    it('drops the date range, which the meeting path already fixes', () => {
+        const parsed = meetingSubjectListQuerySchema.parse({ from: '2025-01-01', introducerId: 'person-1' });
+        expect(parsed).not.toHaveProperty('from');
+        expect(parsed.introducerId).toBe('person-1');
+    });
+});

--- a/src/lib/zod-schemas/subject.ts
+++ b/src/lib/zod-schemas/subject.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+/** Page size of the subject listings when the caller names none. */
+export const DEFAULT_SUBJECT_LIMIT = 50;
+/** Largest page the subject listings serve. */
+export const MAX_SUBJECT_LIMIT = 100;
+
+/** `2025-12-31` — a calendar day, with no time of day in it. */
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * A bound of the date range. Both bounds are inclusive, which a date-only
+ * upper bound only is if it covers the whole day: `new Date('2025-12-31')` is
+ * midnight UTC at the *start* of the 31st, so `lte` against it would drop
+ * every meeting held that day. A full timestamp passes through as written.
+ */
+const dateParam = (label: string, endOfDay = false) => z.string()
+    .refine(val => !isNaN(new Date(val).getTime()), { message: `Invalid '${label}' date` })
+    .transform(val => new Date(endOfDay && DATE_ONLY.test(val) ? `${val}T23:59:59.999Z` : val));
+
+/**
+ * Query parameters of the subject listings. The routes parse
+ * `searchParams`, so every field arrives as a string.
+ */
+export const subjectListQuerySchema = z.object({
+    introducerId: z.string().min(1).optional(),
+    from: dateParam('from').optional(),
+    to: dateParam('to', true).optional(),
+    // The whole string must be digits: parseInt alone reads `10abc` as 10 and
+    // `1.5` as 1, so malformed input would silently return a page of data
+    // instead of the documented validation error.
+    limit: z.string()
+        .regex(/^\d+$/, { message: `Limit must be a whole number between 1 and ${MAX_SUBJECT_LIMIT}` })
+        .optional()
+        .transform(val => val ? parseInt(val, 10) : DEFAULT_SUBJECT_LIMIT)
+        .refine(val => val >= 1 && val <= MAX_SUBJECT_LIMIT, {
+            message: `Limit must be a whole number between 1 and ${MAX_SUBJECT_LIMIT}`,
+        }),
+    includeUnreleased: z.string()
+        .optional()
+        .transform(val => val === 'true'),
+});
+
+/**
+ * The meeting-scoped listing carries the date in its path, so it drops the
+ * date range.
+ */
+export const meetingSubjectListQuerySchema = subjectListQuerySchema.omit({ from: true, to: true });


### PR DESCRIPTION
## Summary
Adds three new public API endpoints for querying subjects (agenda items) across cities and meetings, with support for filtering, pagination, and optional access to unreleased meetings via authentication.

## Key Changes

- **New API Routes**:
  - `GET /api/cities/{cityId}/subjects` — List subjects across all released meetings of a city, with optional date range filtering
  - `GET /api/cities/{cityId}/meetings/{meetingId}/subjects` — List subjects for a specific meeting
  - `GET /api/cities/{cityId}/meetings/{meetingId}/subjects/{subjectId}` — Fetch a single subject
  - `PATCH /api/cities/{cityId}/meetings/{meetingId}/subjects/{subjectId}` — Update agenda flags (superadmin only)

- **Data Access Layer** (`src/lib/db/subjectsPublic.ts`):
  - New `getPublicSubjects()` and `getPublicSubject()` functions that return a trimmed public shape of subjects
  - Deliberately excludes discussion data (contributions, votes, attendance, highlights, decision) to keep the API contract stable
  - Includes location centroids computed via PostGIS `ST_Centroid()`
  - Respects `released` flag on meetings; requires authorization to access unreleased meetings

- **OpenAPI Schema** (`src/lib/openapi/routes/subjects.ts`):
  - Defines `Subject`, `SubjectTopic`, `SubjectLocation`, and `SubjectIntroducer` schemas
  - Registers all four endpoints with full request/response documentation
  - Includes proper error responses (400, 401, 403, 404, 500)

- **Query Validation** (`src/lib/zod-schemas/subject.ts`):
  - `subjectListQuerySchema` — Validates city-level listing with date range, introducer filter, limit, and `includeUnreleased` flag
  - `meetingSubjectListQuerySchema` — Meeting-scoped variant that omits date range (fixed by path)
  - Enforces pagination limits (1–100, default 50)
  - Parses ISO 8601 date strings into Date objects

- **Tests** (`src/lib/zod-schemas/__tests__/subject.test.ts`):
  - Validates default limit application, date parsing, limit bounds, and `includeUnreleased` string handling

## Implementation Details

- Authorization is checked at the route level before querying: if `includeUnreleased=true`, the request must have a valid service key or user session
- Location coordinates are fetched in a single batch query using raw SQL to compute centroids, avoiding N+1 queries
- Results are ordered by meeting date (newest first), then agenda item index, then name
- The public shape is intentionally smaller than the internal `SubjectWithRelations` type to maintain API stability as the extraction pipeline evolves
- All database functions are in `server-only` modules to prevent accidental exposure of unreleased data via Server Actions

https://claude.ai/code/session_01WQEu3ASrXvguG1QkYh88VV





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds public subject-list and subject-detail APIs with filtering, bounded result sizes, OpenAPI documentation, and authenticated access to unreleased meeting data.
- Restricts anonymous reads by meeting release state, public city status, and request realm.
- Returns a stable subject representation with batched PostGIS location centroids.
- Corrects inclusive date-only upper bounds and strict integer-limit parsing.
- Adds focused validation, visibility-filter, and OpenAPI coverage tests.

<h3>Confidence Score: 4/5</h3>

The API behavior appears correct, but the repository’s explicit source-import policy must still be satisfied before merging.

The previous visibility, inclusive-date, and malformed-limit findings are fully fixed. The prior alias-import finding is only partially fixed: the production imports now use `@/`, but `src/lib/db/__tests__/subjectsApi.test.ts` still mocks `../prisma` and `src/lib/zod-schemas/__tests__/subject.test.ts` still imports `../subject`.

**Files Needing Attention:** src/lib/db/__tests__/subjectsApi.test.ts, src/lib/zod-schemas/__tests__/subject.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/db/subjectsApi.ts | Adds the release-, publication-, and realm-aware subject queries and batched location-centroid mapping; the prior source-import violation is fixed. |
| src/app/api/cities/[cityId]/subjects/route.ts | Adds the city-wide subject listing endpoint with validated filters and authorization for unreleased records. |
| src/app/api/cities/[cityId]/meetings/[meetingId]/subjects/route.ts | Adds a meeting-scoped subject listing endpoint using the same visibility and authorization boundaries. |
| src/app/api/cities/[cityId]/meetings/[meetingId]/subjects/[subjectId]/route.ts | Adds public retrieval of a single subject while preserving the existing protected update route. |
| src/lib/zod-schemas/subject.ts | Defines strict query parsing, including whole-day inclusive upper bounds and bounded integer limits. |
| src/lib/openapi/routes/subjects.ts | Documents the subject response contract and all list, detail, and update operations; the prior registry-import violation is fixed. |
| src/lib/db/__tests__/subjectsApi.test.ts | Covers publication and realm filtering but retains a relative Prisma mock path covered by the existing alias-policy thread. |
| src/lib/zod-schemas/__tests__/subject.test.ts | Covers date and query validation but retains a relative subject-schema import covered by the existing alias-policy thread. |

<sub>Reviews (3): Last reviewed commit: ["feat(api): add subjects endpoints"](https://github.com/schemalabz/opencouncil/commit/ba5c9cc61387eef5c20fd0a7f8c3ca931e335807) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62240037)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Meeting publication and records](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/meeting-publication.md)
- Knowledge Base — [Database access and civic models](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/database-access-and-models.md)
- Knowledge Base — [Identity and access control](https://app.greptile.com/schema-labs/-/custom-context/knowledge-base/schemalabz/opencouncil/-/docs/identity-and-access.md)
</details>


<!-- /greptile_comment -->