### PR TITLE
Restore the transcript editor's keyboard shortcuts

### DIFF
--- a/docs/guides/editing-interface.md
+++ b/docs/guides/editing-interface.md
@@ -11,7 +11,6 @@ The system divides editing into distinct categories and modes:
 1.  **Editing Mode Lifecycle**:
     *   **Activation**: Users enter "Editing Mode" via the `EditButton` in the global header. This activates `options.editable` in the `TranscriptOptionsContext`.
     *   **Context Bar**: When active, the `EditingModeBar` appears at the top of the transcript, providing specialized controls:
-        *   **Playback Speed**: Adjust video playback speed (0.5x - 2.0x)
         *   **Skip Interval**: Configure time skip interval for Shift+Arrow navigation (2-30 seconds, default 5s)
         *   **Next Unknown Speaker**: Jump to next segment with unidentified speaker
         *   **Speakers Overview**: View statistics and navigate by speaker
@@ -70,41 +69,14 @@ The system divides editing into distinct categories and modes:
     *   These are treated similarly to user edits but are attributed to 'task' in the `lastModifiedBy` field and `UtteranceEdit` records.
 
 6.  **Interaction Enhancements**:
-    *   **Keyboard Shortcuts**: Centralized management via `KeyboardShortcutsContext` and `EditingContext`. Key shortcuts include:
-        *   **Utterance Navigation**: Arrow keys to jump between utterances
-        *   **Time-based Navigation**: `Shift+Arrow` keys to skip forward/backward by configurable interval (2-30s) - useful for manual transcription and reviewing audio
-        *   **Playback Control**: Space for play/pause, Up/Down arrows for speed adjustment
-        *   **While Editing Utterances**: When actively editing utterance text, all Shift-based shortcuts continue to work:
-            *   Video control (`Shift+Space` for play/pause)
-            *   Time-based navigation (`Shift+Arrow` keys for skip forward/backward)
-            *   Timestamp setting (`Shift+[` and `Shift+]` to set start/end timestamps to current video time)
+    *   **Keyboard Shortcuts**: `ACTION_DEFINITIONS` in `KeyboardShortcutsContext` states what each shortcut is bound to. The in-app `EditingGuideDialog` renders its keys from that list. The guide therefore cannot show a key that the dispatcher does not honour. Do not write the key list down a second time. The rules that the code does not state are:
+        *   **Editing mode claims the bare arrows.** In editing mode the four arrow keys drive playback from anywhere on the page. Focus can stay on the transcript.
+        *   **A reader gets seek, but not speed.** `ArrowLeft` and `ArrowRight` do not scroll a transcript, so a reader keeps them as seek. `ArrowUp` and `ArrowDown` stay scroll keys for a reader. The chosen speed persists in `localStorage`. One stray press would therefore change the speed of every later meeting. A reader changes the speed from the playback dock.
+        *   **A control that owns the keyboard keeps it.** Menus, listboxes, sliders, tab lists, comboboxes and selects keep every key. A focused button keeps only `Space` and `Enter`, which activate it. The button passes every other key to its shortcut. The playback dock's timeline strip claims no arrow key.
+        *   **The utterance editor holds its own keys.** `Utterance` handles the Shift-based shortcuts on its textarea. The dispatcher ignores keys that a user types into a text field.
     *   **Selection Mode**: Managed via `EditingContext`. Supports **Shift+Click** for range selection (selecting multiple sequential utterances) and **Ctrl+Click** for toggling individual selections.
     *   **Speakers Overview**: A dedicated sheet (`SpeakersOverviewSheet`) provides real-time statistics (duration, segment count) and navigation for every speaker in the meeting.
     *   **In-App Guide**: A comprehensive `EditingGuideDialog` provides immediate access to shortcuts and workflow instructions.
-
-**Shortcuts Reference**
-
-| Category | Key(s) | Action |
-| :--- | :--- | :--- |
-| **Playback** | `Space` | Play / Pause |
-| | `ArrowLeft` | Seek to previous utterance |
-| | `ArrowRight` | Seek to next utterance |
-| | `Shift + ArrowLeft` | Skip backward by interval (2-30s, configurable) |
-| | `Shift + ArrowRight` | Skip forward by interval (2-30s, configurable) |
-| | `ArrowUp` | Increase Playback Speed |
-| | `ArrowDown` | Decrease Playback Speed |
-| **Text Editing** | `Enter` | Edit active utterance / Save & Close |
-| | `Escape` | Cancel text edit |
-| **While Editing Utterance** | `Shift + Space` | Play / Pause (works in text editor) |
-| | `Shift + ArrowLeft` | Skip backward (works in text editor) |
-| | `Shift + ArrowRight` | Skip forward (works in text editor) |
-| | `Shift + [` | Set start timestamp to current video time |
-| | `Shift + ]` | Set end timestamp to current video time |
-| **Selection** | `Shift + Click` | Select Range of Utterances |
-| | `Ctrl + Click` | Toggle Selection of Utterance |
-| | `e` | Extract selected utterances to new segment |
-| | `Escape` | Clear selection |
-| **Global** | `Ctrl + b` | Toggle Sidebar |
 
 **Sequence Diagram**
 
@@ -118,7 +90,7 @@ sequenceDiagram
     %% Mode Activation
     User->>Frontend: Clicks "Enable Editing" (EditButton)
     Frontend->>Frontend: Sets options.editable = true
-    Frontend->>Frontend: Shows EditingModeBar (Speed, Unknown Speaker controls)
+    Frontend->>Frontend: Shows EditingModeBar (skip interval, unknown speaker, review)
 
     %% Text Editing Flow
     User->>Frontend: Clicks "Edit" on Utterance
@@ -166,37 +138,6 @@ sequenceDiagram
     Backend->>Database: Recalculate Segment Timestamps
     Backend-->>Frontend: Return updated Segment
 ```
-
-**Key Component Pointers**
-
-*   **Data Models**:
-    *   `Utterance`: [`prisma/schema.prisma`](../../prisma/schema.prisma)
-    *   `UtteranceEdit`: [`prisma/schema.prisma`](../../prisma/schema.prisma)
-    *   `SpeakerSegment`: [`prisma/schema.prisma`](../../prisma/schema.prisma)
-
-*   **Frontend Components**:
-    *   `EditingModeBar`: [`src/components/meetings/EditingModeBar.tsx`](../../src/components/meetings/EditingModeBar.tsx) (Contextual bar with tools and navigation)
-    *   `SpeakersOverviewSheet`: [`src/components/meetings/transcript/SpeakersOverviewSheet.tsx`](../../src/components/meetings/transcript/SpeakersOverviewSheet.tsx) (Speaker statistics and navigation)
-    *   `EditingGuideDialog`: [`src/components/meetings/EditingGuideDialog.tsx`](../../src/components/meetings/EditingGuideDialog.tsx) (In-app user guide)
-    *   `EditButton`: [`src/components/meetings/EditButton.tsx`](../../src/components/meetings/EditButton.tsx) (Entry point in global header)
-    *   `TranscriptControls`: [`src/components/meetings/TranscriptControls.tsx`](../../src/components/meetings/TranscriptControls.tsx) (Video player and clip navigation)
-    *   `Utterance`: [`src/components/meetings/transcript/Utterance.tsx`](../../src/components/meetings/transcript/Utterance.tsx) (Inline editing, visual state)
-    *   `PersonBadge`: [`src/components/persons/PersonBadge.tsx`](../../src/components/persons/PersonBadge.tsx) (Speaker autocomplete and assignment)
-    *   `SpeakerSegment`: [`src/components/meetings/transcript/SpeakerSegment.tsx`](../../src/components/meetings/transcript/SpeakerSegment.tsx) (Displays empty state UI with "Add Utterance" button via `EmptySegmentState` component)
-
-*   **State & Context**:
-    *   `TranscriptOptionsContext`: [`src/components/meetings/options/OptionsContext.tsx`](../../src/components/meetings/options/OptionsContext.tsx) (Manages `editable` state)
-    *   `CouncilMeetingDataContext`: [`src/components/meetings/CouncilMeetingDataContext.tsx`](../../src/components/meetings/CouncilMeetingDataContext.tsx)
-    *   `EditingContext`: [`src/components/meetings/EditingContext.tsx`](../../src/components/meetings/EditingContext.tsx) (Manages utterance selection state and extraction logic)
-    *   `KeyboardShortcutsContext`: [`src/contexts/KeyboardShortcutsContext.tsx`](../../src/contexts/KeyboardShortcutsContext.tsx) (Centralized keyboard shortcut management)
-
-*   **Backend Logic**:
-    *   `editUtterance`: [`src/lib/db/utterance.ts`](../../src/lib/db/utterance.ts)
-    *   `moveUtterancesToSegment`: [`src/lib/db/speakerSegments.ts`](../../src/lib/db/speakerSegments.ts)
-    *   `extractSpeakerSegment`: [`src/lib/db/speakerSegments.ts`](../../src/lib/db/speakerSegments.ts) (Handles extracting utterance ranges into new segments)
-    *   `createEmptySpeakerSegmentBefore/After`: [`src/lib/db/speakerSegments.ts`](../../src/lib/db/speakerSegments.ts) (Handles creating new segments with "New speaker segment" tag)
-    *   `addUtteranceToSegment`: [`src/lib/db/speakerSegments.ts`](../../src/lib/db/speakerSegments.ts) (Unified function for adding utterances to any segment - handles both empty and non-empty cases with automatic timestamp calculation)
-    *   `updateSpeakerSegmentData`: [`src/lib/db/speakerSegments.ts`](../../src/lib/db/speakerSegments.ts) (Handles batch updates, utterance creation/deletion via temp IDs, and timestamp recalculation - used for advanced editing)
 
 **Business Rules & Assumptions**
 

--- a/src/components/meetings/EditingGuideDialog.tsx
+++ b/src/components/meetings/EditingGuideDialog.tsx
@@ -14,6 +14,16 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { BookOpen } from 'lucide-react';
+import { ACTIONS, getActionKeyLabel } from '@/contexts/KeyboardShortcutsContext';
+
+/**
+ * The keys for one action, read from the definitions the dispatcher runs on.
+ * The shortcuts this guide does not own — the ones the utterance editor and the
+ * mouse handle — stay written out below.
+ */
+function ActionKey({ actionId }: { actionId: string }) {
+    return <Badge variant="secondary">{getActionKeyLabel(actionId)}</Badge>;
+}
 
 interface EditingGuideDialogProps {
     children: React.ReactNode;
@@ -108,31 +118,31 @@ export function EditingGuideDialog({ children, onOpenChange }: EditingGuideDialo
                                 <div className="space-y-2">
                                     <div className="flex justify-between items-center py-2 border-b">
                                         <span className="text-sm">{t('shortcuts.playback.playPause')}</span>
-                                        <Badge variant="secondary">Space</Badge>
+                                        <ActionKey actionId={ACTIONS.PLAY_PAUSE.id} />
                                     </div>
                                     <div className="flex justify-between items-center py-2 border-b">
                                         <span className="text-sm">{t('shortcuts.playback.previous')}</span>
-                                        <Badge variant="secondary">←</Badge>
+                                        <ActionKey actionId={ACTIONS.SEEK_PREVIOUS.id} />
                                     </div>
                                     <div className="flex justify-between items-center py-2 border-b">
                                         <span className="text-sm">{t('shortcuts.playback.next')}</span>
-                                        <Badge variant="secondary">→</Badge>
+                                        <ActionKey actionId={ACTIONS.SEEK_NEXT.id} />
                                     </div>
                                     <div className="flex justify-between items-center py-2 border-b">
                                         <span className="text-sm">{t('shortcuts.playback.skipBackward')}</span>
-                                        <Badge variant="secondary">Shift+←</Badge>
+                                        <ActionKey actionId={ACTIONS.SKIP_BACKWARD.id} />
                                     </div>
                                     <div className="flex justify-between items-center py-2 border-b">
                                         <span className="text-sm">{t('shortcuts.playback.skipForward')}</span>
-                                        <Badge variant="secondary">Shift+→</Badge>
+                                        <ActionKey actionId={ACTIONS.SKIP_FORWARD.id} />
                                     </div>
                                     <div className="flex justify-between items-center py-2 border-b">
                                         <span className="text-sm">{t('shortcuts.playback.speedUp')}</span>
-                                        <Badge variant="secondary">↑</Badge>
+                                        <ActionKey actionId={ACTIONS.SPEED_UP.id} />
                                     </div>
                                     <div className="flex justify-between items-center py-2">
                                         <span className="text-sm">{t('shortcuts.playback.speedDown')}</span>
-                                        <Badge variant="secondary">↓</Badge>
+                                        <ActionKey actionId={ACTIONS.SPEED_DOWN.id} />
                                     </div>
                                 </div>
                             </CardContent>
@@ -146,7 +156,7 @@ export function EditingGuideDialog({ children, onOpenChange }: EditingGuideDialo
                                 <div className="space-y-2">
                                     <div className="flex justify-between items-center py-2 border-b">
                                         <span className="text-sm">{t('shortcuts.editing.saveAndNext')}</span>
-                                        <Badge variant="secondary">Enter</Badge>
+                                        <ActionKey actionId={ACTIONS.EDIT_NEXT_UTTERANCE.id} />
                                     </div>
                                     <div className="flex justify-between items-center py-2">
                                         <span className="text-sm">{t('shortcuts.editing.cancel')}</span>
@@ -202,11 +212,11 @@ export function EditingGuideDialog({ children, onOpenChange }: EditingGuideDialo
                                     </div>
                                     <div className="flex justify-between items-center py-2 border-b">
                                         <span className="text-sm">{t('shortcuts.selection.extract')}</span>
-                                        <Badge variant="secondary">e</Badge>
+                                        <ActionKey actionId={ACTIONS.EXTRACT_SEGMENT.id} />
                                     </div>
                                     <div className="flex justify-between items-center py-2">
                                         <span className="text-sm">{t('shortcuts.selection.clear')}</span>
-                                        <Badge variant="secondary">Esc</Badge>
+                                        <ActionKey actionId={ACTIONS.CLEAR_SELECTION.id} />
                                     </div>
                                 </div>
                             </CardContent>

--- a/src/components/meetings/KeyboardShortcuts.tsx
+++ b/src/components/meetings/KeyboardShortcuts.tsx
@@ -16,6 +16,15 @@ export function KeyboardShortcuts() {
     // so registering these without a player would only make the keys dead.
     const hasPlayback = Boolean(meeting.muxPlaybackId || meeting.videoUrl || meeting.audioUrl);
 
+    // Seek belongs to every reader. Left and right only scroll a page sideways,
+    // and a transcript never scrolls sideways, so claiming them costs nothing.
+    const seekScope = { requiresPlaybackFocus: false };
+    // Speed is the other case. Up and down are how a reader scrolls, and the
+    // chosen speed outlives the page, so a stray press would follow a reader to
+    // every meeting they open. Editing mode claims them outright; a reader
+    // changes speed from the dock, where the badge shows the rate in force.
+    const speedScope = { requiresPlaybackFocus: !options.editable };
+
     // Play / Pause
     // Playback belongs to every reader — only editing actions stay gated.
     useKeyboardShortcut(ACTIONS.PLAY_PAUSE.id, () => {
@@ -58,7 +67,7 @@ export function KeyboardShortcuts() {
             const targetUtterance = currentUtterance ? prevUtterances[1] || prevUtterances[0] : prevUtterances[0];
             seekTo(targetUtterance.startTimestamp);
         }
-    }, hasPlayback);
+    }, hasPlayback, seekScope);
 
     // Seek Next (ArrowRight)
     useKeyboardShortcut(ACTIONS.SEEK_NEXT.id, () => {
@@ -70,21 +79,21 @@ export function KeyboardShortcuts() {
         if (nextUtterance) {
             seekTo(nextUtterance.startTimestamp);
         }
-    }, hasPlayback);
+    }, hasPlayback, seekScope);
 
     // Speed Up (ArrowUp)
     useKeyboardShortcut(ACTIONS.SPEED_UP.id, () => {
         const newSpeedUp = Math.min(4, Math.round((options.playbackSpeed + 0.1) * 10) / 10);
         updateOptions({ playbackSpeed: newSpeedUp });
         handleSpeedChange(newSpeedUp.toString());
-    }, hasPlayback);
+    }, hasPlayback, speedScope);
 
     // Speed Down (ArrowDown)
     useKeyboardShortcut(ACTIONS.SPEED_DOWN.id, () => {
         const newSpeedDown = Math.max(0.5, Math.round((options.playbackSpeed - 0.1) * 10) / 10);
         updateOptions({ playbackSpeed: newSpeedDown });
         handleSpeedChange(newSpeedDown.toString());
-    }, hasPlayback);
+    }, hasPlayback, speedScope);
 
     // Skip Backward (Shift + ArrowLeft)
     useKeyboardShortcut(ACTIONS.SKIP_BACKWARD.id, () => {

--- a/src/components/meetings/bar/BarTimeline.tsx
+++ b/src/components/meetings/bar/BarTimeline.tsx
@@ -115,17 +115,13 @@ export function BarTimeline({ mode, compact = false, announce = null, onAnnounce
 
     const onKeyDown = useCallback((e: React.KeyboardEvent) => {
         if (duration <= 0) return;
-        // Shift steps ten seconds: the keyboard's counterpart to the lens's precision.
-        // Left and right seek; up and down are the dock's speed keys, so the strip
-        // lets them through to the shortcut the editing guide advertises.
-        const step = e.shiftKey ? 10 : duration * 0.01;
-        if (e.key === 'ArrowRight') {
-            e.preventDefault();
-            seekTo(Math.min(duration, currentTimeRef.current + step));
-        } else if (e.key === 'ArrowLeft') {
-            e.preventDefault();
-            seekTo(Math.max(0, currentTimeRef.current - step));
-        } else if (e.key === 'PageUp' || e.key === 'PageDown') {
+        // The strip claims no arrow key. All four belong to the shortcuts the
+        // editing guide advertises: left and right step utterance to utterance,
+        // shifted they skip the interval the operator configured, and up and
+        // down set the speed. A one-percent step looked like a slider's job,
+        // but on a three-hour meeting it is nearly two minutes, and it skipped
+        // the utterances the operator was trying to walk through.
+        if (e.key === 'PageUp' || e.key === 'PageDown') {
             // The slider's large step, and the only way to the chapters without
             // a pointer: the rail draws them, and until now nothing but the
             // rail knew they existed.

--- a/src/contexts/KeyboardShortcutsContext.tsx
+++ b/src/contexts/KeyboardShortcutsContext.tsx
@@ -3,6 +3,21 @@ import React, { createContext, useContext, ReactNode, useCallback, useEffect } f
 
 export type KeyboardActionHandler = () => void;
 
+export interface ShortcutRegistrationOptions {
+    /**
+     * Bare arrows scroll the page while reading, so a reader's playback actions
+     * run only from inside the dock. The editing surface claims them outright:
+     * an editor drives the audio while the caret and the focus stay on the
+     * transcript. Defaults to the action definition.
+     */
+    requiresPlaybackFocus?: boolean;
+}
+
+interface ShortcutRegistration {
+    handler: KeyboardActionHandler;
+    requiresPlaybackFocus?: boolean;
+}
+
 export interface KeyboardAction {
     id: string;
     description: string;
@@ -13,7 +28,7 @@ export interface KeyboardAction {
 }
 
 interface KeyboardShortcutsContextType {
-    registerShortcut: (actionId: string, handler: KeyboardActionHandler) => void;
+    registerShortcut: (actionId: string, handler: KeyboardActionHandler, options?: ShortcutRegistrationOptions) => void;
     unregisterShortcut: (actionId: string) => void;
     getShortcutLabel: (actionId: string) => string | null;
 }
@@ -80,10 +95,10 @@ const ACTION_DEFINITIONS: Record<string, Omit<KeyboardAction, 'handler'>> = {
 
 export function KeyboardShortcutsProvider({ children }: { children: ReactNode }) {
     // Map of actionId -> handler
-    const handlers = React.useRef<Map<string, KeyboardActionHandler>>(new Map());
+    const handlers = React.useRef<Map<string, ShortcutRegistration>>(new Map());
 
-    const registerShortcut = useCallback((actionId: string, handler: KeyboardActionHandler) => {
-        handlers.current.set(actionId, handler);
+    const registerShortcut = useCallback((actionId: string, handler: KeyboardActionHandler, options?: ShortcutRegistrationOptions) => {
+        handlers.current.set(actionId, { handler, requiresPlaybackFocus: options?.requiresPlaybackFocus });
     }, []);
 
     const unregisterShortcut = useCallback((actionId: string) => {
@@ -149,8 +164,8 @@ export function KeyboardShortcutsProvider({ children }: { children: ReactNode })
                     continue;
                 }
 
-                const handler = handlers.current.get(action.id);
-                if (!handler) {
+                const registration = handlers.current.get(action.id);
+                if (!registration) {
                     continue;
                 }
 
@@ -164,12 +179,15 @@ export function KeyboardShortcutsProvider({ children }: { children: ReactNode })
                 if (onButton && (matchedKey === ' ' || matchedKey === 'enter')) {
                     continue;
                 }
-                if (isArrow && action.requiresPlaybackFocus && !inPlaybackDock) {
-                    continue;
+                if (isArrow) {
+                    const requiresPlaybackFocus = registration.requiresPlaybackFocus ?? action.requiresPlaybackFocus;
+                    if (requiresPlaybackFocus && !inPlaybackDock) {
+                        continue;
+                    }
                 }
 
                 event.preventDefault();
-                handler();
+                registration.handler();
                 return;
             }
         };
@@ -185,18 +203,25 @@ export function KeyboardShortcutsProvider({ children }: { children: ReactNode })
     );
 }
 
-export function useKeyboardShortcut(actionId: string, handler: KeyboardActionHandler, enabled: boolean = true) {
+export function useKeyboardShortcut(
+    actionId: string,
+    handler: KeyboardActionHandler,
+    enabled: boolean = true,
+    options?: ShortcutRegistrationOptions
+) {
     const context = useContext(KeyboardShortcutsContext);
     if (context === undefined) {
         throw new Error('useKeyboardShortcut must be used within a KeyboardShortcutsProvider');
     }
 
+    const requiresPlaybackFocus = options?.requiresPlaybackFocus;
+
     useEffect(() => {
         if (enabled) {
-            context.registerShortcut(actionId, handler);
+            context.registerShortcut(actionId, handler, { requiresPlaybackFocus });
             return () => context.unregisterShortcut(actionId);
         }
-    }, [actionId, handler, enabled, context]);
+    }, [actionId, handler, enabled, requiresPlaybackFocus, context]);
 }
 
 export const ACTIONS = ACTION_DEFINITIONS;

--- a/src/contexts/KeyboardShortcutsContext.tsx
+++ b/src/contexts/KeyboardShortcutsContext.tsx
@@ -111,61 +111,66 @@ export function KeyboardShortcutsProvider({ children }: { children: ReactNode })
             }
             const inPlaybackDock = event.target instanceof HTMLElement
                 && event.target.closest('[data-playback-focus]') !== null;
-            // Keys mean something else on interactive controls: Space activates a
-            // focused button, arrows move menus, selects, sliders and tab lists.
-            const onInteractiveControl = event.target instanceof HTMLElement && (
+            // A composite widget owns every key: menus, listboxes, sliders, tab
+            // lists, comboboxes and selects move their own selection with the
+            // arrows, close on Escape and jump to a letter as you type it.
+            const onCompositeWidget = event.target instanceof HTMLElement && (
                 event.target instanceof HTMLSelectElement ||
-                event.target instanceof HTMLButtonElement ||
                 event.target.closest('[role="menu"], [role="menubar"], [role="listbox"], [role="slider"], [role="tablist"], [role="combobox"]') !== null
             );
-            // The dock is all buttons and one slider, so this return would reject
-            // every key the dock's own actions claim. It defers to the per-action
-            // check below there, and keeps its verdict everywhere else.
-            if (onInteractiveControl && !inPlaybackDock) {
-                return;
-            }
+            // A focused button owns Space and Enter, which activate it. It owns
+            // no other key, so the rest of the shortcuts still reach their action.
+            const onButton = event.target instanceof HTMLButtonElement;
 
             // Check all definitions
             for (const action of Object.values(ACTION_DEFINITIONS)) {
-                const isMatch = action.keys.some(keyCombo => {
+                const matchedKey = action.keys.map(keyCombo => {
                     const parts = keyCombo.toLowerCase().split('+');
                     const key = parts.pop();
                     const modifiers = parts;
-                    
-                    if (event.key.toLowerCase() !== key) return false;
-                    
+
+                    if (event.key.toLowerCase() !== key) return undefined;
+
                     const ctrl = modifiers.includes('control') || modifiers.includes('ctrl');
                     const meta = modifiers.includes('meta') || modifiers.includes('cmd');
                     const shift = modifiers.includes('shift');
                     const alt = modifiers.includes('alt');
 
-                    return (
+                    const modifiersMatch = (
                         event.ctrlKey === ctrl &&
                         event.metaKey === meta &&
                         event.shiftKey === shift &&
                         event.altKey === alt
                     );
-                });
+                    return modifiersMatch ? key : undefined;
+                }).find(key => key !== undefined);
 
-                if (isMatch) {
-                    // Bare arrows stay scroll keys while reading; they drive
-                    // playback only when focus sits inside the dock (or the
-                    // floating player). Space stays global.
-                    if (action.requiresPlaybackFocus && !inPlaybackDock) {
-                        continue;
-                    }
-                    // Inside the dock only the arrow actions outrank the control
-                    // under focus: Space still activates the focused button.
-                    if (onInteractiveControl && !action.requiresPlaybackFocus) {
-                        continue;
-                    }
-                    const handler = handlers.current.get(action.id);
-                    if (handler) {
-                        event.preventDefault();
-                        handler();
-                        return;
-                    }
+                if (matchedKey === undefined) {
+                    continue;
                 }
+
+                const handler = handlers.current.get(action.id);
+                if (!handler) {
+                    continue;
+                }
+
+                const isArrow = matchedKey.startsWith('arrow');
+
+                // Inside the dock the arrow actions outrank the widget under
+                // focus, which is how the dock's own strip and buttons work.
+                if (onCompositeWidget && !(inPlaybackDock && isArrow)) {
+                    continue;
+                }
+                if (onButton && (matchedKey === ' ' || matchedKey === 'enter')) {
+                    continue;
+                }
+                if (isArrow && action.requiresPlaybackFocus && !inPlaybackDock) {
+                    continue;
+                }
+
+                event.preventDefault();
+                handler();
+                return;
             }
         };
 

--- a/src/contexts/KeyboardShortcutsContext.tsx
+++ b/src/contexts/KeyboardShortcutsContext.tsx
@@ -93,6 +93,35 @@ const ACTION_DEFINITIONS: Record<string, Omit<KeyboardAction, 'handler'>> = {
     }
 };
 
+// How each key is written for a reader. The dispatcher matches on the
+// KeyboardEvent.key values above; a guide has to show them as keys look.
+const KEY_LABELS: Record<string, string> = {
+    ' ': 'Space',
+    arrowleft: '\u2190',
+    arrowright: '\u2192',
+    arrowup: '\u2191',
+    arrowdown: '\u2193',
+    escape: 'Esc',
+};
+
+/**
+ * The keys an action answers to, written the way a guide shows them.
+ *
+ * This is the single statement of what a shortcut is bound to. Anything that
+ * tells a user about a shortcut reads it from here, so the guide cannot promise
+ * a key the dispatcher does not honour.
+ */
+export function getActionKeyLabel(actionId: string): string | null {
+    const def = ACTION_DEFINITIONS[actionId];
+    if (!def) return null;
+    return def.keys
+        .map(combo => combo
+            .split('+')
+            .map(part => KEY_LABELS[part.toLowerCase()] ?? (part.length === 1 ? part.toUpperCase() : part))
+            .join('+'))
+        .join(' or ');
+}
+
 export function KeyboardShortcutsProvider({ children }: { children: ReactNode }) {
     // Map of actionId -> handler
     const handlers = React.useRef<Map<string, ShortcutRegistration>>(new Map());
@@ -105,10 +134,7 @@ export function KeyboardShortcutsProvider({ children }: { children: ReactNode })
         handlers.current.delete(actionId);
     }, []);
 
-    const getShortcutLabel = useCallback((actionId: string) => {
-        const def = ACTION_DEFINITIONS[actionId];
-        return def ? def.keys.join(' or ') : null;
-    }, []);
+    const getShortcutLabel = useCallback((actionId: string) => getActionKeyLabel(actionId), []);
 
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {

--- a/src/contexts/__tests__/KeyboardShortcutsContext.test.tsx
+++ b/src/contexts/__tests__/KeyboardShortcutsContext.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import { KeyboardShortcutsProvider, useKeyboardShortcut, ACTIONS } from '../KeyboardShortcutsContext';
+import { KeyboardShortcutsProvider, useKeyboardShortcut, ACTIONS, getActionKeyLabel } from '../KeyboardShortcutsContext';
 
 type Handlers = {
     seekNext: jest.Mock;
@@ -129,5 +129,27 @@ describe('the timeline strip', () => {
         const { handlers, view } = setup(false);
         fireEvent.keyDown(view.getByTestId('strip'), { key: 'ArrowUp' });
         expect(handlers.speedUp).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('the keys a guide shows', () => {
+    it('writes an arrow as an arrow', () => {
+        expect(getActionKeyLabel(ACTIONS.SEEK_NEXT.id)).toBe('→');
+        expect(getActionKeyLabel(ACTIONS.SPEED_UP.id)).toBe('↑');
+    });
+
+    it('keeps the modifier in front of the key', () => {
+        expect(getActionKeyLabel(ACTIONS.SKIP_FORWARD.id)).toBe('Shift+→');
+    });
+
+    it('names the keys that have no glyph', () => {
+        expect(getActionKeyLabel(ACTIONS.PLAY_PAUSE.id)).toBe('Space');
+        expect(getActionKeyLabel(ACTIONS.CLEAR_SELECTION.id)).toBe('Esc');
+        expect(getActionKeyLabel(ACTIONS.EDIT_NEXT_UTTERANCE.id)).toBe('Enter');
+        expect(getActionKeyLabel(ACTIONS.EXTRACT_SEGMENT.id)).toBe('E');
+    });
+
+    it('has no label for an action that does not exist', () => {
+        expect(getActionKeyLabel('NOT_AN_ACTION')).toBeNull();
     });
 });

--- a/src/contexts/__tests__/KeyboardShortcutsContext.test.tsx
+++ b/src/contexts/__tests__/KeyboardShortcutsContext.test.tsx
@@ -117,3 +117,17 @@ describe('bare arrows for a reader', () => {
         expect(handlers.playPause).toHaveBeenCalledTimes(1);
     });
 });
+
+describe('the timeline strip', () => {
+    it('passes its arrows to the shortcuts, though it is a slider', () => {
+        const { handlers, view } = setup(true);
+        fireEvent.keyDown(view.getByTestId('strip'), { key: 'ArrowRight' });
+        expect(handlers.seekNext).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets a reader reach the speed keys there', () => {
+        const { handlers, view } = setup(false);
+        fireEvent.keyDown(view.getByTestId('strip'), { key: 'ArrowUp' });
+        expect(handlers.speedUp).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/contexts/__tests__/KeyboardShortcutsContext.test.tsx
+++ b/src/contexts/__tests__/KeyboardShortcutsContext.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { KeyboardShortcutsProvider, useKeyboardShortcut, ACTIONS } from '../KeyboardShortcutsContext';
+
+type Handlers = {
+    seekNext: jest.Mock;
+    speedUp: jest.Mock;
+    playPause: jest.Mock;
+    clearSelection: jest.Mock;
+    extract: jest.Mock;
+};
+
+function Shortcuts({ handlers }: { handlers: Handlers }) {
+    useKeyboardShortcut(ACTIONS.SEEK_NEXT.id, handlers.seekNext);
+    useKeyboardShortcut(ACTIONS.SPEED_UP.id, handlers.speedUp);
+    useKeyboardShortcut(ACTIONS.PLAY_PAUSE.id, handlers.playPause);
+    useKeyboardShortcut(ACTIONS.CLEAR_SELECTION.id, handlers.clearSelection, true);
+    useKeyboardShortcut(ACTIONS.EXTRACT_SEGMENT.id, handlers.extract, true);
+    return null;
+}
+
+function setup() {
+    const handlers: Handlers = {
+        seekNext: jest.fn(),
+        speedUp: jest.fn(),
+        playPause: jest.fn(),
+        clearSelection: jest.fn(),
+        extract: jest.fn(),
+    };
+    const view = render(
+        <KeyboardShortcutsProvider>
+            <Shortcuts handlers={handlers} />
+            <p data-testid="transcript">an utterance</p>
+            <button data-testid="toolbar">Speakers</button>
+            <div data-playback-focus="">
+                <button data-testid="dock-play">Play</button>
+                <div role="slider" aria-label="timeline" aria-valuemin={0} aria-valuemax={100} aria-valuenow={0} data-testid="strip" tabIndex={0} />
+            </div>
+            <div role="listbox" data-testid="listbox" tabIndex={-1} />
+        </KeyboardShortcutsProvider>
+    );
+    return { handlers, view };
+}
+
+describe('a control that owns the keyboard', () => {
+    it('leaves Space to a focused button, which it activates', () => {
+        const { handlers, view } = setup();
+        fireEvent.keyDown(view.getByTestId('toolbar'), { key: ' ' });
+        expect(handlers.playPause).not.toHaveBeenCalled();
+    });
+
+    it('passes Escape from a focused button to its action', () => {
+        const { handlers, view } = setup();
+        fireEvent.keyDown(view.getByTestId('toolbar'), { key: 'Escape' });
+        expect(handlers.clearSelection).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes a letter from a focused button to its action', () => {
+        const { handlers, view } = setup();
+        fireEvent.keyDown(view.getByTestId('toolbar'), { key: 'e' });
+        expect(handlers.extract).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves every key to a listbox, which moves its own selection', () => {
+        const { handlers, view } = setup();
+        fireEvent.keyDown(view.getByTestId('listbox'), { key: 'ArrowRight' });
+        fireEvent.keyDown(view.getByTestId('listbox'), { key: 'Escape' });
+        expect(handlers.seekNext).not.toHaveBeenCalled();
+        expect(handlers.clearSelection).not.toHaveBeenCalled();
+    });
+});

--- a/src/contexts/__tests__/KeyboardShortcutsContext.test.tsx
+++ b/src/contexts/__tests__/KeyboardShortcutsContext.test.tsx
@@ -10,16 +10,18 @@ type Handlers = {
     extract: jest.Mock;
 };
 
-function Shortcuts({ handlers }: { handlers: Handlers }) {
-    useKeyboardShortcut(ACTIONS.SEEK_NEXT.id, handlers.seekNext);
-    useKeyboardShortcut(ACTIONS.SPEED_UP.id, handlers.speedUp);
-    useKeyboardShortcut(ACTIONS.PLAY_PAUSE.id, handlers.playPause);
+function Shortcuts({ editable, handlers }: { editable: boolean; handlers: Handlers }) {
+    // Seek belongs to everyone; speed is the editing surface's until a reader
+    // reaches the dock, because up and down are a reader's scroll keys.
+    useKeyboardShortcut(ACTIONS.SEEK_NEXT.id, handlers.seekNext, true, { requiresPlaybackFocus: false });
+    useKeyboardShortcut(ACTIONS.SPEED_UP.id, handlers.speedUp, true, { requiresPlaybackFocus: !editable });
+    useKeyboardShortcut(ACTIONS.PLAY_PAUSE.id, handlers.playPause, true);
     useKeyboardShortcut(ACTIONS.CLEAR_SELECTION.id, handlers.clearSelection, true);
     useKeyboardShortcut(ACTIONS.EXTRACT_SEGMENT.id, handlers.extract, true);
     return null;
 }
 
-function setup() {
+function setup(editable: boolean) {
     const handlers: Handlers = {
         seekNext: jest.fn(),
         speedUp: jest.fn(),
@@ -29,7 +31,7 @@ function setup() {
     };
     const view = render(
         <KeyboardShortcutsProvider>
-            <Shortcuts handlers={handlers} />
+            <Shortcuts editable={editable} handlers={handlers} />
             <p data-testid="transcript">an utterance</p>
             <button data-testid="toolbar">Speakers</button>
             <div data-playback-focus="">
@@ -44,28 +46,74 @@ function setup() {
 
 describe('a control that owns the keyboard', () => {
     it('leaves Space to a focused button, which it activates', () => {
-        const { handlers, view } = setup();
+        const { handlers, view } = setup(true);
         fireEvent.keyDown(view.getByTestId('toolbar'), { key: ' ' });
         expect(handlers.playPause).not.toHaveBeenCalled();
     });
 
     it('passes Escape from a focused button to its action', () => {
-        const { handlers, view } = setup();
+        const { handlers, view } = setup(true);
         fireEvent.keyDown(view.getByTestId('toolbar'), { key: 'Escape' });
         expect(handlers.clearSelection).toHaveBeenCalledTimes(1);
     });
 
     it('passes a letter from a focused button to its action', () => {
-        const { handlers, view } = setup();
+        const { handlers, view } = setup(true);
         fireEvent.keyDown(view.getByTestId('toolbar'), { key: 'e' });
         expect(handlers.extract).toHaveBeenCalledTimes(1);
     });
 
     it('leaves every key to a listbox, which moves its own selection', () => {
-        const { handlers, view } = setup();
+        const { handlers, view } = setup(true);
         fireEvent.keyDown(view.getByTestId('listbox'), { key: 'ArrowRight' });
         fireEvent.keyDown(view.getByTestId('listbox'), { key: 'Escape' });
         expect(handlers.seekNext).not.toHaveBeenCalled();
         expect(handlers.clearSelection).not.toHaveBeenCalled();
+    });
+});
+
+describe('bare arrows in the editing surface', () => {
+    it('seeks to the next utterance with focus on the transcript', () => {
+        const { handlers, view } = setup(true);
+        fireEvent.keyDown(view.getByTestId('transcript'), { key: 'ArrowRight' });
+        expect(handlers.seekNext).toHaveBeenCalledTimes(1);
+    });
+
+    it('changes the speed with focus on the transcript', () => {
+        const { handlers, view } = setup(true);
+        fireEvent.keyDown(view.getByTestId('transcript'), { key: 'ArrowUp' });
+        expect(handlers.speedUp).toHaveBeenCalledTimes(1);
+    });
+
+    it('seeks with focus on a button, which has no arrow behaviour of its own', () => {
+        const { handlers, view } = setup(true);
+        fireEvent.keyDown(view.getByTestId('toolbar'), { key: 'ArrowRight' });
+        expect(handlers.seekNext).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('bare arrows for a reader', () => {
+    it('seeks from the transcript, because left and right never scroll it', () => {
+        const { handlers, view } = setup(false);
+        fireEvent.keyDown(view.getByTestId('transcript'), { key: 'ArrowRight' });
+        expect(handlers.seekNext).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps up and down for scroll, so a stray press cannot store a new speed', () => {
+        const { handlers, view } = setup(false);
+        fireEvent.keyDown(view.getByTestId('transcript'), { key: 'ArrowUp' });
+        expect(handlers.speedUp).not.toHaveBeenCalled();
+    });
+
+    it('changes the speed from inside the dock', () => {
+        const { handlers, view } = setup(false);
+        fireEvent.keyDown(view.getByTestId('dock-play'), { key: 'ArrowUp' });
+        expect(handlers.speedUp).toHaveBeenCalledTimes(1);
+    });
+
+    it('plays and pauses with Space anywhere', () => {
+        const { handlers, view } = setup(false);
+        fireEvent.keyDown(view.getByTestId('transcript'), { key: ' ' });
+        expect(handlers.playPause).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
Operators reported that the arrow keys stopped working in the transcript editor after the city page redesign shipped. Two symptoms: the right arrow no longer stepped to the next utterance while listening, and the up and down arrows no longer changed the playback speed.

A follow-up report named the cause without meaning to. The speed keys still worked, but only after clicking on the meeting's video. That is the new focus gate, described from the outside.

## What happened

#694 rewrote the shortcut dispatcher and added four guards to it. Two of them changed documented behaviour, and none of them reached the guide, the PR description, or the in-app help. The only written record was in commit messages, and those state the new behaviour matches the editing guide when it does not.

Seven documented shortcuts were affected:

| Shortcut | What it did on `main` |
| --- | --- |
| `←` `→` seek utterance | Only with focus inside the playback dock |
| `↑` `↓` speed | Only with focus inside the playback dock |
| `e` extract, `Esc` clear selection, `Shift`+`←→` skip | Dead whenever any button held focus |

Nothing moves focus into the dock on its own, so the first gate stayed shut for a whole editing session. The second gate is why this felt intermittent rather than simply dead: one click on a toolbar button silenced the rest.

## What this changes

**Editing mode gets its keyboard back.** All four arrows drive playback from anywhere on the page, as the guide has always documented.

**A reader gets seek, but not speed.** `←` and `→` only scroll a page sideways and a transcript never scrolls sideways, so a reader keeps them as seek. `↑` and `↓` stay scroll keys for a reader and change speed from the dock. This matters because #694 also made the chosen speed persist in `localStorage`, so one stray press would follow a reader into every meeting they open.

**A focused button keeps only `Space` and `Enter`.** Those are the keys it actually activates on. Every other key now reaches its shortcut. Menus, listboxes, sliders, tab lists and comboboxes still keep every key.

**The timeline strip releases the arrows.** It is a slider that takes focus on a click, and it claimed `←` `→` for a step of one percent of the meeting — close to two minutes on a three hour session, which is what "it skips utterances" meant. It now claims no arrow key. Page keys still jump chapters, `Home` and `End` still reach the ends, and `Shift`+arrow now honours the operator's configured skip interval instead of a fixed ten seconds.

**The in-app guide reads its keys from the dispatcher.** The key list stood in four places and a change reached only one, so the guide kept promising keys the dispatcher had stopped honouring. `getActionKeyLabel` is now the single statement of what a shortcut is bound to, and `EditingGuideDialog` renders from it. `getShortcutLabel` existed for exactly this and had no caller.

**The written guide keeps only its rules.** The shortcut table and the component path list were both stale — the latter pointed at `TranscriptControls.tsx`, deleted in this same redesign. The action definitions and a grep answer both questions and cannot drift. What stays is what the code does not state: why editing mode claims the arrows, why a reader gets seek but not speed, which controls keep their own keys, and the business rules on segments and history.

## Notes for review

The timeline's one percent step was a deliberate choice in #694, and its commit message gives the reason as matching the editing guide. The guide specifies previous and next **utterance**, so this delivers that intent rather than overruling it. @christosporios should confirm. The step is also older than the redesign — the deleted `TranscriptControls.tsx` carried the identical handler, so #694 changed how often it is hit, not the behaviour itself.

Two related findings needed no change. The `isContentEditable` guard added in #694 is dead code, because no `contentEditable` exists in `src/` or `packages/`. The `role="button"` divs are not covered by the button check, but the one on this page calls `preventDefault()`, so nothing is broken today.

## Testing on the preview

Enter editing mode on any meeting, start playback, and use `←` `→` and `↑` `↓` with focus on the transcript. Then click a toolbar button and try `e` and `Esc` on a selection. Then click the timeline and use the arrows there. As a reader, confirm `↑` `↓` still scroll the page and `←` `→` seek.






<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62273633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge, with no outstanding correctness, security, or repository-rule issue.

<h3>Summary</h3>

- Bare arrows control playback across the editing surface.
- Reader mode keeps vertical arrows for scrolling outside the playback dock.
- Focused buttons retain Space and Enter while passing other shortcuts.
- The timeline delegates arrow keys to the global shortcut dispatcher.
- The written and in-app guides now derive shortcut information from current behavior.

<sub>Reviews (4) · Last reviewed commit: ["docs(editing): keep the rules that the c..."](https://github.com/schemalabz/opencouncil/commit/c8a95dec6898f4142e48fd245e7eea406e3348fb)</sub>

<!-- /greptile_comment -->